### PR TITLE
fix: prevent duplicate dashboard overview aggregation

### DIFF
--- a/scripts/lib/agent-overview.mjs
+++ b/scripts/lib/agent-overview.mjs
@@ -165,6 +165,7 @@ export function createOverviewAggregator(options = {}) {
   let cachedSummary = null;
   let cachedAt = 0;
   let overviewCache = null;
+  let buildChain = Promise.resolve();
 
   async function getOverview({ force = false } = {}) {
     const now = nowProvider();
@@ -174,24 +175,42 @@ export function createOverviewAggregator(options = {}) {
         cache: { ...cachedSummary.cache, hit: true },
       };
     }
-    overviewCache ||= await loadOverviewCache(overviewCachePath);
 
-    const summary = await buildOverview({
-      dataDir,
-      now,
-      serviceLogTailBytes,
-      jsonlMaxBytes,
-      failedLogMaxBytes,
-      timelineLimit,
-      overviewCache,
-      overviewCachePath,
-      cachedOutputEventsPerFile,
-      maxIndexBytesPerRefresh,
-      maxIndexLinesPerRefresh,
+    const previousBuild = buildChain;
+    let releaseBuild;
+    buildChain = new Promise((resolve) => {
+      releaseBuild = resolve;
     });
-    cachedSummary = summary;
-    cachedAt = now.getTime();
-    return summary;
+    await previousBuild.catch(() => {});
+    try {
+      const lockedNow = nowProvider();
+      if (!force && cachedSummary && lockedNow.getTime() - cachedAt < cacheTtlMs) {
+        return {
+          ...cachedSummary,
+          cache: { ...cachedSummary.cache, hit: true },
+        };
+      }
+      overviewCache ||= await loadOverviewCache(overviewCachePath);
+
+      const summary = await buildOverview({
+        dataDir,
+        now: lockedNow,
+        serviceLogTailBytes,
+        jsonlMaxBytes,
+        failedLogMaxBytes,
+        timelineLimit,
+        overviewCache,
+        overviewCachePath,
+        cachedOutputEventsPerFile,
+        maxIndexBytesPerRefresh,
+        maxIndexLinesPerRefresh,
+      });
+      cachedSummary = summary;
+      cachedAt = lockedNow.getTime();
+      return summary;
+    } finally {
+      releaseBuild();
+    }
   }
 
   async function getAgent(agentId) {
@@ -646,7 +665,14 @@ function validOutputCacheEntry(entry, filePath, fileStat) {
   if (!entry || entry.version !== OVERVIEW_CACHE_VERSION || entry.path !== filePath) return null;
   if (!Number.isFinite(entry.indexedThroughOffset) || entry.indexedThroughOffset < 0) return null;
   if (!entry.summary || typeof entry.summary !== 'object') return null;
+  if (Number.isFinite(entry.size) && entry.size < entry.indexedThroughOffset) return null;
   if (entry.indexedThroughOffset > fileStat.size) return null;
+  if (entry.indexedThroughOffset === fileStat.size) {
+    if (Number.isFinite(entry.size) && entry.size !== fileStat.size) return null;
+    if (Number.isFinite(entry.mtimeMs) && Math.abs(entry.mtimeMs - fileStat.mtimeMs) > 1) {
+      return null;
+    }
+  }
   if (Number.isFinite(entry.dev) && Number.isFinite(entry.ino)
     && (entry.dev !== fileStat.dev || entry.ino !== fileStat.ino)) {
     return null;

--- a/tests/unit/monitor/agent-overview.test.mjs
+++ b/tests/unit/monitor/agent-overview.test.mjs
@@ -223,6 +223,32 @@ describe('agent overview aggregation', () => {
     expect(rebuilt.cache.indexing).toBe(false);
   });
 
+  it('rebuilds cached totals when a fully indexed file changes without changing size', async () => {
+    const dataDir = await fixtureDir();
+    const outputPath = path.join(dataDir, 'logs', 'output', 'qoder-2026-05-05.jsonl');
+    const original = eventLine({ id: 'qoder-1', agentType: 'qoder', eventName: 'llm.response', tokens: 10 });
+    await writeRuntimeFiles(dataDir, {
+      outputLines: {
+        'qoder-2026-05-05.jsonl': [original],
+      },
+    });
+    const aggregator = createOverviewAggregator({
+      dataDir,
+      nowProvider: () => new Date('2026-05-05T04:01:00.000Z'),
+    });
+
+    const first = await aggregator.getOverview({ force: true });
+    const rewritten = eventLine({ id: 'qoder-2', agentType: 'qoder', eventName: 'llm.response', tokens: 20 });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await writeFile(outputPath, rewritten.padEnd(Buffer.byteLength(original), ' '));
+    const rebuilt = await aggregator.getOverview({ force: true });
+
+    expect(Buffer.byteLength(rewritten.padEnd(Buffer.byteLength(original), ' '))).toBe(Buffer.byteLength(original));
+    expect(first.totals.tokensToday).toBe(10);
+    expect(rebuilt.totals.tokensToday).toBe(20);
+    expect(rebuilt.cache.indexing).toBe(false);
+  });
+
   it('persists derived cache across aggregator instances without storing sensitive bodies', async () => {
     const dataDir = await fixtureDir();
     await writeRuntimeFiles(dataDir, {


### PR DESCRIPTION
## Summary

Fixes a monitor dashboard overview aggregation issue where concurrent `/api/overview` requests could double-count local JSONL records.

Previously, multiple overview requests could share the same in-memory `overviewCache` and read from the same `indexedThroughOffset` at the same time. If both requests processed the same newly appended JSONL chunk, `eventsToday`, `tokensToday`, and per-agent summaries could be incremented more than once.

## Changes

- Serialize `getOverview()` builds so only one overview aggregation mutates the shared cache at a time.
- Strengthen output summary cache validation by checking `size` / `mtimeMs` when a file is considered fully indexed.
- Add unit coverage for rebuilding cached totals when a fully indexed file changes without changing size.

## Validation

- Verified in `/Users/lukechen/loongsuite-pilot`:
  `npm run test -- tests/unit/monitor/agent-overview.test.mjs`