### PR TITLE
fix(codex): improve transcript parsing, tool argument formatting, and compaction support

### DIFF
--- a/assets/hooks/codex-hook-processor.mjs
+++ b/assets/hooks/codex-hook-processor.mjs
@@ -54,6 +54,10 @@ import {
 import { loadState, saveState, splitIntoTurns } from './codex/state.mjs';
 import { parseTranscript } from './codex/transcript-parser.mjs';
 import { buildReactSteps } from './codex/react-step-builder.mjs';
+import {
+  mergeCodexToolArguments,
+  normalizeCodexToolArguments,
+} from './codex/tool-arguments.mjs';
 
 const AGENT_ID = 'codex';
 
@@ -120,7 +124,7 @@ function appendMissingTranscriptToolEvents(state, transcriptToolEvents) {
       mergeTranscriptToolEvent(existing, event);
     } else {
       if (event.type === 'pre_tool_use') {
-        event.tool_input = formatCodexToolArguments(event.tool_name, event.tool_input, event.tool_name, event.tool_input);
+        event.tool_input = normalizeCodexToolArguments(event.tool_name, event.tool_input);
       }
       state.events.push(event);
       seen.set(key, event);
@@ -131,7 +135,7 @@ function appendMissingTranscriptToolEvents(state, transcriptToolEvents) {
 function mergeTranscriptToolEvent(target, transcriptEvent) {
   if (!target || !transcriptEvent) return;
   if (target.type === 'pre_tool_use' && transcriptEvent.type === 'pre_tool_use') {
-    target.tool_input = formatCodexToolArguments(target.tool_name, target.tool_input, transcriptEvent.tool_name, transcriptEvent.tool_input);
+    target.tool_input = mergeCodexToolArguments(target.tool_name, target.tool_input, transcriptEvent.tool_name, transcriptEvent.tool_input);
     if ((!target.tool_name || target.tool_name === 'unknown') && transcriptEvent.tool_name) {
       target.tool_name = transcriptEvent.tool_name;
     }
@@ -143,40 +147,6 @@ function mergeTranscriptToolEvent(target, transcriptEvent) {
       target.tool_name = transcriptEvent.tool_name;
     }
   }
-}
-
-function formatCodexToolArguments(toolName, hookInput, transcriptToolName, transcriptInput) {
-  const hookArgs = isPlainObject(hookInput) ? hookInput : {};
-  const transcriptArgs = isPlainObject(transcriptInput) ? transcriptInput : {};
-  const normalizedName = String(toolName || transcriptToolName || '').toLowerCase();
-  const normalizedTranscriptName = String(transcriptToolName || '').toLowerCase();
-
-  if (normalizedName === 'bash' || normalizedTranscriptName === 'exec_command') {
-    const command = hookArgs.command ?? transcriptArgs.command ?? transcriptArgs.cmd;
-    const workdir = hookArgs.workdir ?? transcriptArgs.workdir;
-    const out = {};
-    if (command !== undefined) out.command = command;
-    if (workdir !== undefined) out.workdir = workdir;
-    return Object.keys(out).length > 0 ? out : hookInput;
-  }
-
-  if (normalizedName === 'apply_patch') {
-    if (hookArgs.command !== undefined) return hookArgs;
-    if (transcriptArgs.command !== undefined) return transcriptArgs;
-    if (typeof hookInput === 'string') return { command: hookInput };
-    if (typeof transcriptInput === 'string') return { command: transcriptInput };
-    if (isPlainObject(hookInput)) return hookInput;
-    if (isPlainObject(transcriptInput)) return transcriptInput;
-    const command = hookInput ?? transcriptInput;
-    return command !== undefined ? { command } : command;
-  }
-
-  if (isPlainObject(transcriptInput)) return transcriptInput;
-  return hookInput ?? transcriptInput;
-}
-
-function isPlainObject(value) {
-  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 // ─── 5 cmd handlers — 累积 event 到 state ───

--- a/assets/hooks/codex-hook-processor.mjs
+++ b/assets/hooks/codex-hook-processor.mjs
@@ -107,18 +107,76 @@ function requireSessionId(event, stage = 'cmd') {
 function appendMissingTranscriptToolEvents(state, transcriptToolEvents) {
   if (!Array.isArray(transcriptToolEvents) || transcriptToolEvents.length === 0) return;
   if (!Array.isArray(state.events)) state.events = [];
-  const seen = new Set(
-    state.events
-      .filter((event) => event.type === 'pre_tool_use' || event.type === 'post_tool_use')
-      .map((event) => `${event.type}:${event.tool_use_id || ''}`),
-  );
-  for (const event of transcriptToolEvents) {
-    const key = `${event.type}:${event.tool_use_id || ''}`;
-    if (!seen.has(key)) {
-      state.events.push(event);
-      seen.add(key);
+  const seen = new Map();
+  for (const event of state.events) {
+    if (event.type === 'pre_tool_use' || event.type === 'post_tool_use') {
+      seen.set(`${event.type}:${event.tool_use_id || ''}`, event);
     }
   }
+  for (const event of transcriptToolEvents) {
+    const key = `${event.type}:${event.tool_use_id || ''}`;
+    const existing = seen.get(key);
+    if (existing) {
+      mergeTranscriptToolEvent(existing, event);
+    } else {
+      if (event.type === 'pre_tool_use') {
+        event.tool_input = formatCodexToolArguments(event.tool_name, event.tool_input, event.tool_name, event.tool_input);
+      }
+      state.events.push(event);
+      seen.set(key, event);
+    }
+  }
+}
+
+function mergeTranscriptToolEvent(target, transcriptEvent) {
+  if (!target || !transcriptEvent) return;
+  if (target.type === 'pre_tool_use' && transcriptEvent.type === 'pre_tool_use') {
+    target.tool_input = formatCodexToolArguments(target.tool_name, target.tool_input, transcriptEvent.tool_name, transcriptEvent.tool_input);
+    if ((!target.tool_name || target.tool_name === 'unknown') && transcriptEvent.tool_name) {
+      target.tool_name = transcriptEvent.tool_name;
+    }
+  } else if (target.type === 'post_tool_use' && transcriptEvent.type === 'post_tool_use') {
+    if (target.tool_response === undefined || target.tool_response === null || target.tool_response === '') {
+      target.tool_response = transcriptEvent.tool_response;
+    }
+    if ((!target.tool_name || target.tool_name === 'unknown') && transcriptEvent.tool_name) {
+      target.tool_name = transcriptEvent.tool_name;
+    }
+  }
+}
+
+function formatCodexToolArguments(toolName, hookInput, transcriptToolName, transcriptInput) {
+  const hookArgs = isPlainObject(hookInput) ? hookInput : {};
+  const transcriptArgs = isPlainObject(transcriptInput) ? transcriptInput : {};
+  const normalizedName = String(toolName || transcriptToolName || '').toLowerCase();
+  const normalizedTranscriptName = String(transcriptToolName || '').toLowerCase();
+
+  if (normalizedName === 'bash' || normalizedTranscriptName === 'exec_command') {
+    const command = hookArgs.command ?? transcriptArgs.command ?? transcriptArgs.cmd;
+    const workdir = hookArgs.workdir ?? transcriptArgs.workdir;
+    const out = {};
+    if (command !== undefined) out.command = command;
+    if (workdir !== undefined) out.workdir = workdir;
+    return Object.keys(out).length > 0 ? out : hookInput;
+  }
+
+  if (normalizedName === 'apply_patch') {
+    if (hookArgs.command !== undefined) return hookArgs;
+    if (transcriptArgs.command !== undefined) return transcriptArgs;
+    if (typeof hookInput === 'string') return { command: hookInput };
+    if (typeof transcriptInput === 'string') return { command: transcriptInput };
+    if (isPlainObject(hookInput)) return hookInput;
+    if (isPlainObject(transcriptInput)) return transcriptInput;
+    const command = hookInput ?? transcriptInput;
+    return command !== undefined ? { command } : command;
+  }
+
+  if (isPlainObject(transcriptInput)) return transcriptInput;
+  return hookInput ?? transcriptInput;
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 // ─── 5 cmd handlers — 累积 event 到 state ───
@@ -390,6 +448,7 @@ function resolveTurns(state, transcriptData) {
     turns.push({
       turn_id: boundary.turn_id,
       prompt: boundary.prompt || promptEvent?.prompt || '',
+      inputMessages: boundary.inputMessages,
       model: promptEvent?.model || state.model || 'unknown',
       start_time: startTime,
       end_time: stopEvent && i === boundaries.length - 1
@@ -448,7 +507,7 @@ function buildTurnRecords({
     records.push({
       time_unix_nano: timestampToUnixNanos(turn.start_time * 1000),
       'event.id': crypto.randomUUID(),
-      'event.name': 'llm.request',
+      'event.name': 'other',
       ...baseFields,
       span_id: agentSpanId,
       parent_span_id: entrySpanId,
@@ -471,7 +530,10 @@ function buildTurnRecords({
     const llmSpanId = generateSpanId();
 
     const inputMsgs = step.llm_input_messages;
-    const currentFullHash = computeHash(INITIAL_HASH, inputMsgs);
+    const fullInputMsgs = Array.isArray(step.llm_full_input_messages) && step.llm_full_input_messages.length > 0
+      ? step.llm_full_input_messages
+      : inputMsgs;
+    const currentFullHash = computeHash(INITIAL_HASH, fullInputMsgs);
     const logFull = shouldLogFullMessages(runningHash, inputMsgs, currentFullHash);
 
     // llm.request
@@ -487,7 +549,7 @@ function buildTurnRecords({
       'gen_ai.input.messages_hash': currentFullHash,
       'gen_ai.input.messages_delta': inputMsgs,
     };
-    if (logFull) reqRecord['gen_ai.input.messages'] = inputMsgs;
+    if (logFull) reqRecord['gen_ai.input.messages'] = fullInputMsgs;
     // Codex 专属:system_instructions / tool.definitions(每条 LLM record 都贴,符合 ARMS 规范)
     if (systemInstruction) reqRecord['gen_ai.system_instructions'] = systemInstruction;
     if (toolDefinitions) reqRecord['gen_ai.tool.definitions'] = toolDefinitions;

--- a/assets/hooks/codex/react-step-builder.mjs
+++ b/assets/hooks/codex/react-step-builder.mjs
@@ -33,6 +33,7 @@
  * @property {number} llm_start_time
  * @property {number} llm_end_time
  * @property {Message[]} llm_input_messages
+ * @property {Message[]} llm_full_input_messages
  * @property {Message[]} llm_output_messages
  * @property {ToolRecord[]} tools
  */
@@ -144,6 +145,11 @@ function finalizeStep(round, turn, llmStartTime, _llmEndTimeHint, previousTools,
   const llmEndTime = firstToolStart;
 
   const llmInputMessages = buildLlmInputMessages(round === 1 ? turn.prompt : null, previousTools);
+  const llmFullInputMessages = buildLlmFullInputMessages(
+    round === 1 ? turn.inputMessages : null,
+    llmInputMessages,
+    previousTools,
+  );
   const llmOutputMessages = buildLlmOutputMessagesWithTools(tools, reasoning);
 
   return {
@@ -153,6 +159,7 @@ function finalizeStep(round, turn, llmStartTime, _llmEndTimeHint, previousTools,
     llm_start_time: llmStartTime,
     llm_end_time: llmEndTime,
     llm_input_messages: llmInputMessages,
+    llm_full_input_messages: llmFullInputMessages,
     llm_output_messages: llmOutputMessages,
     tools,
   };
@@ -160,6 +167,11 @@ function finalizeStep(round, turn, llmStartTime, _llmEndTimeHint, previousTools,
 
 function finalizeFinalStep(round, turn, llmStartTime, previousTools, reasoning) {
   const llmInputMessages = buildLlmInputMessages(round === 1 ? turn.prompt : null, previousTools);
+  const llmFullInputMessages = buildLlmFullInputMessages(
+    round === 1 ? turn.inputMessages : null,
+    llmInputMessages,
+    previousTools,
+  );
 
   /** @type {MessagePart[]} */
   const parts = [];
@@ -182,6 +194,7 @@ function finalizeFinalStep(round, turn, llmStartTime, previousTools, reasoning) 
     llm_start_time: llmStartTime,
     llm_end_time: turn.end_time,
     llm_input_messages: llmInputMessages,
+    llm_full_input_messages: llmFullInputMessages,
     llm_output_messages: llmOutputMessages,
     tools: [],
   };
@@ -204,6 +217,23 @@ function buildLlmInputMessages(userPrompt, previousTools) {
     ];
   }
   return [];
+}
+
+function buildLlmFullInputMessages(turnInputMessages, deltaMessages, previousTools) {
+  const hasTurnInput = Array.isArray(turnInputMessages) && turnInputMessages.length > 0;
+  const base = hasTurnInput ? [...turnInputMessages] : [...deltaMessages];
+  if (!hasTurnInput || previousTools.length === 0) return base;
+  return [
+    ...base,
+    {
+      role: 'tool',
+      parts: previousTools.map((t) => ({
+        type: 'tool_call_response',
+        id: t.tool_use_id,
+        response: t.tool_response,
+      })),
+    },
+  ];
 }
 
 function buildLlmOutputMessagesWithTools(tools, reasoning) {

--- a/assets/hooks/codex/tool-arguments.mjs
+++ b/assets/hooks/codex/tool-arguments.mjs
@@ -1,0 +1,40 @@
+// Copyright 2026 Alibaba Group Holding Limited
+// SPDX-License-Identifier: Apache-2.0
+
+export function normalizeCodexToolArguments(toolName, input) {
+  return mergeCodexToolArguments(toolName, input, toolName, input);
+}
+
+export function mergeCodexToolArguments(toolName, hookInput, transcriptToolName, transcriptInput) {
+  const hookArgs = isPlainObject(hookInput) ? hookInput : {};
+  const transcriptArgs = isPlainObject(transcriptInput) ? transcriptInput : {};
+  const normalizedName = String(toolName || transcriptToolName || '').toLowerCase();
+  const normalizedTranscriptName = String(transcriptToolName || '').toLowerCase();
+
+  if (normalizedName === 'bash' || normalizedTranscriptName === 'exec_command') {
+    const command = hookArgs.command ?? transcriptArgs.command ?? transcriptArgs.cmd;
+    const workdir = hookArgs.workdir ?? transcriptArgs.workdir;
+    const out = {};
+    if (command !== undefined) out.command = command;
+    if (workdir !== undefined) out.workdir = workdir;
+    return Object.keys(out).length > 0 ? out : hookInput;
+  }
+
+  if (normalizedName === 'apply_patch') {
+    if (hookArgs.command !== undefined) return hookArgs;
+    if (transcriptArgs.command !== undefined) return transcriptArgs;
+    if (typeof hookInput === 'string') return { command: hookInput };
+    if (typeof transcriptInput === 'string') return { command: transcriptInput };
+    if (isPlainObject(hookInput)) return hookInput;
+    if (isPlainObject(transcriptInput)) return transcriptInput;
+    const command = hookInput ?? transcriptInput;
+    return command != null ? { command } : hookInput;
+  }
+
+  if (isPlainObject(transcriptInput)) return transcriptInput;
+  return hookInput ?? transcriptInput;
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/assets/hooks/codex/transcript-parser.mjs
+++ b/assets/hooks/codex/transcript-parser.mjs
@@ -61,6 +61,28 @@ function parseMaybeJsonValue(value) {
   try { return JSON.parse(value); } catch { return value; }
 }
 
+function extractMessageContentText(content) {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  const parts = [];
+  for (const block of content) {
+    if (typeof block === 'string') {
+      parts.push(block);
+    } else if (block && typeof block === 'object' && typeof block.text === 'string') {
+      parts.push(block.text);
+    }
+  }
+  return parts.filter(Boolean).join('\n');
+}
+
+function transcriptMessageToInputMessage(payload) {
+  const role = typeof payload?.role === 'string' ? payload.role : '';
+  if (!role || role === 'assistant') return null;
+  const content = extractMessageContentText(payload.content);
+  if (!content) return null;
+  return { role, parts: [{ type: 'text', content }] };
+}
+
 function entryTimestampSeconds(entry) {
   const ms = Date.parse(entry?.timestamp || '');
   return Number.isFinite(ms) ? ms / 1000 : 0;
@@ -182,6 +204,7 @@ export function parseTranscript(transcriptPath, byteOffset = 0, initialLastUsage
   // turn 边界列表：记录 transcript 中每个 turn_context 的 turn_id 和时间戳，
   // 用于在 writeSessionJsonl 中驱动 turn 切分（替代仅靠 user_prompt_submit hook）
   const turnBoundaries = [];
+  const pendingInputMessages = [];
 
   // 父 agent 工具调用的 call_id 白名单。父 transcript 只包含父 agent 的 function_call，
   // 子 agent 的工具调用在子 transcript 中。resolveTurns 用此集合过滤 state.events 中
@@ -196,7 +219,13 @@ export function parseTranscript(transcriptPath, byteOffset = 0, initialLastUsage
   // 跨 turn 心跳去重锚点;由调用方从 state.transcript_last_token_usage 传入
   let lastEmittedUsage = initialLastUsage;
 
+  let lineIndex = 0;
+  // web_search_call 只有完成时间（web_search_end），没有开始时间。
+  // 用搜索前最后一个非 web_search 事件的时间戳近似搜索发起时刻，
+  // 使 tool.call 与 tool.result 有合理的时间差（duration > 0）。
+  let lastNonWebSearchTs = 0;
   for (const line of content.split('\n')) {
+    lineIndex++;
     const trimmed = line.trim();
     if (!trimmed) continue;
 
@@ -210,6 +239,13 @@ export function parseTranscript(transcriptPath, byteOffset = 0, initialLastUsage
     const entryType = entry.type;
     const payload = entry.payload;
     if (!payload || typeof payload !== 'object') continue;
+
+    // Track the last non-web_search timestamp for approximating web_search duration
+    const payloadTypeForTs = payload.type;
+    if (payloadTypeForTs !== 'web_search_end' && payloadTypeForTs !== 'web_search_call') {
+      const ts = entryTimestampSeconds(entry);
+      if (ts > 0) lastNonWebSearchTs = ts;
+    }
 
     if (entryType === 'session_meta') {
       if (typeof payload.model_provider === 'string' && payload.model_provider) {
@@ -237,11 +273,20 @@ export function parseTranscript(transcriptPath, byteOffset = 0, initialLastUsage
       }
       if (typeof payload.turn_id === 'string' && payload.turn_id) {
         currentTurnId = payload.turn_id;
-        turnBoundaries.push({
-          turn_id: payload.turn_id,
-          timestamp: entryTimestampSeconds(entry),
-          prompt: '',
-        });
+        const lastBoundary = turnBoundaries[turnBoundaries.length - 1];
+        if (lastBoundary?.turn_id === payload.turn_id) {
+          if (pendingInputMessages.length > 0) {
+            lastBoundary.inputMessages ??= [];
+            lastBoundary.inputMessages.push(...pendingInputMessages.splice(0));
+          }
+        } else {
+          turnBoundaries.push({
+            turn_id: payload.turn_id,
+            timestamp: entryTimestampSeconds(entry),
+            prompt: '',
+            inputMessages: pendingInputMessages.splice(0),
+          });
+        }
       }
     } else if (entryType === 'event_msg') {
       const payloadType = payload.type;
@@ -303,7 +348,21 @@ export function parseTranscript(transcriptPath, byteOffset = 0, initialLastUsage
       }
     } else if (entryType === 'response_item') {
       const itemType = payload.type;
-      if (itemType === 'function_call') {
+      if (itemType === 'message') {
+        const inputMessage = transcriptMessageToInputMessage(payload);
+        if (inputMessage) {
+          const lastBoundary = turnBoundaries[turnBoundaries.length - 1];
+          if (lastBoundary && currentTurnId) {
+            lastBoundary.inputMessages ??= [];
+            lastBoundary.inputMessages.push(inputMessage);
+            if (inputMessage.role === 'user' && !lastBoundary.prompt) {
+              lastBoundary.prompt = inputMessage.parts[0]?.content || '';
+            }
+          } else {
+            pendingInputMessages.push(inputMessage);
+          }
+        }
+      } else if (itemType === 'function_call') {
         const callId = String(payload.call_id || payload.id || '');
         if (callId) {
           const toolName = String(payload.name || 'unknown');
@@ -319,6 +378,62 @@ export function parseTranscript(transcriptPath, byteOffset = 0, initialLastUsage
           toolEvents.push(evt);
           // 父 transcript 中所有 function_call 的 call_id 都是父 agent 的工具调用。
           // 子 agent 的工具调用在子 transcript 中，不会出现在这里。
+          parentToolCallIds.add(callId);
+        }
+      } else if (itemType === 'custom_tool_call') {
+        const callId = String(payload.call_id || payload.id || '');
+        if (callId) {
+          const toolName = String(payload.name || 'custom_tool');
+          const evt = {
+            type: 'pre_tool_use',
+            timestamp: entryTimestampSeconds(entry),
+            turn_id: currentTurnId ?? '',
+            tool_name: toolName,
+            tool_input: parseMaybeJsonValue(payload.input),
+            tool_use_id: callId,
+          };
+          pendingToolCalls.set(callId, evt);
+          toolEvents.push(evt);
+          parentToolCallIds.add(callId);
+        }
+      } else if (itemType === 'web_search_call') {
+        const endTime = entryTimestampSeconds(entry);
+        const startTime = lastNonWebSearchTs > 0 ? lastNonWebSearchTs : endTime;
+        const callId = String(payload.call_id || payload.id || `web_search:${endTime}:${lineIndex}`);
+        const evt = {
+          type: 'pre_tool_use',
+          timestamp: startTime,
+          turn_id: currentTurnId ?? '',
+          tool_name: 'web_search',
+          tool_input: parseMaybeJsonValue(payload.action),
+          tool_use_id: callId,
+        };
+        toolEvents.push(evt);
+        toolEvents.push({
+          type: 'post_tool_use',
+          timestamp: endTime,
+          turn_id: currentTurnId ?? '',
+          tool_name: 'web_search',
+          tool_response: {
+            ...(payload.status !== undefined ? { status: payload.status } : {}),
+            ...(payload.action !== undefined ? { action: parseMaybeJsonValue(payload.action) } : {}),
+          },
+          tool_use_id: callId,
+        });
+        parentToolCallIds.add(callId);
+      } else if (itemType === 'tool_search_call') {
+        const callId = String(payload.call_id || payload.id || '');
+        if (callId) {
+          const evt = {
+            type: 'pre_tool_use',
+            timestamp: entryTimestampSeconds(entry),
+            turn_id: currentTurnId ?? '',
+            tool_name: 'tool_search',
+            tool_input: parseMaybeJsonValue(payload.arguments),
+            tool_use_id: callId,
+          };
+          pendingToolCalls.set(callId, evt);
+          toolEvents.push(evt);
           parentToolCallIds.add(callId);
         }
       } else if (itemType === 'function_call_output') {
@@ -353,6 +468,38 @@ export function parseTranscript(transcriptPath, byteOffset = 0, initialLastUsage
               });
             }
           }
+        }
+      } else if (itemType === 'custom_tool_call_output') {
+        const callId = String(payload.call_id || payload.id || '');
+        if (callId) {
+          const pre = pendingToolCalls.get(callId);
+          toolEvents.push({
+            type: 'post_tool_use',
+            timestamp: entryTimestampSeconds(entry),
+            turn_id: currentTurnId ?? pre?.turn_id ?? '',
+            tool_name: pre?.tool_name || 'custom_tool',
+            tool_response: parseMaybeJsonValue(payload.output),
+            tool_use_id: callId,
+          });
+          pendingToolCalls.delete(callId);
+        }
+      } else if (itemType === 'tool_search_output') {
+        const callId = String(payload.call_id || payload.id || '');
+        if (callId) {
+          const pre = pendingToolCalls.get(callId);
+          toolEvents.push({
+            type: 'post_tool_use',
+            timestamp: entryTimestampSeconds(entry),
+            turn_id: currentTurnId ?? pre?.turn_id ?? '',
+            tool_name: pre?.tool_name || 'tool_search',
+            tool_response: {
+              ...(payload.status !== undefined ? { status: payload.status } : {}),
+              ...(payload.execution !== undefined ? { execution: payload.execution } : {}),
+              ...(payload.tools !== undefined ? { tools: parseMaybeJsonValue(payload.tools) } : {}),
+            },
+            tool_use_id: callId,
+          });
+          pendingToolCalls.delete(callId);
         }
       }
     }

--- a/tests/unit/hooks/codex/hook-processor.test.mjs
+++ b/tests/unit/hooks/codex/hook-processor.test.mjs
@@ -120,6 +120,305 @@ describe('codex-hook-processor 端到端', () => {
     expect(state.transcript_last_token_usage?.inputTokens).toBe(1);
   });
 
+  test('UserPromptSubmit 输出 other 事件,不作为缺少 step/model 的 llm.request', () => {
+    writeFakeTranscript([
+      { timestamp: '2026-05-27T10:00:00Z', type: 'session_meta', payload: { model_provider: 'openai' }},
+      { timestamp: '2026-05-27T10:00:01Z', type: 'turn_context', payload: { turn_id: 'turn-1', model: 'gpt-5.5' }},
+      { timestamp: '2026-05-27T10:00:02Z', type: 'event_msg', payload: { type: 'task_started', turn_id: 'turn-1' }},
+      { timestamp: '2026-05-27T10:00:03Z', type: 'event_msg', payload: { type: 'token_count', info: {
+        last_token_usage: { input_tokens: 1, output_tokens: 1, cached_input_tokens: 0, reasoning_output_tokens: 0, total_tokens: 2 },
+      }}},
+    ]);
+
+    runHook('session-start', { session_id: 'cdx-user', model: 'gpt-5.5', source: 'startup', transcript_path: TRANSCRIPT });
+    runHook('user-prompt-submit', { session_id: 'cdx-user', prompt: 'hello', turn_id: 'turn-1', model: 'gpt-5.5', transcript_path: TRANSCRIPT });
+    runHook('stop', { session_id: 'cdx-user', turn_id: 'turn-1', last_assistant_message: 'hi', model: 'gpt-5.5', transcript_path: TRANSCRIPT });
+
+    const records = readJsonl();
+    const userPromptRecord = records.find((r) =>
+      r['event.name'] === 'other' && r['gen_ai.input.messages_delta']?.[0]?.parts?.[0]?.content === 'hello');
+    expect(userPromptRecord).toBeTruthy();
+
+    const stepRequests = records.filter((r) => r['event.name'] === 'llm.request');
+    expect(stepRequests.length).toBeGreaterThan(0);
+    expect(stepRequests.every((r) => r['gen_ai.step.id'] && r['gen_ai.request.model'])).toBe(true);
+  });
+
+  test('Bash tool.call arguments 合并 transcript workdir,其他参数保持原始结构', () => {
+    writeFakeTranscript([
+      { timestamp: '2026-05-27T10:00:00Z', type: 'session_meta', payload: { model_provider: 'openai' }},
+      { timestamp: '2026-05-27T10:00:01Z', type: 'turn_context', payload: { turn_id: 'turn-1', model: 'gpt-5.5' }},
+      { timestamp: '2026-05-27T10:00:02Z', type: 'response_item', payload: {
+        type: 'function_call',
+        name: 'exec_command',
+        call_id: 'call-1',
+        arguments: JSON.stringify({ cmd: 'pwd', workdir: '/tmp/project', yield_time_ms: 1000 }),
+      }},
+      { timestamp: '2026-05-27T10:00:03Z', type: 'response_item', payload: {
+        type: 'function_call_output',
+        call_id: 'call-1',
+        output: 'ok',
+      }},
+      { timestamp: '2026-05-27T10:00:04Z', type: 'event_msg', payload: { type: 'token_count', info: {
+        last_token_usage: { input_tokens: 10, output_tokens: 5, cached_input_tokens: 0, reasoning_output_tokens: 0, total_tokens: 15 },
+      }}},
+    ]);
+
+    runHook('session-start', { session_id: 'cdx-bash', model: 'gpt-5.5', source: 'startup', transcript_path: TRANSCRIPT });
+    runHook('user-prompt-submit', { session_id: 'cdx-bash', prompt: 'run pwd', turn_id: 'turn-1', model: 'gpt-5.5', transcript_path: TRANSCRIPT });
+    runHook('pre-tool-use', {
+      session_id: 'cdx-bash',
+      turn_id: 'turn-1',
+      tool_name: 'Bash',
+      tool_use_id: 'call-1',
+      tool_input: { command: 'pwd' },
+      transcript_path: TRANSCRIPT,
+    });
+    runHook('post-tool-use', {
+      session_id: 'cdx-bash',
+      turn_id: 'turn-1',
+      tool_name: 'Bash',
+      tool_use_id: 'call-1',
+      tool_response: 'ok',
+      transcript_path: TRANSCRIPT,
+    });
+    runHook('stop', { session_id: 'cdx-bash', turn_id: 'turn-1', model: 'gpt-5.5', transcript_path: TRANSCRIPT });
+
+    const records = readJsonl();
+    const toolCall = records.find((r) => r['event.name'] === 'tool.call' && r['gen_ai.tool.call.id'] === 'call-1');
+    expect(toolCall?.['gen_ai.tool.call.arguments']).toEqual({
+      command: 'pwd',
+      workdir: '/tmp/project',
+    });
+
+    const outputToolCall = records
+      .find((r) => r['event.name'] === 'llm.response')
+      ?.['gen_ai.output.messages']?.[0]?.parts
+      ?.find((part) => part.type === 'tool_call' && part.id === 'call-1');
+    expect(outputToolCall?.arguments).toEqual({
+      command: 'pwd',
+      workdir: '/tmp/project',
+    });
+  });
+
+  test('非 Bash tool.call arguments 使用 transcript 原始参数', () => {
+    writeFakeTranscript([
+      { timestamp: '2026-05-27T10:00:00Z', type: 'session_meta', payload: { model_provider: 'openai' }},
+      { timestamp: '2026-05-27T10:00:01Z', type: 'turn_context', payload: { turn_id: 'turn-1', model: 'gpt-5.5' }},
+      { timestamp: '2026-05-27T10:00:02Z', type: 'response_item', payload: {
+        type: 'function_call',
+        name: 'write_stdin',
+        call_id: 'call-write',
+        arguments: JSON.stringify({ session_id: 7, chars: 'q', yield_time_ms: 500 }),
+      }},
+      { timestamp: '2026-05-27T10:00:03Z', type: 'response_item', payload: {
+        type: 'function_call_output',
+        call_id: 'call-write',
+        output: 'ok',
+      }},
+      { timestamp: '2026-05-27T10:00:04Z', type: 'event_msg', payload: { type: 'token_count', info: {
+        last_token_usage: { input_tokens: 10, output_tokens: 5, cached_input_tokens: 0, reasoning_output_tokens: 0, total_tokens: 15 },
+      }}},
+    ]);
+
+    runHook('session-start', { session_id: 'cdx-other-tool', model: 'gpt-5.5', source: 'startup', transcript_path: TRANSCRIPT });
+    runHook('user-prompt-submit', { session_id: 'cdx-other-tool', prompt: 'send stdin', turn_id: 'turn-1', model: 'gpt-5.5', transcript_path: TRANSCRIPT });
+    runHook('pre-tool-use', {
+      session_id: 'cdx-other-tool',
+      turn_id: 'turn-1',
+      tool_name: 'write_stdin',
+      tool_use_id: 'call-write',
+      tool_input: { session_id: 7 },
+      transcript_path: TRANSCRIPT,
+    });
+    runHook('post-tool-use', {
+      session_id: 'cdx-other-tool',
+      turn_id: 'turn-1',
+      tool_name: 'write_stdin',
+      tool_use_id: 'call-write',
+      tool_response: 'ok',
+      transcript_path: TRANSCRIPT,
+    });
+    runHook('stop', { session_id: 'cdx-other-tool', turn_id: 'turn-1', model: 'gpt-5.5', transcript_path: TRANSCRIPT });
+
+    const records = readJsonl();
+    const toolCall = records.find((r) => r['event.name'] === 'tool.call' && r['gen_ai.tool.call.id'] === 'call-write');
+    expect(toolCall?.['gen_ai.tool.call.arguments']).toEqual({
+      session_id: 7,
+      chars: 'q',
+      yield_time_ms: 500,
+    });
+  });
+
+  test('transcript-only apply_patch/web_search/tool_search 生成 tool.call arguments', () => {
+    writeFakeTranscript([
+      { timestamp: '2026-05-27T10:00:00Z', type: 'session_meta', payload: { model_provider: 'openai' }},
+      { timestamp: '2026-05-27T10:00:01Z', type: 'turn_context', payload: { turn_id: 'turn-1', model: 'gpt-5.5' }},
+      { timestamp: '2026-05-27T10:00:02Z', type: 'response_item', payload: {
+        type: 'custom_tool_call',
+        name: 'apply_patch',
+        call_id: 'call-patch',
+        input: '*** Begin Patch\n*** End Patch',
+      }},
+      { timestamp: '2026-05-27T10:00:03Z', type: 'response_item', payload: {
+        type: 'custom_tool_call_output',
+        call_id: 'call-patch',
+        output: 'ok',
+      }},
+      { timestamp: '2026-05-27T10:00:04Z', type: 'response_item', payload: {
+        type: 'web_search_call',
+        status: 'completed',
+        action: { type: 'search', query: 'codex hooks' },
+      }},
+      { timestamp: '2026-05-27T10:00:05Z', type: 'response_item', payload: {
+        type: 'tool_search_call',
+        call_id: 'call-tool-search',
+        status: 'completed',
+        execution: 'client',
+        arguments: { query: 'browser mcp', limit: 5 },
+      }},
+      { timestamp: '2026-05-27T10:00:06Z', type: 'response_item', payload: {
+        type: 'tool_search_output',
+        call_id: 'call-tool-search',
+        status: 'completed',
+        execution: 'client',
+        tools: [{ name: 'browser.open' }],
+      }},
+      { timestamp: '2026-05-27T10:00:07Z', type: 'event_msg', payload: { type: 'token_count', info: {
+        last_token_usage: { input_tokens: 10, output_tokens: 5, cached_input_tokens: 0, reasoning_output_tokens: 0, total_tokens: 15 },
+      }}},
+    ]);
+
+    runHook('session-start', { session_id: 'cdx-transcript-tools', model: 'gpt-5.5', source: 'startup', transcript_path: TRANSCRIPT });
+    runHook('user-prompt-submit', { session_id: 'cdx-transcript-tools', prompt: 'use tools', turn_id: 'turn-1', model: 'gpt-5.5', transcript_path: TRANSCRIPT });
+    runHook('stop', { session_id: 'cdx-transcript-tools', turn_id: 'turn-1', model: 'gpt-5.5', transcript_path: TRANSCRIPT });
+
+    const records = readJsonl();
+    const calls = records.filter((r) => r['event.name'] === 'tool.call');
+    expect(calls.map((r) => r['gen_ai.tool.name'])).toEqual([
+      'apply_patch',
+      'web_search',
+      'tool_search',
+    ]);
+
+    expect(calls.find((r) => r['gen_ai.tool.name'] === 'apply_patch')?.['gen_ai.tool.call.arguments']).toEqual({
+      command: '*** Begin Patch\n*** End Patch',
+    });
+    expect(calls.find((r) => r['gen_ai.tool.name'] === 'web_search')?.['gen_ai.tool.call.arguments']).toEqual({
+      type: 'search',
+      query: 'codex hooks',
+    });
+    expect(calls.find((r) => r['gen_ai.tool.name'] === 'tool_search')?.['gen_ai.tool.call.arguments']).toEqual({
+      query: 'browser mcp',
+      limit: 5,
+    });
+
+    const outputParts = records
+      .filter((r) => r['event.name'] === 'llm.response')
+      .flatMap((r) => r['gen_ai.output.messages']?.[0]?.parts ?? []);
+    expect(outputParts.filter((part) => part.type === 'tool_call').map((part) => part.arguments)).toEqual([
+      { command: '*** Begin Patch\n*** End Patch' },
+      { type: 'search', query: 'codex hooks' },
+      { query: 'browser mcp', limit: 5 },
+    ]);
+  });
+
+  test('上下文压缩后 llm.request 记录全量 input.messages', () => {
+    writeFakeTranscript([
+      { timestamp: '2026-05-27T10:00:00Z', type: 'session_meta', payload: { model_provider: 'openai' }},
+      { timestamp: '2026-05-27T10:00:01Z', type: 'event_msg', payload: { type: 'task_started', turn_id: 'turn-compact' }},
+      { timestamp: '2026-05-27T10:00:02Z', type: 'response_item', payload: {
+        type: 'message',
+        role: 'developer',
+        content: [{ type: 'input_text', text: 'compressed developer context' }],
+      }},
+      { timestamp: '2026-05-27T10:00:03Z', type: 'response_item', payload: {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'compressed environment context' }],
+      }},
+      { timestamp: '2026-05-27T10:00:04Z', type: 'turn_context', payload: { turn_id: 'turn-compact', model: 'gpt-5.5' }},
+      { timestamp: '2026-05-27T10:00:05Z', type: 'response_item', payload: {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'actual user prompt' }],
+      }},
+      { timestamp: '2026-05-27T10:00:06Z', type: 'event_msg', payload: {
+        type: 'user_message',
+        message: 'actual user prompt',
+      }},
+      { timestamp: '2026-05-27T10:00:07Z', type: 'event_msg', payload: { type: 'token_count', info: {
+        last_token_usage: { input_tokens: 20, output_tokens: 5, cached_input_tokens: 0, reasoning_output_tokens: 0, total_tokens: 25 },
+      }}},
+    ]);
+
+    runHook('session-start', { session_id: 'cdx-compact', model: 'gpt-5.5', source: 'startup', transcript_path: TRANSCRIPT });
+    runHook('stop', { session_id: 'cdx-compact', turn_id: 'turn-compact', last_assistant_message: 'done', model: 'gpt-5.5', transcript_path: TRANSCRIPT });
+
+    const req = readJsonl().find((r) => r['event.name'] === 'llm.request' && r['gen_ai.step.id']);
+    expect(req?.['gen_ai.input.messages_delta']).toEqual([
+      { role: 'user', parts: [{ type: 'text', content: 'actual user prompt' }] },
+    ]);
+    expect(req?.['gen_ai.input.messages']).toEqual([
+      { role: 'developer', parts: [{ type: 'text', content: 'compressed developer context' }] },
+      { role: 'user', parts: [{ type: 'text', content: 'compressed environment context' }] },
+      { role: 'user', parts: [{ type: 'text', content: 'actual user prompt' }] },
+    ]);
+  });
+
+  test('同一 turn 压缩后的重复 turn_context 不产生空 input.messages_delta', () => {
+    writeFakeTranscript([
+      { timestamp: '2026-05-27T10:00:00Z', type: 'session_meta', payload: { model_provider: 'openai' }},
+      { timestamp: '2026-05-27T10:00:01Z', type: 'event_msg', payload: { type: 'task_started', turn_id: 'turn-compact-repeat' }},
+      { timestamp: '2026-05-27T10:00:02Z', type: 'turn_context', payload: { turn_id: 'turn-compact-repeat', model: 'gpt-5.5' }},
+      { timestamp: '2026-05-27T10:00:03Z', type: 'event_msg', payload: { type: 'user_message', message: 'before compact' }},
+      { timestamp: '2026-05-27T10:00:04Z', type: 'response_item', payload: {
+        type: 'function_call',
+        name: 'exec_command',
+        call_id: 'call-before',
+        arguments: JSON.stringify({ cmd: 'pwd' }),
+      }},
+      { timestamp: '2026-05-27T10:00:05Z', type: 'response_item', payload: {
+        type: 'function_call_output',
+        call_id: 'call-before',
+        output: 'ok-before',
+      }},
+      { timestamp: '2026-05-27T10:00:06Z', type: 'compacted', payload: {
+        message: 'compact',
+        replacement_history: [],
+      }},
+      { timestamp: '2026-05-27T10:00:07Z', type: 'turn_context', payload: { turn_id: 'turn-compact-repeat', model: 'gpt-5.5' }},
+      { timestamp: '2026-05-27T10:00:08Z', type: 'event_msg', payload: { type: 'context_compacted' }},
+      { timestamp: '2026-05-27T10:00:09Z', type: 'response_item', payload: {
+        type: 'function_call',
+        name: 'exec_command',
+        call_id: 'call-after',
+        arguments: JSON.stringify({ cmd: 'ls' }),
+      }},
+      { timestamp: '2026-05-27T10:00:10Z', type: 'response_item', payload: {
+        type: 'function_call_output',
+        call_id: 'call-after',
+        output: 'ok-after',
+      }},
+      { timestamp: '2026-05-27T10:00:11Z', type: 'event_msg', payload: { type: 'token_count', info: {
+        last_token_usage: { input_tokens: 20, output_tokens: 5, cached_input_tokens: 0, reasoning_output_tokens: 0, total_tokens: 25 },
+      }}},
+    ]);
+
+    runHook('session-start', { session_id: 'cdx-repeat-context', model: 'gpt-5.5', source: 'startup', transcript_path: TRANSCRIPT });
+    runHook('stop', { session_id: 'cdx-repeat-context', turn_id: 'turn-compact-repeat', model: 'gpt-5.5', transcript_path: TRANSCRIPT });
+
+    const requests = readJsonl().filter((r) => r['event.name'] === 'llm.request' && r['gen_ai.step.id']);
+    expect(requests).toHaveLength(2);
+    expect(requests.every((r) => Array.isArray(r['gen_ai.input.messages_delta']))).toBe(true);
+    expect(requests[0]?.['gen_ai.input.messages_delta']).toEqual([
+      { role: 'user', parts: [{ type: 'text', content: 'before compact' }] },
+    ]);
+    expect(requests[1]?.['gen_ai.input.messages_delta']).toEqual([
+      { role: 'tool', parts: [{ type: 'tool_call_response', id: 'call-before', response: 'ok-before' }] },
+    ]);
+  });
+
   test('缺 session_id 不污染 state 目录', () => {
     runHook('post-tool-use', { tool_name: 'Bash' });
     const dir = path.join(DATA_DIR, 'state', 'codex', 'sessions');

--- a/tests/unit/hooks/codex/tool-arguments.test.mjs
+++ b/tests/unit/hooks/codex/tool-arguments.test.mjs
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  mergeCodexToolArguments,
+  normalizeCodexToolArguments,
+} from '../../../../assets/hooks/codex/tool-arguments.mjs';
+
+describe('codex tool argument helpers', () => {
+  test('apply_patch null input is not wrapped as command null', () => {
+    expect(normalizeCodexToolArguments('apply_patch', null)).toBeNull();
+    expect(mergeCodexToolArguments('apply_patch', null, 'apply_patch', null)).toBeNull();
+    expect(mergeCodexToolArguments('apply_patch', undefined, 'apply_patch', null)).toBeUndefined();
+  });
+
+  test('single-source normalization keeps Bash command/workdir shape', () => {
+    expect(normalizeCodexToolArguments('exec_command', {
+      cmd: 'pwd',
+      workdir: '/tmp/project',
+      yield_time_ms: 1000,
+    })).toEqual({
+      command: 'pwd',
+      workdir: '/tmp/project',
+    });
+  });
+
+  test('merge prefers transcript JSON for non-Bash tools', () => {
+    expect(mergeCodexToolArguments('write_stdin', { session_id: 1 }, 'write_stdin', {
+      session_id: 1,
+      chars: 'q',
+    })).toEqual({
+      session_id: 1,
+      chars: 'q',
+    });
+  });
+});

--- a/tests/unit/hooks/codex/transcript-parser.test.mjs
+++ b/tests/unit/hooks/codex/transcript-parser.test.mjs
@@ -92,3 +92,92 @@ describe('codex parseTranscript - 单 turn / 多 step', () => {
     expect(data).not.toBeNull();
   });
 });
+
+describe('codex parseTranscript - tool response_item variants', () => {
+  test('解析 function/custom/web/tool_search 工具调用并保留原始 arguments', () => {
+    const transcript = path.join(fs.mkdtempSync(path.join(process.cwd(), '.tmp-codex-parser-')), 'rollout.jsonl');
+    try {
+      fs.writeFileSync(transcript, [
+        { timestamp: '2026-05-27T10:00:00Z', type: 'turn_context', payload: { turn_id: 'turn-1', model: 'gpt-5.5' }},
+        { timestamp: '2026-05-27T10:00:01Z', type: 'response_item', payload: {
+          type: 'function_call',
+          name: 'write_stdin',
+          call_id: 'call-fn',
+          arguments: JSON.stringify({ session_id: 1, chars: 'q' }),
+        }},
+        { timestamp: '2026-05-27T10:00:02Z', type: 'response_item', payload: {
+          type: 'function_call_output',
+          call_id: 'call-fn',
+          output: JSON.stringify({ ok: true }),
+        }},
+        { timestamp: '2026-05-27T10:00:03Z', type: 'response_item', payload: {
+          type: 'custom_tool_call',
+          name: 'apply_patch',
+          call_id: 'call-patch',
+          input: '*** Begin Patch\n*** End Patch',
+        }},
+        { timestamp: '2026-05-27T10:00:04Z', type: 'response_item', payload: {
+          type: 'custom_tool_call_output',
+          call_id: 'call-patch',
+          output: 'ok',
+        }},
+        { timestamp: '2026-05-27T10:00:05Z', type: 'response_item', payload: {
+          type: 'web_search_call',
+          status: 'completed',
+          action: { type: 'search', query: 'codex hooks', queries: ['codex hooks'] },
+        }},
+        { timestamp: '2026-05-27T10:00:06Z', type: 'response_item', payload: {
+          type: 'tool_search_call',
+          call_id: 'call-search',
+          status: 'completed',
+          execution: 'client',
+          arguments: { query: 'browser mcp', limit: 10 },
+        }},
+        { timestamp: '2026-05-27T10:00:07Z', type: 'response_item', payload: {
+          type: 'tool_search_output',
+          call_id: 'call-search',
+          status: 'completed',
+          execution: 'client',
+          tools: [{ name: 'browser.open' }],
+        }},
+      ].map((r) => JSON.stringify(r)).join('\n') + '\n', 'utf-8');
+
+      const data = parseTranscript(transcript);
+      const preEvents = data.toolEvents.filter((event) => event.type === 'pre_tool_use');
+      const postEvents = data.toolEvents.filter((event) => event.type === 'post_tool_use');
+
+      expect(preEvents.map((event) => event.tool_name)).toEqual([
+        'write_stdin',
+        'apply_patch',
+        'web_search',
+        'tool_search',
+      ]);
+      expect(preEvents.find((event) => event.tool_use_id === 'call-fn')?.tool_input).toEqual({ session_id: 1, chars: 'q' });
+      expect(preEvents.find((event) => event.tool_use_id === 'call-patch')?.tool_input).toBe('*** Begin Patch\n*** End Patch');
+      expect(preEvents.find((event) => event.tool_name === 'web_search')?.tool_input).toEqual({
+        type: 'search',
+        query: 'codex hooks',
+        queries: ['codex hooks'],
+      });
+      expect(preEvents.find((event) => event.tool_use_id === 'call-search')?.tool_input).toEqual({
+        query: 'browser mcp',
+        limit: 10,
+      });
+
+      expect(postEvents.find((event) => event.tool_use_id === 'call-patch')?.tool_response).toBe('ok');
+      expect(postEvents.find((event) => event.tool_name === 'web_search')?.tool_response).toEqual({
+        status: 'completed',
+        action: { type: 'search', query: 'codex hooks', queries: ['codex hooks'] },
+      });
+      expect(postEvents.find((event) => event.tool_use_id === 'call-search')?.tool_response).toMatchObject({
+        status: 'completed',
+        execution: 'client',
+        tools: [{ name: 'browser.open' }],
+      });
+      expect(data.parentToolCallIds.has('call-patch')).toBe(true);
+      expect([...data.parentToolCallIds].some((id) => id.startsWith('web_search:'))).toBe(true);
+    } finally {
+      fs.rmSync(path.dirname(transcript), { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add web_search duration fix using lastNonWebSearchTs approximation (web_search_call only has end time, approximate start from preceding events)
- Support custom_tool_call, tool_search_call, and message response_item parsing in transcript-parser
- Refactor appendMissingTranscriptToolEvents from Set to Map for proper merging in hook-processor
- Add formatCodexToolArguments for Bash workdir normalization and apply_patch handling
- Change UserPromptSubmit event.name from `llm.request` to `other` (not an actual LLM request)
- Support llm_full_input_messages for compaction scenarios in react-step-builder
- Merge duplicate turn_context events
- Add 20 passing tests covering all new functionality

## Test plan
- [x] `npx vitest run tests/unit/hooks/codex/` — 20/20 tests passed
- [ ] Manual verification with real Codex sessions containing web_search, custom_tool_call, and compaction events