### PR TITLE
fix: chunked OTLP export with gzip to prevent large trace failures

### DIFF
--- a/src/core/config-loader.ts
+++ b/src/core/config-loader.ts
@@ -446,6 +446,8 @@ function buildOtlpTraceConfigNew(
     captureMessageContent,
     debug: otlp?.debug ?? false,
     turnIdleTimeoutMs: otlp?.turnIdleTimeoutMs ?? 0,
+    maxExportBatchBytes: otlp?.maxExportBatchBytes,
+    compression: otlp?.compression,
   };
 }
 
@@ -471,6 +473,8 @@ function buildOtlpTraceConfigLegacy(config: AnalyticsConfig): OtlpTraceFlusherCo
     captureMessageContent,
     debug: cms.debug ?? false,
     turnIdleTimeoutMs: 0,
+    maxExportBatchBytes: undefined,
+    compression: undefined,
   };
 }
 

--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -7,6 +7,7 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
+import { CompressionAlgorithm } from '@opentelemetry/otlp-exporter-base';
 import {
   convertEventLogToTrace,
   ExtendedTelemetryHandler,
@@ -76,6 +77,18 @@ function getPilotVersion(): string {
   } catch {
     return 'unknown';
   }
+}
+
+const DEFAULT_MAX_EXPORT_BATCH_BYTES = 10 * 1024 * 1024; // 10 MB
+
+function estimateSpanSize(span: ReadableSpan): number {
+  let size = 512;
+  const attrs = span.attributes;
+  for (const val of Object.values(attrs)) {
+    if (typeof val === 'string') size += val.length;
+    else size += 32;
+  }
+  return size;
 }
 
 export class OtlpTraceFlusher extends BaseFlusher {
@@ -238,7 +251,7 @@ export class OtlpTraceFlusher extends BaseFlusher {
     if (this.cfg.debug) {
       await this.writeDebugLog(agentType, spans);
     }
-    await this.doExport(exportState, agentType, spans);
+    await this.exportInBatches(exportState, agentType, spans);
   }
 
   // --- Internal ---
@@ -349,7 +362,37 @@ export class OtlpTraceFlusher extends BaseFlusher {
       await this.writeDebugLog(agentType, spans);
     }
 
-    await this.doExport(exportState, agentType, spans);
+    await this.exportInBatches(exportState, agentType, spans);
+  }
+
+  private async exportInBatches(
+    exportState: AgentExportState,
+    agentType: string,
+    spans: ReadableSpan[],
+  ): Promise<void> {
+    const maxBytes = this.cfg.maxExportBatchBytes ?? DEFAULT_MAX_EXPORT_BATCH_BYTES;
+    const batches: ReadableSpan[][] = [];
+    let current: ReadableSpan[] = [];
+    let currentSize = 0;
+
+    for (const span of spans) {
+      const size = estimateSpanSize(span);
+      if (current.length > 0 && currentSize + size > maxBytes) {
+        batches.push(current);
+        current = [];
+        currentSize = 0;
+      }
+      current.push(span);
+      currentSize += size;
+    }
+    if (current.length > 0) batches.push(current);
+
+    if (batches.length > 1) {
+      logger.info(`Exporting ${spans.length} spans in ${batches.length} batches`, { agentType, maxBytes });
+    }
+    for (const batch of batches) {
+      await this.doExport(exportState, agentType, batch);
+    }
   }
 
   private doExport(
@@ -396,6 +439,7 @@ export class OtlpTraceFlusher extends BaseFlusher {
     const exporter = new OTLPTraceExporter({
       url: this.resolvedEndpointUrl,
       headers: this.cfg.headers ?? {},
+      compression: (this.cfg.compression ?? 'gzip') as CompressionAlgorithm,
     });
 
     state = { exporter };

--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -83,10 +83,16 @@ const DEFAULT_MAX_EXPORT_BATCH_BYTES = 10 * 1024 * 1024; // 10 MB
 
 function estimateSpanSize(span: ReadableSpan): number {
   let size = 512;
-  const attrs = span.attributes;
-  for (const val of Object.values(attrs)) {
+  for (const val of Object.values(span.attributes)) {
     if (typeof val === 'string') size += val.length;
     else size += 32;
+  }
+  for (const event of span.events ?? []) {
+    size += 64;
+    for (const val of Object.values(event.attributes ?? {})) {
+      if (typeof val === 'string') size += val.length;
+      else size += 32;
+    }
   }
   return size;
 }
@@ -439,7 +445,9 @@ export class OtlpTraceFlusher extends BaseFlusher {
     const exporter = new OTLPTraceExporter({
       url: this.resolvedEndpointUrl,
       headers: this.cfg.headers ?? {},
-      compression: (this.cfg.compression ?? 'gzip') as CompressionAlgorithm,
+      compression: this.cfg.compression === 'none'
+        ? CompressionAlgorithm.NONE
+        : CompressionAlgorithm.GZIP,
     });
 
     state = { exporter };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,6 +48,8 @@ export interface OtlpTraceRawConfig {
   debug?: boolean;
   captureMessageContent?: boolean;
   turnIdleTimeoutMs?: number;
+  maxExportBatchBytes?: number;
+  compression?: 'none' | 'gzip';
 }
 
 export interface AnalyticsConfig {
@@ -94,6 +96,8 @@ export interface OtlpTraceFlusherConfig {
   captureMessageContent?: boolean;
   debug?: boolean;
   turnIdleTimeoutMs?: number;
+  maxExportBatchBytes?: number;
+  compression?: 'none' | 'gzip';
 }
 
 export type SlsMode = 'ak' | 'webtracking';

--- a/tests/unit/flushers/otlp-trace-flusher/export.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/export.test.ts
@@ -24,6 +24,7 @@ vi.spyOn(fsUtils, 'appendLine').mockResolvedValue(undefined);
 vi.spyOn(fsUtils, 'ensureDir').mockResolvedValue(undefined);
 
 import { OtlpTraceFlusher } from '../../../../src/flushers/otlp-trace-flusher.js';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
 
 function makeConfig(overrides: Record<string, unknown> = {}) {
   return {
@@ -158,6 +159,19 @@ describe('OtlpTraceFlusher - export', () => {
 
     expect(mockExport).toHaveBeenCalledTimes(1);
     expect(mockExport.mock.calls[0][0]).toHaveLength(100);
+  });
+
+  it('enables gzip compression by default on OTLPTraceExporter', async () => {
+    const flusher = new OtlpTraceFlusher(makeConfig());
+    const spans = [makeMockSpan()] as any;
+
+    await flusher.exportSpansForAgent('claude-code', spans);
+    await flusher.shutdown();
+
+    const MockExporter = vi.mocked(OTLPTraceExporter);
+    expect(MockExporter).toHaveBeenCalled();
+    const ctorArg = MockExporter.mock.calls[0][0] as Record<string, unknown>;
+    expect(ctorArg.compression).toBe('gzip');
   });
 
   it('writes to BOTH debug and failed-log when debug=true and export fails', async () => {

--- a/tests/unit/flushers/otlp-trace-flusher/export.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/export.test.ts
@@ -114,6 +114,52 @@ describe('OtlpTraceFlusher - export', () => {
     expect(written._error.message).toContain('401');
   });
 
+  it('exports small total size in a single call', async () => {
+    // maxExportBatchBytes=10KB, each span ~522 bytes → 10 spans ≈ 5KB < 10KB → 1 batch
+    const flusher = new OtlpTraceFlusher(makeConfig({ maxExportBatchBytes: 10 * 1024 }));
+    const spans = Array.from({ length: 10 }, () => makeMockSpan()) as any;
+
+    await flusher.exportSpansForAgent('claude-code', spans);
+    await flusher.shutdown();
+
+    expect(mockExport).toHaveBeenCalledTimes(1);
+    expect(mockExport.mock.calls[0][0]).toHaveLength(10);
+  });
+
+  it('splits spans into batches by estimated size', async () => {
+    // Each span with 4KB payload → ~4612 bytes estimated
+    // maxExportBatchBytes=10KB → fits ~2 spans per batch
+    // 5 spans → 3 batches (2+2+1)
+    function makeLargeSpan() {
+      return {
+        ...makeMockSpan(),
+        attributes: { 'gen_ai.agent.type': 'claude-code', 'gen_ai.input.messages': 'x'.repeat(4096) },
+      };
+    }
+    const flusher = new OtlpTraceFlusher(makeConfig({ maxExportBatchBytes: 10 * 1024 }));
+    const spans = Array.from({ length: 5 }, () => makeLargeSpan()) as any;
+
+    await flusher.exportSpansForAgent('claude-code', spans);
+    await flusher.shutdown();
+
+    expect(mockExport).toHaveBeenCalledTimes(3);
+    expect(mockExport.mock.calls[0][0]).toHaveLength(2);
+    expect(mockExport.mock.calls[1][0]).toHaveLength(2);
+    expect(mockExport.mock.calls[2][0]).toHaveLength(1);
+  });
+
+  it('uses default 10MB limit when maxExportBatchBytes not configured', async () => {
+    // Small spans (~522 bytes each), 100 of them ≈ 52KB ≪ 10MB → single batch
+    const flusher = new OtlpTraceFlusher(makeConfig());
+    const spans = Array.from({ length: 100 }, () => makeMockSpan()) as any;
+
+    await flusher.exportSpansForAgent('claude-code', spans);
+    await flusher.shutdown();
+
+    expect(mockExport).toHaveBeenCalledTimes(1);
+    expect(mockExport.mock.calls[0][0]).toHaveLength(100);
+  });
+
   it('writes to BOTH debug and failed-log when debug=true and export fails', async () => {
     mockExport.mockImplementationOnce((_s, cb) => {
       cb({ code: ExportResultCode.FAILED, error: new Error('timeout') });


### PR DESCRIPTION
## Summary

- Large traces (1000+ spans, e.g. 1329 spans from a long Cursor session) failed to export because `OtlpTraceFlusher` sent all spans in a single `OTLPTraceExporter.export()` call, exceeding the 10s timeout and ARMS body size limit (~2-5MB).
- This PR splits the export into batches by estimated serialized size (default 10MB pre-compression), and enables gzip compression by default on `OTLPTraceExporter`.

## Changes

- **`src/flushers/otlp-trace-flusher.ts`**: Add `exportInBatches()` method that accumulates spans by estimated size, splitting into new batches when the threshold is exceeded. Add lightweight `estimateSpanSize()` that sums attribute string lengths (no `JSON.stringify`). Enable gzip compression by default.
- **`src/types/index.ts`**: Add `maxExportBatchBytes` and `compression` fields to `OtlpTraceFlusherConfig` and `OtlpTraceRawConfig`.
- **`src/core/config-loader.ts`**: Pass through new config fields in both `buildOtlpTraceConfigNew` and `buildOtlpTraceConfigLegacy`.
- **`tests/unit/flushers/otlp-trace-flusher/export.test.ts`**: Add 3 test cases for size-based batching behavior.

## Test plan

- [x] TypeScript type check passes
- [x] All 40 existing + new unit tests pass (7 test files)
- [ ] Verify with a real large trace (1000+ spans) that export succeeds after this change

Made with [Cursor](https://cursor.com)