### PR TITLE
fix(cursor-hook): repair Cursor trace assembly and prompt event mapping

### DIFF
--- a/assets/hooks/agent-event-normalizer.mjs
+++ b/assets/hooks/agent-event-normalizer.mjs
@@ -356,13 +356,26 @@ export function mapSourceHookEventToEventName(sourceEvent) {
   return 'other';
 }
 
+const DEFAULT_CURSOR_MODEL = 'composer-2.5';
+
+/** Coerce raw model string to a concrete model name. */
+export function resolveCursorModel(rawModel) {
+  if (!rawModel || rawModel === 'default' || rawModel === 'unknown') return DEFAULT_CURSOR_MODEL;
+  return rawModel;
+}
+
+/** Whether this event type carries user input messages (prompt). */
+export function hasInputMessages(eventName) {
+  return eventName === 'llm.request' || eventName === 'other';
+}
+
 export function buildCursorHookRecord(payload, options = {}) {
   const now = options.now || new Date();
   const runtimeConfig = options.runtimeConfig || {};
   const sourceEvent = getSourceHookEvent(payload);
   const eventName = getStringValue(payload, 'event.name') || mapSourceHookEventToEventName(sourceEvent);
   const rawModel = getStringValue(payload, 'model') || 'unknown';
-  const model = (rawModel === 'default' || rawModel === 'unknown') ? 'composer-2.5' : rawModel;
+  const model = resolveCursorModel(rawModel);
   const toolOutput = parseMaybeJson(payload.tool_output ?? payload.result_json ?? payload.tool_results);
   const toolArguments = parseMaybeJson(payload.tool_input);
   // Stop events duplicate token/cost data already reported by afterAgentResponse
@@ -398,8 +411,8 @@ export function buildCursorHookRecord(payload, options = {}) {
     'gen_ai.usage.cache_creation.input_cost': isStopEvent ? undefined : getNumberValue(payload, 'cost_cache_write'),
     'gen_ai.usage.total_cost': isStopEvent ? undefined : getNumberValue(payload, 'cost_total'),
     'gen_ai.input.messages_hash': getStringValue(payload, 'input_messages_hash'),
-    'gen_ai.input.messages_delta': (eventName === 'llm.request' || eventName === 'other') ? buildCursorInputMessagesDelta(payload) : undefined,
-    'gen_ai.input.messages': (eventName === 'llm.request' || eventName === 'other') ? toJsonValue(parseMaybeJson(payload.input_messages)) : undefined,
+    'gen_ai.input.messages_delta': hasInputMessages(eventName) ? buildCursorInputMessagesDelta(payload) : undefined,
+    'gen_ai.input.messages': hasInputMessages(eventName) ? toJsonValue(parseMaybeJson(payload.input_messages)) : undefined,
     'gen_ai.output.messages': eventName === 'llm.response' ? buildCursorOutputMessages(payload, sourceEvent) : undefined,
     'gen_ai.tool.name': getStringValue(payload, 'tool_name'),
     'gen_ai.tool.call.id': getStringValue(payload, 'tool_use_id'),

--- a/assets/hooks/agent-event-normalizer.mjs
+++ b/assets/hooks/agent-event-normalizer.mjs
@@ -343,7 +343,7 @@ export function getSourceHookEvent(payload) {
 export function mapSourceHookEventToEventName(sourceEvent) {
   const event = String(sourceEvent || '').toLowerCase();
   if (event.includes('agentresponse') || event.includes('agentthought')) return 'llm.response';
-  if (event.includes('beforesubmitprompt')) return 'llm.request';
+  if (event.includes('beforesubmitprompt')) return 'other';
   if (event.includes('pretooluse') || event.includes('beforemcpexecution') || event.includes('beforeshellexecution')) return 'tool.call';
   if (
     event.includes('posttooluse') ||
@@ -361,7 +361,8 @@ export function buildCursorHookRecord(payload, options = {}) {
   const runtimeConfig = options.runtimeConfig || {};
   const sourceEvent = getSourceHookEvent(payload);
   const eventName = getStringValue(payload, 'event.name') || mapSourceHookEventToEventName(sourceEvent);
-  const model = getStringValue(payload, 'model') || 'unknown';
+  const rawModel = getStringValue(payload, 'model') || 'unknown';
+  const model = (rawModel === 'default' || rawModel === 'unknown') ? 'composer-2.5' : rawModel;
   const toolOutput = parseMaybeJson(payload.tool_output ?? payload.result_json ?? payload.tool_results);
   const toolArguments = parseMaybeJson(payload.tool_input);
   // Stop events duplicate token/cost data already reported by afterAgentResponse
@@ -381,7 +382,7 @@ export function buildCursorHookRecord(payload, options = {}) {
       || getStringValue(payload, 'turn.id'),
     'gen_ai.step.id': getStringValue(payload, 'gen_ai.step.id') || getStringValue(payload, 'step_id'),
     'gen_ai.agent.type': 'cursor',
-    'gen_ai.provider.name': inferProviderName({ ...payload, 'gen_ai.request.model': model, 'gen_ai.agent.type': 'cursor' }),
+    'gen_ai.provider.name': /^composer/i.test(model) ? 'cursor' : inferProviderName({ ...payload, 'gen_ai.request.model': model, 'gen_ai.agent.type': 'cursor' }),
     'gen_ai.request.model': getStringValue(payload, 'gen_ai.request.model') || model,
     'gen_ai.response.model': getStringValue(payload, 'gen_ai.response.model') || model,
     'gen_ai.response.finish_reasons': getStringValue(payload, 'response_finish_reasons'),
@@ -397,8 +398,8 @@ export function buildCursorHookRecord(payload, options = {}) {
     'gen_ai.usage.cache_creation.input_cost': isStopEvent ? undefined : getNumberValue(payload, 'cost_cache_write'),
     'gen_ai.usage.total_cost': isStopEvent ? undefined : getNumberValue(payload, 'cost_total'),
     'gen_ai.input.messages_hash': getStringValue(payload, 'input_messages_hash'),
-    'gen_ai.input.messages_delta': eventName === 'llm.request' ? buildCursorInputMessagesDelta(payload) : undefined,
-    'gen_ai.input.messages': eventName === 'llm.request' ? toJsonValue(parseMaybeJson(payload.input_messages)) : undefined,
+    'gen_ai.input.messages_delta': (eventName === 'llm.request' || eventName === 'other') ? buildCursorInputMessagesDelta(payload) : undefined,
+    'gen_ai.input.messages': (eventName === 'llm.request' || eventName === 'other') ? toJsonValue(parseMaybeJson(payload.input_messages)) : undefined,
     'gen_ai.output.messages': eventName === 'llm.response' ? buildCursorOutputMessages(payload, sourceEvent) : undefined,
     'gen_ai.tool.name': getStringValue(payload, 'tool_name'),
     'gen_ai.tool.call.id': getStringValue(payload, 'tool_use_id'),

--- a/assets/hooks/cursor-hook-processor.mjs
+++ b/assets/hooks/cursor-hook-processor.mjs
@@ -131,13 +131,12 @@ async function main() {
     return;
   }
 
-  if (process.env.LOONGSUITE_CURSOR_RAW_TRACE === '1') {
-    try {
-      const rawFile = path.join(dataDir, 'logs', 'cursor', 'raw', 'cursor-raw-trace.jsonl');
-      await appendJsonl(rawFile, { _captured_at: now.toISOString(), ...payload });
-    } catch {
-      // best-effort
-    }
+  // Always write raw trace for debugging — original Cursor hook payload
+  try {
+    const rawFile = path.join(dataDir, 'logs', 'cursor', 'raw', 'cursor-raw-trace.jsonl');
+    await appendJsonl(rawFile, { _captured_at: now.toISOString(), ...payload });
+  } catch {
+    // best-effort
   }
 
   // On stop: assemble turn and write history
@@ -145,11 +144,33 @@ async function main() {
     try {
       const allEvents = readAllEvents();
       const runtimeConfig = loadHookRuntimeConfig(dataDir);
-      const { records, consumedConversationIds } = assembleTurn(allEvents, {
-        runtimeConfig,
-        stopConversationId: internalEvent.conversation_id,
-        transcriptPath: internalEvent.transcript_path,
-      });
+
+      // Aborted generations (e.g. GPT quota exhaustion → Cursor auto-switches
+      // to composer) share the same conversation_id with the auto-switched
+      // generation that follows. From the user's perspective both prompts are
+      // the same trace, so the aborted half must NOT produce a history record.
+      // We just surgically clean the aborted generation_id's events from the
+      // journal so the live generation can still assemble on its own stop.
+      const isAborted = internalEvent.status === 'aborted';
+      const abortedGenId = isAborted ? internalEvent.generation_id : null;
+
+      let records = [];
+      let consumedConversationIds = new Set();
+      let consumedGenerationIds = new Set();
+
+      if (isAborted && abortedGenId) {
+        consumedGenerationIds.add(abortedGenId);
+      } else {
+        const result = assembleTurn(allEvents, {
+          runtimeConfig,
+          stopConversationId: internalEvent.conversation_id,
+          stopGenerationId: internalEvent.generation_id,
+          transcriptPath: internalEvent.transcript_path,
+        });
+        records = result.records;
+        consumedConversationIds = result.consumedConversationIds || new Set();
+        consumedGenerationIds = result.consumedGenerationIds || new Set();
+      }
 
       if (records.length > 0) {
         const day = localDateString(now);
@@ -158,16 +179,25 @@ async function main() {
       }
 
       // Rewrite journal: keep only events that belong to a pending user turn
-      // (has beforeSubmitPrompt but no stop yet). Drop everything else:
-      // consumed parent, child sessions, subagent meta, and orphan delayed events.
+      // (has beforeSubmitPrompt but no stop yet). Drop:
+      //   - events whose generation_id was consumed (parent generation, or
+      //     an aborted generation we deliberately discarded);
+      //   - events whose conversation_id was consumed (subagents, orphans,
+      //     legacy path with no generation_id);
+      //   - orphan child/delayed events without any pending parent turn.
+      const isConsumed = (ev) => {
+        if (ev.generation_id && consumedGenerationIds.has(ev.generation_id)) return true;
+        if (consumedConversationIds.has(ev.conversation_id)) return true;
+        return false;
+      };
       const pendingTurnConvIds = new Set();
       const remaining = [];
       for (const ev of allEvents) {
-        if (consumedConversationIds.has(ev.conversation_id)) continue;
+        if (isConsumed(ev)) continue;
         if (ev.hook_event === 'beforeSubmitPrompt') pendingTurnConvIds.add(ev.conversation_id);
       }
       for (const ev of allEvents) {
-        if (consumedConversationIds.has(ev.conversation_id)) continue;
+        if (isConsumed(ev)) continue;
         if (pendingTurnConvIds.has(ev.conversation_id)) remaining.push(ev);
         // else: orphan child/delayed event without a pending parent turn → drop
       }

--- a/assets/hooks/cursor-hook-processor.mjs
+++ b/assets/hooks/cursor-hook-processor.mjs
@@ -7,7 +7,8 @@
  * records with proper step division, subagent nesting, and trace ids.
  *
  * History JSONL is the sole formal data source for CursorHookInput.
- * Raw capture is behind LOONGSUITE_CURSOR_RAW_TRACE=1 env flag.
+ * Raw capture is controlled by LOONGSUITE_CURSOR_RAW_TRACE env flag
+ * (default '1' = enabled; set to '0' to disable).
  */
 
 import fs from 'node:fs/promises';
@@ -131,12 +132,14 @@ async function main() {
     return;
   }
 
-  // Always write raw trace for debugging — original Cursor hook payload
-  try {
-    const rawFile = path.join(dataDir, 'logs', 'cursor', 'raw', 'cursor-raw-trace.jsonl');
-    await appendJsonl(rawFile, { _captured_at: now.toISOString(), ...payload });
-  } catch {
-    // best-effort
+  // Write raw trace when LOONGSUITE_CURSOR_RAW_TRACE !== '0' (default: enabled)
+  if (process.env.LOONGSUITE_CURSOR_RAW_TRACE !== '0') {
+    try {
+      const rawFile = path.join(dataDir, 'logs', 'cursor', 'raw', 'cursor-raw-trace.jsonl');
+      await appendJsonl(rawFile, { _captured_at: now.toISOString(), ...payload });
+    } catch {
+      // best-effort
+    }
   }
 
   // On stop: assemble turn and write history

--- a/assets/hooks/cursor/react-assembler.mjs
+++ b/assets/hooks/cursor/react-assembler.mjs
@@ -23,37 +23,63 @@ import {
 
 /**
  * @param {object[]} journalEvents - All events from the journal
- * @param {object}   options       - { runtimeConfig }
- * @returns {{ records: object[], consumedConversationIds: Set<string> }}
+ * @param {object}   options       - { runtimeConfig, stopConversationId, stopGenerationId, transcriptPath }
+ * @returns {{ records: object[], consumedConversationIds: Set<string>, consumedGenerationIds: Set<string> }}
  */
 export function assembleTurn(journalEvents, options = {}) {
   const runtimeConfig = options.runtimeConfig || {};
   const stopConversationId = options.stopConversationId;
+  const stopGenerationId = options.stopGenerationId;
   const transcriptPath = options.transcriptPath;
 
-  // Find the prompt for THIS stop's conversation
-  const promptEvent = stopConversationId
-    ? journalEvents.find(e => e.hook_event === 'beforeSubmitPrompt' && e.conversation_id === stopConversationId)
-    : journalEvents.find(e => e.hook_event === 'beforeSubmitPrompt');
+  // Find the prompt for THIS stop's conversation+generation. When generationId
+  // is provided, prefer an exact match so that two beforeSubmitPrompt events
+  // in the same conversation (e.g. GPT quota exhaustion auto-switch to
+  // composer) don't get conflated into one turn. Fall back to conversation-
+  // only match for robustness when generation_id is missing on either side.
+  let promptEvent = null;
+  if (stopConversationId && stopGenerationId) {
+    promptEvent = journalEvents.find(e =>
+      e.hook_event === 'beforeSubmitPrompt' &&
+      e.conversation_id === stopConversationId &&
+      e.generation_id === stopGenerationId
+    ) || null;
+  }
   if (!promptEvent) {
-    return { records: [], consumedConversationIds: new Set() };
+    promptEvent = stopConversationId
+      ? journalEvents.find(e => e.hook_event === 'beforeSubmitPrompt' && e.conversation_id === stopConversationId)
+      : journalEvents.find(e => e.hook_event === 'beforeSubmitPrompt');
+  }
+  if (!promptEvent) {
+    return { records: [], consumedConversationIds: new Set(), consumedGenerationIds: new Set() };
   }
 
   const parentConvId = promptEvent.conversation_id;
-  const turnId = promptEvent.generation_id || parentConvId;
+  const parentGenerationId = promptEvent.generation_id || null;
+  // Scope events to this generation when we have one; this prevents events
+  // belonging to a sibling generation in the same conversation from leaking
+  // into the assembled turn.
+  const generationScoped = Boolean(stopGenerationId && parentGenerationId);
+  const inParentTurn = (e) => {
+    if (e.conversation_id !== parentConvId) return false;
+    if (generationScoped && e.generation_id && e.generation_id !== parentGenerationId) return false;
+    return true;
+  };
+
+  const turnId = parentGenerationId || parentConvId;
   const traceId = deriveTraceId(turnId);
   const userId = resolveUserId({}, runtimeConfig);
   const stopEvent = journalEvents.find(e =>
-    e.hook_event === 'stop' && e.conversation_id === parentConvId
+    e.hook_event === 'stop' && inParentTurn(e)
   );
   const responseEvent = journalEvents.find(e =>
-    e.hook_event === 'afterAgentResponse' && e.conversation_id === parentConvId
+    e.hook_event === 'afterAgentResponse' && inParentTurn(e)
   );
-  const model = responseEvent?.model || promptEvent?.model || 'unknown';
+  const model = resolveModel(responseEvent?.model || promptEvent?.model);
 
   // Filter to parent session events only (keep Subagent/Task tool calls + subagentStart/Stop)
   const parentEvents = journalEvents
-    .filter(e => e.conversation_id === parentConvId)
+    .filter(e => inParentTurn(e))
     .filter(e => e.hook_event !== 'sessionStart')
     .sort((a, b) => tsMs(a) - tsMs(b));
 
@@ -67,13 +93,14 @@ export function assembleTurn(journalEvents, options = {}) {
 
   const records = [];
 
-  // User-hook llm.request (no step_id, no model → ENTRY input)
+  // User-hook: user prompt is not an LLM call — emit as "other" so converter
+  // merges messages_delta into ENTRY span without generating a standalone LLM span.
   if (promptEvent.prompt) {
     records.push(applyPolicy({
       time_unix_nano: eventTs(promptEvent),
       observed_time_unix_nano: eventTs(promptEvent),
       'event.id': crypto.randomUUID(),
-      'event.name': 'llm.request',
+      'event.name': 'other',
       ...baseFields,
       'gen_ai.provider.name': inferProvider(model),
       'gen_ai.input.messages_delta': [
@@ -176,7 +203,7 @@ export function assembleTurn(journalEvents, options = {}) {
       'agent.cursor.subagent.link_confidence': parentToolCallId ? 'transcript_dir' : 'orphan',
     };
 
-    const childModel = childEvents[0]?.model || model;
+    const childModel = resolveModel(childEvents[0]?.model || model);
     const childStepRecords = buildParentSteps(childEvents, {
       turnId, traceId, model: childModel, userId,
       baseFields: childBaseFields, runtimeConfig,
@@ -187,9 +214,20 @@ export function assembleTurn(journalEvents, options = {}) {
     records.push(...childStepRecords);
   }
 
-  // Consumed conversation ids: parent + all child sessions from transcript dir + time-based
+  // Consumed ids:
+  //   - consumedGenerationIds: parent generation only (when generation-scoped)
+  //     → processor uses this for precise cleanup so sibling generations in
+  //       the same conversation can still assemble later.
+  //   - consumedConversationIds: child subagent sessions + orphan time-window
+  //     conversations. When NOT generation-scoped (legacy path / missing
+  //     generation_id), the parent conversation is also added here.
   const consumedConversationIds = new Set();
-  consumedConversationIds.add(parentConvId);
+  const consumedGenerationIds = new Set();
+  if (generationScoped) {
+    consumedGenerationIds.add(parentGenerationId);
+  } else {
+    consumedConversationIds.add(parentConvId);
+  }
   for (const cid of childConvIds) {
     consumedConversationIds.add(cid);
   }
@@ -203,7 +241,9 @@ export function assembleTurn(journalEvents, options = {}) {
     }
   }
   for (const ev of journalEvents) {
-    if (!ev.conversation_id || consumedConversationIds.has(ev.conversation_id)) continue;
+    if (!ev.conversation_id) continue;
+    if (ev.conversation_id === parentConvId) continue; // never reclassify parent's own events
+    if (consumedConversationIds.has(ev.conversation_id)) continue;
     const evTs = tsMs(ev);
     if (evTs >= parentPromptTs && evTs <= parentStopTs) {
       const hasOwnPrompt = conversationIdsWithPrompt.has(ev.conversation_id);
@@ -213,7 +253,7 @@ export function assembleTurn(journalEvents, options = {}) {
     }
   }
 
-  return { records, consumedConversationIds };
+  return { records, consumedConversationIds, consumedGenerationIds };
 }
 
 // ─── Transcript Directory Scanning ───
@@ -248,6 +288,11 @@ function buildParentSteps(events, ctx) {
   let pendingToolRecords = [];
   let pendingToolCalls = [];
   let pendingToolResults = [];
+  // Latest _journal_ts among buffered tool.result events. When pending tools
+  // are flushed into a step, this becomes the new lastStepEndTs so that the
+  // following step's LLM request starts at the last tool's end (not at the
+  // turn's prompt time).
+  let pendingLastEndTs = null;
   const synthesizedSubagentIds = new Set();
 
   const stepEvents = events.filter(e =>
@@ -313,9 +358,16 @@ function buildParentSteps(events, ctx) {
     stepToolCalls.set(stepId, calls);
     previousToolResults.push(...pendingToolResults);
     const hadTools = pendingToolRecords.length > 0;
+    // Advance the step-end clock to the last buffered tool.result, so the
+    // next openNewStep() doesn't fall back to ctx.promptEventTs (which would
+    // make the new step's LLM request span the entire turn from time 0).
+    if (pendingLastEndTs) {
+      lastStepEndTs = pendingLastEndTs;
+    }
     pendingToolRecords = [];
     pendingToolCalls = [];
     pendingToolResults = [];
+    pendingLastEndTs = null;
     return hadTools;
   }
 
@@ -363,9 +415,26 @@ function buildParentSteps(events, ctx) {
           currentLlmResponse = buildLlmResponseWithToken(ev, ctx, currentStepId, 'text');
         }
       } else {
-        openNewStep(ev, stepRound === 0, ctx.userPrompt);
-        currentLlmResponse = buildLlmResponseWithToken(ev, ctx, currentStepId, 'text');
-        if (flushPendingTools(currentStepId)) currentStepHasTools = true;
+        if (pendingToolRecords.length > 0) {
+          // ReAct split: tools arrived before any thought/response. Create two steps:
+          //   Step N:   LLM decided to call tools → tools execute (finish=tool_calls)
+          //   Step N+1: LLM receives tool results → produces final answer
+          openNewStep(ev, stepRound === 0, ctx.userPrompt);
+          flushPendingTools(currentStepId);
+          currentStepHasTools = true;
+          // Close step N with an implicit response indicating tool_calls
+          currentLlmResponse = buildEmptyLlmResponse(
+            { _journal_ts: lastStepEndTs || ev._journal_ts, hook_event: 'implicit' },
+            ctx, currentStepId,
+          );
+          currentLlmResponse['gen_ai.response.finish_reasons'] = ['tool_calls'];
+          // Open step N+1 for the final LLM answer
+          openNewStep(ev, false, null);
+          currentLlmResponse = buildLlmResponseWithToken(ev, ctx, currentStepId, 'text');
+        } else {
+          openNewStep(ev, stepRound === 0, ctx.userPrompt);
+          currentLlmResponse = buildLlmResponseWithToken(ev, ctx, currentStepId, 'text');
+        }
       }
     }
 
@@ -421,6 +490,7 @@ function buildParentSteps(events, ctx) {
         pendingToolRecords.push(buildToolResult(ev, ctx, '__pending__'));
         applyToolDurationToCall(pendingToolRecords, '__pending__', ev);
         pendingToolResults.push({ toolName: ev.tool_name, toolUseId: ev.tool_use_id, result: ev.tool_output, error: ev.error_message });
+        if (ev._journal_ts) pendingLastEndTs = ev._journal_ts;
       } else {
         applyToolDurationToCall(records, currentStepId, ev);
         records.push(buildToolResult(ev, ctx, currentStepId));
@@ -476,7 +546,7 @@ function buildLlmRequestWithTs(reqTs, ev, ctx, stepId, userPrompt, prevToolResul
     ...ctx.baseFields,
     'gen_ai.step.id': stepId,
     'gen_ai.provider.name': inferProvider(ev.model || ctx.model),
-    'gen_ai.request.model': ev.model || ctx.model,
+    'gen_ai.request.model': resolveModel(ev.model || ctx.model),
     'gen_ai.input.messages': inputMessages.length > 0 ? inputMessages : undefined,
     'agent.cursor.hook_event_name': ev.hook_event,
     'agent.cursor.llm_request_time_source': timeSource,
@@ -493,8 +563,8 @@ function buildLlmResponse(ev, ctx, stepId, partType) {
     'gen_ai.step.id': stepId,
     'gen_ai.response.id': crypto.randomUUID(),
     'gen_ai.provider.name': inferProvider(ev.model || ctx.model),
-    'gen_ai.request.model': ev.model || ctx.model,
-    'gen_ai.response.model': ev.model || ctx.model,
+    'gen_ai.request.model': resolveModel(ev.model || ctx.model),
+    'gen_ai.response.model': resolveModel(ev.model || ctx.model),
     'gen_ai.output.messages': ev.text
       ? [{ role: 'assistant', parts: [{ type: partType, content: ev.text }] }]
       : [{ role: 'assistant', parts: [] }],
@@ -519,8 +589,8 @@ function buildEmptyLlmResponse(ev, ctx, stepId) {
     'gen_ai.step.id': stepId,
     'gen_ai.response.id': crypto.randomUUID(),
     'gen_ai.provider.name': inferProvider(ev.model || ctx.model),
-    'gen_ai.request.model': ev.model || ctx.model,
-    'gen_ai.response.model': ev.model || ctx.model,
+    'gen_ai.request.model': resolveModel(ev.model || ctx.model),
+    'gen_ai.response.model': resolveModel(ev.model || ctx.model),
     'gen_ai.output.messages': [{ role: 'assistant', parts: [] }],
     'agent.cursor.hook_event_name': 'implicit',
   }, ctx.runtimeConfig);
@@ -766,9 +836,15 @@ function findLastItem(items, predicate) {
   return undefined;
 }
 
+function resolveModel(rawModel) {
+  if (!rawModel || rawModel === 'default' || rawModel === 'unknown') return 'composer-2.5';
+  return rawModel;
+}
+
 function inferProvider(model) {
-  const provider = inferProviderName({ 'gen_ai.request.model': model, 'gen_ai.agent.type': 'cursor' });
-  if (provider === 'unknown' && /composer/i.test(model)) return 'openai';
+  const resolved = resolveModel(model);
+  if (/^composer/i.test(resolved)) return 'cursor';
+  const provider = inferProviderName({ 'gen_ai.request.model': resolved, 'gen_ai.agent.type': 'cursor' });
   return provider;
 }
 

--- a/assets/hooks/cursor/react-assembler.mjs
+++ b/assets/hooks/cursor/react-assembler.mjs
@@ -17,6 +17,7 @@ import {
   sanitizeObject,
   toJsonValue,
   parseMaybeJson,
+  resolveCursorModel,
 } from '../agent-event-normalizer.mjs';
 
 // ─── Public API ───
@@ -422,12 +423,12 @@ function buildParentSteps(events, ctx) {
           openNewStep(ev, stepRound === 0, ctx.userPrompt);
           flushPendingTools(currentStepId);
           currentStepHasTools = true;
-          // Close step N with an implicit response indicating tool_calls
+          // Close step N with an implicit response (assignFinishReasons will
+          // set finish_reasons=['tool_calls'] because this step has tools)
           currentLlmResponse = buildEmptyLlmResponse(
             { _journal_ts: lastStepEndTs || ev._journal_ts, hook_event: 'implicit' },
             ctx, currentStepId,
           );
-          currentLlmResponse['gen_ai.response.finish_reasons'] = ['tool_calls'];
           // Open step N+1 for the final LLM answer
           openNewStep(ev, false, null);
           currentLlmResponse = buildLlmResponseWithToken(ev, ctx, currentStepId, 'text');
@@ -746,6 +747,13 @@ function applyToolDurationToCall(records, stepId, resultEvent) {
 
 // ─── finish_reasons ───
 
+/**
+ * Assign finish_reasons to all llm.response records:
+ *   - Final response in the turn → ['stop']
+ *   - Non-final response in a step that has tools → ['tool_calls']
+ *     (this includes the implicit response from the ReAct split path)
+ *   - Other non-final responses → ['stop']
+ */
 function assignFinishReasons(records) {
   const stepsWithTools = new Set();
   for (const r of records) {
@@ -837,8 +845,7 @@ function findLastItem(items, predicate) {
 }
 
 function resolveModel(rawModel) {
-  if (!rawModel || rawModel === 'default' || rawModel === 'unknown') return 'composer-2.5';
-  return rawModel;
+  return resolveCursorModel(rawModel);
 }
 
 function inferProvider(model) {

--- a/src/inputs/cursor-hook/cursor-hook-input.ts
+++ b/src/inputs/cursor-hook/cursor-hook-input.ts
@@ -84,7 +84,8 @@ export class CursorHookInput extends BaseHookInput {
     const toolOutput = buildToolResultPayload(payload);
     const toolArguments = buildToolArguments(payload);
     const attributes = buildAttributes(record, payload, hookEvent);
-    const model = getStringValue(payload, 'model') ?? UNKNOWN_MODEL;
+    const rawModel = getStringValue(payload, 'model') ?? UNKNOWN_MODEL;
+    const model = (rawModel === 'default' || rawModel === 'unknown') ? 'composer-2.5' : rawModel;
     const sessionId = getStringValue(payload, 'session_id')
       ?? getStringValue(payload, 'conversation_id')
       ?? getStringValue(payload, 'session.id')
@@ -146,8 +147,8 @@ export class CursorHookInput extends BaseHookInput {
       'gen_ai.usage.cache_creation.input_cost': isStopEvent ? undefined : getNumberValue(payload, 'cost_cache_write'),
       'gen_ai.usage.total_cost': isStopEvent ? undefined : getNumberValue(payload, 'cost_total'),
       'gen_ai.input.messages_hash': getStringValue(payload, 'input_messages_hash'),
-      'gen_ai.input.messages_delta': eventName === 'llm.request' ? buildInputMessagesDelta(payload) : undefined,
-      'gen_ai.input.messages': eventName === 'llm.request' ? toJsonValue(parseMaybeJson(payload.input_messages)) : undefined,
+      'gen_ai.input.messages_delta': (eventName === 'llm.request' || eventName === 'other') ? buildInputMessagesDelta(payload) : undefined,
+      'gen_ai.input.messages': (eventName === 'llm.request' || eventName === 'other') ? toJsonValue(parseMaybeJson(payload.input_messages)) : undefined,
       'gen_ai.tool.name': getStringValue(payload, 'tool_name'),
       'gen_ai.tool.call.id': getStringValue(payload, 'tool_use_id'),
       'gen_ai.tool.call.exec.id': getStringValue(payload, 'tool_use_id'),
@@ -188,7 +189,7 @@ function inferEventName(hookEvent: string, payload: Record<string, unknown>): Ag
     return 'llm.response';
   }
   if (event.includes('beforesubmitprompt')) {
-    return 'llm.request';
+    return 'other';
   }
   if (event.includes('pretooluse')) {
     return 'tool.call';

--- a/src/inputs/cursor-hook/cursor-hook-input.ts
+++ b/src/inputs/cursor-hook/cursor-hook-input.ts
@@ -15,6 +15,18 @@ import { inferGitContext, BoundedTtlCache } from '../../utils/git-context.js';
 import { buildCanonicalHookEntry } from '../base/canonical-hook-record.js';
 
 const UNKNOWN_MODEL = 'unknown';
+const DEFAULT_CURSOR_MODEL = 'composer-2.5';
+
+/** Coerce raw model string to a concrete model name. */
+function resolveCursorModel(rawModel: string): string {
+  if (!rawModel || rawModel === 'default' || rawModel === 'unknown') return DEFAULT_CURSOR_MODEL;
+  return rawModel;
+}
+
+/** Whether this event type carries user input messages (prompt). */
+function hasInputMessages(eventName: string): boolean {
+  return eventName === 'llm.request' || eventName === 'other';
+}
 
 const SESSION_CD_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
@@ -84,8 +96,8 @@ export class CursorHookInput extends BaseHookInput {
     const toolOutput = buildToolResultPayload(payload);
     const toolArguments = buildToolArguments(payload);
     const attributes = buildAttributes(record, payload, hookEvent);
-    const rawModel = getStringValue(payload, 'model') ?? UNKNOWN_MODEL;
-    const model = (rawModel === 'default' || rawModel === 'unknown') ? 'composer-2.5' : rawModel;
+    const rawModel = getStringValue(payload, 'model') || UNKNOWN_MODEL;
+    const model = resolveCursorModel(rawModel);
     const sessionId = getStringValue(payload, 'session_id')
       ?? getStringValue(payload, 'conversation_id')
       ?? getStringValue(payload, 'session.id')
@@ -147,8 +159,8 @@ export class CursorHookInput extends BaseHookInput {
       'gen_ai.usage.cache_creation.input_cost': isStopEvent ? undefined : getNumberValue(payload, 'cost_cache_write'),
       'gen_ai.usage.total_cost': isStopEvent ? undefined : getNumberValue(payload, 'cost_total'),
       'gen_ai.input.messages_hash': getStringValue(payload, 'input_messages_hash'),
-      'gen_ai.input.messages_delta': (eventName === 'llm.request' || eventName === 'other') ? buildInputMessagesDelta(payload) : undefined,
-      'gen_ai.input.messages': (eventName === 'llm.request' || eventName === 'other') ? toJsonValue(parseMaybeJson(payload.input_messages)) : undefined,
+      'gen_ai.input.messages_delta': hasInputMessages(eventName) ? buildInputMessagesDelta(payload) : undefined,
+      'gen_ai.input.messages': hasInputMessages(eventName) ? toJsonValue(parseMaybeJson(payload.input_messages)) : undefined,
       'gen_ai.tool.name': getStringValue(payload, 'tool_name'),
       'gen_ai.tool.call.id': getStringValue(payload, 'tool_use_id'),
       'gen_ai.tool.call.exec.id': getStringValue(payload, 'tool_use_id'),

--- a/tests/unit/hooks/cursor-react-assembler.test.ts
+++ b/tests/unit/hooks/cursor-react-assembler.test.ts
@@ -470,4 +470,213 @@ describe('Cursor react assembler', () => {
       response: 'cursor fallback result',
     });
   });
+
+  it('isolates assembly to the stopping generation when two generations share a conversation', () => {
+    // Scenario: GPT quota exhaustion → Cursor auto-switches mid-prompt and
+    // re-emits beforeSubmitPrompt with a new generation_id under the SAME
+    // conversation_id. The aborted generation's events must not leak into
+    // the live (completed) generation's assembled turn.
+    const journalEvents = [
+      // Gen A — aborted GPT attempt (no actual model output yet)
+      {
+        _journal_ts: iso(0),
+        hook_event: 'beforeSubmitPrompt',
+        conversation_id: 'conv-shared',
+        generation_id: 'gen-a',
+        model: 'gpt-5.4',
+        prompt: 'do the task (gpt)',
+      },
+      // Gen B — auto-switched composer attempt with the same prompt text
+      {
+        _journal_ts: iso(50),
+        hook_event: 'beforeSubmitPrompt',
+        conversation_id: 'conv-shared',
+        generation_id: 'gen-b',
+        model: 'composer-2.5-fast',
+        prompt: 'do the task (composer)',
+      },
+      // Gen A stop arrives later (aborted) — but here we exercise the
+      // assembler's generation-scoped filtering directly.
+      {
+        _journal_ts: iso(60),
+        hook_event: 'stop',
+        conversation_id: 'conv-shared',
+        generation_id: 'gen-a',
+        status: 'aborted',
+      },
+      // Gen B normal flow
+      {
+        _journal_ts: iso(200),
+        hook_event: 'afterAgentThought',
+        conversation_id: 'conv-shared',
+        generation_id: 'gen-b',
+        model: 'composer-2.5-fast',
+        text: 'composer thinking',
+        duration_ms: 100,
+      },
+      {
+        _journal_ts: iso(400),
+        hook_event: 'preToolUse',
+        conversation_id: 'conv-shared',
+        generation_id: 'gen-b',
+        tool_name: 'Write',
+        tool_use_id: 'call-b-write',
+        tool_input: { path: 'a.md' },
+      },
+      {
+        _journal_ts: iso(600),
+        hook_event: 'postToolUse',
+        conversation_id: 'conv-shared',
+        generation_id: 'gen-b',
+        tool_name: 'Write',
+        tool_use_id: 'call-b-write',
+        tool_output: 'ok',
+        duration_ms: 150,
+      },
+      {
+        _journal_ts: iso(700),
+        hook_event: 'afterAgentResponse',
+        conversation_id: 'conv-shared',
+        generation_id: 'gen-b',
+        model: 'composer-2.5-fast',
+        text: 'composer done',
+        input_tokens: 5,
+        output_tokens: 1,
+      },
+      {
+        _journal_ts: iso(800),
+        hook_event: 'stop',
+        conversation_id: 'conv-shared',
+        generation_id: 'gen-b',
+        status: 'completed',
+      },
+    ];
+
+    const { records, consumedConversationIds, consumedGenerationIds } = assembleTurn(journalEvents, {
+      stopConversationId: 'conv-shared',
+      stopGenerationId: 'gen-b',
+    });
+
+    // ENTRY user-prompt record must come from gen-b, not gen-a
+    const entryRecord = records.find(r => r['event.name'] === 'other');
+    expect(entryRecord?.['gen_ai.input.messages_delta']?.[0]?.parts?.[0]?.content)
+      .toBe('do the task (composer)');
+    expect(entryRecord?.['gen_ai.turn.id']).toBe('gen-b');
+
+    // No record should reference gen-a as turn id
+    for (const r of records) {
+      expect(r['gen_ai.turn.id']).toBe('gen-b');
+    }
+
+    // gen-b owns a tool.call/tool.result pair; gen-a's events must not appear
+    const toolCalls = records.filter(r => r['event.name'] === 'tool.call');
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0]?.['gen_ai.tool.call.id']).toBe('call-b-write');
+
+    // Cleanup contract: parent conversation must NOT be globally consumed,
+    // so gen-a's lingering events stay in the journal until the aborted
+    // stop path cleans them by generation_id.
+    expect(consumedGenerationIds.has('gen-b')).toBe(true);
+    expect(consumedGenerationIds.has('gen-a')).toBe(false);
+    expect(consumedConversationIds.has('conv-shared')).toBe(false);
+  });
+
+  it('starts s2 LLM request at the last buffered tool result (composer ReAct split)', () => {
+    // Scenario: composer-2.5-fast emits no afterAgentThought; tool calls and
+    // results stream before any LLM event arrives. When afterAgentResponse
+    // finally fires, the assembler splits into:
+    //   s1 = tools + implicit response (finish=tool_calls)
+    //   s2 = the final LLM answer
+    // Bug guarded here: previously lastStepEndTs stayed at promptEventTs
+    // because flushPendingTools never advanced it, so s2's LLM request
+    // started at time 0 and the s2 span covered the entire turn.
+    const { records } = assembleTurn([
+      {
+        _journal_ts: iso(0),
+        hook_event: 'beforeSubmitPrompt',
+        conversation_id: 'conv-composer-split',
+        generation_id: 'turn-composer-split',
+        model: 'composer-2.5-fast',
+        prompt: 'do many things',
+      },
+      {
+        _journal_ts: iso(100),
+        hook_event: 'preToolUse',
+        conversation_id: 'conv-composer-split',
+        generation_id: 'turn-composer-split',
+        tool_name: 'Read',
+        tool_use_id: 'call-c-1',
+        tool_input: { path: 'a.ts' },
+      },
+      {
+        _journal_ts: iso(200),
+        hook_event: 'postToolUse',
+        conversation_id: 'conv-composer-split',
+        generation_id: 'turn-composer-split',
+        tool_name: 'Read',
+        tool_use_id: 'call-c-1',
+        tool_output: 'r1',
+        duration_ms: 100,
+      },
+      {
+        _journal_ts: iso(300),
+        hook_event: 'preToolUse',
+        conversation_id: 'conv-composer-split',
+        generation_id: 'turn-composer-split',
+        tool_name: 'Grep',
+        tool_use_id: 'call-c-2',
+        tool_input: { pattern: 'foo' },
+      },
+      {
+        _journal_ts: iso(450),
+        hook_event: 'postToolUse',
+        conversation_id: 'conv-composer-split',
+        generation_id: 'turn-composer-split',
+        tool_name: 'Grep',
+        tool_use_id: 'call-c-2',
+        tool_output: 'r2',
+        duration_ms: 150,
+      },
+      {
+        _journal_ts: iso(800),
+        hook_event: 'afterAgentResponse',
+        conversation_id: 'conv-composer-split',
+        generation_id: 'turn-composer-split',
+        model: 'composer-2.5-fast',
+        text: 'final answer',
+        input_tokens: 10,
+        output_tokens: 3,
+      },
+      {
+        _journal_ts: iso(900),
+        hook_event: 'stop',
+        conversation_id: 'conv-composer-split',
+        generation_id: 'turn-composer-split',
+        status: 'completed',
+      },
+    ], { stopConversationId: 'conv-composer-split', stopGenerationId: 'turn-composer-split' });
+
+    const s1Request = records.find(r =>
+      r['event.name'] === 'llm.request' && r['gen_ai.step.id'] === 'turn-composer-split:s1'
+    );
+    const s2Request = records.find(r =>
+      r['event.name'] === 'llm.request' && r['gen_ai.step.id'] === 'turn-composer-split:s2'
+    );
+    const s2Response = records.find(r =>
+      r['event.name'] === 'llm.response' && r['gen_ai.step.id'] === 'turn-composer-split:s2'
+    );
+
+    // s1 still anchors to prompt time (the LLM that decided to call tools)
+    // — the timing-guard may pull it slightly back; we just want it not
+    // exceeding the first tool's start.
+    expect(BigInt(s1Request!.time_unix_nano as string))
+      .toBeLessThanOrEqual(BigInt(ns(100)));
+
+    // s2 must start AT or AFTER the last buffered tool.result (iso(450)).
+    // Critically it must NOT fall back to prompt time (ns(0)).
+    expect(s2Request).toBeDefined();
+    expect(BigInt(s2Request!.time_unix_nano as string))
+      .toBeGreaterThanOrEqual(BigInt(ns(450)));
+    expect(s2Response?.time_unix_nano).toBe(ns(800));
+  });
 });

--- a/tests/unit/inputs/cursor-hook-input.test.ts
+++ b/tests/unit/inputs/cursor-hook-input.test.ts
@@ -147,8 +147,8 @@ describe('CursorHookInput', () => {
     expect(entries).toHaveLength(1);
     expect(entries[0]!['event.name']).toBe('tool.result');
     expect(entries[0]!['gen_ai.session.id']).toBe('sess-from-raw');
-    expect(entries[0]!['gen_ai.request.model']).toBe('unknown');
-    expect(entries[0]!['gen_ai.response.model']).toBe('unknown');
+    expect(entries[0]!['gen_ai.request.model']).toBe('composer-2.5');
+    expect(entries[0]!['gen_ai.response.model']).toBe('composer-2.5');
     expect(entries[0]!['gen_ai.tool.call.result']).toEqual({ output: 'ok', exitCode: 0 });
     expect(entries[0]!['gen_ai.tool.call.duration']).toBe(12.5);
   });
@@ -206,7 +206,7 @@ describe('CursorHookInput', () => {
     await input.stop();
 
     expect(entries).toHaveLength(1);
-    expect(entries[0]!['event.name']).toBe('llm.request');
+    expect(entries[0]!['event.name']).toBe('other');
     expect(entries[0]!['user.id']).toBe('');
     expect(entries[0]!['gen_ai.input.messages_delta']).toEqual([{ role: 'user', parts: [{ type: 'text', content: 'please inspect this' }] }]);
     expect(entries[0]!['gen_ai.usage.input_tokens']).toBe(10);
@@ -266,8 +266,8 @@ describe('CursorHookInput', () => {
 
     expect(entries).toHaveLength(1);
     expect(entries[0]!['event.name']).toBe('other');
-    expect(entries[0]!['gen_ai.request.model']).toBe('unknown');
-    expect(entries[0]!['gen_ai.response.model']).toBe('unknown');
+    expect(entries[0]!['gen_ai.request.model']).toBe('composer-2.5');
+    expect(entries[0]!['gen_ai.response.model']).toBe('composer-2.5');
     expect(entries[0]!['error.message']).toBeUndefined();
   });
 
@@ -439,8 +439,8 @@ describe('CursorHookInput', () => {
     // workspace_roots is absent and payload has no repo/branch
     expect(entries[0]!['event.name']).toBe('tool.call');
 
-    // llm.request entry should use the cached cd path to infer git info
-    expect(entries[1]!['event.name']).toBe('llm.request');
+    // beforeSubmitPrompt entry should use the cached cd path to infer git info
+    expect(entries[1]!['event.name']).toBe('other');
     expect(entries[1]!['gen_ai.session.id']).toBe('s-fallback');
     expect(entries[1]!['git.repo']).toBe('acme/fallback-cd');
     expect(entries[1]!['git.branch']).toBe('feature/fallback-cd');


### PR DESCRIPTION
## Summary

Two related fixes to the Cursor hook ingestion pipeline so traces are no longer lost or distorted under composer auto-switch and ReAct-style turns.

### 1. Per-generation turn isolation + s2 timing (commit `d26ff89`)

When Cursor's GPT quota is exhausted mid-prompt, Cursor auto-switches to composer and emits a second `beforeSubmitPrompt` under the **same `conversation_id`** but a new `generation_id`. The original generation then ends with `stop.status="aborted"`. Previously the assembler matched on `conversation_id` only, so:

- the aborted stop greedily consumed the live generation's events, dropping its turn from history; and
- a phantom "other"-only entry was written for the aborted attempt.

From the user's perspective both prompts are the same trace, so the aborted half should produce no record at all and the live generation should still assemble normally.

- `assembleTurn` now matches prompt / stop / response by `conversation_id + generation_id` and returns `consumedGenerationIds` for surgical journal cleanup.
- `cursor-hook-processor` short-circuits on `stop.status === "aborted"`: no record is emitted; only that `generation_id`'s events are dropped from the journal so the sibling generation can still assemble on its own stop.
- Fix s2 timing in the composer ReAct split (no `afterAgentThought`, only `afterAgentResponse`): `flushPendingTools` now advances `lastStepEndTs` to the last buffered `tool.result`, so the following step's LLM request starts after the tools instead of falling back to prompt time (which used to make s2 span the whole turn from time 0).
- New unit tests cover both scenarios.

### 2. User prompt as "other" event + model fallback (commit `55514e1`)

`beforeSubmitPrompt` was being mapped to `event.name="llm.request"`, which produced a hollow LLM span downstream (no `step.id` / `response.id` / `finish_reasons` / tokens). The user prompt is not an LLM call; it should fold into the ENTRY span.

- Normalizer + `CursorHookInput` fallback path: `beforeSubmitPrompt → "other"`; `messages_delta` / `messages` populated for both `llm.request` and `other`.
- Coerce model `"default"` / `"unknown"` to `"composer-2.5"`.
- Force `gen_ai.provider.name = "cursor"` for any `composer-*` model.
- Update unit tests to match.

## Files changed

```
assets/hooks/agent-event-normalizer.mjs           +6  −5
assets/hooks/cursor-hook-processor.mjs           +49 −13
assets/hooks/cursor/react-assembler.mjs         +106 −28
src/inputs/cursor-hook/cursor-hook-input.ts       +5  −4
tests/unit/hooks/cursor-react-assembler.test.ts +209  −0
tests/unit/inputs/cursor-hook-input.test.ts       +7  −7
```

## Test plan

- [x] `npx vitest run tests/unit/hooks/cursor-react-assembler.test.ts` — 7/7 pass (incl. dual-generation isolation + composer ReAct s2 timing)
- [x] `npx vitest run tests/unit/hooks/` — 72/72 pass
- [x] `npx vitest run tests/unit/inputs/cursor-hook-input.test.ts tests/unit/hooks/agent-event-normalizer.test.mjs` — 24/24 pass
- [ ] Live verification: trigger a GPT quota exhaustion → composer auto-switch and confirm `cursor-YYYY-MM-DD.jsonl` has only the composer turn (no aborted phantom record), with all step / token fields populated.