### PR TITLE
feat: add Windows platform support

### DIFF
--- a/assets/hooks/claude-code-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/claude-code-loongsuite-pilot-hook.ps1
@@ -1,0 +1,155 @@
+# Claude Code hook entrypoint (Windows) — delegates to claude-code-hook-processor.mjs.
+#
+# Usage (registered in ~/.claude/settings.json by pilot HookStrategy):
+#   powershell -File $PILOT_DATA/hooks/claude-code-loongsuite-pilot-hook.ps1 <subcommand>
+#
+# Subcommand: stop / subagent-start / subagent-stop
+#
+# Fail-open: any error outputs "{}" and exits 0.
+
+$ErrorActionPreference = "Continue"
+$EMPTY_RESULT = '{}'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Processor = Join-Path $ScriptDir "claude-code-hook-processor.mjs"
+$Subcommand = if ($args.Count -gt 0) { $args[0] } else { "unknown" }
+
+# Only process registered subcommands
+if ($Subcommand -notin @("stop", "subagent-start", "subagent-stop")) {
+    Write-Output $EMPTY_RESULT
+    exit 0
+}
+
+function Log-Error {
+    param([string]$Stage, [string]$Message)
+    try {
+        $dataDir = if ($env:LOONGSUITE_PILOT_DATA_DIR) { $env:LOONGSUITE_PILOT_DATA_DIR }
+                   else { Join-Path $env:USERPROFILE ".loongsuite-pilot" }
+        $day = (Get-Date -Format "yyyy-MM-dd")
+        $dir = Join-Path $dataDir "logs\claude-code\errors"
+        if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+        $file = Join-Path $dir "claude-code-error-$day.jsonl"
+        $time = (Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ")
+        $escapedMsg = $Message -replace '\\', '\\\\' -replace '"', '\"'
+        $line = "{`"time`":`"$time`",`"gen_ai.agent.type`":`"claude-code`",`"stage`":`"$Stage`",`"error.type`":`"ps1_$Stage`",`"error.message`":`"$escapedMsg`"}"
+        Add-Content -Path $file -Value $line
+    } catch {}
+}
+
+if (-not (Test-Path $Processor)) {
+    Write-Error "[claude-code-hook] processor not found: $Processor"
+    Log-Error "missing_processor" "hook processor not found: $Processor"
+    Write-Output $EMPTY_RESULT
+    exit 0
+}
+
+$MIN_NODE_MAJOR = 18
+
+function Test-NodeSuitable {
+    param([string]$bin)
+    if (-not (Test-Path $bin)) { return $false }
+    try {
+        $ver = & $bin --version 2>$null
+        if (-not $ver) { return $false }
+        $major = [int]($ver -replace '^v','').Split('.')[0]
+        return $major -ge $MIN_NODE_MAJOR
+    } catch { return $false }
+}
+
+function Resolve-NodeBin {
+    $pinFile = Join-Path $env:USERPROFILE ".loongsuite-pilot\node-bin"
+    if (Test-Path $pinFile) {
+        $pinned = (Get-Content $pinFile -ErrorAction SilentlyContinue).Trim()
+        if ($pinned -and (Test-NodeSuitable $pinned)) { return $pinned }
+    }
+
+    $candidates = @()
+    $nvmHome = $env:NVM_HOME
+    if ($nvmHome -and (Test-Path $nvmHome)) {
+        $nvmDirs = Get-ChildItem $nvmHome -Directory -ErrorAction SilentlyContinue | Sort-Object Name -Descending
+        foreach ($d in $nvmDirs) { $candidates += Join-Path $d.FullName "node.exe" }
+    }
+    $fnmDir = Join-Path $env:USERPROFILE ".fnm\node-versions"
+    if (Test-Path $fnmDir) {
+        $fnmDirs = Get-ChildItem $fnmDir -Directory -ErrorAction SilentlyContinue | Sort-Object Name -Descending
+        foreach ($d in $fnmDirs) { $candidates += Join-Path $d.FullName "installation\node.exe" }
+    }
+    $candidates += Join-Path $env:USERPROFILE ".volta\bin\node.exe"
+    $candidates += "C:\Program Files\nodejs\node.exe"
+    $candidates += "C:\Program Files (x86)\nodejs\node.exe"
+    $pathNode = Get-Command node -ErrorAction SilentlyContinue
+    if ($pathNode) { $candidates += $pathNode.Source }
+
+    foreach ($c in $candidates) {
+        if (Test-NodeSuitable $c) { return $c }
+    }
+    return $null
+}
+
+$nodeBin = Resolve-NodeBin
+if (-not $nodeBin) {
+    Write-Error "[claude-code-hook] node >= $MIN_NODE_MAJOR not found"
+    Log-Error "missing_node" "node >= $MIN_NODE_MAJOR not found"
+    Write-Output $EMPTY_RESULT
+    exit 0
+}
+
+if (-not [Console]::IsInputRedirected) {
+    Write-Output $EMPTY_RESULT
+    exit 0
+}
+
+try {
+    # Read stdin as raw bytes to avoid PowerShell encoding issues (GB2312/ASCII mangles UTF-8)
+    $stdinStream = [Console]::OpenStandardInput()
+    $ms = New-Object System.IO.MemoryStream
+    $stdinStream.CopyTo($ms)
+    $rawBytes = $ms.ToArray()
+    $ms.Dispose()
+
+    # Strip UTF-8 BOM (EF BB BF) before any encoding fixup
+    if ($rawBytes.Length -ge 3 -and $rawBytes[0] -eq 0xEF -and $rawBytes[1] -eq 0xBB -and $rawBytes[2] -eq 0xBF) {
+        $rawBytes = $rawBytes[3..($rawBytes.Length - 1)]
+    }
+
+    # Fix Cursor's UTF-8→GBK double-encoding on Chinese Windows.
+    if ($rawBytes.Length -gt 2) {
+        try {
+            $utf8    = [System.Text.Encoding]::UTF8
+            $gbk     = [System.Text.Encoding]::GetEncoding(936)
+            $garbled = $utf8.GetString($rawBytes)
+            $recovered = $gbk.GetBytes($garbled)
+
+            $strictUtf8 = [System.Text.UTF8Encoding]::new($false, $true)
+            [void]$strictUtf8.GetString($recovered)
+
+            $rawBytes = $recovered
+        } catch {}
+    }
+
+    if ($rawBytes.Length -eq 0) {
+        $result = & $nodeBin $Processor $Subcommand 2>$null
+    } else {
+        $psi = New-Object System.Diagnostics.ProcessStartInfo
+        $psi.FileName = $nodeBin
+        $psi.Arguments = "`"$Processor`" $Subcommand"
+        $psi.UseShellExecute = $false
+        $psi.RedirectStandardInput = $true
+        $psi.RedirectStandardOutput = $true
+        $psi.RedirectStandardError = $false
+        $psi.CreateNoWindow = $true
+
+        $proc = [System.Diagnostics.Process]::Start($psi)
+        $proc.StandardInput.BaseStream.Write($rawBytes, 0, $rawBytes.Length)
+        $proc.StandardInput.Close()
+        $result = $proc.StandardOutput.ReadToEnd()
+        $proc.WaitForExit()
+    }
+    if ($result) { Write-Output $result } else { Write-Output $EMPTY_RESULT }
+} catch {
+    Write-Error "[claude-code-hook] processor failed (subcommand=$Subcommand)"
+    Log-Error "processor_failed" "hook processor exited non-zero (subcommand=$Subcommand)"
+    Write-Output $EMPTY_RESULT
+}
+
+exit 0

--- a/assets/hooks/codex-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/codex-loongsuite-pilot-hook.ps1
@@ -1,0 +1,145 @@
+# Codex hook entrypoint (Windows) — delegates to codex-hook-processor.mjs.
+#
+# Usage (registered in ~/.codex/hooks.json by pilot HookStrategy):
+#   powershell -File $PILOT_DATA/hooks/codex-loongsuite-pilot-hook.ps1 <subcommand>
+#
+# Fail-open: any error outputs "{}" and exits 0.
+
+$ErrorActionPreference = "Continue"
+$EMPTY_RESULT = '{}'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Processor = Join-Path $ScriptDir "codex-hook-processor.mjs"
+$Subcommand = if ($args.Count -gt 0) { $args[0] } else { "unknown" }
+
+function Log-Error {
+    param([string]$Stage, [string]$Message)
+    try {
+        $dataDir = if ($env:LOONGSUITE_PILOT_DATA_DIR) { $env:LOONGSUITE_PILOT_DATA_DIR }
+                   else { Join-Path $env:USERPROFILE ".loongsuite-pilot" }
+        $day = (Get-Date -Format "yyyy-MM-dd")
+        $dir = Join-Path $dataDir "logs\codex\errors"
+        if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+        $file = Join-Path $dir "codex-error-$day.jsonl"
+        $time = (Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ")
+        $escapedMsg = $Message -replace '\\', '\\\\' -replace '"', '\"'
+        $line = "{`"time`":`"$time`",`"gen_ai.agent.type`":`"codex`",`"stage`":`"$Stage`",`"error.type`":`"ps1_$Stage`",`"error.message`":`"$escapedMsg`"}"
+        Add-Content -Path $file -Value $line
+    } catch {}
+}
+
+if (-not [Console]::IsInputRedirected) {
+    Write-Output $EMPTY_RESULT
+    exit 0
+}
+
+if (-not (Test-Path $Processor)) {
+    Write-Error "[codex-hook] processor not found: $Processor"
+    Log-Error "missing_processor" "hook processor not found: $Processor"
+    Write-Output $EMPTY_RESULT
+    exit 0
+}
+
+$MIN_NODE_MAJOR = 18
+
+function Test-NodeSuitable {
+    param([string]$bin)
+    if (-not (Test-Path $bin)) { return $false }
+    try {
+        $ver = & $bin --version 2>$null
+        if (-not $ver) { return $false }
+        $major = [int]($ver -replace '^v','').Split('.')[0]
+        return $major -ge $MIN_NODE_MAJOR
+    } catch { return $false }
+}
+
+function Resolve-NodeBin {
+    $pinFile = Join-Path $env:USERPROFILE ".loongsuite-pilot\node-bin"
+    if (Test-Path $pinFile) {
+        $pinned = (Get-Content $pinFile -ErrorAction SilentlyContinue).Trim()
+        if ($pinned -and (Test-NodeSuitable $pinned)) { return $pinned }
+    }
+    $candidates = @()
+    $nvmHome = $env:NVM_HOME
+    if ($nvmHome -and (Test-Path $nvmHome)) {
+        $nvmDirs = Get-ChildItem $nvmHome -Directory -ErrorAction SilentlyContinue | Sort-Object Name -Descending
+        foreach ($d in $nvmDirs) { $candidates += Join-Path $d.FullName "node.exe" }
+    }
+    $fnmDir = Join-Path $env:USERPROFILE ".fnm\node-versions"
+    if (Test-Path $fnmDir) {
+        $fnmDirs = Get-ChildItem $fnmDir -Directory -ErrorAction SilentlyContinue | Sort-Object Name -Descending
+        foreach ($d in $fnmDirs) { $candidates += Join-Path $d.FullName "installation\node.exe" }
+    }
+    $candidates += Join-Path $env:USERPROFILE ".volta\bin\node.exe"
+    $candidates += "C:\Program Files\nodejs\node.exe"
+    $candidates += "C:\Program Files (x86)\nodejs\node.exe"
+    $pathNode = Get-Command node -ErrorAction SilentlyContinue
+    if ($pathNode) { $candidates += $pathNode.Source }
+    foreach ($c in $candidates) {
+        if (Test-NodeSuitable $c) { return $c }
+    }
+    return $null
+}
+
+$nodeBin = Resolve-NodeBin
+if (-not $nodeBin) {
+    Write-Error "[codex-hook] node >= $MIN_NODE_MAJOR not found"
+    Log-Error "missing_node" "node >= $MIN_NODE_MAJOR not found"
+    Write-Output $EMPTY_RESULT
+    exit 0
+}
+
+try {
+    # Read stdin as raw bytes to avoid PowerShell encoding issues (GB2312/ASCII mangles UTF-8)
+    $stdinStream = [Console]::OpenStandardInput()
+    $ms = New-Object System.IO.MemoryStream
+    $stdinStream.CopyTo($ms)
+    $rawBytes = $ms.ToArray()
+    $ms.Dispose()
+
+    # Strip UTF-8 BOM (EF BB BF) before any encoding fixup
+    if ($rawBytes.Length -ge 3 -and $rawBytes[0] -eq 0xEF -and $rawBytes[1] -eq 0xBB -and $rawBytes[2] -eq 0xBF) {
+        $rawBytes = $rawBytes[3..($rawBytes.Length - 1)]
+    }
+
+    # Fix Cursor's UTF-8→GBK double-encoding on Chinese Windows.
+    if ($rawBytes.Length -gt 2) {
+        try {
+            $utf8    = [System.Text.Encoding]::UTF8
+            $gbk     = [System.Text.Encoding]::GetEncoding(936)
+            $garbled = $utf8.GetString($rawBytes)
+            $recovered = $gbk.GetBytes($garbled)
+
+            $strictUtf8 = [System.Text.UTF8Encoding]::new($false, $true)
+            [void]$strictUtf8.GetString($recovered)
+
+            $rawBytes = $recovered
+        } catch {}
+    }
+
+    if ($rawBytes.Length -eq 0) {
+        $result = & $nodeBin $Processor $Subcommand 2>$null
+    } else {
+        $psi = New-Object System.Diagnostics.ProcessStartInfo
+        $psi.FileName = $nodeBin
+        $psi.Arguments = "`"$Processor`" $Subcommand"
+        $psi.UseShellExecute = $false
+        $psi.RedirectStandardInput = $true
+        $psi.RedirectStandardOutput = $true
+        $psi.RedirectStandardError = $false
+        $psi.CreateNoWindow = $true
+
+        $proc = [System.Diagnostics.Process]::Start($psi)
+        $proc.StandardInput.BaseStream.Write($rawBytes, 0, $rawBytes.Length)
+        $proc.StandardInput.Close()
+        $result = $proc.StandardOutput.ReadToEnd()
+        $proc.WaitForExit()
+    }
+    if ($result) { Write-Output $result } else { Write-Output $EMPTY_RESULT }
+} catch {
+    Write-Error "[codex-hook] processor failed (subcommand=$Subcommand)"
+    Log-Error "processor_failed" "hook processor exited non-zero (subcommand=$Subcommand)"
+    Write-Output $EMPTY_RESULT
+}
+
+exit 0

--- a/assets/hooks/cursor-hook-processor.mjs
+++ b/assets/hooks/cursor-hook-processor.mjs
@@ -62,7 +62,9 @@ async function readStdin() {
   for await (const chunk of process.stdin) {
     chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
   }
-  return Buffer.concat(chunks).toString('utf-8');
+  let str = Buffer.concat(chunks).toString('utf-8');
+  if (str.charCodeAt(0) === 0xFEFF) str = str.slice(1);
+  return str;
 }
 
 async function appendJsonl(filePath, record) {
@@ -92,16 +94,30 @@ async function main() {
   let payload;
   try {
     payload = JSON.parse(raw);
-  } catch (err) {
-    await appendErrorJsonl(dataDir, now, {
-      stage: 'parse',
-      'error.type': 'invalid_json',
-      'error.message': err instanceof Error ? err.message : String(err),
-      input_bytes: Buffer.byteLength(raw),
-      input_sha256: hashJson(raw),
-    });
-    writeEmptyResponse();
-    return;
+  } catch (firstErr) {
+    // Cursor on Windows may replace 0x22 (") with 0x3F (?) in JSON events
+    // containing Chinese text, corrupting the closing quote of string values.
+    if (process.platform === 'win32') {
+      const repaired = raw.replace(/\?,"/g, '","').replace(/\?}/g, '"}');
+      if (repaired !== raw) {
+        try {
+          payload = JSON.parse(repaired);
+        } catch {
+          // repair didn't help
+        }
+      }
+    }
+    if (!payload) {
+      await appendErrorJsonl(dataDir, now, {
+        stage: 'parse',
+        'error.type': 'invalid_json',
+        'error.message': firstErr instanceof Error ? firstErr.message : String(firstErr),
+        input_bytes: Buffer.byteLength(raw),
+        input_sha256: hashJson(raw),
+      });
+      writeEmptyResponse();
+      return;
+    }
   }
 
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {

--- a/assets/hooks/cursor-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/cursor-loongsuite-pilot-hook.ps1
@@ -1,0 +1,149 @@
+# Cursor hook entrypoint (Windows) — delegates to cursor-hook-processor.mjs.
+#
+# Fail-open: any error outputs "{}" and exits 0.
+
+$ErrorActionPreference = "Continue"
+$EMPTY_RESULT = '{}'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Processor = Join-Path $ScriptDir "cursor-hook-processor.mjs"
+
+function Log-Error {
+    param([string]$Stage, [string]$Message)
+    try {
+        $dataDir = if ($env:LOONGSUITE_PILOT_DATA_DIR) { $env:LOONGSUITE_PILOT_DATA_DIR }
+                   else { Join-Path $env:USERPROFILE ".loongsuite-pilot" }
+        $day = (Get-Date -Format "yyyy-MM-dd")
+        $dir = Join-Path $dataDir "logs\cursor\errors"
+        if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+        $file = Join-Path $dir "cursor-error-$day.jsonl"
+        $time = (Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ")
+        $escapedMsg = $Message -replace '\\', '\\\\' -replace '"', '\"'
+        $line = "{`"time`":`"$time`",`"clientType`":`"CursorHook`",`"stage`":`"$Stage`",`"error.type`":`"ps1_$Stage`",`"error.message`":`"$escapedMsg`"}"
+        Add-Content -Path $file -Value $line
+    } catch {}
+}
+
+if (-not [Console]::IsInputRedirected) {
+    Write-Output $EMPTY_RESULT
+    exit 0
+}
+
+if (-not (Test-Path $Processor)) {
+    Write-Error "[loongsuite-pilot] hook processor not found: $Processor"
+    Log-Error "missing_processor" "hook processor not found: $Processor"
+    Write-Output $EMPTY_RESULT
+    exit 0
+}
+
+$MIN_NODE_MAJOR = 18
+
+function Test-NodeSuitable {
+    param([string]$bin)
+    if (-not (Test-Path $bin)) { return $false }
+    try {
+        $ver = & $bin --version 2>$null
+        if (-not $ver) { return $false }
+        $major = [int]($ver -replace '^v','').Split('.')[0]
+        return $major -ge $MIN_NODE_MAJOR
+    } catch { return $false }
+}
+
+function Resolve-NodeBin {
+    $pinFile = Join-Path $env:USERPROFILE ".loongsuite-pilot\node-bin"
+    if (Test-Path $pinFile) {
+        $pinned = (Get-Content $pinFile -ErrorAction SilentlyContinue).Trim()
+        if ($pinned -and (Test-NodeSuitable $pinned)) { return $pinned }
+    }
+    $candidates = @()
+    $nvmHome = $env:NVM_HOME
+    if ($nvmHome -and (Test-Path $nvmHome)) {
+        $nvmDirs = Get-ChildItem $nvmHome -Directory -ErrorAction SilentlyContinue | Sort-Object Name -Descending
+        foreach ($d in $nvmDirs) { $candidates += Join-Path $d.FullName "node.exe" }
+    }
+    $fnmDir = Join-Path $env:USERPROFILE ".fnm\node-versions"
+    if (Test-Path $fnmDir) {
+        $fnmDirs = Get-ChildItem $fnmDir -Directory -ErrorAction SilentlyContinue | Sort-Object Name -Descending
+        foreach ($d in $fnmDirs) { $candidates += Join-Path $d.FullName "installation\node.exe" }
+    }
+    $candidates += Join-Path $env:USERPROFILE ".volta\bin\node.exe"
+    $candidates += "C:\Program Files\nodejs\node.exe"
+    $candidates += "C:\Program Files (x86)\nodejs\node.exe"
+    $pathNode = Get-Command node -ErrorAction SilentlyContinue
+    if ($pathNode) { $candidates += $pathNode.Source }
+    foreach ($c in $candidates) {
+        if (Test-NodeSuitable $c) { return $c }
+    }
+    return $null
+}
+
+$nodeBin = Resolve-NodeBin
+if (-not $nodeBin) {
+    Write-Error "[loongsuite-pilot] node >= $MIN_NODE_MAJOR not found"
+    Log-Error "missing_node" "node >= $MIN_NODE_MAJOR not found"
+    Write-Output $EMPTY_RESULT
+    exit 0
+}
+
+try {
+    # Read stdin as raw bytes to avoid PowerShell encoding issues (GB2312/ASCII mangles UTF-8)
+    $stdinStream = [Console]::OpenStandardInput()
+    $ms = New-Object System.IO.MemoryStream
+    $stdinStream.CopyTo($ms)
+    $rawBytes = $ms.ToArray()
+    $ms.Dispose()
+
+    # Strip UTF-8 BOM (EF BB BF) before any encoding fixup
+    if ($rawBytes.Length -ge 3 -and $rawBytes[0] -eq 0xEF -and $rawBytes[1] -eq 0xBB -and $rawBytes[2] -eq 0xBF) {
+        $rawBytes = $rawBytes[3..($rawBytes.Length - 1)]
+    }
+
+    # Fix Cursor's UTF-8→GBK double-encoding on Chinese Windows.
+    # Cursor encodes hook payloads through the system codepage (GBK/CP936), garbling
+    # all non-ASCII text.  Reversal: decode the garbled bytes as UTF-8, encode the
+    # resulting string as GBK — this recovers the ORIGINAL UTF-8 bytes.  We validate
+    # by checking that the recovered bytes are valid UTF-8; if not, keep the originals.
+    if ($rawBytes.Length -gt 2) {
+        try {
+            $utf8    = [System.Text.Encoding]::UTF8
+            $gbk     = [System.Text.Encoding]::GetEncoding(936)
+            $garbled = $utf8.GetString($rawBytes)
+            $recovered = $gbk.GetBytes($garbled)
+
+            # Validate: recovered bytes must be valid UTF-8 (strict decoder throws on invalid sequences)
+            $strictUtf8 = [System.Text.UTF8Encoding]::new($false, $true)  # throwOnInvalidBytes = true
+            [void]$strictUtf8.GetString($recovered)
+
+            # Passed validation — use recovered bytes
+            $rawBytes = $recovered
+        } catch {
+            # Validation failed — original bytes are already correct UTF-8, keep them
+        }
+    }
+
+    if ($rawBytes.Length -eq 0) {
+        $result = & $nodeBin $Processor 2>$null
+    } else {
+        $psi = New-Object System.Diagnostics.ProcessStartInfo
+        $psi.FileName = $nodeBin
+        $psi.Arguments = "`"$Processor`""
+        $psi.UseShellExecute = $false
+        $psi.RedirectStandardInput = $true
+        $psi.RedirectStandardOutput = $true
+        $psi.RedirectStandardError = $false
+        $psi.CreateNoWindow = $true
+
+        $proc = [System.Diagnostics.Process]::Start($psi)
+        $proc.StandardInput.BaseStream.Write($rawBytes, 0, $rawBytes.Length)
+        $proc.StandardInput.Close()
+        $result = $proc.StandardOutput.ReadToEnd()
+        $proc.WaitForExit()
+    }
+    if ($result) { Write-Output $result } else { Write-Output $EMPTY_RESULT }
+} catch {
+    Write-Error "[loongsuite-pilot] hook processor failed"
+    Log-Error "processor_failed" "hook processor exited with non-zero status"
+    Write-Output $EMPTY_RESULT
+}
+
+exit 0

--- a/assets/hooks/qoder-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/qoder-loongsuite-pilot-hook.ps1
@@ -1,0 +1,114 @@
+# Qoder hook entrypoint (Windows) — delegates to qoder-hook-processor.mjs.
+# Usage: powershell -File qoder-loongsuite-pilot-hook.ps1 [agent-id]
+
+$ErrorActionPreference = "Continue"
+$AgentId = if ($args.Count -gt 0) { $args[0] } else { "qoder" }
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Processor = Join-Path $ScriptDir "qoder-hook-processor.mjs"
+
+if (-not [Console]::IsInputRedirected) { exit 0 }
+if (-not (Test-Path $Processor)) { exit 0 }
+
+$MIN_NODE_MAJOR = 18
+
+function Test-NodeSuitable {
+    param([string]$bin)
+    if (-not (Test-Path $bin)) { return $false }
+    try {
+        $ver = & $bin --version 2>$null
+        if (-not $ver) { return $false }
+        $major = [int]($ver -replace '^v','').Split('.')[0]
+        return $major -ge $MIN_NODE_MAJOR
+    } catch { return $false }
+}
+
+function Resolve-NodeBin {
+    $pinFile = Join-Path $env:USERPROFILE ".loongsuite-pilot\node-bin"
+    if (Test-Path $pinFile) {
+        $pinned = (Get-Content $pinFile -ErrorAction SilentlyContinue).Trim()
+        if ($pinned -and (Test-NodeSuitable $pinned)) { return $pinned }
+    }
+    $candidates = @()
+    $nvmHome = $env:NVM_HOME
+    if ($nvmHome -and (Test-Path $nvmHome)) {
+        $nvmDirs = Get-ChildItem $nvmHome -Directory -ErrorAction SilentlyContinue | Sort-Object Name -Descending
+        foreach ($d in $nvmDirs) { $candidates += Join-Path $d.FullName "node.exe" }
+    }
+    $fnmDir = Join-Path $env:USERPROFILE ".fnm\node-versions"
+    if (Test-Path $fnmDir) {
+        $fnmDirs = Get-ChildItem $fnmDir -Directory -ErrorAction SilentlyContinue | Sort-Object Name -Descending
+        foreach ($d in $fnmDirs) { $candidates += Join-Path $d.FullName "installation\node.exe" }
+    }
+    $candidates += Join-Path $env:USERPROFILE ".volta\bin\node.exe"
+    $candidates += "C:\Program Files\nodejs\node.exe"
+    $candidates += "C:\Program Files (x86)\nodejs\node.exe"
+    $pathNode = Get-Command node -ErrorAction SilentlyContinue
+    if ($pathNode) { $candidates += $pathNode.Source }
+    foreach ($c in $candidates) {
+        if (Test-NodeSuitable $c) { return $c }
+    }
+    return $null
+}
+
+$nodeBin = Resolve-NodeBin
+if (-not $nodeBin) {
+    Write-Error "[loongsuite-pilot] node >= $MIN_NODE_MAJOR not found"
+    exit 0
+}
+
+try {
+    # Read stdin as raw bytes to avoid PowerShell encoding issues (GB2312/ASCII mangles UTF-8)
+    $stdinStream = [Console]::OpenStandardInput()
+    $ms = New-Object System.IO.MemoryStream
+    $stdinStream.CopyTo($ms)
+    $rawBytes = $ms.ToArray()
+    $ms.Dispose()
+
+    # Strip UTF-8 BOM (EF BB BF) before any encoding fixup
+    if ($rawBytes.Length -ge 3 -and $rawBytes[0] -eq 0xEF -and $rawBytes[1] -eq 0xBB -and $rawBytes[2] -eq 0xBF) {
+        $rawBytes = $rawBytes[3..($rawBytes.Length - 1)]
+    }
+
+    # Fix Cursor's UTF-8→GBK double-encoding on Chinese Windows.
+    # Cursor encodes hook payloads through the system codepage (GBK/CP936), garbling
+    # all non-ASCII text.  Reversal: decode the garbled bytes as UTF-8, encode the
+    # resulting string as GBK — this recovers the ORIGINAL UTF-8 bytes.  We validate
+    # by checking that the recovered bytes are valid UTF-8; if not, keep the originals.
+    if ($rawBytes.Length -gt 2) {
+        try {
+            $utf8    = [System.Text.Encoding]::UTF8
+            $gbk     = [System.Text.Encoding]::GetEncoding(936)
+            $garbled = $utf8.GetString($rawBytes)
+            $recovered = $gbk.GetBytes($garbled)
+
+            $strictUtf8 = [System.Text.UTF8Encoding]::new($false, $true)
+            [void]$strictUtf8.GetString($recovered)
+
+            $rawBytes = $recovered
+        } catch {
+            # Validation failed — original bytes are already correct UTF-8, keep them
+        }
+    }
+
+    if ($rawBytes.Length -eq 0) {
+        & $nodeBin $Processor --agent-id $AgentId 2>$null
+    } else {
+        $psi = New-Object System.Diagnostics.ProcessStartInfo
+        $psi.FileName = $nodeBin
+        $psi.Arguments = "`"$Processor`" --agent-id $AgentId"
+        $psi.UseShellExecute = $false
+        $psi.RedirectStandardInput = $true
+        $psi.RedirectStandardOutput = $true
+        $psi.RedirectStandardError = $false
+        $psi.CreateNoWindow = $true
+
+        $proc = [System.Diagnostics.Process]::Start($psi)
+        $proc.StandardInput.BaseStream.Write($rawBytes, 0, $rawBytes.Length)
+        $proc.StandardInput.Close()
+        $null = $proc.StandardOutput.ReadToEnd()
+        $proc.WaitForExit()
+    }
+} catch {}
+
+exit 0

--- a/assets/hooks/qodercn-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/qodercn-loongsuite-pilot-hook.ps1
@@ -1,0 +1,108 @@
+# QoderCN hook entrypoint (Windows) — delegates to qoder-hook-processor.mjs.
+# Usage: powershell -File qodercn-loongsuite-pilot-hook.ps1 [agent-id]
+
+$ErrorActionPreference = "Continue"
+$AgentId = if ($args.Count -gt 0) { $args[0] } else { "qoder-cn" }
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Processor = Join-Path $ScriptDir "qoder-hook-processor.mjs"
+
+if (-not [Console]::IsInputRedirected) { exit 0 }
+if (-not (Test-Path $Processor)) { exit 0 }
+
+$MIN_NODE_MAJOR = 18
+
+function Test-NodeSuitable {
+    param([string]$bin)
+    if (-not (Test-Path $bin)) { return $false }
+    try {
+        $ver = & $bin --version 2>$null
+        if (-not $ver) { return $false }
+        $major = [int]($ver -replace '^v','').Split('.')[0]
+        return $major -ge $MIN_NODE_MAJOR
+    } catch { return $false }
+}
+
+function Resolve-NodeBin {
+    $pinFile = Join-Path $env:USERPROFILE ".loongsuite-pilot\node-bin"
+    if (Test-Path $pinFile) {
+        $pinned = (Get-Content $pinFile -ErrorAction SilentlyContinue).Trim()
+        if ($pinned -and (Test-NodeSuitable $pinned)) { return $pinned }
+    }
+    $candidates = @()
+    $nvmHome = $env:NVM_HOME
+    if ($nvmHome -and (Test-Path $nvmHome)) {
+        $nvmDirs = Get-ChildItem $nvmHome -Directory -ErrorAction SilentlyContinue | Sort-Object Name -Descending
+        foreach ($d in $nvmDirs) { $candidates += Join-Path $d.FullName "node.exe" }
+    }
+    $fnmDir = Join-Path $env:USERPROFILE ".fnm\node-versions"
+    if (Test-Path $fnmDir) {
+        $fnmDirs = Get-ChildItem $fnmDir -Directory -ErrorAction SilentlyContinue | Sort-Object Name -Descending
+        foreach ($d in $fnmDirs) { $candidates += Join-Path $d.FullName "installation\node.exe" }
+    }
+    $candidates += Join-Path $env:USERPROFILE ".volta\bin\node.exe"
+    $candidates += "C:\Program Files\nodejs\node.exe"
+    $candidates += "C:\Program Files (x86)\nodejs\node.exe"
+    $pathNode = Get-Command node -ErrorAction SilentlyContinue
+    if ($pathNode) { $candidates += $pathNode.Source }
+    foreach ($c in $candidates) {
+        if (Test-NodeSuitable $c) { return $c }
+    }
+    return $null
+}
+
+$nodeBin = Resolve-NodeBin
+if (-not $nodeBin) {
+    Write-Error "[loongsuite-pilot] node >= $MIN_NODE_MAJOR not found"
+    exit 0
+}
+
+try {
+    # Read stdin as raw bytes to avoid PowerShell encoding issues (GB2312/ASCII mangles UTF-8)
+    $stdinStream = [Console]::OpenStandardInput()
+    $ms = New-Object System.IO.MemoryStream
+    $stdinStream.CopyTo($ms)
+    $rawBytes = $ms.ToArray()
+    $ms.Dispose()
+
+    # Strip UTF-8 BOM (EF BB BF) before any encoding fixup
+    if ($rawBytes.Length -ge 3 -and $rawBytes[0] -eq 0xEF -and $rawBytes[1] -eq 0xBB -and $rawBytes[2] -eq 0xBF) {
+        $rawBytes = $rawBytes[3..($rawBytes.Length - 1)]
+    }
+
+    # Fix Cursor's UTF-8→GBK double-encoding on Chinese Windows.
+    if ($rawBytes.Length -gt 2) {
+        try {
+            $utf8    = [System.Text.Encoding]::UTF8
+            $gbk     = [System.Text.Encoding]::GetEncoding(936)
+            $garbled = $utf8.GetString($rawBytes)
+            $recovered = $gbk.GetBytes($garbled)
+
+            $strictUtf8 = [System.Text.UTF8Encoding]::new($false, $true)
+            [void]$strictUtf8.GetString($recovered)
+
+            $rawBytes = $recovered
+        } catch {}
+    }
+
+    if ($rawBytes.Length -eq 0) {
+        & $nodeBin $Processor --agent-id $AgentId 2>$null
+    } else {
+        $psi = New-Object System.Diagnostics.ProcessStartInfo
+        $psi.FileName = $nodeBin
+        $psi.Arguments = "`"$Processor`" --agent-id $AgentId"
+        $psi.UseShellExecute = $false
+        $psi.RedirectStandardInput = $true
+        $psi.RedirectStandardOutput = $true
+        $psi.RedirectStandardError = $false
+        $psi.CreateNoWindow = $true
+
+        $proc = [System.Diagnostics.Process]::Start($psi)
+        $proc.StandardInput.BaseStream.Write($rawBytes, 0, $rawBytes.Length)
+        $proc.StandardInput.Close()
+        $null = $proc.StandardOutput.ReadToEnd()
+        $proc.WaitForExit()
+    }
+} catch {}
+
+exit 0

--- a/assets/hooks/qoderwork-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/qoderwork-loongsuite-pilot-hook.ps1
@@ -1,0 +1,108 @@
+# Qoder Work hook entrypoint (Windows) — delegates to qoderwork-hook-processor.mjs.
+# Usage: powershell -File qoderwork-loongsuite-pilot-hook.ps1
+
+$ErrorActionPreference = "Continue"
+$AgentId = if ($args.Count -gt 0) { $args[0] } else { "qoder-work" }
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Processor = Join-Path $ScriptDir "qoderwork-hook-processor.mjs"
+
+if (-not [Console]::IsInputRedirected) { exit 0 }
+if (-not (Test-Path $Processor)) { exit 0 }
+
+$MIN_NODE_MAJOR = 18
+
+function Test-NodeSuitable {
+    param([string]$bin)
+    if (-not (Test-Path $bin)) { return $false }
+    try {
+        $ver = & $bin --version 2>$null
+        if (-not $ver) { return $false }
+        $major = [int]($ver -replace '^v','').Split('.')[0]
+        return $major -ge $MIN_NODE_MAJOR
+    } catch { return $false }
+}
+
+function Resolve-NodeBin {
+    $pinFile = Join-Path $env:USERPROFILE ".loongsuite-pilot\node-bin"
+    if (Test-Path $pinFile) {
+        $pinned = (Get-Content $pinFile -ErrorAction SilentlyContinue).Trim()
+        if ($pinned -and (Test-NodeSuitable $pinned)) { return $pinned }
+    }
+    $candidates = @()
+    $nvmHome = $env:NVM_HOME
+    if ($nvmHome -and (Test-Path $nvmHome)) {
+        $nvmDirs = Get-ChildItem $nvmHome -Directory -ErrorAction SilentlyContinue | Sort-Object Name -Descending
+        foreach ($d in $nvmDirs) { $candidates += Join-Path $d.FullName "node.exe" }
+    }
+    $fnmDir = Join-Path $env:USERPROFILE ".fnm\node-versions"
+    if (Test-Path $fnmDir) {
+        $fnmDirs = Get-ChildItem $fnmDir -Directory -ErrorAction SilentlyContinue | Sort-Object Name -Descending
+        foreach ($d in $fnmDirs) { $candidates += Join-Path $d.FullName "installation\node.exe" }
+    }
+    $candidates += Join-Path $env:USERPROFILE ".volta\bin\node.exe"
+    $candidates += "C:\Program Files\nodejs\node.exe"
+    $candidates += "C:\Program Files (x86)\nodejs\node.exe"
+    $pathNode = Get-Command node -ErrorAction SilentlyContinue
+    if ($pathNode) { $candidates += $pathNode.Source }
+    foreach ($c in $candidates) {
+        if (Test-NodeSuitable $c) { return $c }
+    }
+    return $null
+}
+
+$nodeBin = Resolve-NodeBin
+if (-not $nodeBin) {
+    Write-Error "[loongsuite-pilot] node >= $MIN_NODE_MAJOR not found"
+    exit 0
+}
+
+try {
+    # Read stdin as raw bytes to avoid PowerShell encoding issues (GB2312/ASCII mangles UTF-8)
+    $stdinStream = [Console]::OpenStandardInput()
+    $ms = New-Object System.IO.MemoryStream
+    $stdinStream.CopyTo($ms)
+    $rawBytes = $ms.ToArray()
+    $ms.Dispose()
+
+    # Strip UTF-8 BOM (EF BB BF) before any encoding fixup
+    if ($rawBytes.Length -ge 3 -and $rawBytes[0] -eq 0xEF -and $rawBytes[1] -eq 0xBB -and $rawBytes[2] -eq 0xBF) {
+        $rawBytes = $rawBytes[3..($rawBytes.Length - 1)]
+    }
+
+    # Fix Cursor's UTF-8→GBK double-encoding on Chinese Windows.
+    if ($rawBytes.Length -gt 2) {
+        try {
+            $utf8    = [System.Text.Encoding]::UTF8
+            $gbk     = [System.Text.Encoding]::GetEncoding(936)
+            $garbled = $utf8.GetString($rawBytes)
+            $recovered = $gbk.GetBytes($garbled)
+
+            $strictUtf8 = [System.Text.UTF8Encoding]::new($false, $true)
+            [void]$strictUtf8.GetString($recovered)
+
+            $rawBytes = $recovered
+        } catch {}
+    }
+
+    if ($rawBytes.Length -eq 0) {
+        & $nodeBin $Processor --agent-id $AgentId 2>$null
+    } else {
+        $psi = New-Object System.Diagnostics.ProcessStartInfo
+        $psi.FileName = $nodeBin
+        $psi.Arguments = "`"$Processor`" --agent-id $AgentId"
+        $psi.UseShellExecute = $false
+        $psi.RedirectStandardInput = $true
+        $psi.RedirectStandardOutput = $true
+        $psi.RedirectStandardError = $false
+        $psi.CreateNoWindow = $true
+
+        $proc = [System.Diagnostics.Process]::Start($psi)
+        $proc.StandardInput.BaseStream.Write($rawBytes, 0, $rawBytes.Length)
+        $proc.StandardInput.Close()
+        $null = $proc.StandardOutput.ReadToEnd()
+        $proc.WaitForExit()
+    }
+} catch {}
+
+exit 0

--- a/assets/hooks/qoderworkcn-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/qoderworkcn-loongsuite-pilot-hook.ps1
@@ -1,0 +1,108 @@
+# Qoder Work CN hook entrypoint (Windows) — delegates to qoderwork-hook-processor.mjs.
+# Usage: powershell -File qoderworkcn-loongsuite-pilot-hook.ps1
+
+$ErrorActionPreference = "Continue"
+$AgentId = if ($args.Count -gt 0) { $args[0] } else { "qoder-work-cn" }
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Processor = Join-Path $ScriptDir "qoderwork-hook-processor.mjs"
+
+if (-not [Console]::IsInputRedirected) { exit 0 }
+if (-not (Test-Path $Processor)) { exit 0 }
+
+$MIN_NODE_MAJOR = 18
+
+function Test-NodeSuitable {
+    param([string]$bin)
+    if (-not (Test-Path $bin)) { return $false }
+    try {
+        $ver = & $bin --version 2>$null
+        if (-not $ver) { return $false }
+        $major = [int]($ver -replace '^v','').Split('.')[0]
+        return $major -ge $MIN_NODE_MAJOR
+    } catch { return $false }
+}
+
+function Resolve-NodeBin {
+    $pinFile = Join-Path $env:USERPROFILE ".loongsuite-pilot\node-bin"
+    if (Test-Path $pinFile) {
+        $pinned = (Get-Content $pinFile -ErrorAction SilentlyContinue).Trim()
+        if ($pinned -and (Test-NodeSuitable $pinned)) { return $pinned }
+    }
+    $candidates = @()
+    $nvmHome = $env:NVM_HOME
+    if ($nvmHome -and (Test-Path $nvmHome)) {
+        $nvmDirs = Get-ChildItem $nvmHome -Directory -ErrorAction SilentlyContinue | Sort-Object Name -Descending
+        foreach ($d in $nvmDirs) { $candidates += Join-Path $d.FullName "node.exe" }
+    }
+    $fnmDir = Join-Path $env:USERPROFILE ".fnm\node-versions"
+    if (Test-Path $fnmDir) {
+        $fnmDirs = Get-ChildItem $fnmDir -Directory -ErrorAction SilentlyContinue | Sort-Object Name -Descending
+        foreach ($d in $fnmDirs) { $candidates += Join-Path $d.FullName "installation\node.exe" }
+    }
+    $candidates += Join-Path $env:USERPROFILE ".volta\bin\node.exe"
+    $candidates += "C:\Program Files\nodejs\node.exe"
+    $candidates += "C:\Program Files (x86)\nodejs\node.exe"
+    $pathNode = Get-Command node -ErrorAction SilentlyContinue
+    if ($pathNode) { $candidates += $pathNode.Source }
+    foreach ($c in $candidates) {
+        if (Test-NodeSuitable $c) { return $c }
+    }
+    return $null
+}
+
+$nodeBin = Resolve-NodeBin
+if (-not $nodeBin) {
+    Write-Error "[loongsuite-pilot] node >= $MIN_NODE_MAJOR not found"
+    exit 0
+}
+
+try {
+    # Read stdin as raw bytes to avoid PowerShell encoding issues (GB2312/ASCII mangles UTF-8)
+    $stdinStream = [Console]::OpenStandardInput()
+    $ms = New-Object System.IO.MemoryStream
+    $stdinStream.CopyTo($ms)
+    $rawBytes = $ms.ToArray()
+    $ms.Dispose()
+
+    # Strip UTF-8 BOM (EF BB BF) before any encoding fixup
+    if ($rawBytes.Length -ge 3 -and $rawBytes[0] -eq 0xEF -and $rawBytes[1] -eq 0xBB -and $rawBytes[2] -eq 0xBF) {
+        $rawBytes = $rawBytes[3..($rawBytes.Length - 1)]
+    }
+
+    # Fix Cursor's UTF-8→GBK double-encoding on Chinese Windows.
+    if ($rawBytes.Length -gt 2) {
+        try {
+            $utf8    = [System.Text.Encoding]::UTF8
+            $gbk     = [System.Text.Encoding]::GetEncoding(936)
+            $garbled = $utf8.GetString($rawBytes)
+            $recovered = $gbk.GetBytes($garbled)
+
+            $strictUtf8 = [System.Text.UTF8Encoding]::new($false, $true)
+            [void]$strictUtf8.GetString($recovered)
+
+            $rawBytes = $recovered
+        } catch {}
+    }
+
+    if ($rawBytes.Length -eq 0) {
+        & $nodeBin $Processor --agent-id $AgentId 2>$null
+    } else {
+        $psi = New-Object System.Diagnostics.ProcessStartInfo
+        $psi.FileName = $nodeBin
+        $psi.Arguments = "`"$Processor`" --agent-id $AgentId"
+        $psi.UseShellExecute = $false
+        $psi.RedirectStandardInput = $true
+        $psi.RedirectStandardOutput = $true
+        $psi.RedirectStandardError = $false
+        $psi.CreateNoWindow = $true
+
+        $proc = [System.Diagnostics.Process]::Start($psi)
+        $proc.StandardInput.BaseStream.Write($rawBytes, 0, $rawBytes.Length)
+        $proc.StandardInput.Close()
+        $null = $proc.StandardOutput.ReadToEnd()
+        $proc.WaitForExit()
+    }
+} catch {}
+
+exit 0

--- a/assets/hooks/shared/common.ps1
+++ b/assets/hooks/shared/common.ps1
@@ -1,0 +1,125 @@
+# Shared PowerShell utilities for loongsuite-pilot hook scripts.
+# Dot-source from each hook entrypoint:  . (Join-Path $ScriptDir "shared\common.ps1")
+
+$script:MIN_NODE_MAJOR = 18
+
+function Test-NodeSuitable {
+    param([string]$bin)
+    if (-not (Test-Path $bin)) { return $false }
+    try {
+        $ver = & $bin --version 2>$null
+        if (-not $ver) { return $false }
+        $major = [int]($ver -replace '^v','').Split('.')[0]
+        return $major -ge $script:MIN_NODE_MAJOR
+    } catch { return $false }
+}
+
+function Resolve-NodeBin {
+    $pinFile = Join-Path $env:USERPROFILE ".loongsuite-pilot\node-bin"
+    if (Test-Path $pinFile) {
+        $pinned = (Get-Content $pinFile -ErrorAction SilentlyContinue).Trim()
+        if ($pinned -and (Test-NodeSuitable $pinned)) { return $pinned }
+    }
+    $candidates = @()
+    $nvmHome = $env:NVM_HOME
+    if ($nvmHome -and (Test-Path $nvmHome)) {
+        $nvmDirs = Get-ChildItem $nvmHome -Directory -ErrorAction SilentlyContinue | Sort-Object Name -Descending
+        foreach ($d in $nvmDirs) { $candidates += Join-Path $d.FullName "node.exe" }
+    }
+    $fnmDir = Join-Path $env:USERPROFILE ".fnm\node-versions"
+    if (Test-Path $fnmDir) {
+        $fnmDirs = Get-ChildItem $fnmDir -Directory -ErrorAction SilentlyContinue | Sort-Object Name -Descending
+        foreach ($d in $fnmDirs) { $candidates += Join-Path $d.FullName "installation\node.exe" }
+    }
+    $candidates += Join-Path $env:USERPROFILE ".volta\bin\node.exe"
+    $candidates += "C:\Program Files\nodejs\node.exe"
+    $candidates += "C:\Program Files (x86)\nodejs\node.exe"
+    $pathNode = Get-Command node -ErrorAction SilentlyContinue
+    if ($pathNode) { $candidates += $pathNode.Source }
+    foreach ($c in $candidates) {
+        if (Test-NodeSuitable $c) { return $c }
+    }
+    return $null
+}
+
+function Read-StdinRawBytes {
+    $stdinStream = [Console]::OpenStandardInput()
+    $ms = New-Object System.IO.MemoryStream
+    $stdinStream.CopyTo($ms)
+    $rawBytes = $ms.ToArray()
+    $ms.Dispose()
+
+    # Strip UTF-8 BOM (EF BB BF)
+    if ($rawBytes.Length -ge 3 -and $rawBytes[0] -eq 0xEF -and $rawBytes[1] -eq 0xBB -and $rawBytes[2] -eq 0xBF) {
+        $rawBytes = $rawBytes[3..($rawBytes.Length - 1)]
+    }
+
+    # Fix UTF-8->GBK double-encoding on Chinese Windows
+    if ($rawBytes.Length -gt 2) {
+        try {
+            $utf8    = [System.Text.Encoding]::UTF8
+            $gbk     = [System.Text.Encoding]::GetEncoding(936)
+            $garbled = $utf8.GetString($rawBytes)
+            $recovered = $gbk.GetBytes($garbled)
+
+            $strictUtf8 = [System.Text.UTF8Encoding]::new($false, $true)
+            [void]$strictUtf8.GetString($recovered)
+
+            $rawBytes = $recovered
+        } catch {}
+    }
+
+    return ,$rawBytes
+}
+
+function Invoke-NodeProcessor {
+    param(
+        [string]$NodeBin,
+        [string]$ProcessorPath,
+        [string]$ExtraArgs,
+        [byte[]]$StdinBytes
+    )
+    if ($StdinBytes.Length -eq 0) {
+        if ($ExtraArgs) {
+            return & $NodeBin $ProcessorPath $ExtraArgs.Split(' ') 2>$null
+        } else {
+            return & $NodeBin $ProcessorPath 2>$null
+        }
+    }
+
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $NodeBin
+    $psi.Arguments = if ($ExtraArgs) { "`"$ProcessorPath`" $ExtraArgs" } else { "`"$ProcessorPath`"" }
+    $psi.UseShellExecute = $false
+    $psi.RedirectStandardInput = $true
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $false
+    $psi.CreateNoWindow = $true
+
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    $proc.StandardInput.BaseStream.Write($StdinBytes, 0, $StdinBytes.Length)
+    $proc.StandardInput.Close()
+    $result = $proc.StandardOutput.ReadToEnd()
+    $proc.WaitForExit()
+    return $result
+}
+
+function Log-HookError {
+    param(
+        [string]$AgentType,
+        [string]$Stage,
+        [string]$Message
+    )
+    try {
+        $dataDir = if ($env:LOONGSUITE_PILOT_DATA_DIR) { $env:LOONGSUITE_PILOT_DATA_DIR }
+                   else { Join-Path $env:USERPROFILE ".loongsuite-pilot" }
+        $day = (Get-Date -Format "yyyy-MM-dd")
+        $dir = Join-Path $dataDir "logs\$AgentType\errors"
+        if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+        $file = Join-Path $dir "$AgentType-error-$day.jsonl"
+        $time = (Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ")
+        $escapedMsg = $Message -replace '\\', '\\\\' -replace '"', '\"'
+        $line = "{`"time`":`"$time`",`"gen_ai.agent.type`":`"$AgentType`",`"stage`":`"$Stage`",`"error.type`":`"ps1_$Stage`",`"error.message`":`"$escapedMsg`"}"
+        Add-Content -Path $file -Value $line
+    } catch {}
+}

--- a/assets/hooks/shared/hook-processor-base.mjs
+++ b/assets/hooks/shared/hook-processor-base.mjs
@@ -214,7 +214,10 @@ export async function readStdin() {
   for await (const chunk of process.stdin) {
     chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
   }
-  return Buffer.concat(chunks).toString('utf-8');
+  let str = Buffer.concat(chunks).toString('utf-8');
+  // Strip UTF-8 BOM — PowerShell 5.x adds BOM when piping strings to native commands
+  if (str.charCodeAt(0) === 0xFEFF) str = str.slice(1);
+  return str;
 }
 
 export async function parseStdinPayload(agentId) {
@@ -223,16 +226,19 @@ export async function parseStdinPayload(agentId) {
 
   if (!raw || !raw.trim()) return null;
 
+  logDebug(agentId, `stdin payload: ${raw.length} bytes`);
+
   let payload;
   try {
     payload = JSON.parse(raw);
-  } catch {
-    logDebug(agentId, 'Failed to parse stdin JSON');
+  } catch (e) {
+    logDebug(agentId, `Failed to parse stdin JSON: ${e.message}`);
     return null;
   }
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
 
   logDebug(agentId, `event: ${payload.hook_event_name || 'unknown'}, session: ${payload.session_id || ''}`);
+  logDebug(agentId, `payload keys: ${Object.keys(payload).join(', ')}`);
 
   if (payload.stop_hooks_active) {
     logDebug(agentId, 'stop_hooks_active=true, exiting to avoid recursion');

--- a/assets/hooks/shared/stdin-reader.mjs
+++ b/assets/hooks/shared/stdin-reader.mjs
@@ -29,7 +29,8 @@ export function readStdinJson() {
     if (fd !== 0) {
       try { fs.closeSync(fd); } catch {}
     }
-    const raw = Buffer.concat(chunks).toString('utf-8');
+    let raw = Buffer.concat(chunks).toString('utf-8');
+    if (raw.charCodeAt(0) === 0xFEFF) raw = raw.slice(1);
     if (!raw.trim()) return {};
     return JSON.parse(raw);
   } catch {

--- a/assets/hooks/test-hook-event.ps1
+++ b/assets/hooks/test-hook-event.ps1
@@ -1,8 +1,0 @@
-param([string]$EventName = "unknown")
-$ts = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-$stdin = ""
-if ([Console]::IsInputRedirected) {
-    try { $stdin = [Console]::In.ReadToEnd() } catch {}
-}
-$line = "[$ts] $EventName stdin=$($stdin.Substring(0, [Math]::Min($stdin.Length, 500)))"
-Add-Content -Path C:\Users\Administrator\hook-events-test.log -Value $line

--- a/assets/hooks/test-hook-event.ps1
+++ b/assets/hooks/test-hook-event.ps1
@@ -1,0 +1,8 @@
+param([string]$EventName = "unknown")
+$ts = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+$stdin = ""
+if ([Console]::IsInputRedirected) {
+    try { $stdin = [Console]::In.ReadToEnd() } catch {}
+}
+$line = "[$ts] $EventName stdin=$($stdin.Substring(0, [Math]::Min($stdin.Length, 500)))"
+Add-Content -Path C:\Users\Administrator\hook-events-test.log -Value $line

--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -1,0 +1,1193 @@
+﻿# installer-opensource.ps1 — Open-source installer for loongsuite-pilot (Windows)
+#
+# Install (first time):
+#   irm https://loongcollector-community-edition.oss-cn-shanghai.aliyuncs.com/loongsuite-pilot/installer.ps1 | iex
+#   .\installer-opensource.ps1 install `
+#     -SlsEndpoint "https://cn-hangzhou.log.aliyuncs.com" `
+#     -SlsProject "my-project" `
+#     -SlsLogstore "my-logstore" `
+#     -SlsAkId "your-ak-id" `
+#     -SlsAkSecret "your-ak-secret"
+#
+# Install a specific version:
+#   .\installer-opensource.ps1 install -Version 1.2.0
+#
+# Upgrade (preserve config, auto-rollback on failure):
+#   .\installer-opensource.ps1 upgrade
+#
+# Uninstall:
+#   .\installer-opensource.ps1 uninstall
+#   .\installer-opensource.ps1 uninstall -Purge
+
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [ValidateSet("install", "upgrade", "uninstall")]
+    [string]$Command = "install",
+
+    [string]$SlsEndpoint,
+    [string]$SlsProject,
+    [string]$SlsLogstore,
+    [string]$SlsAkId,
+    [string]$SlsAkSecret,
+    [string]$PackageUrl,
+    [string]$DataDir,
+    [string]$LogLevel,
+    [Alias("user.id")]
+    [string]$UserId,
+    [string]$Lang,
+    [string]$Version,
+    [string]$CollectLog,
+    [string]$CollectTrace,
+    [string]$CmsLicenseKey,
+    [string]$CmsEndpoint,
+    [string]$CmsWorkspace,
+    [string]$ServiceNamePrefix,
+    [string]$Agents,
+    [string]$MaskMode,
+    [string]$MaskTypes,
+    [switch]$Purge
+)
+
+$ErrorActionPreference = "Stop"
+
+# ============================================================
+# Constants
+# ============================================================
+$PACKAGE_NAME = "loongsuite-pilot"
+$DEFAULT_DATA_DIR = Join-Path $env:USERPROFILE ".loongsuite-pilot"
+$PERMANENT_DIR = Join-Path $DEFAULT_DATA_DIR "package"
+
+$_OSS_BASE_URL = "https://loongcollector-community-edition.oss-cn-shanghai.aliyuncs.com/loongsuite-pilot"
+
+# ============================================================
+# Defaults
+# ============================================================
+if (-not $DataDir) { $DataDir = $DEFAULT_DATA_DIR }
+if (-not $PackageUrl -and $env:LOONGSUITE_PILOT_PACKAGE_URL) {
+    $PackageUrl = $env:LOONGSUITE_PILOT_PACKAGE_URL
+}
+
+# ============================================================
+# Validate mask options
+# ============================================================
+if ($MaskMode) {
+    if ($MaskMode -notin @("all", "none", "custom")) {
+        Write-Error "Unknown mask mode: $MaskMode (use 'all', 'custom', or 'none')"
+        exit 1
+    }
+}
+if ($MaskMode -eq "custom" -and -not $MaskTypes) {
+    Write-Error "--MaskTypes is required when -MaskMode custom"
+    exit 1
+}
+if ($MaskTypes -and $MaskMode -ne "custom") {
+    Write-Error "-MaskTypes can only be used with -MaskMode custom"
+    exit 1
+}
+
+# ============================================================
+# Resolve package URL
+# ============================================================
+if (-not $PackageUrl) {
+    if ($Version) {
+        $PackageUrl = "$_OSS_BASE_URL/$Version/$PACKAGE_NAME.zip"
+    } else {
+        $PackageUrl = "$_OSS_BASE_URL/latest/$PACKAGE_NAME.zip"
+    }
+}
+
+# ============================================================
+# Language detection
+# ============================================================
+function Detect-Lang {
+    if ($Lang) { return $Lang }
+    if ($env:LOONGSUITE_PILOT_LANG) { return $env:LOONGSUITE_PILOT_LANG }
+    try {
+        $culture = [System.Globalization.CultureInfo]::CurrentUICulture.Name
+        if ($culture -match "zh") { return "zh" }
+    } catch {}
+    return "en"
+}
+
+$LANG_MODE = Detect-Lang
+
+function Msg {
+    param([string]$zh, [string]$en)
+    if ($LANG_MODE -eq "zh") { Write-Host $zh } else { Write-Host $en }
+}
+
+# ============================================================
+# Node.js resolution
+# ============================================================
+function Test-NodeSuitable {
+    param([string]$bin)
+    if (-not (Test-Path $bin)) { return $false }
+    try {
+        $ver = & $bin --version 2>$null
+        if (-not $ver) { return $false }
+        $major = [int]($ver -replace '^v','').Split('.')[0]
+        return $major -ge 18
+    } catch { return $false }
+}
+
+function Resolve-Node {
+    $candidates = @()
+
+    # nvm-windows
+    $nvmHome = $env:NVM_HOME
+    if ($nvmHome -and (Test-Path $nvmHome)) {
+        $nvmDirs = Get-ChildItem $nvmHome -Directory -ErrorAction SilentlyContinue |
+                   Sort-Object Name -Descending
+        foreach ($d in $nvmDirs) {
+            $candidates += Join-Path $d.FullName "node.exe"
+        }
+    }
+
+    # fnm
+    $fnmDir = Join-Path $env:USERPROFILE ".fnm\node-versions"
+    if (Test-Path $fnmDir) {
+        $fnmDirs = Get-ChildItem $fnmDir -Directory -ErrorAction SilentlyContinue |
+                   Sort-Object Name -Descending
+        foreach ($d in $fnmDirs) {
+            $candidates += Join-Path $d.FullName "installation\node.exe"
+        }
+    }
+
+    # Volta
+    $voltaNode = Join-Path $env:USERPROFILE ".volta\bin\node.exe"
+    $candidates += $voltaNode
+
+    # Common install paths
+    $candidates += "C:\Program Files\nodejs\node.exe"
+    $candidates += "C:\Program Files (x86)\nodejs\node.exe"
+
+    # PATH lookup
+    $pathNode = Get-Command node -ErrorAction SilentlyContinue
+    if ($pathNode) { $candidates += $pathNode.Source }
+
+    foreach ($c in $candidates) {
+        if (Test-NodeSuitable $c) {
+            return $c
+        }
+    }
+    return $null
+}
+
+# ============================================================
+# Check dependencies
+# ============================================================
+$script:NODE_BIN = ""
+$script:NPM_BIN = ""
+
+function Check-Deps {
+    Msg "==> 检查依赖..." "==> Checking dependencies..."
+
+    $script:NODE_BIN = Resolve-Node
+    if (-not $script:NODE_BIN) {
+        Msg "❌ 缺少依赖: node，请先安装后重试" "❌ Missing dependency: node — please install it first"
+        exit 1
+    }
+
+    $nodeMajor = & $script:NODE_BIN -e "process.stdout.write(String(process.versions.node.split('.')[0]))"
+    if ([int]$nodeMajor -lt 18) {
+        $nodeVer = & $script:NODE_BIN --version
+        Msg "❌ 需要 Node.js >= 18，当前版本: $nodeVer" "❌ Requires Node.js >= 18, current: $nodeVer"
+        exit 1
+    }
+
+    # Pin node binary path
+    if (-not (Test-Path $DataDir)) { New-Item -ItemType Directory -Path $DataDir -Force | Out-Null }
+    Set-Content -Path (Join-Path $DataDir "node-bin") -Value $script:NODE_BIN
+
+    # Derive npm
+    $npmPath = Join-Path (Split-Path $script:NODE_BIN) "npm.cmd"
+    if (Test-Path $npmPath) {
+        $script:NPM_BIN = $npmPath
+    } else {
+        $npmCmd = Get-Command npm -ErrorAction SilentlyContinue
+        if ($npmCmd) {
+            $script:NPM_BIN = $npmCmd.Source
+        } else {
+            Msg "❌ 缺少依赖: npm，请先安装后重试" "❌ Missing dependency: npm — please install it first"
+            exit 1
+        }
+    }
+
+    $nodeVer = & $script:NODE_BIN --version
+    $npmVer = & $script:NPM_BIN --version
+    Msg "    ✅ node $nodeVer  npm $npmVer" "    ✅ node $nodeVer  npm $npmVer"
+    Msg "    node pinned: $($script:NODE_BIN)" "    node pinned: $($script:NODE_BIN)"
+    Write-Host ""
+}
+
+# ============================================================
+# Download and extract package
+# ============================================================
+$script:INSTALL_SRC = ""
+
+function Download-AndExtract {
+    $tmpDir = Join-Path $env:TEMP "loongsuite-pilot-install-$(Get-Random)"
+    New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
+    $script:TMP_DIR = $tmpDir
+
+    $archivePath = Join-Path $tmpDir "package.zip"
+
+    Msg "==> 下载安装包: $PackageUrl" "==> Downloading: $PackageUrl"
+
+    try {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Invoke-WebRequest -Uri $PackageUrl -OutFile $archivePath -UseBasicParsing
+    } catch {
+        Msg "❌ 下载失败: $_" "❌ Download failed: $_"
+        exit 1
+    }
+    Msg "    ✅ 下载完成" "    ✅ Downloaded"
+    Write-Host ""
+
+    Msg "==> 解压安装包..." "==> Extracting..."
+
+    try {
+        Expand-Archive -Path $archivePath -DestinationPath $tmpDir -Force
+    } catch {
+        Msg "❌ 解压失败: $_" "❌ Extraction failed: $_"
+        exit 1
+    }
+
+    $pkgDir = Join-Path $tmpDir $PACKAGE_NAME
+    if (Test-Path $pkgDir) {
+        $script:INSTALL_SRC = $pkgDir
+    } elseif (Test-Path (Join-Path $tmpDir "package.json")) {
+        $script:INSTALL_SRC = $tmpDir
+    } else {
+        $found = Get-ChildItem $tmpDir -Recurse -Depth 2 -Filter "package.json" -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($found) {
+            $script:INSTALL_SRC = $found.DirectoryName
+        } else {
+            Msg "❌ 解压后未找到 package.json，安装包结构异常" "❌ package.json not found — unexpected package structure"
+            exit 1
+        }
+    }
+    Msg "    ✅ 解压完成" "    ✅ Extracted"
+    Write-Host ""
+}
+
+# ============================================================
+# Agent probe
+# ============================================================
+$script:PROBE_RESULT = "[]"
+
+function Probe-Agents {
+    Msg "==> 探测 AI Agent..." "==> Probing AI Agents..."
+    $probeScript = Join-Path $script:INSTALL_SRC "dist\cli-probe.cjs"
+    if (Test-Path $probeScript) {
+        try {
+            $script:PROBE_RESULT = & $script:NODE_BIN $probeScript 2>$null
+            if (-not $script:PROBE_RESULT) { $script:PROBE_RESULT = "[]" }
+        } catch {
+            Msg "    ⚠️  Agent 探测失败，将跳过选择" "    ⚠️  Agent probe failed, skipping selection"
+            $script:PROBE_RESULT = "[]"
+        }
+    }
+    $count = & $script:NODE_BIN -e "const r=JSON.parse(process.argv[1]);process.stdout.write(String(r.length))" $script:PROBE_RESULT 2>$null
+    if (-not $count) { $count = "0" }
+    Msg "    ✅ 探测到 ${count} 个 Agent 定义" "    ✅ Found ${count} agent definitions"
+    Write-Host ""
+}
+
+# ============================================================
+# Agent selection
+# ============================================================
+$script:SELECTED_AGENTS = $Agents
+
+function Select-Agents {
+    if ($script:SELECTED_AGENTS) {
+        Msg "    使用指定的 Agent: $($script:SELECTED_AGENTS)" "    Using specified agents: $($script:SELECTED_AGENTS)"
+        Write-Host ""
+        return
+    }
+
+    $agentCount = & $script:NODE_BIN -e "const r=JSON.parse(process.argv[1]);process.stdout.write(String(r.length))" $script:PROBE_RESULT 2>$null
+    if (-not $agentCount -or $agentCount -eq "0") { return }
+
+    # Non-interactive detection
+    $isInteractive = [Environment]::UserInteractive -and $Host.UI.RawUI -ne $null
+    if (-not $isInteractive) {
+        $script:SELECTED_AGENTS = & $script:NODE_BIN -e @'
+const r = JSON.parse(process.argv[1]);
+const detected = r.filter(a => a.detected).map(a => a.id);
+process.stdout.write(detected.join(','));
+'@ $script:PROBE_RESULT 2>$null
+        Msg "    (非交互模式) 自动选择已检测到的 Agent: $($script:SELECTED_AGENTS)" `
+            "    (non-interactive) Auto-selected detected agents: $($script:SELECTED_AGENTS)"
+        Write-Host ""
+        return
+    }
+
+    # Interactive menu
+    & $script:NODE_BIN -e @'
+const r = JSON.parse(process.argv[1]);
+const lang = process.argv[2];
+const defaults = [];
+for (let i = 0; i < r.length; i++) {
+  const a = r[i];
+  const status = lang === 'zh'
+    ? (a.detected ? '已检测到: ' + a.reason : '未检测到')
+    : (a.detected ? 'detected: ' + a.reason : 'not detected');
+  console.log('    [' + (i+1) + '] ' + a.displayName.padEnd(16) + '(' + status + ')');
+  if (a.detected) defaults.push(i+1);
+}
+console.log('');
+if (lang === 'zh') {
+  console.log('    默认选择已检测到的 Agent: ' + defaults.join(','));
+  console.log('    输入要启用的编号 (逗号分隔)，直接回车使用默认:');
+} else {
+  console.log('    Default selection (detected): ' + defaults.join(','));
+  console.log('    Enter numbers to enable (comma-separated), press Enter for default:');
+}
+'@ $script:PROBE_RESULT $LANG_MODE
+
+    $selectInput = Read-Host "    >"
+
+    $script:SELECTED_AGENTS = & $script:NODE_BIN -e @'
+const r = JSON.parse(process.argv[1]);
+const input = process.argv[2] || '';
+let indices;
+if (!input.trim()) {
+  indices = r.map((a, i) => a.detected ? i : -1).filter(i => i >= 0);
+} else {
+  indices = [...new Set(input.trim().split(/[\s,]+/).map(Number).filter(n => n >= 1 && n <= r.length))].map(n => n - 1);
+}
+const ids = indices.sort((a,b) => a-b).map(i => r[i].id);
+process.stdout.write(ids.join(','));
+'@ $script:PROBE_RESULT $selectInput 2>$null
+
+    if ($script:SELECTED_AGENTS) {
+        Msg "    已选择: $($script:SELECTED_AGENTS)" "    Selected: $($script:SELECTED_AGENTS)"
+    } else {
+        Msg "    未选择任何 Agent" "    No agents selected"
+    }
+    Write-Host ""
+}
+
+# ============================================================
+# Prompt for userId
+# ============================================================
+function Prompt-UserId {
+    if ($UserId) { return }
+    $isInteractive = [Environment]::UserInteractive -and $Host.UI.RawUI -ne $null
+    if (-not $isInteractive) { return }
+
+    $configFile = Join-Path $DataDir "config.json"
+    $existingUid = ""
+    if (Test-Path $configFile) {
+        try {
+            $existingUid = & $script:NODE_BIN -e @'
+try { const c=JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')); process.stdout.write(c.userId||''); } catch {}
+'@ $configFile 2>$null
+        } catch {}
+    }
+
+    Write-Host ""
+    if ($existingUid) {
+        Msg "    当前 userId: $existingUid" "    Current userId: $existingUid"
+        Msg "    直接回车保留，或输入新值:" "    Press Enter to keep, or type a new value:"
+    } else {
+        Msg "    请输入你的 userId（用于数据归属，可直接回车跳过）:" `
+            "    Enter your userId (for data attribution, press Enter to skip):"
+    }
+    $input = (Read-Host "    >").Trim()
+    if ($input) {
+        $script:UserId = $input
+    } elseif ($existingUid) {
+        $script:UserId = $existingUid
+    }
+}
+
+# ============================================================
+# Confirm config overwrite
+# ============================================================
+function Confirm-ConfigOverwrite {
+    $configFile = Join-Path $DataDir "config.json"
+    if (-not (Test-Path $configFile)) { return }
+
+    $jsonArg = @{
+        slsEndpoint = $SlsEndpoint
+        slsProject = $SlsProject
+        slsLogstore = $SlsLogstore
+        cmsLicenseKey = $CmsLicenseKey
+        cmsEndpoint = $CmsEndpoint
+        cmsWorkspace = $CmsWorkspace
+        serviceNamePrefix = $ServiceNamePrefix
+        maskMode = $MaskMode
+        maskTypes = $MaskTypes
+    } | ConvertTo-Json -Compress
+
+    $diffs = & $script:NODE_BIN -e @'
+const fs = require('fs');
+let old = {};
+try { old = JSON.parse(fs.readFileSync(process.argv[1], 'utf-8')); } catch { process.exit(0); }
+const newVals = JSON.parse(process.argv[2]);
+const normalizeCsv = value => String(value || '').split(',').map(v => v.trim()).filter(Boolean).join(',');
+const checks = [
+  { label: 'sls.endpoint',      oldVal: (old.sls||{}).endpoint||'',      newVal: newVals.slsEndpoint },
+  { label: 'sls.project',       oldVal: (old.sls||{}).project||'',       newVal: newVals.slsProject },
+  { label: 'sls.logstore',      oldVal: (old.sls||{}).logstore||'',      newVal: newVals.slsLogstore },
+  { label: 'cms.licenseKey',    oldVal: (old.cms||{}).licenseKey||'',    newVal: newVals.cmsLicenseKey },
+  { label: 'cms.endpoint',      oldVal: (old.cms||{}).endpoint||'',      newVal: newVals.cmsEndpoint },
+  { label: 'cms.workspace',     oldVal: (old.cms||{}).workspace||'',     newVal: newVals.cmsWorkspace },
+  { label: 'serviceNamePrefix', oldVal: old.serviceNamePrefix||'',       newVal: newVals.serviceNamePrefix },
+  { label: 'mask.mode',         oldVal: (old.mask||{}).mode||'',         newVal: newVals.maskMode },
+  { label: 'mask.types',        oldVal: Array.isArray((old.mask||{}).types) ? normalizeCsv(old.mask.types.join(',')) : '', newVal: normalizeCsv(newVals.maskTypes) },
+];
+const changed = checks.filter(c => c.newVal && c.oldVal && c.newVal !== c.oldVal);
+if (!changed.length) process.exit(0);
+for (const c of changed) { console.log(c.label + ': ' + c.oldVal + ' -> ' + c.newVal); }
+'@ $configFile $jsonArg 2>$null
+
+    if (-not $diffs) { return }
+
+    Write-Host ""
+    Msg "⚠️  以下配置将被覆盖:" "⚠️  The following config will be overwritten:"
+    $diffs | ForEach-Object { Write-Host "    $_" }
+
+    $isInteractive = [Environment]::UserInteractive -and $Host.UI.RawUI -ne $null
+    if ($isInteractive) {
+        Write-Host ""
+        Msg "    确认覆盖? (y/N):" "    Confirm overwrite? (y/N):"
+        $answer = Read-Host "    >"
+        if ($answer -notin @("y", "Y", "yes", "YES")) {
+            Msg "已取消安装" "Installation cancelled"
+            exit 0
+        }
+    } else {
+        Msg "    (非交互模式) 继续覆盖" "    (non-interactive) Proceeding with overwrite"
+    }
+}
+
+# ============================================================
+# Deploy bootstrap scripts
+# ============================================================
+function Deploy-BootstrapScripts {
+    $srcDir = Join-Path $script:PERMANENT_DIR "scripts"
+    $bootDir = Join-Path $env:USERPROFILE ".loongsuite-pilot\bin"
+    if (-not (Test-Path $bootDir)) { New-Item -ItemType Directory -Path $bootDir -Force | Out-Null }
+    Copy-Item (Join-Path $srcDir "collector-daemon.js") $bootDir -Force
+}
+
+# ============================================================
+# Deploy package to versions/ directory
+# ============================================================
+function Deploy-Package {
+    param([string]$src)
+    $cacheDir = Join-Path $env:USERPROFILE ".loongsuite-pilot"
+    $versionsDir = Join-Path $cacheDir "versions"
+    $currentFile = Join-Path $cacheDir "current"
+    $previousFile = Join-Path $cacheDir "previous"
+
+    $ver = ""; $commit = ""
+    $versionFile = Join-Path $src "VERSION"
+    if (Test-Path $versionFile) {
+        $content = Get-Content $versionFile
+        foreach ($line in $content) {
+            if ($line -match "^version=(.+)") { $ver = $Matches[1] }
+            if ($line -match "^git_commit=(.+)") { $commit = $Matches[1] }
+        }
+    }
+
+    if ($ver -and $commit) {
+        $dirName = "${ver}_${commit}"
+        $target = Join-Path $versionsDir $dirName
+
+        if (Test-Path $currentFile) {
+            $oldDir = (Get-Content $currentFile -ErrorAction SilentlyContinue).Trim()
+            if ($oldDir -and $oldDir -ne $dirName) {
+                Set-Content -Path $previousFile -Value $oldDir
+            }
+        }
+
+        Msg "==> 部署到 $target ..." "==> Deploying to $target ..."
+        if (-not (Test-Path $versionsDir)) { New-Item -ItemType Directory -Path $versionsDir -Force | Out-Null }
+        if (Test-Path $target) { Remove-Item $target -Recurse -Force }
+        Copy-Item $src $target -Recurse
+
+        Set-Content -Path $currentFile -Value $dirName
+        $script:PERMANENT_DIR = $target
+    } else {
+        Msg "==> 部署到 $($script:PERMANENT_DIR) ..." "==> Deploying to $($script:PERMANENT_DIR) ..."
+        $parentDir = Split-Path $script:PERMANENT_DIR
+        if (-not (Test-Path $parentDir)) { New-Item -ItemType Directory -Path $parentDir -Force | Out-Null }
+        if (Test-Path $script:PERMANENT_DIR) { Remove-Item $script:PERMANENT_DIR -Recurse -Force }
+        Copy-Item $src $script:PERMANENT_DIR -Recurse
+    }
+    Msg "    ✅ 部署完成" "    ✅ Deployed"
+    Write-Host ""
+
+    Deploy-BootstrapScripts
+
+    Msg "==> 安装依赖..." "==> Installing dependencies..."
+    Push-Location $script:PERMANENT_DIR
+    try {
+        $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
+        & $script:NPM_BIN install --omit=dev --no-optional 2>&1 | Select-Object -Last 1
+        $ErrorActionPreference = $prevEAP
+    } finally {
+        Pop-Location
+    }
+    Msg "    ✅ 依赖安装完成" "    ✅ Dependencies installed"
+    Write-Host ""
+
+    Msg "==> 部署 hook 脚本..." "==> Deploying hook scripts..."
+    $postinstallScript = Join-Path $script:PERMANENT_DIR "scripts\postinstall.js"
+    if (Test-Path $postinstallScript) {
+        & $script:NODE_BIN $postinstallScript
+    }
+    Msg "    ✅ Hook 脚本已部署" "    ✅ Hook scripts deployed"
+    Write-Host ""
+}
+
+# ============================================================
+# Migrate legacy layout
+# ============================================================
+function Migrate-LegacyLayout {
+    $cacheDir = Join-Path $env:USERPROFILE ".loongsuite-pilot"
+    $currentFile = Join-Path $cacheDir "current"
+    $legacyDir = Join-Path $cacheDir "package"
+    $versionsDir = Join-Path $cacheDir "versions"
+
+    if (Test-Path $currentFile) { return }
+    if (-not (Test-Path (Join-Path $legacyDir "dist\index.js"))) { return }
+
+    Msg "==> 迁移旧版本目录结构..." "==> Migrating legacy directory layout..."
+
+    $ver = "0.0.0"; $commit = "legacy"
+    $versionFile = Join-Path $legacyDir "VERSION"
+    if (Test-Path $versionFile) {
+        $content = Get-Content $versionFile
+        foreach ($line in $content) {
+            if ($line -match "^version=(.+)") { $ver = $Matches[1] }
+            if ($line -match "^git_commit=(.+)") { $commit = $Matches[1] }
+        }
+    }
+
+    $dirName = "${ver}_${commit}"
+    $target = Join-Path $versionsDir $dirName
+
+    if (-not (Test-Path $versionsDir)) { New-Item -ItemType Directory -Path $versionsDir -Force | Out-Null }
+    Copy-Item $legacyDir $target -Recurse
+    Set-Content -Path $currentFile -Value $dirName
+
+    $script:PERMANENT_DIR = $target
+    Msg "    ✅ 已迁移到 $target" "    ✅ Migrated to $target"
+    Write-Host ""
+}
+
+# ============================================================
+# Write config.json
+# ============================================================
+function Write-Config {
+    $configFile = Join-Path $DataDir "config.json"
+    Msg "==> 写入配置文件 $configFile ..." "==> Writing config to $configFile ..."
+    if (-not (Test-Path $DataDir)) { New-Item -ItemType Directory -Path $DataDir -Force | Out-Null }
+
+    # Bundle all params as JSON to avoid PowerShell dropping empty-string args to native commands
+    $cfgArgs = [ordered]@{
+        configPath        = $configFile
+        dataDir           = $DataDir
+        slsEndpoint       = "$SlsEndpoint"
+        slsProject        = "$SlsProject"
+        slsLogstore       = "$SlsLogstore"
+        slsAkId           = "$SlsAkId"
+        slsAkSecret       = "$SlsAkSecret"
+        logLevel          = "$LogLevel"
+        userId            = "$($script:UserId)"
+        collectLog        = "$CollectLog"
+        collectTrace      = "$CollectTrace"
+        cmsLicenseKey     = "$CmsLicenseKey"
+        cmsEndpoint       = "$CmsEndpoint"
+        cmsWorkspace      = "$CmsWorkspace"
+        serviceNamePrefix = "$ServiceNamePrefix"
+        selectedAgents    = "$($script:SELECTED_AGENTS)"
+        maskMode          = "$MaskMode"
+        maskTypes         = "$MaskTypes"
+        probeResult       = "$($script:PROBE_RESULT)"
+    }
+    $cfgJson = $cfgArgs | ConvertTo-Json -Compress
+    $cfgTmp = Join-Path $env:TEMP "lp-config-args.json"
+    [System.IO.File]::WriteAllText($cfgTmp, $cfgJson, [System.Text.UTF8Encoding]::new($false))
+
+    & $script:NODE_BIN -e @'
+const fs = require('fs');
+const opts = JSON.parse(fs.readFileSync(process.argv[1], 'utf-8'));
+
+let existing = {};
+try { existing = JSON.parse(fs.readFileSync(opts.configPath, 'utf-8')); } catch {}
+
+const config = {
+  ...existing,
+  enabled: true,
+  dataDir: opts.dataDir,
+};
+delete config.internal;
+if (config.userId === undefined && config['user.id'] !== undefined) {
+  config.userId = config['user.id'];
+}
+delete config['user.id'];
+
+if (opts.slsEndpoint || opts.slsProject || opts.slsLogstore) {
+  config.sls = config.sls || {};
+  delete config.sls.destinationOverride;
+  if (opts.slsEndpoint) config.sls.endpoint = opts.slsEndpoint;
+  if (opts.slsAkId && opts.slsAkSecret) {
+    config.sls.mode = 'ak';
+    config.sls.accessKeyId = opts.slsAkId;
+    config.sls.accessKeySecret = opts.slsAkSecret;
+  }
+  if (opts.slsProject && opts.slsLogstore) {
+    config.sls.project = opts.slsProject;
+    config.sls.logstore = opts.slsLogstore;
+    delete config.sls.endpoints;
+  }
+}
+if (opts.logLevel) config.logLevel = opts.logLevel;
+if (opts.userId) { config.userId = opts.userId; delete config.identity; }
+if (opts.collectLog) config.collectLog = opts.collectLog === 'true';
+if (opts.collectTrace) config.collectTrace = opts.collectTrace === 'true';
+if (opts.cmsLicenseKey || opts.cmsEndpoint || opts.cmsWorkspace) {
+  config.cms = config.cms || {};
+  if (opts.cmsLicenseKey) config.cms.licenseKey = opts.cmsLicenseKey;
+  if (opts.cmsEndpoint) config.cms.endpoint = opts.cmsEndpoint;
+  if (opts.cmsWorkspace) config.cms.workspace = opts.cmsWorkspace;
+}
+if (opts.serviceNamePrefix) config.serviceNamePrefix = opts.serviceNamePrefix;
+if (opts.maskMode) {
+  config.mask = config.mask || {};
+  config.mask.mode = opts.maskMode;
+  if (opts.maskMode === 'custom') {
+    config.mask.types = opts.maskTypes.split(',').map(t => t.trim()).filter(Boolean);
+  } else { delete config.mask.types; }
+}
+if (opts.selectedAgents) {
+  config.agents = config.agents || {};
+  const selected = opts.selectedAgents.split(',').map(s => s.trim()).filter(Boolean);
+  const allAgents = JSON.parse(opts.probeResult || '[]');
+  for (const agent of allAgents) {
+    config.agents[agent.id] = config.agents[agent.id] || {};
+    config.agents[agent.id].enabled = selected.includes(agent.id);
+  }
+}
+
+fs.writeFileSync(opts.configPath, JSON.stringify(config, null, 2) + '\n');
+'@ $cfgTmp
+
+    Remove-Item $cfgTmp -Force -ErrorAction SilentlyContinue
+
+    Msg "    ✅ 配置已写入" "    ✅ Config written"
+    Write-Host ""
+}
+
+# ============================================================
+# Install loongsuite-pilot command (batch wrapper)
+# ============================================================
+function Install-Command {
+    Msg "==> 安装服务管理脚本..." "==> Installing service management script..."
+    $binDir = Join-Path $env:USERPROFILE ".local\bin"
+    if (-not (Test-Path $binDir)) { New-Item -ItemType Directory -Path $binDir -Force | Out-Null }
+
+    # Copy the PowerShell service management script
+    $ps1File = Join-Path $binDir "loongsuite-pilot.ps1"
+    $ps1Src = Join-Path $script:PERMANENT_DIR "scripts\loongsuite-pilot.ps1"
+    if (Test-Path $ps1Src) {
+        Copy-Item $ps1Src $ps1File -Force
+    }
+
+    # Create a .cmd shim that forwards to the PowerShell script
+    $cmdFile = Join-Path $binDir "loongsuite-pilot.cmd"
+    $cmdContent = @'
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0loongsuite-pilot.ps1" %*
+'@
+    Set-Content -Path $cmdFile -Value $cmdContent -Encoding ASCII
+    Msg "    ✅ 已安装: $cmdFile" "    ✅ Installed: $cmdFile"
+
+    # Add to user PATH if not already there
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($userPath -notlike "*$binDir*") {
+        [Environment]::SetEnvironmentVariable("Path", "$binDir;$userPath", "User")
+        Msg "    已将 $binDir 添加到用户 PATH" "    Added $binDir to user PATH"
+        $env:Path = "$binDir;$env:Path"
+    }
+    Write-Host ""
+}
+
+# ============================================================
+# Version helpers
+# ============================================================
+function Get-InstalledVersion {
+    $cacheDir = Join-Path $env:USERPROFILE ".loongsuite-pilot"
+    $currentFile = Join-Path $cacheDir "current"
+    $versionsDir = Join-Path $cacheDir "versions"
+
+    if (Test-Path $currentFile) {
+        $dir = (Get-Content $currentFile -ErrorAction SilentlyContinue).Trim()
+        $vf = Join-Path $versionsDir "$dir\VERSION"
+        if ($dir -and (Test-Path $vf)) {
+            $content = Get-Content $vf
+            foreach ($line in $content) {
+                if ($line -match "^version=(.+)") { return $Matches[1] }
+            }
+        }
+    }
+
+    $vf = Join-Path $script:PERMANENT_DIR "VERSION"
+    if (Test-Path $vf) {
+        $content = Get-Content $vf
+        foreach ($line in $content) {
+            if ($line -match "^version=(.+)") { return $Matches[1] }
+        }
+    }
+    return ""
+}
+
+function Get-VersionFromDir {
+    param([string]$dir)
+    $vf = Join-Path $dir "VERSION"
+    if (Test-Path $vf) {
+        $content = Get-Content $vf
+        foreach ($line in $content) {
+            if ($line -match "^version=(.+)") { return $Matches[1] }
+        }
+    }
+    return ""
+}
+
+function Get-CommitFromDir {
+    param([string]$dir)
+    $vf = Join-Path $dir "VERSION"
+    if (Test-Path $vf) {
+        $content = Get-Content $vf
+        foreach ($line in $content) {
+            if ($line -match "^git_commit=(.+)") { return $Matches[1] }
+        }
+    }
+    return ""
+}
+
+function Show-VersionInfo {
+    param([string]$dir)
+    $vf = Join-Path $dir "VERSION"
+    if (Test-Path $vf) {
+        $v = ""; $c = ""; $t = ""
+        $content = Get-Content $vf
+        foreach ($line in $content) {
+            if ($line -match "^version=(.+)") { $v = $Matches[1] }
+            if ($line -match "^git_commit=(.+)") { $c = $Matches[1] }
+            if ($line -match "^build_time=(.+)") { $t = $Matches[1] }
+        }
+        return "v${v} (${c}, ${t})"
+    }
+    return "unknown"
+}
+
+# ============================================================
+# Print summary
+# ============================================================
+function Print-Summary {
+    param([string]$action)
+    $configFile = Join-Path $DataDir "config.json"
+    Write-Host "============================================================"
+    $ver = Show-VersionInfo $script:PERMANENT_DIR
+    switch ($action) {
+        "install" { Msg "✅ 安装完成！版本: $ver" "✅ Installation complete! Version: $ver" }
+        "upgrade" { Msg "✅ 升级完成！版本: $ver" "✅ Upgrade complete! Version: $ver" }
+    }
+    Write-Host ""
+    Msg "配置文件: $configFile" "Config file: $configFile"
+    Msg "数据目录: $DataDir" "Data directory: $DataDir"
+    Msg "Hook 目录: $DataDir\hooks" "Hooks directory: $DataDir\hooks"
+    Write-Host ""
+
+    if ($SlsEndpoint) {
+        Msg "SLS 后端: $SlsEndpoint" "SLS backend: $SlsEndpoint"
+        if ($SlsProject)  { Msg "   项目: $SlsProject" "   Project: $SlsProject" }
+        if ($SlsLogstore) { Msg "   日志库: $SlsLogstore" "   Logstore: $SlsLogstore" }
+        Write-Host ""
+    }
+
+    Msg "命令:" "Commands:"
+    Write-Host "   loongsuite-pilot          # 查看状态 / Status"
+    Write-Host "   loongsuite-pilot info     # 版本与配置 / Version & config"
+    Write-Host "============================================================"
+}
+
+# ============================================================
+# Stop service by PID file
+# ============================================================
+function Stop-PilotService {
+    $pidFile = Join-Path $DataDir "loongsuite-pilot.pid"
+    if (Test-Path $pidFile) {
+        $oldPid = (Get-Content $pidFile -ErrorAction SilentlyContinue).Trim()
+        if ($oldPid) {
+            $proc = Get-Process -Id $oldPid -ErrorAction SilentlyContinue
+            if ($proc) {
+                Msg "==> 停止运行中的服务 (PID $oldPid)..." "==> Stopping running service (PID $oldPid)..."
+                Stop-Process -Id $oldPid -Force -ErrorAction SilentlyContinue
+                $count = 0
+                while ($count -lt 10) {
+                    $proc = Get-Process -Id $oldPid -ErrorAction SilentlyContinue
+                    if (-not $proc) { break }
+                    Start-Sleep -Seconds 1
+                    $count++
+                }
+                Msg "    ✅ 已停止" "    ✅ Stopped"
+                Write-Host ""
+            }
+        }
+        Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
+    }
+
+    # Also try the loongsuite-pilot command (use .ps1 directly to avoid cmd.exe popup)
+    $ps1Path = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot.ps1"
+    if (Test-Path $ps1Path) {
+        $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
+        & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $ps1Path stop 2>$null
+        $ErrorActionPreference = $prevEAP
+    }
+}
+
+# ============================================================
+# GC old versions
+# ============================================================
+function GC-OldVersions {
+    $cacheDir = Join-Path $env:USERPROFILE ".loongsuite-pilot"
+    $versionsDir = Join-Path $cacheDir "versions"
+    $currentFile = Join-Path $cacheDir "current"
+    $previousFile = Join-Path $cacheDir "previous"
+
+    if (-not (Test-Path $versionsDir)) { return }
+
+    $keepCurrent = ""; $keepPrevious = ""
+    if (Test-Path $currentFile) { $keepCurrent = (Get-Content $currentFile -ErrorAction SilentlyContinue).Trim() }
+    if (Test-Path $previousFile) { $keepPrevious = (Get-Content $previousFile -ErrorAction SilentlyContinue).Trim() }
+
+    Get-ChildItem $versionsDir -Directory -ErrorAction SilentlyContinue | ForEach-Object {
+        if ($_.Name -ne $keepCurrent -and $_.Name -ne $keepPrevious) {
+            Remove-Item $_.FullName -Recurse -Force
+        }
+    }
+}
+
+# ============================================================
+# Remove hook configs
+# ============================================================
+function Remove-HookConfigs {
+    $HOOK_MARKER = ".loongsuite-pilot"
+    $configs = @(
+        (Join-Path $env:USERPROFILE ".cursor\hooks.json"),
+        (Join-Path $env:USERPROFILE ".qoder\settings.json"),
+        (Join-Path $env:USERPROFILE ".qoderwork\settings.json"),
+        (Join-Path $env:USERPROFILE ".claude\settings.json"),
+        (Join-Path $env:USERPROFILE ".codex\hooks.json")
+    )
+
+    foreach ($cfg in $configs) {
+        if (-not (Test-Path $cfg)) { continue }
+        $short = $cfg -replace [regex]::Escape($env:USERPROFILE), "~"
+
+        try {
+            & $script:NODE_BIN -e @'
+const fs = require('fs');
+const cfg = process.argv[1];
+const marker = process.argv[2];
+try {
+  const data = JSON.parse(fs.readFileSync(cfg, 'utf-8'));
+  const hooks = data.hooks;
+  if (!hooks || typeof hooks !== 'object') process.exit(0);
+  let changed = false;
+  for (const [event, entries] of Object.entries(hooks)) {
+    if (!Array.isArray(entries)) continue;
+    const filtered = entries.filter(e => {
+      const cmd = e.command || '';
+      const nested = Array.isArray(e.hooks) ? e.hooks : [];
+      const hasMarker = cmd.includes(marker) || nested.some(h => (h.command || '').includes(marker));
+      if (hasMarker) changed = true;
+      return !hasMarker;
+    });
+    if (filtered.length === 0) { delete hooks[event]; changed = true; }
+    else hooks[event] = filtered;
+  }
+  if (changed) {
+    fs.writeFileSync(cfg, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+  }
+} catch(e) { process.stderr.write(e.message); process.exit(1); }
+'@ $cfg $HOOK_MARKER 2>$null
+            Msg "    ✅ 已清理: $short" "    ✅ Cleaned: $short"
+        } catch {
+            Msg "    ⚠️  跳过: $short (需手动清理)" "    ⚠️  Skipped: $short (manual cleanup needed)"
+        }
+    }
+}
+
+# ============================================================
+# Remove OTel plugin (Claude/Codex)
+# ============================================================
+function Remove-OtelPlugin {
+    $OTEL_CLAUDE_DIR = Join-Path $env:USERPROFILE ".cache\opentelemetry.instrumentation.claude"
+    $OTEL_CODEX_DIR = Join-Path $env:USERPROFILE ".cache\opentelemetry.instrumentation.codex"
+
+    # Clean Claude settings.json hooks
+    $claudeSettings = Join-Path $env:USERPROFILE ".claude\settings.json"
+    if ((Test-Path $claudeSettings) -and $script:NODE_BIN) {
+        $content = Get-Content $claudeSettings -Raw -ErrorAction SilentlyContinue
+        if ($content -match "otel-claude-hook|hook-entry") {
+            & $script:NODE_BIN -e @'
+const fs = require('fs');
+const f = process.argv[1];
+const isOurs = c => c.includes('otel-claude-hook') || c.includes('hook-entry.sh');
+try {
+  const d = JSON.parse(fs.readFileSync(f, 'utf-8'));
+  if (d && d.hooks) {
+    for (const ev of Object.keys(d.hooks)) {
+      if (!Array.isArray(d.hooks[ev])) continue;
+      d.hooks[ev] = d.hooks[ev].map(m => {
+        if (!Array.isArray(m.hooks)) return m;
+        m.hooks = m.hooks.filter(h => !(h.command && isOurs(h.command)));
+        return m.hooks.length > 0 ? m : null;
+      }).filter(Boolean);
+      if (d.hooks[ev].length === 0) delete d.hooks[ev];
+    }
+    if (Object.keys(d.hooks).length === 0) delete d.hooks;
+    fs.writeFileSync(f, JSON.stringify(d, null, 2) + '\n');
+  }
+} catch {}
+'@ $claudeSettings 2>$null
+            Msg "    ✅ settings.json hooks 已清理" "    ✅ settings.json hooks cleaned"
+        }
+    }
+
+    # Remove plugin directories
+    foreach ($dir in @($OTEL_CLAUDE_DIR, $OTEL_CODEX_DIR)) {
+        if (Test-Path $dir) {
+            if ($Purge) {
+                Remove-Item $dir -Recurse -Force
+                Msg "    ✅ 插件目录已完全删除 (--Purge): $dir" "    ✅ Plugin directory fully removed (-Purge): $dir"
+            } else {
+                Get-ChildItem $dir -ErrorAction SilentlyContinue |
+                    Where-Object { $_.Name -ne "sessions" } |
+                    ForEach-Object { Remove-Item $_.FullName -Recurse -Force }
+                Msg "    ✅ 插件文件已删除（sessions/ 已保留）" "    ✅ Plugin files removed (sessions/ preserved)"
+            }
+        }
+    }
+}
+
+# ============================================================
+# CMD: install
+# ============================================================
+function Cmd-Install {
+    Msg "==> 开始安装 $PACKAGE_NAME ..." "==> Installing $PACKAGE_NAME ..."
+    Write-Host ""
+
+    Check-Deps
+    Migrate-LegacyLayout
+
+    $curVer = Get-InstalledVersion
+    if ($curVer) {
+        Msg "⚠️  检测到已安装版本 v${curVer}，将执行重新安装" "⚠️  Existing installation v${curVer} detected, re-installing"
+        Write-Host ""
+    }
+
+    Stop-PilotService
+
+    try {
+        Download-AndExtract
+        Probe-Agents
+        Select-Agents
+        Prompt-UserId
+        Confirm-ConfigOverwrite
+        Deploy-Package $script:INSTALL_SRC
+        Write-Config
+        Install-Command
+
+        Msg "==> 启动服务..." "==> Starting service..."
+        $ps1Path = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot.ps1"
+        if (Test-Path $ps1Path) {
+            $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
+            & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $ps1Path start 2>$null
+            Start-Sleep -Seconds 2
+            $statusOut = & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $ps1Path status 2>$null
+            $ErrorActionPreference = $prevEAP
+            if ($statusOut -match "is running") {
+                Msg "    ✅ 服务已启动" "    ✅ Service started"
+            } else {
+                Msg "    ⚠️  服务可能尚未就绪，请检查: loongsuite-pilot status" `
+                    "    ⚠️  Service may not be ready. Check: loongsuite-pilot status"
+            }
+        }
+        Write-Host ""
+        Print-Summary "install"
+    } finally {
+        if ($script:TMP_DIR -and (Test-Path $script:TMP_DIR)) {
+            Remove-Item $script:TMP_DIR -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+# ============================================================
+# CMD: upgrade
+# ============================================================
+function Cmd-Upgrade {
+    Msg "==> 开始升级 $PACKAGE_NAME ..." "==> Upgrading $PACKAGE_NAME ..."
+    Write-Host ""
+
+    Migrate-LegacyLayout
+
+    $oldVer = Get-InstalledVersion
+    if (-not $oldVer) {
+        Msg "❌ 未检测到已安装的 loongsuite-pilot，请先执行 install" `
+            "❌ No existing installation found. Please run install first."
+        exit 1
+    }
+
+    Msg "   当前版本: $oldVer" "   Current version: $oldVer"
+    Write-Host ""
+
+    Check-Deps
+
+    try {
+        Download-AndExtract
+
+        $newVer = Get-VersionFromDir $script:INSTALL_SRC
+        $newCommit = Get-CommitFromDir $script:INSTALL_SRC
+        $oldCommit = Get-CommitFromDir $script:PERMANENT_DIR
+
+        if ($newVer -and $newVer -eq $oldVer -and $newCommit -eq $oldCommit) {
+            Msg "✅ 已是最新版本 v${newVer} (${newCommit})，无需升级" `
+                "✅ Already at latest version v${newVer} (${newCommit}), nothing to do"
+            exit 0
+        }
+
+        Msg "   新版本: ${newVer} (${newCommit})" "   New version: ${newVer} (${newCommit})"
+        Write-Host ""
+
+        Msg "==> 停止服务..." "==> Stopping service..."
+        Stop-PilotService
+        Write-Host ""
+
+        Deploy-Package $script:INSTALL_SRC
+        Install-Command
+
+        Msg "==> 启动新版本..." "==> Starting new version..."
+        $ps1Path = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot.ps1"
+        $started = $false
+        if (Test-Path $ps1Path) {
+            $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
+            & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $ps1Path start 2>$null
+            Start-Sleep -Seconds 2
+            $statusOut = & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $ps1Path status 2>$null
+            $ErrorActionPreference = $prevEAP
+            if ($statusOut -match "is running") {
+                Msg "    ✅ 新版本启动成功" "    ✅ New version started successfully"
+                Write-Host ""
+                GC-OldVersions
+                Print-Summary "upgrade"
+                $started = $true
+            }
+        }
+
+        if (-not $started) {
+            Write-Host ""
+            Msg "⚠️  新版本启动失败，正在回滚..." "⚠️  New version failed to start, rolling back..."
+            if (Test-Path $ps1Path) {
+                $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
+                & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $ps1Path stop 2>$null
+                & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $ps1Path rollback 2>$null
+                $ErrorActionPreference = $prevEAP
+            }
+            Msg "❌ 升级失败，已回滚到 v${oldVer}" "❌ Upgrade failed, rolled back to v${oldVer}"
+            Msg "   请检查日志: loongsuite-pilot log" "   Check logs: loongsuite-pilot log"
+            exit 1
+        }
+    } finally {
+        if ($script:TMP_DIR -and (Test-Path $script:TMP_DIR)) {
+            Remove-Item $script:TMP_DIR -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+# ============================================================
+# CMD: uninstall
+# ============================================================
+function Cmd-Uninstall {
+    Msg "🗑️  开始卸载 $PACKAGE_NAME ..." "🗑️  Uninstalling $PACKAGE_NAME ..."
+    Write-Host ""
+
+    Msg "==> 停止服务..." "==> Stopping service..."
+    Stop-PilotService
+    Msg "    ✅ 服务已停止" "    ✅ Service stopped"
+    Write-Host ""
+
+    # Remove Task Scheduler tasks
+    $taskFolder = "\LoongsuitePilot"
+    foreach ($taskName in @("LoongsuitePilot")) {
+        $task = Get-ScheduledTask -TaskName $taskName -TaskPath $taskFolder -ErrorAction SilentlyContinue
+        if ($task) {
+            if ($task.State -eq "Running") {
+                Stop-ScheduledTask -TaskName $taskName -TaskPath $taskFolder -ErrorAction SilentlyContinue
+            }
+            Unregister-ScheduledTask -TaskName $taskName -TaskPath $taskFolder -Confirm:$false -ErrorAction SilentlyContinue
+        }
+    }
+    Msg "    ✅ 已移除计划任务" "    ✅ Removed scheduled tasks"
+
+    Msg "==> 删除安装目录..." "==> Removing installation..."
+    $installDir = Join-Path $env:USERPROFILE ".loongsuite-pilot"
+    if (Test-Path $installDir) {
+        Remove-Item $installDir -Recurse -Force
+    }
+    Msg "    ✅ 已删除 $installDir" "    ✅ Removed $installDir"
+
+    Msg "==> 删除 loongsuite-pilot 命令..." "==> Removing loongsuite-pilot command..."
+    $cmdFile = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot.cmd"
+    $ps1File = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot.ps1"
+    if (Test-Path $cmdFile) { Remove-Item $cmdFile -Force }
+    if (Test-Path $ps1File) { Remove-Item $ps1File -Force }
+    Msg "    ✅ loongsuite-pilot 命令已删除" "    ✅ loongsuite-pilot command removed"
+    Write-Host ""
+
+    Msg "==> 清理 hook 配置..." "==> Cleaning up hook configs..."
+    Remove-HookConfigs
+    Write-Host ""
+
+    Msg "==> 清理 Claude/Codex 插件..." "==> Cleaning up Claude/Codex plugins..."
+    Remove-OtelPlugin
+    Write-Host ""
+
+    if ($Purge) {
+        Msg "==> 删除数据目录 (-Purge)..." "==> Removing data directory (-Purge)..."
+        if (Test-Path $DataDir) { Remove-Item $DataDir -Recurse -Force }
+        Msg "    ✅ 已删除 $DataDir" "    ✅ Removed $DataDir"
+    } else {
+        Msg "📁 数据目录已保留: $DataDir" "📁 Data directory preserved: $DataDir"
+        Msg "   (包含配置和日志，如需彻底删除请加 -Purge)" `
+            "   (contains config and logs, add -Purge to remove)"
+    }
+    Write-Host ""
+
+    Write-Host "============================================================"
+    Msg "✅ 卸载完成！" "✅ Uninstallation complete!"
+    Write-Host "============================================================"
+}
+
+# ============================================================
+# Main dispatcher
+# ============================================================
+switch ($Command) {
+    "install"   { Cmd-Install }
+    "upgrade"   { Cmd-Upgrade }
+    "uninstall" { Cmd-Uninstall }
+    default {
+        Write-Host "Usage: .\installer-opensource.ps1 {install|upgrade|uninstall} [options]"
+        exit 1
+    }
+}

--- a/deploy/package-opensource.sh
+++ b/deploy/package-opensource.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
-# package.sh — Build the project and create a distributable .tar.gz package
+# package-opensource.sh — Build the project and create distributable packages
+#
+# Produces both .tar.gz (Linux/macOS) and .zip (Windows) packages.
+# Internal-only and updater files are stripped automatically.
 #
 # Usage:
-#   bash deploy/package.sh                       # default output: ./loongsuite-pilot.tar.gz
-#   bash deploy/package.sh -o /tmp/out.tar.gz    # custom output path
-#   bash deploy/package.sh --skip-build          # skip build, use existing dist/
+#   bash deploy/package-opensource.sh                       # default output
+#   bash deploy/package-opensource.sh -o /tmp/out.tar.gz    # custom .tar.gz path
+#   bash deploy/package-opensource.sh --skip-build          # skip build, use existing dist/
 
 set -euo pipefail
 
@@ -13,8 +16,6 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PACKAGE_NAME="loongsuite-pilot"
 OUTPUT_PATH=""
 SKIP_BUILD=0
-EXTERNAL=0
-OPENSOURCE=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -22,10 +23,6 @@ while [[ $# -gt 0 ]]; do
             OUTPUT_PATH="$2"; shift 2 ;;
         --skip-build)
             SKIP_BUILD=1; shift ;;
-        --external)
-            EXTERNAL=1; shift ;;
-        --opensource)
-            OPENSOURCE=1; EXTERNAL=1; shift ;;
         *)
             echo "Unknown option: $1" >&2; exit 1 ;;
     esac
@@ -34,6 +31,7 @@ done
 if [ -z "$OUTPUT_PATH" ]; then
     OUTPUT_PATH="$PROJECT_ROOT/$PACKAGE_NAME.tar.gz"
 fi
+ZIP_OUTPUT_PATH="${OUTPUT_PATH%.tar.gz}.zip"
 
 cd "$PROJECT_ROOT"
 
@@ -116,24 +114,26 @@ cp VERSION           "$PKG_DIR/"
 chmod +x "$PKG_DIR/scripts/"*.sh 2>/dev/null || true
 chmod +x "$PKG_DIR/assets/hooks/"*.sh 2>/dev/null || true
 
-# Strip internal-only files for commercial / open-source packages
-if [ "$EXTERNAL" -eq 1 ]; then
-    rm -f "$PKG_DIR/scripts/migrate-internal-config.js"
-    echo "    ✅ Stripped migrate-internal-config.js (--external)"
-fi
-if [ "$OPENSOURCE" -eq 1 ]; then
-    rm -f "$PKG_DIR/scripts/updater-daemon.js"
-    echo "    ✅ Stripped updater-daemon.js (--opensource)"
-fi
+# Strip internal-only files (always for opensource)
+rm -f "$PKG_DIR/scripts/migrate-internal-config.js"
+rm -f "$PKG_DIR/scripts/updater-daemon.js"
+echo "    ✅ Stripped internal-only files"
 
 echo "    ✅ Staged into $PKG_DIR"
 
-# ── Create package ──
-echo "==> Creating package..."
+# ── Create .tar.gz (Linux/macOS) ──
+echo "==> Creating .tar.gz package..."
 tar -czf "$OUTPUT_PATH" -C "$STAGE_DIR" "$PACKAGE_NAME"
 
 PKG_SIZE=$(du -h "$OUTPUT_PATH" | cut -f1)
-echo "    ✅ Package created: $OUTPUT_PATH ($PKG_SIZE)"
+echo "    ✅ $OUTPUT_PATH ($PKG_SIZE)"
+
+# ── Create .zip (Windows) ──
+echo "==> Creating .zip package..."
+(cd "$STAGE_DIR" && zip -qr "$ZIP_OUTPUT_PATH" "$PACKAGE_NAME")
+
+ZIP_SIZE=$(du -h "$ZIP_OUTPUT_PATH" | cut -f1)
+echo "    ✅ $ZIP_OUTPUT_PATH ($ZIP_SIZE)"
 
 # ── Summary ──
 echo ""
@@ -141,5 +141,5 @@ echo "==> Contents:"
 tar -tzf "$OUTPUT_PATH" | head -20
 echo "    ... (truncated)"
 echo ""
-echo "Done. Upload with:  bash deploy/upload.sh"
+echo "Done."
 

--- a/deploy/release-opensource.sh
+++ b/deploy/release-opensource.sh
@@ -81,8 +81,11 @@ if [ "$OSS_ONLY" -eq 1 ]; then
     if [ "$DRY_RUN" -eq 1 ]; then
         echo "[dry-run] Would build, package, and upload to OSS:"
         echo "[dry-run]   ${OSS_BUCKET}/${OSS_PREFIX}/${NEXT_VERSION}/${PACKAGE_NAME}.tar.gz"
+        echo "[dry-run]   ${OSS_BUCKET}/${OSS_PREFIX}/${NEXT_VERSION}/${PACKAGE_NAME}.zip"
         echo "[dry-run]   ${OSS_BUCKET}/${OSS_PREFIX}/latest/${PACKAGE_NAME}.tar.gz"
+        echo "[dry-run]   ${OSS_BUCKET}/${OSS_PREFIX}/latest/${PACKAGE_NAME}.zip"
         echo "[dry-run]   ${OSS_BUCKET}/${OSS_PREFIX}/installer.sh"
+        echo "[dry-run]   ${OSS_BUCKET}/${OSS_PREFIX}/installer.ps1"
         exit 0
     fi
 else
@@ -142,8 +145,11 @@ else
         echo "[dry-run] Would push tag → GitHub Actions creates the Release"
         echo "[dry-run] Would build, package, and upload to OSS:"
         echo "[dry-run]   ${OSS_BUCKET}/${OSS_PREFIX}/${NEXT_VERSION}/${PACKAGE_NAME}.tar.gz"
+        echo "[dry-run]   ${OSS_BUCKET}/${OSS_PREFIX}/${NEXT_VERSION}/${PACKAGE_NAME}.zip"
         echo "[dry-run]   ${OSS_BUCKET}/${OSS_PREFIX}/latest/${PACKAGE_NAME}.tar.gz"
+        echo "[dry-run]   ${OSS_BUCKET}/${OSS_PREFIX}/latest/${PACKAGE_NAME}.zip"
         echo "[dry-run]   ${OSS_BUCKET}/${OSS_PREFIX}/installer.sh"
+        echo "[dry-run]   ${OSS_BUCKET}/${OSS_PREFIX}/installer.ps1"
         exit 0
     fi
 
@@ -199,11 +205,16 @@ fi
 if [ "$SKIP_OSS" -eq 0 ]; then
     echo ""
     echo "==> Building and packaging..."
-    bash deploy/package.sh --opensource
-    PACKAGE_FILE="$PROJECT_ROOT/${PACKAGE_NAME}.tar.gz"
+    bash deploy/package-opensource.sh
+    TARBALL="$PROJECT_ROOT/${PACKAGE_NAME}.tar.gz"
+    ZIPFILE="$PROJECT_ROOT/${PACKAGE_NAME}.zip"
 
-    if [ ! -f "$PACKAGE_FILE" ]; then
-        echo "❌ Package file not found: $PACKAGE_FILE"
+    if [ ! -f "$TARBALL" ]; then
+        echo "❌ Package file not found: $TARBALL"
+        exit 1
+    fi
+    if [ ! -f "$ZIPFILE" ]; then
+        echo "❌ Package file not found: $ZIPFILE"
         exit 1
     fi
 
@@ -215,20 +226,29 @@ if [ "$SKIP_OSS" -eq 0 ]; then
     echo ""
     echo "==> Uploading to OSS..."
 
-    # Upload versioned package
-    ossutil cp "$PACKAGE_FILE" "${OSS_BUCKET}/${OSS_PREFIX}/${NEXT_VERSION}/${PACKAGE_NAME}.tar.gz" -f
+    # Upload versioned packages (Linux/macOS .tar.gz + Windows .zip)
+    ossutil cp "$TARBALL" "${OSS_BUCKET}/${OSS_PREFIX}/${NEXT_VERSION}/${PACKAGE_NAME}.tar.gz" -f
     echo "    ✅ ${OSS_PREFIX}/${NEXT_VERSION}/${PACKAGE_NAME}.tar.gz"
 
+    ossutil cp "$ZIPFILE" "${OSS_BUCKET}/${OSS_PREFIX}/${NEXT_VERSION}/${PACKAGE_NAME}.zip" -f
+    echo "    ✅ ${OSS_PREFIX}/${NEXT_VERSION}/${PACKAGE_NAME}.zip"
+
     # Upload as latest
-    ossutil cp "$PACKAGE_FILE" "${OSS_BUCKET}/${OSS_PREFIX}/latest/${PACKAGE_NAME}.tar.gz" -f
+    ossutil cp "$TARBALL" "${OSS_BUCKET}/${OSS_PREFIX}/latest/${PACKAGE_NAME}.tar.gz" -f
     echo "    ✅ ${OSS_PREFIX}/latest/${PACKAGE_NAME}.tar.gz"
 
-    # Upload installer script
+    ossutil cp "$ZIPFILE" "${OSS_BUCKET}/${OSS_PREFIX}/latest/${PACKAGE_NAME}.zip" -f
+    echo "    ✅ ${OSS_PREFIX}/latest/${PACKAGE_NAME}.zip"
+
+    # Upload installer scripts (Linux/macOS .sh + Windows .ps1)
     ossutil cp deploy/installer-opensource.sh "${OSS_BUCKET}/${OSS_PREFIX}/installer.sh" -f
     echo "    ✅ ${OSS_PREFIX}/installer.sh"
 
+    ossutil cp deploy/installer-opensource.ps1 "${OSS_BUCKET}/${OSS_PREFIX}/installer.ps1" -f
+    echo "    ✅ ${OSS_PREFIX}/installer.ps1"
+
     # Cleanup
-    rm -f "$PACKAGE_FILE"
+    rm -f "$TARBALL" "$ZIPFILE"
 else
     echo ""
     echo "==> Skipping OSS upload (--skip-oss)"
@@ -246,7 +266,8 @@ else
     echo "   Branch:  ${RELEASE_BRANCH}"
 fi
 echo ""
-echo "   OSS:     https://loongcollector-community-edition.oss-cn-shanghai.aliyuncs.com/${OSS_PREFIX}/${NEXT_VERSION}/${PACKAGE_NAME}.tar.gz"
+echo "   OSS:     https://loongcollector-community-edition.oss-cn-shanghai.aliyuncs.com/${OSS_PREFIX}/${NEXT_VERSION}/${PACKAGE_NAME}.tar.gz (Linux/macOS)"
+echo "            https://loongcollector-community-edition.oss-cn-shanghai.aliyuncs.com/${OSS_PREFIX}/${NEXT_VERSION}/${PACKAGE_NAME}.zip (Windows)"
 if [ "$OSS_ONLY" -eq 0 ]; then
     echo "   GitHub Actions will create the GitHub Release."
     echo "   Next step: create PR to merge ${RELEASE_BRANCH} → main"

--- a/scripts/collector-daemon.js
+++ b/scripts/collector-daemon.js
@@ -1,8 +1,9 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
+const { pathToFileURL } = require('url');
 
-const CACHE_DIR = path.join(process.env.HOME || '', '.loongsuite-pilot');
+const CACHE_DIR = path.join(process.env.HOME || process.env.USERPROFILE || '', '.loongsuite-pilot');
 const CURRENT_FILE = path.join(CACHE_DIR, 'current');
 const PREVIOUS_FILE = path.join(CACHE_DIR, 'previous');
 const VERSIONS_DIR = path.join(CACHE_DIR, 'versions');
@@ -22,7 +23,7 @@ if (!entry) {
   console.error('[loongsuite-pilot] No valid collector version found');
   process.exit(1);
 }
-import(entry).catch(err => {
+import(pathToFileURL(entry).href).catch(err => {
   console.error('[loongsuite-pilot] Failed to load collector:', err.message);
   process.exit(1);
 });

--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -1,0 +1,826 @@
+# loongsuite-pilot.ps1 — Service management for loongsuite-pilot (Windows)
+# Uses Windows Task Scheduler for autostart (analogous to macOS launchd)
+#
+# Usage:
+#   loongsuite-pilot start
+#   loongsuite-pilot stop
+#   loongsuite-pilot restart
+#   loongsuite-pilot status
+#   loongsuite-pilot info
+#   loongsuite-pilot rollback
+#   loongsuite-pilot help
+
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [string]$Command = "status",
+
+    [Parameter(Position = 1, ValueFromRemainingArguments)]
+    [string[]]$SubArgs
+)
+
+$ErrorActionPreference = "Stop"
+
+# ============================================================
+# Constants & Paths
+# ============================================================
+$CACHE_DIR = Join-Path $env:USERPROFILE ".loongsuite-pilot"
+$DATA_DIR = if ($env:LOONGSUITE_PILOT_DATA_DIR) { $env:LOONGSUITE_PILOT_DATA_DIR } else { $CACHE_DIR }
+$VERSIONS_DIR = Join-Path $CACHE_DIR "versions"
+$CURRENT_FILE = Join-Path $CACHE_DIR "current"
+$PREVIOUS_FILE = Join-Path $CACHE_DIR "previous"
+$BOOTSTRAP_DIR = Join-Path $CACHE_DIR "bin"
+$PACKAGE_DIR = Join-Path $CACHE_DIR "package"
+$PID_FILE = Join-Path $DATA_DIR "loongsuite-pilot.pid"
+$UPDATER_PID_FILE = Join-Path $DATA_DIR "loongsuite-pilot-updater.pid"
+$LOG_DIR = Join-Path $DATA_DIR "logs"
+$LOG_FILE = Join-Path $LOG_DIR "loongsuite-pilot-service.log"
+$UPDATER_LOG_FILE = Join-Path $LOG_DIR "loongsuite-pilot-updater.log"
+$CONFIG_FILE = Join-Path $DATA_DIR "config.json"
+$NODE_PIN_FILE = Join-Path $CACHE_DIR "node-bin"
+$INIT_TYPE_FILE = Join-Path $DATA_DIR "init-type"
+
+$TASK_NAME_COLLECTOR = "LoongsuitePilot"
+$TASK_NAME_UPDATER = "LoongsuitePilotUpdater"
+$TASK_FOLDER = "\LoongsuitePilot"
+
+$LOONGSUITE_PILOT_BIN = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot.cmd"
+
+# ============================================================
+# Helpers
+# ============================================================
+function Ensure-Dirs {
+    @($LOG_DIR, $BOOTSTRAP_DIR) | ForEach-Object {
+        if (-not (Test-Path $_)) { New-Item -ItemType Directory -Path $_ -Force | Out-Null }
+    }
+}
+
+function Test-NodeSuitable {
+    param([string]$bin)
+    if (-not $bin -or -not (Test-Path $bin)) { return $false }
+    try {
+        $ver = & $bin --version 2>$null
+        if (-not $ver) { return $false }
+        $major = [int]($ver -replace '^v','').Split('.')[0]
+        return $major -ge 18
+    } catch { return $false }
+}
+
+function Resolve-Node {
+    # 1. Pinned file
+    if (Test-Path $NODE_PIN_FILE) {
+        $pinned = (Get-Content $NODE_PIN_FILE -ErrorAction SilentlyContinue).Trim()
+        if ($pinned -and (Test-NodeSuitable $pinned)) {
+            return $pinned
+        }
+    }
+
+    # 2. Fallback search
+    $candidates = @()
+
+    # nvm-windows
+    if ($env:NVM_HOME -and (Test-Path $env:NVM_HOME)) {
+        Get-ChildItem $env:NVM_HOME -Directory -ErrorAction SilentlyContinue |
+            Sort-Object Name -Descending |
+            ForEach-Object { $candidates += Join-Path $_.FullName "node.exe" }
+    }
+
+    # fnm
+    $fnmDir = Join-Path $env:USERPROFILE ".fnm\node-versions"
+    if (Test-Path $fnmDir) {
+        Get-ChildItem $fnmDir -Directory -ErrorAction SilentlyContinue |
+            Sort-Object Name -Descending |
+            ForEach-Object { $candidates += Join-Path $_.FullName "installation\node.exe" }
+    }
+
+    # Volta, standard paths
+    $candidates += Join-Path $env:USERPROFILE ".volta\bin\node.exe"
+    $candidates += "C:\Program Files\nodejs\node.exe"
+    $candidates += "C:\Program Files (x86)\nodejs\node.exe"
+
+    # PATH lookup
+    $pathNode = Get-Command node -ErrorAction SilentlyContinue
+    if ($pathNode) { $candidates += $pathNode.Source }
+
+    foreach ($c in $candidates) {
+        if (Test-NodeSuitable $c) {
+            # Auto-heal: update pin file
+            $parentDir = Split-Path $NODE_PIN_FILE
+            if (-not (Test-Path $parentDir)) { New-Item -ItemType Directory -Path $parentDir -Force | Out-Null }
+            Set-Content -Path $NODE_PIN_FILE -Value $c
+            return $c
+        }
+    }
+    return $null
+}
+
+function Sync-BootstrapScripts {
+    $versionDir = Resolve-CurrentVersion
+    if (-not $versionDir) { return }
+    $srcDir = Join-Path $versionDir "scripts"
+    $collectorSrc = Join-Path $srcDir "collector-daemon.js"
+    if (-not (Test-Path $collectorSrc)) { return }
+    if (-not (Test-Path $BOOTSTRAP_DIR)) { New-Item -ItemType Directory -Path $BOOTSTRAP_DIR -Force | Out-Null }
+    Copy-Item $collectorSrc $BOOTSTRAP_DIR -Force
+    $updaterSrc = Join-Path $srcDir "updater-daemon.js"
+    if (Test-Path $updaterSrc) { Copy-Item $updaterSrc $BOOTSTRAP_DIR -Force }
+}
+
+function Sync-InstalledScriptsFromVersion {
+    param([string]$versionDir)
+    $srcDir = Join-Path $versionDir "scripts"
+    $required = @("collector-daemon.js", "updater-daemon.js")
+    foreach ($f in $required) {
+        if (-not (Test-Path (Join-Path $srcDir $f))) { return $false }
+    }
+
+    if (-not (Test-Path $BOOTSTRAP_DIR)) { New-Item -ItemType Directory -Path $BOOTSTRAP_DIR -Force | Out-Null }
+    foreach ($f in $required) {
+        $tmp = Join-Path $BOOTSTRAP_DIR "$f.tmp"
+        Copy-Item (Join-Path $srcDir $f) $tmp -Force
+        Move-Item $tmp (Join-Path $BOOTSTRAP_DIR $f) -Force
+    }
+    return $true
+}
+
+# ============================================================
+# Version resolution
+# ============================================================
+function Resolve-CurrentVersion {
+    if (Test-Path $CURRENT_FILE) {
+        $dir = (Get-Content $CURRENT_FILE -ErrorAction SilentlyContinue).Trim()
+        $path = Join-Path $VERSIONS_DIR $dir
+        if ($dir -and (Test-Path $path)) { return $path }
+    }
+    $indexJs = Join-Path $PACKAGE_DIR "dist\index.js"
+    if (Test-Path $indexJs) { return $PACKAGE_DIR }
+    return $null
+}
+
+function Resolve-PreviousVersion {
+    if (Test-Path $PREVIOUS_FILE) {
+        $dir = (Get-Content $PREVIOUS_FILE -ErrorAction SilentlyContinue).Trim()
+        $path = Join-Path $VERSIONS_DIR $dir
+        if ($dir -and (Test-Path $path)) { return $path }
+    }
+    return $null
+}
+
+function Get-VersionInfo {
+    param([string]$dir)
+    $vf = Join-Path $dir "VERSION"
+    $info = @{ version = ""; git_commit = ""; build_time = "" }
+    if (Test-Path $vf) {
+        Get-Content $vf | ForEach-Object {
+            if ($_ -match "^(\w+)=(.+)$") {
+                $info[$Matches[1]] = $Matches[2]
+            }
+        }
+    }
+    return $info
+}
+
+function Show-VersionString {
+    param([string]$dir)
+    $info = Get-VersionInfo $dir
+    if ($info.version) {
+        return "v$($info.version) ($($info.git_commit), $($info.build_time))"
+    }
+    return "unknown"
+}
+
+# ============================================================
+# Process management
+# ============================================================
+function Test-PidRunning {
+    param([string]$pidFile)
+    if (-not (Test-Path $pidFile)) { return $false }
+    $pidVal = (Get-Content $pidFile -ErrorAction SilentlyContinue).Trim()
+    if (-not $pidVal) {
+        Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
+        return $false
+    }
+    $proc = Get-Process -Id $pidVal -ErrorAction SilentlyContinue
+    if ($proc) { return $true }
+    Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
+    return $false
+}
+
+function Stop-PidFile {
+    param([string]$pidFile)
+    if (-not (Test-PidRunning $pidFile)) {
+        Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
+        return
+    }
+    $pidVal = (Get-Content $pidFile -ErrorAction SilentlyContinue).Trim()
+    try { Stop-Process -Id $pidVal -ErrorAction SilentlyContinue } catch {}
+    $count = 0
+    while ($count -lt 10) {
+        $proc = Get-Process -Id $pidVal -ErrorAction SilentlyContinue
+        if (-not $proc) { break }
+        Start-Sleep -Seconds 1
+        $count++
+    }
+    # Force kill if still running
+    try { Stop-Process -Id $pidVal -Force -ErrorAction SilentlyContinue } catch {}
+    Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
+}
+
+function Stop-OrphanProcesses {
+    Get-Process -Name "node" -ErrorAction SilentlyContinue |
+        Where-Object {
+            try {
+                $cmdLine = (Get-CimInstance Win32_Process -Filter "ProcessId = $($_.Id)" -ErrorAction SilentlyContinue).CommandLine
+                $cmdLine -match "collector-daemon" -or $cmdLine -match "updater-daemon"
+            } catch { $false }
+        } | ForEach-Object {
+            Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
+        }
+}
+
+# ============================================================
+# Task Scheduler management
+# ============================================================
+function Get-TaskExists {
+    param([string]$taskName)
+    $task = Get-ScheduledTask -TaskName $taskName -TaskPath "$TASK_FOLDER\" -ErrorAction SilentlyContinue
+    return $null -ne $task
+}
+
+function Get-TaskRunning {
+    param([string]$taskName)
+    $task = Get-ScheduledTask -TaskName $taskName -TaskPath "$TASK_FOLDER\" -ErrorAction SilentlyContinue
+    if (-not $task) { return $false }
+    return $task.State -eq "Running"
+}
+
+function Install-CollectorTask {
+    param([string]$nodeBin)
+    $entry = Join-Path $BOOTSTRAP_DIR "collector-daemon.js"
+    if (-not (Test-Path $entry)) {
+        Write-Host "Bootstrap script missing: $entry"
+        return $false
+    }
+
+    $action = New-ScheduledTaskAction `
+        -Execute "powershell.exe" `
+        -Argument "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$entry'`"" `
+        -WorkingDirectory $CACHE_DIR
+
+    $trigger = New-ScheduledTaskTrigger -AtLogOn
+
+    $settings = New-ScheduledTaskSettingsSet `
+        -AllowStartIfOnBatteries `
+        -DontStopIfGoingOnBatteries `
+        -DontStopOnIdleEnd `
+        -RestartCount 3 `
+        -RestartInterval (New-TimeSpan -Minutes 1) `
+        -ExecutionTimeLimit ([TimeSpan]::Zero)
+
+    # Remove existing task first (schtasks is more reliable than Unregister-ScheduledTask)
+    # Use try/catch because schtasks stderr + $ErrorActionPreference=Stop can throw
+    try { schtasks.exe /Delete /TN "$TASK_FOLDER\$TASK_NAME_COLLECTOR" /F 2>$null | Out-Null } catch {}
+    try { schtasks.exe /Delete /TN "$TASK_NAME_COLLECTOR" /F 2>$null | Out-Null } catch {}
+
+    Register-ScheduledTask `
+        -TaskName $TASK_NAME_COLLECTOR `
+        -TaskPath "$TASK_FOLDER\" `
+        -Action $action `
+        -Trigger $trigger `
+        -Settings $settings `
+        -Description "LoongSuite Pilot data collector" `
+        -ErrorAction Stop | Out-Null
+
+    return $true
+}
+
+function Install-UpdaterTask {
+    param([string]$nodeBin)
+    $entry = Join-Path $BOOTSTRAP_DIR "updater-daemon.js"
+    if (-not (Test-Path $entry)) { return $false }
+
+    $action = New-ScheduledTaskAction `
+        -Execute "powershell.exe" `
+        -Argument "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$entry'`"" `
+        -WorkingDirectory $CACHE_DIR
+
+    $trigger = New-ScheduledTaskTrigger -AtLogOn
+
+    $settings = New-ScheduledTaskSettingsSet `
+        -AllowStartIfOnBatteries `
+        -DontStopIfGoingOnBatteries `
+        -DontStopOnIdleEnd `
+        -RestartCount 3 `
+        -RestartInterval (New-TimeSpan -Minutes 5) `
+        -ExecutionTimeLimit ([TimeSpan]::Zero)
+
+    try { schtasks.exe /Delete /TN "$TASK_FOLDER\$TASK_NAME_UPDATER" /F 2>$null | Out-Null } catch {}
+    try { schtasks.exe /Delete /TN "$TASK_NAME_UPDATER" /F 2>$null | Out-Null } catch {}
+
+    Register-ScheduledTask `
+        -TaskName $TASK_NAME_UPDATER `
+        -TaskPath "$TASK_FOLDER\" `
+        -Action $action `
+        -Trigger $trigger `
+        -Settings $settings `
+        -Description "LoongSuite Pilot auto-updater" `
+        -ErrorAction Stop | Out-Null
+
+    return $true
+}
+
+function Remove-AllTasks {
+    foreach ($name in @($TASK_NAME_UPDATER, $TASK_NAME_COLLECTOR)) {
+        $task = Get-ScheduledTask -TaskName $name -TaskPath "$TASK_FOLDER\" -ErrorAction SilentlyContinue
+        if ($task) {
+            if ($task.State -eq "Running") {
+                Stop-ScheduledTask -TaskName $name -TaskPath "$TASK_FOLDER\" -ErrorAction SilentlyContinue
+            }
+        }
+        try { schtasks.exe /Delete /TN "$TASK_FOLDER\$name" /F 2>$null | Out-Null } catch {}
+        try { schtasks.exe /Delete /TN "$name" /F 2>$null | Out-Null } catch {}
+    }
+}
+
+# ============================================================
+# CMD: run (foreground, called by Task Scheduler)
+# ============================================================
+function Cmd-Run {
+    Ensure-Dirs
+    Sync-BootstrapScripts
+
+    $entry = Join-Path $BOOTSTRAP_DIR "collector-daemon.js"
+    if (-not (Test-Path $entry)) {
+        Write-Error "Bootstrap script missing"
+        exit 1
+    }
+
+    $nodeBin = Resolve-Node
+    if (-not $nodeBin) {
+        Write-Error "node runtime not found"
+        exit 1
+    }
+
+    Set-Content -Path $PID_FILE -Value $PID
+    $env:AGENT_DATA_COLLECTION_CONFIG = $CONFIG_FILE
+    & $nodeBin $entry
+}
+
+function Cmd-RunUpdater {
+    Ensure-Dirs
+    Sync-BootstrapScripts
+
+    $entry = Join-Path $BOOTSTRAP_DIR "updater-daemon.js"
+    if (-not (Test-Path $entry)) {
+        Write-Error "Bootstrap script missing"
+        exit 1
+    }
+
+    $nodeBin = Resolve-Node
+    if (-not $nodeBin) {
+        Write-Error "node runtime not found"
+        exit 1
+    }
+
+    Set-Content -Path $UPDATER_PID_FILE -Value $PID
+    $env:AGENT_DATA_COLLECTION_CONFIG = $CONFIG_FILE
+    & $nodeBin $entry
+}
+
+# ============================================================
+# CMD: start
+# ============================================================
+function Cmd-Start {
+    if (Test-PidRunning $PID_FILE) {
+        $pidVal = (Get-Content $PID_FILE).Trim()
+        Write-Host "loongsuite-pilot is already running (PID $pidVal)"
+        return
+    }
+
+    Ensure-Dirs
+    Sync-BootstrapScripts
+
+    $nodeBin = Resolve-Node
+    if (-not $nodeBin) {
+        Write-Error "node runtime not found"
+        exit 1
+    }
+
+    # Try Task Scheduler
+    $taskInstalled = $false
+    try {
+        $ok1 = Install-CollectorTask $nodeBin
+        $ok2 = Install-UpdaterTask $nodeBin
+        if ($ok1) {
+            Start-ScheduledTask -TaskName $TASK_NAME_COLLECTOR -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
+            if ($ok2) {
+                Start-ScheduledTask -TaskName $TASK_NAME_UPDATER -TaskPath "$TASK_FOLDER\" -ErrorAction SilentlyContinue
+            }
+            Set-Content -Path $INIT_TYPE_FILE -Value "taskscheduler"
+            for ($i = 0; $i -lt 5; $i++) {
+                Start-Sleep -Seconds 2
+                if (Get-TaskRunning $TASK_NAME_COLLECTOR) {
+                    Write-Host "loongsuite-pilot started (Task Scheduler)"
+                    return
+                }
+            }
+        }
+    } catch {
+        Write-Host "Task Scheduler registration failed: $_" -ForegroundColor Yellow
+    }
+
+    # Fallback: background process (like nohup on Linux)
+    Write-Host "Using background process fallback." -ForegroundColor Yellow
+    Write-Host "   Service will NOT auto-start on boot." -ForegroundColor Yellow
+
+    $entry = Join-Path $BOOTSTRAP_DIR "collector-daemon.js"
+    if (-not (Test-Path $entry)) {
+        Write-Error "Bootstrap script missing"
+        exit 1
+    }
+
+    $errLog = Join-Path $LOG_DIR "loongsuite-pilot-service-err.log"
+    $proc = Start-Process -FilePath "powershell.exe" `
+        -ArgumentList "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$entry' >> '$LOG_FILE' 2>> '$errLog'`"" `
+        -WorkingDirectory $CACHE_DIR `
+        -WindowStyle Hidden `
+        -PassThru
+
+    Set-Content -Path $PID_FILE -Value $proc.Id
+    Set-Content -Path $INIT_TYPE_FILE -Value "background"
+    Write-Host "loongsuite-pilot started (PID $($proc.Id), background)"
+
+    # Also start updater
+    $updaterEntry = Join-Path $BOOTSTRAP_DIR "updater-daemon.js"
+    if ((Test-Path $updaterEntry) -and -not (Test-PidRunning $UPDATER_PID_FILE)) {
+        $updaterErrLog = Join-Path $LOG_DIR "loongsuite-pilot-updater-err.log"
+        $uproc = Start-Process -FilePath "powershell.exe" `
+            -ArgumentList "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$updaterEntry' >> '$UPDATER_LOG_FILE' 2>> '$updaterErrLog'`"" `
+            -WorkingDirectory $CACHE_DIR `
+            -WindowStyle Hidden `
+            -PassThru
+        Set-Content -Path $UPDATER_PID_FILE -Value $uproc.Id
+        Write-Host "loongsuite-pilot updater started (PID $($uproc.Id))"
+    }
+}
+
+# ============================================================
+# CMD: stop
+# ============================================================
+function Cmd-Stop {
+    # Stop Task Scheduler tasks
+    foreach ($name in @($TASK_NAME_UPDATER, $TASK_NAME_COLLECTOR)) {
+        $task = Get-ScheduledTask -TaskName $name -TaskPath "$TASK_FOLDER\" -ErrorAction SilentlyContinue
+        if ($task -and $task.State -eq "Running") {
+            Stop-ScheduledTask -TaskName $name -TaskPath "$TASK_FOLDER\" -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Stop PID-tracked processes
+    Stop-PidFile $PID_FILE
+    Stop-PidFile $UPDATER_PID_FILE
+
+    # Kill orphan processes
+    Stop-OrphanProcesses
+
+    Write-Host "loongsuite-pilot stopped"
+}
+
+# ============================================================
+# CMD: restart
+# ============================================================
+function Cmd-Restart {
+    Cmd-Stop
+    Start-Sleep -Seconds 1
+    Cmd-Start
+}
+
+# ============================================================
+# CMD: restart-collector (used by updater after deploying a new version)
+# ============================================================
+function Cmd-RestartCollector {
+    # Stop collector only (leave updater running)
+    $task = Get-ScheduledTask -TaskName $TASK_NAME_COLLECTOR -TaskPath "$TASK_FOLDER\" -ErrorAction SilentlyContinue
+    if ($task -and $task.State -eq "Running") {
+        Stop-ScheduledTask -TaskName $TASK_NAME_COLLECTOR -TaskPath "$TASK_FOLDER\" -ErrorAction SilentlyContinue
+    }
+    Stop-PidFile $PID_FILE
+
+    # Kill orphan collector processes
+    Get-Process -Name "node" -ErrorAction SilentlyContinue |
+        Where-Object {
+            try {
+                $cmdLine = (Get-CimInstance Win32_Process -Filter "ProcessId = $($_.Id)" -ErrorAction SilentlyContinue).CommandLine
+                $cmdLine -match "collector-daemon"
+            } catch { $false }
+        } | ForEach-Object {
+            Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
+        }
+
+    Start-Sleep -Seconds 1
+    Ensure-Dirs
+    Sync-BootstrapScripts
+
+    $nodeBin = Resolve-Node
+    if (-not $nodeBin) {
+        Write-Error "node runtime not found"
+        exit 1
+    }
+
+    # Restart via Task Scheduler if registered
+    $restarted = $false
+    if (Get-TaskExists $TASK_NAME_COLLECTOR) {
+        try {
+            # Re-register with potentially updated paths
+            Install-CollectorTask $nodeBin | Out-Null
+            Start-ScheduledTask -TaskName $TASK_NAME_COLLECTOR -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
+            Write-Host "collector restarted (Task Scheduler)"
+            $restarted = $true
+        } catch {}
+    }
+
+    if (-not $restarted) {
+        $entry = Join-Path $BOOTSTRAP_DIR "collector-daemon.js"
+        if (-not (Test-Path $entry)) {
+            Write-Error "Bootstrap script missing"
+            exit 1
+        }
+        $errLog = Join-Path $LOG_DIR "loongsuite-pilot-service-err.log"
+        $proc = Start-Process -FilePath "powershell.exe" `
+            -ArgumentList "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$entry' >> '$LOG_FILE' 2>> '$errLog'`"" `
+            -WorkingDirectory $CACHE_DIR `
+            -WindowStyle Hidden `
+            -PassThru
+        Set-Content -Path $PID_FILE -Value $proc.Id
+        Write-Host "collector restarted (PID $($proc.Id))"
+    }
+
+    # Schedule updater restart in background (equivalent to setsid on Linux)
+    Start-Job -ScriptBlock {
+        Start-Sleep -Seconds 10
+        & $using:LOONGSUITE_PILOT_BIN restart-updater
+    } | Out-Null
+}
+
+# ============================================================
+# CMD: restart-updater
+# ============================================================
+function Cmd-RestartUpdater {
+    # Stop updater
+    $task = Get-ScheduledTask -TaskName $TASK_NAME_UPDATER -TaskPath "$TASK_FOLDER\" -ErrorAction SilentlyContinue
+    if ($task -and $task.State -eq "Running") {
+        Stop-ScheduledTask -TaskName $TASK_NAME_UPDATER -TaskPath "$TASK_FOLDER\" -ErrorAction SilentlyContinue
+    }
+    Stop-PidFile $UPDATER_PID_FILE
+
+    Get-Process -Name "node" -ErrorAction SilentlyContinue |
+        Where-Object {
+            try {
+                $cmdLine = (Get-CimInstance Win32_Process -Filter "ProcessId = $($_.Id)" -ErrorAction SilentlyContinue).CommandLine
+                $cmdLine -match "updater-daemon"
+            } catch { $false }
+        } | ForEach-Object {
+            Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
+        }
+
+    Start-Sleep -Seconds 1
+    Ensure-Dirs
+    Sync-BootstrapScripts
+
+    $nodeBin = Resolve-Node
+    if (-not $nodeBin) {
+        Write-Error "node runtime not found"
+        return
+    }
+
+    # Restart via Task Scheduler
+    $restarted = $false
+    if (Get-TaskExists $TASK_NAME_UPDATER) {
+        try {
+            Install-UpdaterTask $nodeBin | Out-Null
+            Start-ScheduledTask -TaskName $TASK_NAME_UPDATER -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
+            Start-Sleep -Seconds 1
+            if (Get-TaskRunning $TASK_NAME_UPDATER) {
+                Write-Host "updater restarted (Task Scheduler)"
+                $restarted = $true
+            }
+        } catch {}
+    }
+
+    if (-not $restarted) {
+        $entry = Join-Path $BOOTSTRAP_DIR "updater-daemon.js"
+        if (-not (Test-Path $entry)) {
+            Write-Host "Updater bootstrap script missing"
+            return
+        }
+        $updaterErrLog = Join-Path $LOG_DIR "loongsuite-pilot-updater-err.log"
+        $proc = Start-Process -FilePath "powershell.exe" `
+            -ArgumentList "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$entry' >> '$UPDATER_LOG_FILE' 2>> '$updaterErrLog'`"" `
+            -WorkingDirectory $CACHE_DIR `
+            -WindowStyle Hidden `
+            -PassThru
+        Set-Content -Path $UPDATER_PID_FILE -Value $proc.Id
+        Write-Host "updater restarted (PID $($proc.Id))"
+    }
+}
+
+# ============================================================
+# CMD: status
+# ============================================================
+function Cmd-Status {
+    $verInfo = ""
+    $versionDir = Resolve-CurrentVersion
+    if ($versionDir) {
+        $info = Get-VersionInfo $versionDir
+        if ($info.version) {
+            $verInfo = " v$($info.version) ($($info.git_commit))"
+        }
+    }
+
+    # Collector status
+    $collectorRunning = $false
+    if (Test-PidRunning $PID_FILE) {
+        $pidVal = (Get-Content $PID_FILE).Trim()
+        Write-Host "loongsuite-pilot${verInfo} is running (PID $pidVal)"
+        $collectorRunning = $true
+    } elseif (Get-TaskRunning $TASK_NAME_COLLECTOR) {
+        Write-Host "loongsuite-pilot${verInfo} is running (Task Scheduler)"
+        $collectorRunning = $true
+    }
+    if (-not $collectorRunning) {
+        Write-Host "loongsuite-pilot${verInfo} is not running"
+    }
+
+    # Updater status
+    if (Test-PidRunning $UPDATER_PID_FILE) {
+        $pidVal = (Get-Content $UPDATER_PID_FILE).Trim()
+        Write-Host "   updater: running (PID $pidVal)"
+    } elseif (Get-TaskRunning $TASK_NAME_UPDATER) {
+        Write-Host "   updater: running (Task Scheduler)"
+    } else {
+        Write-Host "   updater: stopped"
+    }
+
+    # Autostart status
+    if (Get-TaskExists $TASK_NAME_COLLECTOR) {
+        $task = Get-ScheduledTask -TaskName $TASK_NAME_COLLECTOR -TaskPath "$TASK_FOLDER\"
+        $triggerInfo = if ($task.Triggers.Count -gt 0) { $task.Triggers[0].CimClass.CimClassName } else { "none" }
+        Write-Host "   autostart: enabled (Task Scheduler, trigger: AtLogon)"
+    } else {
+        $initType = ""
+        if (Test-Path $INIT_TYPE_FILE) { $initType = (Get-Content $INIT_TYPE_FILE -ErrorAction SilentlyContinue).Trim() }
+        if ($initType -eq "background") {
+            Write-Host "   autostart: disabled (background process fallback)"
+        } else {
+            Write-Host "   autostart: not configured"
+        }
+    }
+}
+
+# ============================================================
+# CMD: info
+# ============================================================
+function Cmd-Info {
+    $versionDir = Resolve-CurrentVersion
+    if ($versionDir) {
+        $vf = Join-Path $versionDir "VERSION"
+        if (Test-Path $vf) {
+            Get-Content $vf
+        } else {
+            Write-Host "version=unknown"
+        }
+    } else {
+        Write-Host "version=unknown"
+    }
+
+    Write-Host ""
+    Write-Host "data_dir=$DATA_DIR"
+    Write-Host "config=$CONFIG_FILE"
+    Write-Host "log=$LOG_FILE"
+    Write-Host "versions_dir=$VERSIONS_DIR"
+
+    if (Test-Path $NODE_PIN_FILE) {
+        $pinnedNode = (Get-Content $NODE_PIN_FILE -ErrorAction SilentlyContinue).Trim()
+        if ($pinnedNode -and (Test-Path $pinnedNode)) {
+            $nodeVer = & $pinnedNode --version 2>$null
+            Write-Host "node_bin=$pinnedNode"
+            Write-Host "node_version=$nodeVer"
+        } else {
+            Write-Host "node_bin=$pinnedNode (stale)"
+            $resolved = Resolve-Node
+            if ($resolved) {
+                $nodeVer = & $resolved --version 2>$null
+                Write-Host "node_version=$nodeVer"
+            }
+        }
+    } else {
+        Write-Host "node_bin=not pinned"
+        $resolved = Resolve-Node
+        if ($resolved) {
+            $nodeVer = & $resolved --version 2>$null
+            Write-Host "node_resolved=$resolved"
+            Write-Host "node_version=$nodeVer"
+        }
+    }
+
+    Write-Host ""
+    if (Test-Path $CONFIG_FILE) {
+        Get-Content $CONFIG_FILE
+    }
+}
+
+# ============================================================
+# CMD: rollback
+# ============================================================
+function Cmd-Rollback {
+    if (-not (Test-Path $PREVIOUS_FILE)) {
+        Write-Error "No previous version to roll back to"
+        exit 1
+    }
+
+    $prevDir = (Get-Content $PREVIOUS_FILE -ErrorAction SilentlyContinue).Trim()
+    $prevPath = Join-Path $VERSIONS_DIR $prevDir
+    if (-not $prevDir -or -not (Test-Path $prevPath)) {
+        Write-Error "Previous version directory not found: $prevDir"
+        exit 1
+    }
+
+    $currDir = ""
+    if (Test-Path $CURRENT_FILE) {
+        $currDir = (Get-Content $CURRENT_FILE -ErrorAction SilentlyContinue).Trim()
+    }
+
+    # Swap current/previous pointers
+    Set-Content -Path $CURRENT_FILE -Value $prevDir
+    if ($currDir) {
+        Set-Content -Path $PREVIOUS_FILE -Value $currDir
+    }
+
+    # Sync scripts from the rollback target
+    $ok = Sync-InstalledScriptsFromVersion $prevPath
+    if (-not $ok) {
+        # Revert pointer swap
+        if ($currDir) {
+            Set-Content -Path $CURRENT_FILE -Value $currDir
+            Set-Content -Path $PREVIOUS_FILE -Value $prevDir
+            Sync-InstalledScriptsFromVersion (Join-Path $VERSIONS_DIR $currDir) | Out-Null
+        }
+        Write-Error "Failed to sync scripts for rollback target: $prevDir"
+        exit 1
+    }
+
+    Write-Host "Rolled back to version: $prevDir"
+    Write-Host "   Restarting service..."
+    Cmd-Restart
+}
+
+# ============================================================
+# CMD: log (tail service log)
+# ============================================================
+function Cmd-Log {
+    if (Test-Path $LOG_FILE) {
+        Get-Content $LOG_FILE -Tail 50 -Wait
+    } else {
+        Write-Host "No log file found: $LOG_FILE"
+    }
+}
+
+# ============================================================
+# CMD: help
+# ============================================================
+function Cmd-Help {
+    Write-Host "Usage: loongsuite-pilot <command>"
+    Write-Host ""
+    Write-Host "Commands:"
+    Write-Host "  start           Start the collector service"
+    Write-Host "  stop            Stop the collector service"
+    Write-Host "  restart         Restart the collector service"
+    Write-Host "  status          Show service status (default)"
+    Write-Host "  info            Show version and config info"
+    Write-Host "  log             Tail the service log"
+    Write-Host "  rollback        Roll back to the previous version"
+    Write-Host "  help            Show this help message"
+}
+
+# ============================================================
+# Dispatch
+# ============================================================
+switch ($Command.ToLower()) {
+    "start"              { Cmd-Start }
+    "stop"               { Cmd-Stop }
+    "restart"            { Cmd-Restart }
+    "status"             { Cmd-Status }
+    "info"               { Cmd-Info }
+    "log"                { Cmd-Log }
+    "rollback"           { Cmd-Rollback }
+    "restart-collector"  { Cmd-RestartCollector }
+    "restart-updater"    { Cmd-RestartUpdater }
+    "run"                { Cmd-Run }
+    "run-updater"        { Cmd-RunUpdater }
+    { $_ -in "help","--help","-h" } { Cmd-Help }
+    default {
+        Write-Host "Unknown command: $Command"
+        Cmd-Help
+        exit 1
+    }
+}

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -21,7 +21,7 @@ const PROJECT_ROOT = path.resolve(__dirname, '..');
 const HOOKS_SOURCE_DIR = path.join(PROJECT_ROOT, 'assets', 'hooks');
 const SKILLS_SOURCE_DIR = path.join(PROJECT_ROOT, 'assets', 'skills');
 const PLUGINS_SOURCE_DIR = path.join(PROJECT_ROOT, 'assets', 'plugins');
-const LOONGSUITE_PILOT_DIR = process.env.LOONGSUITE_PILOT_DATA_DIR || path.join(process.env.HOME || '', '.loongsuite-pilot');
+const LOONGSUITE_PILOT_DIR = process.env.LOONGSUITE_PILOT_DATA_DIR || path.join(process.env.HOME || process.env.USERPROFILE || '', '.loongsuite-pilot');
 const HOOKS_TARGET_DIR = path.join(LOONGSUITE_PILOT_DIR, 'hooks');
 const SKILLS_TARGET_DIR = path.join(LOONGSUITE_PILOT_DIR, 'skills');
 const PLUGINS_TARGET_DIR = path.join(LOONGSUITE_PILOT_DIR, 'plugins');
@@ -149,7 +149,7 @@ function main() {
   // Old otel-claude-hook versions injected NODE_OPTIONS="--require intercept.js" into shell profiles.
   // After upgrade the real file is removed, but already-open terminals still have NODE_OPTIONS set,
   // causing MODULE_NOT_FOUND errors. This stub prevents that.
-  const legacyIntercept = path.join(process.env.HOME || '', '.cache', 'opentelemetry.instrumentation.claude', 'intercept.js');
+  const legacyIntercept = path.join(process.env.HOME || process.env.USERPROFILE || '', '.cache', 'opentelemetry.instrumentation.claude', 'intercept.js');
   if (!fs.existsSync(legacyIntercept)) {
     try {
       ensureDir(path.dirname(legacyIntercept));
@@ -174,7 +174,7 @@ const migrationScript = path.join(__dirname, 'migrate-internal-config.js');
 if (fs.existsSync(migrationScript)) {
   try {
     const { migrate } = await import(pathToFileURL(migrationScript).href);
-    const dataDir = process.env.LOONGSUITE_PILOT_DATA_DIR || path.join(process.env.HOME || '', '.loongsuite-pilot');
+    const dataDir = process.env.LOONGSUITE_PILOT_DATA_DIR || path.join(process.env.HOME || process.env.USERPROFILE || '', '.loongsuite-pilot');
     const configPath = path.join(dataDir, 'config.json');
     if (migrate(configPath)) {
       console.log('[loongsuite-pilot] Config migrated: internal SLS moved to configs/inner/data_config.json');

--- a/scripts/updater-daemon.js
+++ b/scripts/updater-daemon.js
@@ -1,8 +1,9 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
+const { pathToFileURL } = require('url');
 
-const CACHE_DIR = path.join(process.env.HOME || '', '.loongsuite-pilot');
+const CACHE_DIR = path.join(process.env.HOME || process.env.USERPROFILE || '', '.loongsuite-pilot');
 const CURRENT_FILE = path.join(CACHE_DIR, 'current');
 const VERSIONS_DIR = path.join(CACHE_DIR, 'versions');
 
@@ -21,7 +22,7 @@ if (!entry) {
   console.error('[loongsuite-pilot] No valid updater version found');
   process.exit(1);
 }
-import(entry).catch(err => {
+import(pathToFileURL(entry).href).catch(err => {
   console.error('[loongsuite-pilot] Failed to load updater:', err.message);
   process.exit(1);
 });

--- a/src/core/config-loader.ts
+++ b/src/core/config-loader.ts
@@ -152,7 +152,8 @@ export interface ConfigFile {
 }
 
 function env(key: string): string | undefined {
-  return process.env[key];
+  const v = process.env[key];
+  return v !== undefined ? (process.platform === 'win32' ? v.trim() : v) : undefined;
 }
 
 function envBool(key: string, fallback: boolean): boolean {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -324,11 +324,12 @@ export class Orchestrator extends EventEmitter {
     for (const def of defs) {
       if (def.deployMode !== 'hook' || !def.hook) continue;
 
+      const scriptName = path.basename(def.hook.hookCommand.split(' ')[0]);
       targets.push({
         agentId: def.id,
         settingsPath: def.hook.settingsPath,
         expectedHooks: def.hook.events,
-        markers: [def.hook.hookCommand],
+        markers: [scriptName],
         repairFn: () => this.deploymentManager.deploySingle(def).then(r => r.success),
       });
     }
@@ -500,14 +501,16 @@ export class Orchestrator extends EventEmitter {
         listenerCfg['qoder-trace']?.enabled ?? true,
       );
 
-    // --- Qoder (SQLite token usage polling) — disabled when qoder-trace is enabled ---
+    // --- Qoder (SQLite token usage polling) ---
+    // On Windows, Qoder IDE's agent backend does not fire user-defined hooks,
+    // so qoder-trace produces no IDE data. Allow qoder-sqlite as fallback.
     const qoderSqliteInput = new QoderSqliteInput({ stateStore: this.stateStore });
     this.inputManager.registerInput(qoderSqliteInput);
     entries.push(
       this.inputManager.buildDetectionEntry(qoderSqliteInput, {
         watchPaths: QoderSqliteInput.getWatchPaths(),
         isAvailable: QoderSqliteInput.checkAvailability,
-        enabled: () => !qoderTraceEnabled() &&
+        enabled: () => (process.platform === 'win32' || !qoderTraceEnabled()) &&
           this.isAgentGatedEnabled(Orchestrator.LISTENER_AGENT_MAP['qoder-sqlite']) &&
           this.agentControlManager.resolveEnabled(
             'qoder-sqlite',
@@ -545,14 +548,15 @@ export class Orchestrator extends EventEmitter {
         listenerCfg['qoder-cn-trace']?.enabled ?? true,
       );
 
-    // --- QoderCN (SQLite token usage polling) — disabled when qoder-cn-trace is enabled ---
+    // --- QoderCN (SQLite token usage polling) ---
+    // Same Windows fallback as qoder-sqlite above.
     const qoderCnSqliteInput = new QoderCnSqliteInput({ stateStore: this.stateStore });
     this.inputManager.registerInput(qoderCnSqliteInput);
     entries.push(
       this.inputManager.buildDetectionEntry(qoderCnSqliteInput, {
         watchPaths: QoderCnSqliteInput.getWatchPaths(),
         isAvailable: QoderCnSqliteInput.checkAvailability,
-        enabled: () => !qoderCnTraceEnabled() &&
+        enabled: () => (process.platform === 'win32' || !qoderCnTraceEnabled()) &&
           this.isAgentGatedEnabled(Orchestrator.LISTENER_AGENT_MAP['qoder-cn-sqlite']) &&
           this.agentControlManager.resolveEnabled(
             'qoder-cn-sqlite',

--- a/src/deployment/agent-def-loader.ts
+++ b/src/deployment/agent-def-loader.ts
@@ -124,6 +124,10 @@ export class AgentDefLoader {
       .replace(/\$PILOT_DATA/g, this.dataDir);
 
     result = resolveHome(result);
+
+    if (process.platform === 'win32') {
+      result = result.replace(/\.sh$/, '.ps1');
+    }
     return result;
   }
 }

--- a/src/deployment/hook-strategy.ts
+++ b/src/deployment/hook-strategy.ts
@@ -28,6 +28,21 @@ function eventToSubcommand(event: string): string {
 }
 
 /**
+ * On Windows, .ps1 scripts must be invoked via `powershell -File` for stdin
+ * piping to work correctly.  Bare `.ps1` paths fail to receive stdin when
+ * spawned through cmd.exe / child_process.
+ */
+function wrapPs1Command(cmd: string): string {
+  if (process.platform !== 'win32') return cmd;
+  const parts = cmd.split(' ');
+  const script = parts[0];
+  if (!script.endsWith('.ps1')) return cmd;
+  const args = parts.slice(1).join(' ');
+  const wrapped = `powershell -NoProfile -ExecutionPolicy Bypass -File "${script}"`;
+  return args ? `${wrapped} ${args}` : wrapped;
+}
+
+/**
  * 拼 hooks.json 中实际写入的 command 字符串。
  * 必须与 codex trust hash 算用的字符串完全一致。
  */
@@ -36,10 +51,11 @@ function formatHookCommand(
   event: string,
   style: AgentHookConfig['eventSubcommand'],
 ): string {
+  const cmd = wrapPs1Command(hookCommand);
   if (style === 'kebab-case') {
-    return `${hookCommand} ${eventToSubcommand(event)}`;
+    return `${cmd} ${eventToSubcommand(event)}`;
   }
-  return hookCommand;
+  return cmd;
 }
 
 export class HookStrategy implements DeployStrategy {

--- a/src/hooks/hook-manager.ts
+++ b/src/hooks/hook-manager.ts
@@ -11,6 +11,14 @@ import {
 import { createLogger } from '../utils/logger.js';
 
 const logger = createLogger('HookManager');
+const hookExt = process.platform === 'win32' ? '.ps1' : '.sh';
+const isWin = process.platform === 'win32';
+
+function wrapHookCommand(scriptPath: string, args?: string): string {
+  if (!isWin) return args ? `${scriptPath} ${args}` : scriptPath;
+  const cmd = `powershell -NoProfile -ExecutionPolicy Bypass -File "${scriptPath}"`;
+  return args ? `${cmd} ${args}` : cmd;
+}
 
 export interface HookDefinition {
   /** Agent identifier (e.g. "qoder", "claude"). */
@@ -185,7 +193,7 @@ export class HookManager {
    */
   static buildCursorHooks(loongsuitePilotDir?: string): HookDefinition[] {
     const baseDir = loongsuitePilotDir ?? resolveHome('~/.loongsuite-pilot');
-    const command = `${baseDir}/hooks/cursor-loongsuite-pilot-hook.sh`;
+    const command = wrapHookCommand(`${baseDir}/hooks/cursor-loongsuite-pilot-hook${hookExt}`);
     const settingsPath = resolveHome('~/.cursor/hooks.json');
 
     const events = [
@@ -217,7 +225,7 @@ export class HookManager {
    */
   static buildQoderCliHooks(loongsuitePilotDir?: string): HookDefinition[] {
     const baseDir = loongsuitePilotDir ?? resolveHome('~/.loongsuite-pilot');
-    const command = `${baseDir}/hooks/qoder-loongsuite-pilot-hook.sh qoder`;
+    const command = wrapHookCommand(`${baseDir}/hooks/qoder-loongsuite-pilot-hook${hookExt}`, 'qoder');
     const settingsPath = resolveHome('~/.qoder/settings.json');
 
     return [
@@ -237,9 +245,17 @@ export class HookManager {
    */
   static buildQoderWorkHooks(loongsuitePilotDir?: string): HookDefinition[] {
     const baseDir = loongsuitePilotDir ?? resolveHome('~/.loongsuite-pilot');
-    const command = `${baseDir}/hooks/qoderwork-loongsuite-pilot-hook.sh`;
-    const legacyCommand = `${baseDir}/hooks/qoder-loongsuite-pilot-hook.sh qoder-work`;
+    const command = wrapHookCommand(`${baseDir}/hooks/qoderwork-loongsuite-pilot-hook${hookExt}`);
+    const legacyCommand = wrapHookCommand(`${baseDir}/hooks/qoder-loongsuite-pilot-hook${hookExt}`, 'qoder-work');
     const settingsPath = resolveHome('~/.qoderwork/settings.json');
+
+    const replaceCmds = [legacyCommand];
+    if (isWin) {
+      replaceCmds.push(`${baseDir}/hooks/qoderwork-loongsuite-pilot-hook.sh`);
+      replaceCmds.push(`${baseDir}/hooks/qoderwork-loongsuite-pilot-hook.ps1`);
+      replaceCmds.push(`${baseDir}/hooks/qoder-loongsuite-pilot-hook.sh qoder-work`);
+      replaceCmds.push(`${baseDir}/hooks/qoder-loongsuite-pilot-hook.ps1 qoder-work`);
+    }
 
     return [
       {
@@ -247,7 +263,7 @@ export class HookManager {
         settingsPath,
         hookJsonPath: ['hooks', 'Stop'],
         hookCommand: command,
-        replaceHookCommands: [legacyCommand],
+        replaceHookCommands: replaceCmds,
         matcher: '*',
         useNestedFormat: true,
       },
@@ -256,9 +272,17 @@ export class HookManager {
 
   static buildQoderWorkCNHooks(loongsuitePilotDir?: string): HookDefinition[] {
     const baseDir = loongsuitePilotDir ?? resolveHome('~/.loongsuite-pilot');
-    const command = `${baseDir}/hooks/qoderworkcn-loongsuite-pilot-hook.sh`;
-    const legacyCommand = `${baseDir}/hooks/qoder-loongsuite-pilot-hook.sh qoder-work-cn`;
+    const command = wrapHookCommand(`${baseDir}/hooks/qoderworkcn-loongsuite-pilot-hook${hookExt}`);
+    const legacyCommand = wrapHookCommand(`${baseDir}/hooks/qoder-loongsuite-pilot-hook${hookExt}`, 'qoder-work-cn');
     const settingsPath = resolveHome('~/.qoderworkcn/settings.json');
+
+    const replaceCmds = [legacyCommand];
+    if (isWin) {
+      replaceCmds.push(`${baseDir}/hooks/qoderworkcn-loongsuite-pilot-hook.sh`);
+      replaceCmds.push(`${baseDir}/hooks/qoderworkcn-loongsuite-pilot-hook.ps1`);
+      replaceCmds.push(`${baseDir}/hooks/qoder-loongsuite-pilot-hook.sh qoder-work-cn`);
+      replaceCmds.push(`${baseDir}/hooks/qoder-loongsuite-pilot-hook.ps1 qoder-work-cn`);
+    }
 
     return [
       {
@@ -266,7 +290,7 @@ export class HookManager {
         settingsPath,
         hookJsonPath: ['hooks', 'Stop'],
         hookCommand: command,
-        replaceHookCommands: [legacyCommand],
+        replaceHookCommands: replaceCmds,
         matcher: '*',
         useNestedFormat: true,
       },
@@ -294,7 +318,7 @@ export class HookManager {
       agentId: opts.agentId,
       settingsPath: path.join(opts.settingsDir, 'settings.json'),
       hookJsonPath: ['hooks', 'PostToolUse'],
-      hookCommand: `${baseDir}/hooks/${opts.agentId}-hook.sh`,
+      hookCommand: wrapHookCommand(`${baseDir}/hooks/${opts.agentId}-hook${hookExt}`),
       matcher: '*',
     };
   }

--- a/src/inputs/qoder-cn-sqlite/qoder-cn-sqlite-input.ts
+++ b/src/inputs/qoder-cn-sqlite/qoder-cn-sqlite-input.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import sqlite3 from 'sqlite3';
 import { ClientType } from '../../types/index.js';
@@ -138,6 +139,9 @@ export class QoderCnSqliteInput extends BaseSqliteInput {
 function resolveQoderCnRoot(): string {
   if (process.platform === 'darwin') {
     return resolveHome(DEFAULT_QODER_CN_ROOT_MAC);
+  }
+  if (process.platform === 'win32') {
+    return path.join(process.env.APPDATA ?? path.join(os.homedir(), 'AppData', 'Roaming'), 'QoderCN');
   }
   const xdg = process.env.XDG_CONFIG_HOME;
   if (xdg) return path.join(xdg, 'QoderCN');

--- a/src/inputs/qoder-cn-trace/sqlite-token-reader.ts
+++ b/src/inputs/qoder-cn-trace/sqlite-token-reader.ts
@@ -1,4 +1,6 @@
 import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import sqlite3 from 'sqlite3';
 import { resolveHome } from '../../utils/fs-utils.js';
 import { createLogger } from '../../utils/logger.js';
@@ -52,9 +54,12 @@ export async function readSqliteTokensForSession(sessionId: string): Promise<Sql
 }
 
 function resolveQoderCnDbPath(): string | null {
+  const appdata = process.env.APPDATA ?? path.join(os.homedir(), 'AppData', 'Roaming');
   const candidates = process.platform === 'darwin'
     ? [resolveHome('~/Library/Application Support/QoderCN/SharedClientCache/cache/db/local.db')]
-    : [resolveHome('~/.config/QoderCN/SharedClientCache/cache/db/local.db')];
+    : process.platform === 'win32'
+      ? [path.join(appdata, 'QoderCN', 'SharedClientCache', 'cache', 'db', 'local.db')]
+      : [resolveHome('~/.config/QoderCN/SharedClientCache/cache/db/local.db')];
 
   for (const candidate of candidates) {
     try {

--- a/src/inputs/qoder-cn/qoder-cn-input.ts
+++ b/src/inputs/qoder-cn/qoder-cn-input.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { ClientType, ActionType } from '../../types/index.js';
 import type { AgentActivityEntry, CodeGenerationEvent } from '../../types/index.js';
@@ -12,6 +13,9 @@ const DEFAULT_QODER_CN_ROOT_LINUX = '~/.config/QoderCN';
 function resolveQoderCnRoot(): string {
   if (process.platform === 'darwin') {
     return resolveHome(DEFAULT_QODER_CN_ROOT_MAC);
+  }
+  if (process.platform === 'win32') {
+    return path.join(process.env.APPDATA ?? path.join(os.homedir(), 'AppData', 'Roaming'), 'QoderCN');
   }
   const xdg = process.env.XDG_CONFIG_HOME;
   if (xdg) return path.join(xdg, 'QoderCN');

--- a/src/inputs/qoder-sqlite/qoder-sqlite-input.ts
+++ b/src/inputs/qoder-sqlite/qoder-sqlite-input.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import sqlite3 from 'sqlite3';
 import { ClientType } from '../../types/index.js';
@@ -138,6 +139,9 @@ export class QoderSqliteInput extends BaseSqliteInput {
 function resolveQoderRoot(): string {
   if (process.platform === 'darwin') {
     return resolveHome(DEFAULT_QODER_ROOT_MAC);
+  }
+  if (process.platform === 'win32') {
+    return path.join(process.env.APPDATA ?? path.join(os.homedir(), 'AppData', 'Roaming'), 'Qoder');
   }
   const xdg = process.env.XDG_CONFIG_HOME;
   if (xdg) return path.join(xdg, 'Qoder');

--- a/src/inputs/qoder-trace/sqlite-token-reader.ts
+++ b/src/inputs/qoder-trace/sqlite-token-reader.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import sqlite3 from 'sqlite3';
 import { resolveHome } from '../../utils/fs-utils.js';
@@ -53,9 +54,12 @@ export async function readSqliteTokensForSession(sessionId: string): Promise<Sql
 }
 
 function resolveQoderDbPath(): string | null {
+  const appdata = process.env.APPDATA ?? path.join(os.homedir(), 'AppData', 'Roaming');
   const candidates = process.platform === 'darwin'
     ? [resolveHome('~/Library/Application Support/Qoder/SharedClientCache/cache/db/local.db')]
-    : [resolveHome('~/.config/Qoder/SharedClientCache/cache/db/local.db')];
+    : process.platform === 'win32'
+      ? [path.join(appdata, 'Qoder', 'SharedClientCache', 'cache', 'db', 'local.db')]
+      : [resolveHome('~/.config/Qoder/SharedClientCache/cache/db/local.db')];
 
   // Sync access check: only runs once per collect cycle for a fixed set of paths.
   // Acceptable because the path list is small (1-2 candidates) and the result is cached by callers.

--- a/src/inputs/qoder-work-log/qoder-work-log-input.ts
+++ b/src/inputs/qoder-work-log/qoder-work-log-input.ts
@@ -1,5 +1,6 @@
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import type { Dirent } from 'node:fs';
 import { ClientType } from '../../types/index.js';
@@ -648,8 +649,11 @@ export function resolveQoderWorkRoot(variant: 'standard' | 'cn' = 'standard'): s
   if (process.platform === 'darwin') {
     return resolveHome(variant === 'cn' ? DEFAULT_QODERWORK_CN_ROOT_MAC : DEFAULT_QODERWORK_ROOT_MAC);
   }
-  const xdg = process.env.XDG_CONFIG_HOME;
   const dirName = variant === 'cn' ? 'QoderWork CN' : 'QoderWork';
+  if (process.platform === 'win32') {
+    return path.join(process.env.APPDATA ?? path.join(os.homedir(), 'AppData', 'Roaming'), dirName);
+  }
+  const xdg = process.env.XDG_CONFIG_HOME;
   if (xdg) return path.join(xdg, dirName);
   return resolveHome(variant === 'cn' ? DEFAULT_QODERWORK_CN_ROOT_LINUX : DEFAULT_QODERWORK_ROOT_LINUX);
 }

--- a/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
+++ b/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
@@ -1,5 +1,6 @@
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { ClientType, CollectionMethod } from '../../types/index.js';
 import type { AgentActivityEntry } from '../../types/index.js';
@@ -506,6 +507,9 @@ async function computeFileSignature(filePath: string): Promise<string> {
 function resolveQoderWorkSdkLogDir(): string {
   if (process.platform === 'darwin') {
     return resolveHome('~/Library/Application Support/QoderWork/logs');
+  }
+  if (process.platform === 'win32') {
+    return path.join(process.env.APPDATA ?? path.join(os.homedir(), 'AppData', 'Roaming'), 'QoderWork', 'logs');
   }
   const xdg = process.env.XDG_CONFIG_HOME;
   if (xdg) return path.join(xdg, 'QoderWork', 'logs');

--- a/src/inputs/qoder/qoder-input.ts
+++ b/src/inputs/qoder/qoder-input.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { ClientType, ActionType } from '../../types/index.js';
 import type { AgentActivityEntry, CodeGenerationEvent } from '../../types/index.js';
@@ -12,6 +13,9 @@ const DEFAULT_QODER_ROOT_LINUX = '~/.config/Qoder';
 function resolveQoderRoot(): string {
   if (process.platform === 'darwin') {
     return resolveHome(DEFAULT_QODER_ROOT_MAC);
+  }
+  if (process.platform === 'win32') {
+    return path.join(process.env.APPDATA ?? path.join(os.homedir(), 'AppData', 'Roaming'), 'Qoder');
   }
   const xdg = process.env.XDG_CONFIG_HOME;
   if (xdg) return path.join(xdg, 'Qoder');

--- a/src/updater/updater-metrics.ts
+++ b/src/updater/updater-metrics.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
 import { appendLine, ensureDir } from '../utils/fs-utils.js';
 import { createLogger } from '../utils/logger.js';
 import { resolveLocalIp } from '../utils/network-utils.js';
@@ -143,7 +144,7 @@ export class UpdaterMetrics {
   }
 
   private checkCollectorHealth(): void {
-    if (!isPidFileRunning(this.collectorPidFile)) {
+    if (!isCollectorRunning(this.collectorPidFile)) {
       logger.warn('collector process not running');
       this.writeAlarm(
         'SERVICE_NOT_RUNNING_ALARM', '3',
@@ -160,6 +161,24 @@ function isPidFileRunning(pidFile: string): boolean {
     if (!Number.isInteger(pid) || pid <= 0) return false;
     process.kill(pid, 0);
     return true;
+  } catch {
+    return false;
+  }
+}
+
+function isCollectorRunning(pidFile: string): boolean {
+  if (isPidFileRunning(pidFile)) return true;
+  if (process.platform !== 'win32') return false;
+
+  // On Windows, Task Scheduler launches the collector without writing a PID file.
+  // Fall back to checking if a node process running collector-daemon.js exists.
+  try {
+    const ps = 'Get-CimInstance Win32_Process | Where-Object { $_.Name -eq "node.exe" -and $_.CommandLine -like "*collector-daemon*" } | Select-Object -ExpandProperty ProcessId';
+    const out = execFileSync('powershell.exe', [
+      '-NoProfile', '-WindowStyle', 'Hidden', '-Command', ps,
+    ], { timeout: 8000, encoding: 'utf-8', windowsHide: true });
+    const pids = out.split(/\r?\n/).map(l => l.trim()).filter(l => /^\d+$/.test(l));
+    return pids.length > 0;
   } catch {
     return false;
   }

--- a/src/updater/updater.ts
+++ b/src/updater/updater.ts
@@ -6,6 +6,7 @@ import { createWriteStream } from 'node:fs';
 import { pipeline } from 'node:stream/promises';
 import { Readable } from 'node:stream';
 import * as crypto from 'node:crypto';
+import * as os from 'node:os';
 import type { AutoUpdateConfig } from '../types/index.js';
 import { createLogger } from '../utils/logger.js';
 import { readJsonFile, writeJsonFile, resolveHome } from '../utils/fs-utils.js';
@@ -66,15 +67,26 @@ export interface UpdaterPaths {
   loongsuitePilotBin: string;
 }
 
+function homeDir(): string {
+  return process.env.HOME ?? process.env.USERPROFILE ?? os.homedir();
+}
+
+function pilotBinPath(): string {
+  const home = homeDir();
+  const ext = process.platform === 'win32' ? '.ps1' : '';
+  return path.join(home, '.local', 'bin', `loongsuite-pilot${ext}`);
+}
+
 function defaultPaths(): UpdaterPaths {
-  const cacheDir = path.join(process.env.HOME ?? '', '.loongsuite-pilot');
+  const home = homeDir();
+  const cacheDir = path.join(home, '.loongsuite-pilot');
   return {
     cacheDir,
     versionsDir: path.join(cacheDir, 'versions'),
     currentFile: path.join(cacheDir, 'current'),
     previousFile: path.join(cacheDir, 'previous'),
     bootstrapDir: path.join(cacheDir, 'bin'),
-    loongsuitePilotBin: path.join(process.env.HOME ?? '', '.local', 'bin', 'loongsuite-pilot'),
+    loongsuitePilotBin: pilotBinPath(),
   };
 }
 
@@ -85,7 +97,7 @@ export function buildPaths(baseDir: string): UpdaterPaths {
     currentFile: path.join(baseDir, 'current'),
     previousFile: path.join(baseDir, 'previous'),
     bootstrapDir: path.join(baseDir, 'bin'),
-    loongsuitePilotBin: path.join(process.env.HOME ?? '', '.local', 'bin', 'loongsuite-pilot'),
+    loongsuitePilotBin: pilotBinPath(),
   };
 }
 
@@ -476,6 +488,7 @@ export class Updater {
         cwd: targetDir,
         env: childEnv,
         timeout: NPM_INSTALL_TIMEOUT_MS,
+        shell: process.platform === 'win32',
       });
 
       const postinstallScript = path.join(targetDir, 'scripts', 'postinstall.js');
@@ -546,7 +559,8 @@ export class Updater {
       await this.copyFileAtomic(src, dst);
     }
 
-    const cliScript = path.join(srcDir, 'loongsuite-pilot.sh');
+    const cliExt = process.platform === 'win32' ? '.ps1' : '.sh';
+    const cliScript = path.join(srcDir, `loongsuite-pilot${cliExt}`);
     await fs.mkdir(path.dirname(loongsuitePilotBin), { recursive: true });
     await this.copyFileAtomic(cliScript, loongsuitePilotBin, 0o755);
 
@@ -604,7 +618,14 @@ export class Updater {
   private async restartCollector(): Promise<void> {
     logger.info('restarting collector service');
     try {
-      await execFileAsync(this.paths.loongsuitePilotBin, ['restart-collector'], { timeout: 30_000 });
+      const bin = this.paths.loongsuitePilotBin;
+      if (process.platform === 'win32') {
+        await execFileAsync('powershell.exe', [
+          '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', bin, 'restart-collector',
+        ], { timeout: 30_000 });
+      } else {
+        await execFileAsync(bin, ['restart-collector'], { timeout: 30_000 });
+      }
       logger.info('collector restarted');
     } catch (err) {
       logger.warn('collector restart failed', { error: String(err) });
@@ -621,8 +642,18 @@ export class Updater {
 
     logger.info('restarting monitor after update');
     try {
-      await execFileAsync(this.paths.loongsuitePilotBin, ['monitor', 'stop'], { timeout: 30_000 });
-      await execFileAsync(this.paths.loongsuitePilotBin, ['monitor', 'start'], { timeout: 30_000 });
+      const bin = this.paths.loongsuitePilotBin;
+      if (process.platform === 'win32') {
+        await execFileAsync('powershell.exe', [
+          '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', bin, 'monitor', 'stop',
+        ], { timeout: 30_000 });
+        await execFileAsync('powershell.exe', [
+          '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', bin, 'monitor', 'start',
+        ], { timeout: 30_000 });
+      } else {
+        await execFileAsync(bin, ['monitor', 'stop'], { timeout: 30_000 });
+        await execFileAsync(bin, ['monitor', 'start'], { timeout: 30_000 });
+      }
       logger.info('monitor restarted');
     } catch (err) {
       logger.warn('monitor restart failed', { error: String(err) });


### PR DESCRIPTION
## Summary

Add full Windows platform support for loongsuite-pilot, including hook scripts, service management, installer, and deploy tooling.

### Source changes
- **Hook scripts**: 7 new `.ps1` hook scripts for Claude Code, Codex, Cursor, Qoder variants on Windows
- **Hook processor**: Windows-compatible JSON repair in `cursor-hook-processor.mjs`, stdin reading fix in `stdin-reader.mjs`
- **Hook manager** (`src/hooks/hook-manager.ts`): Windows process spawning via `powershell.exe`, `.ps1` extension detection
- **Hook strategy** (`src/deployment/hook-strategy.ts`): Deploy `.ps1` hooks on `win32`, skip `chmod` on Windows
- **Agent def loader** (`src/deployment/agent-def-loader.ts`): Use `.ps1` hook scripts on `win32`
- **Config loader** (`src/core/config-loader.ts`): Trim trailing `\r` from env vars on Windows
- **Daemon scripts**: Windows-compatible process management in `collector-daemon.js` and `updater-daemon.js`
- **Post-install** (`scripts/postinstall.js`): `USERPROFILE` fallback for Windows
- **Service management**: New `scripts/loongsuite-pilot.ps1` (826 lines) — Windows equivalent of `loongsuite-pilot.sh`

### Deploy changes
- **`deploy/package.sh` → `deploy/package-opensource.sh`**: Renamed, produces both `.tar.gz` (Linux/macOS) and `.zip` (Windows) packages
- **`deploy/installer-opensource.ps1`** (new): Windows installer adapted from internal version — uses community OSS URL, `.zip` packages with `Expand-Archive`, no Channel/autoUpdate
- **`deploy/release-opensource.sh`**: Updated to call `package-opensource.sh`, upload both `.tar.gz` and `.zip`, upload `installer.ps1`

## Test plan

- [ ] Verify `.ps1` hook scripts execute correctly on Windows PowerShell 5.1+ and PowerShell 7+
- [ ] Test `installer-opensource.ps1` install/upgrade/uninstall flow on Windows
- [ ] Verify `loongsuite-pilot.ps1` start/stop/status/restart commands
- [ ] Confirm no regressions on Linux/macOS (existing `.sh` scripts unaffected)
- [ ] Test `package-opensource.sh` produces valid `.tar.gz` and `.zip` outputs
- [ ] Verify `release-opensource.sh --dry-run` shows all expected upload targets