### PR TITLE
fix(windows): resolve three platform-specific bugs

### DIFF
--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -11,6 +11,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
 import {
   parseArgs,
@@ -120,7 +121,7 @@ async function main() {
 // getLineRange prevents double-processing if another hook invocation somehow occurs.
 function spawnDelayedRetry(agentId, transcriptPath, sessionId, logPrefix, cwd) {
   const nodebin = process.argv[0];
-  const script = new URL(import.meta.url).pathname;
+  const script = fileURLToPath(import.meta.url);
   const spawnArgs = [
     script,
     '--agent-id', agentId,

--- a/assets/hooks/shared/hook-processor-base.mjs
+++ b/assets/hooks/shared/hook-processor-base.mjs
@@ -7,13 +7,14 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import { fileURLToPath } from 'node:url';
 import {
   buildQoderHookRecord,
   loadHookRuntimeConfig,
 } from '../agent-event-normalizer.mjs';
 
 const ENABLE_LOGGING = true;
-export const HOOKS_DIR = path.dirname(path.dirname(new URL(import.meta.url).pathname));
+export const HOOKS_DIR = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 export const LOONGSUITE_PILOT_LOGS_BASE_DIR = (() => {
   const configured = process.env.LOONGSUITE_PILOT_DATA_DIR;
   return path.join(configured || path.join(os.homedir(), '.loongsuite-pilot'), 'logs');

--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -267,15 +267,25 @@ function Install-CollectorTask {
         -Argument "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$entry'`"" `
         -WorkingDirectory $CACHE_DIR
 
-    $trigger = New-ScheduledTaskTrigger -AtLogOn
+    # Two triggers: AtLogOn for initial start + repeating every 5 min as a watchdog.
+    # If the process crashes or is killed, the repeating trigger re-launches it.
+    # MultipleInstances=IgnoreNew ensures a second instance is never spawned while running.
+    $triggerLogon = New-ScheduledTaskTrigger -AtLogOn
+    $triggerRepeat = New-ScheduledTaskTrigger -Once -At (Get-Date) `
+        -RepetitionInterval (New-TimeSpan -Minutes 5)
 
     $settings = New-ScheduledTaskSettingsSet `
         -AllowStartIfOnBatteries `
         -DontStopIfGoingOnBatteries `
         -DontStopOnIdleEnd `
+        -MultipleInstances IgnoreNew `
         -RestartCount 3 `
         -RestartInterval (New-TimeSpan -Minutes 1) `
         -ExecutionTimeLimit ([TimeSpan]::Zero)
+
+    # S4U logon type: runs under the user's identity in a non-interactive session,
+    # so the process survives RDP/SSH disconnect without requiring a stored password.
+    $principal = New-ScheduledTaskPrincipal -UserId (whoami) -LogonType S4U -RunLevel Limited
 
     # Remove existing task first (schtasks is more reliable than Unregister-ScheduledTask)
     # Use try/catch because schtasks stderr + $ErrorActionPreference=Stop can throw
@@ -286,8 +296,9 @@ function Install-CollectorTask {
         -TaskName $TASK_NAME_COLLECTOR `
         -TaskPath "$TASK_FOLDER\" `
         -Action $action `
-        -Trigger $trigger `
+        -Trigger @($triggerLogon, $triggerRepeat) `
         -Settings $settings `
+        -Principal $principal `
         -Description "LoongSuite Pilot data collector" `
         -ErrorAction Stop | Out-Null
 
@@ -304,15 +315,20 @@ function Install-UpdaterTask {
         -Argument "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$entry'`"" `
         -WorkingDirectory $CACHE_DIR
 
-    $trigger = New-ScheduledTaskTrigger -AtLogOn
+    $triggerLogon = New-ScheduledTaskTrigger -AtLogOn
+    $triggerRepeat = New-ScheduledTaskTrigger -Once -At (Get-Date) `
+        -RepetitionInterval (New-TimeSpan -Minutes 5)
 
     $settings = New-ScheduledTaskSettingsSet `
         -AllowStartIfOnBatteries `
         -DontStopIfGoingOnBatteries `
         -DontStopOnIdleEnd `
+        -MultipleInstances IgnoreNew `
         -RestartCount 3 `
         -RestartInterval (New-TimeSpan -Minutes 5) `
         -ExecutionTimeLimit ([TimeSpan]::Zero)
+
+    $principal = New-ScheduledTaskPrincipal -UserId (whoami) -LogonType S4U -RunLevel Limited
 
     try { schtasks.exe /Delete /TN "$TASK_FOLDER\$TASK_NAME_UPDATER" /F 2>$null | Out-Null } catch {}
     try { schtasks.exe /Delete /TN "$TASK_NAME_UPDATER" /F 2>$null | Out-Null } catch {}
@@ -321,8 +337,9 @@ function Install-UpdaterTask {
         -TaskName $TASK_NAME_UPDATER `
         -TaskPath "$TASK_FOLDER\" `
         -Action $action `
-        -Trigger $trigger `
+        -Trigger @($triggerLogon, $triggerRepeat) `
         -Settings $settings `
+        -Principal $principal `
         -Description "LoongSuite Pilot auto-updater" `
         -ErrorAction Stop | Out-Null
 


### PR DESCRIPTION
## Summary

- **Fix hook processor path on Windows**: replace `new URL(import.meta.url).pathname` with `fileURLToPath()` to avoid the leading `/` that produces invalid double-drive paths (`C:\C:\...`), which caused line record persistence to silently fail on every hook invocation.
- **Fix Task Scheduler tasks dying on session disconnect**: register tasks with S4U principal (`LogonType=S4U`) so processes run in a non-interactive session and survive RDP/SSH disconnect, instead of being killed with `STATUS_CONTROL_C_EXIT` (0xC000013A). Also add a repeating 5-minute watchdog trigger with `MultipleInstances=IgnoreNew` so crashed processes are automatically restarted.
- **Fix updater self-restart after deploying a new version**: replace `Start-Job` with `Start-Process` in `Cmd-RestartCollector` so the deferred `restart-updater` call survives the parent PowerShell session exiting (equivalent to `setsid` on Linux/macOS).

## Test plan

- [x] Verified on Windows Server (ECS) that service survives SSH disconnect
- [x] Verified `Logon Mode` changed from `Interactive only` to `Interactive/Background`
- [ ] Verify line records are correctly persisted after hook invocation on Windows
- [ ] Verify updater logs show `updater stopped` + `updater process starting` after deploying a new version

Made with [Cursor](https://cursor.com)