### PR TITLE
fix: avoid creating bash_profile for PATH setup

### DIFF
--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -823,7 +823,16 @@ PATHBLOCK
                 ;;
             */bash)
                 ensure_path_block "$HOME/.bashrc" || true
-                ensure_path_block "$HOME/.bash_profile" || true
+                # Do not create ~/.bash_profile just to add PATH. On Debian/Ubuntu
+                # style accounts, its mere presence prevents bash login shells from
+                # reading ~/.profile, which often sources ~/.bashrc and user aliases.
+                if [ -f "$HOME/.bash_profile" ]; then
+                    ensure_path_block "$HOME/.bash_profile" || true
+                elif [ -f "$HOME/.bash_login" ]; then
+                    ensure_path_block "$HOME/.bash_login" || true
+                else
+                    ensure_path_block "$HOME/.profile" || true
+                fi
                 ;;
             *)
                 ensure_path_block "$HOME/.bashrc" || true

--- a/tests/unit/deploy/installer-profile-selection.test.mjs
+++ b/tests/unit/deploy/installer-profile-selection.test.mjs
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const installerPath = resolve('deploy', 'installer-opensource.sh');
+
+function readInstaller() {
+  return readFileSync(installerPath, 'utf-8');
+}
+
+function extractBashShellCase(script) {
+  const match = script.match(/\*\/bash\)([\s\S]*?)\n\s*;;/);
+  if (!match) throw new Error('bash shell case not found');
+  return match[1];
+}
+
+describe('installer bash profile selection', () => {
+  it('does not create ~/.bash_profile when adding ~/.local/bin to PATH', () => {
+    const bashCase = extractBashShellCase(readInstaller());
+
+    expect(bashCase).toContain('ensure_path_block "$HOME/.bashrc"');
+    expect(bashCase).toContain('[ -f "$HOME/.bash_profile" ]');
+    expect(bashCase).toContain('[ -f "$HOME/.bash_login" ]');
+    expect(bashCase).toContain('ensure_path_block "$HOME/.profile"');
+
+    const bashrcWrite = bashCase.indexOf('ensure_path_block "$HOME/.bashrc"');
+    const bashProfileCheck = bashCase.indexOf('[ -f "$HOME/.bash_profile" ]');
+    const bashProfileWrite = bashCase.indexOf('ensure_path_block "$HOME/.bash_profile"');
+    const profileWrite = bashCase.indexOf('ensure_path_block "$HOME/.profile"');
+
+    expect(bashrcWrite).toBeGreaterThanOrEqual(0);
+    expect(bashProfileCheck).toBeGreaterThan(bashrcWrite);
+    expect(bashProfileWrite).toBeGreaterThan(bashProfileCheck);
+    expect(profileWrite).toBeGreaterThan(bashProfileWrite);
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes a shell profile side effect in the open-source installer.

When installing for a bash user without an existing `~/.bash_profile`, the installer currently creates one just to prepend `~/.local/bin` to `PATH`. On Debian/Ubuntu-style accounts, bash login shells read `~/.bash_profile` instead of `~/.profile` when it exists. Since the default `~/.profile` is commonly responsible for sourcing `~/.bashrc`, creating `~/.bash_profile` can silently skip user aliases and interactive shell setup. A visible symptom is aliases like `ll` no longer being available in new login shells.

## Fix

- Keep writing the PATH block to `~/.bashrc` for bash users.
- Only write `~/.bash_profile` if the user already has one.
- Otherwise write `~/.bash_login` if it already exists.
- Fall back to `~/.profile` instead of creating `~/.bash_profile`.
- Add a unit test to guard this installer profile selection behavior.

## Validation

- `bash -n deploy/installer-opensource.sh`
- `vitest run tests/unit/deploy/installer-profile-selection.test.mjs`
