### PR TITLE
fix(windows): resolve Chinese garbling in Cursor hook on Windows

### DIFF
--- a/assets/hooks/cursor-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/cursor-loongsuite-pilot-hook.ps1
@@ -93,32 +93,9 @@ try {
     $rawBytes = $ms.ToArray()
     $ms.Dispose()
 
-    # Strip UTF-8 BOM (EF BB BF) before any encoding fixup
+    # Strip UTF-8 BOM (EF BB BF) before passing to Node.
     if ($rawBytes.Length -ge 3 -and $rawBytes[0] -eq 0xEF -and $rawBytes[1] -eq 0xBB -and $rawBytes[2] -eq 0xBF) {
         $rawBytes = $rawBytes[3..($rawBytes.Length - 1)]
-    }
-
-    # Fix Cursor's UTF-8→GBK double-encoding on Chinese Windows.
-    # Cursor encodes hook payloads through the system codepage (GBK/CP936), garbling
-    # all non-ASCII text.  Reversal: decode the garbled bytes as UTF-8, encode the
-    # resulting string as GBK — this recovers the ORIGINAL UTF-8 bytes.  We validate
-    # by checking that the recovered bytes are valid UTF-8; if not, keep the originals.
-    if ($rawBytes.Length -gt 2) {
-        try {
-            $utf8    = [System.Text.Encoding]::UTF8
-            $gbk     = [System.Text.Encoding]::GetEncoding(936)
-            $garbled = $utf8.GetString($rawBytes)
-            $recovered = $gbk.GetBytes($garbled)
-
-            # Validate: recovered bytes must be valid UTF-8 (strict decoder throws on invalid sequences)
-            $strictUtf8 = [System.Text.UTF8Encoding]::new($false, $true)  # throwOnInvalidBytes = true
-            [void]$strictUtf8.GetString($recovered)
-
-            # Passed validation — use recovered bytes
-            $rawBytes = $recovered
-        } catch {
-            # Validation failed — original bytes are already correct UTF-8, keep them
-        }
     }
 
     if ($rawBytes.Length -eq 0) {

--- a/assets/hooks/cursor/react-assembler.mjs
+++ b/assets/hooks/cursor/react-assembler.mjs
@@ -33,6 +33,12 @@ export function assembleTurn(journalEvents, options = {}) {
   const stopGenerationId = options.stopGenerationId;
   const transcriptPath = options.transcriptPath;
 
+  // On Windows, Cursor corrupts non-ASCII response text through the system codepage.
+  // Read the correct text from the transcript file (which is always valid UTF-8).
+  const transcriptTexts = process.platform === 'win32'
+    ? readTranscriptTexts(transcriptPath)
+    : null;
+
   // Find the prompt for THIS stop's conversation+generation. When generationId
   // is provided, prefer an exact match so that two beforeSubmitPrompt events
   // in the same conversation (e.g. GPT quota exhaustion auto-switch to
@@ -96,7 +102,8 @@ export function assembleTurn(journalEvents, options = {}) {
 
   // User-hook: user prompt is not an LLM call — emit as "other" so converter
   // merges messages_delta into ENTRY span without generating a standalone LLM span.
-  if (promptEvent.prompt) {
+  const userPromptText = transcriptTexts?.userPrompt || promptEvent.prompt;
+  if (userPromptText) {
     records.push(applyPolicy({
       time_unix_nano: eventTs(promptEvent),
       observed_time_unix_nano: eventTs(promptEvent),
@@ -105,7 +112,7 @@ export function assembleTurn(journalEvents, options = {}) {
       ...baseFields,
       'gen_ai.provider.name': inferProvider(model),
       'gen_ai.input.messages_delta': [
-        { role: 'user', parts: [{ type: 'text', content: promptEvent.prompt }] },
+        { role: 'user', parts: [{ type: 'text', content: userPromptText }] },
       ],
       'agent.cursor.hook_event_name': 'beforeSubmitPrompt',
       'agent.cursor.composer_mode': promptEvent.composer_mode,
@@ -184,9 +191,10 @@ export function assembleTurn(journalEvents, options = {}) {
   // Build parent ReAct steps (with subagentResults for input enrichment)
   const stepRecords = buildParentSteps(parentEvents, {
     turnId, traceId, model, userId, baseFields, runtimeConfig,
-    userPrompt: promptEvent.prompt,
+    userPrompt: transcriptTexts?.userPrompt || promptEvent.prompt,
     promptEventTs: promptEvent._journal_ts,
     subagentResults,
+    transcriptResponseText: transcriptTexts?.assistantResponse,
   });
   records.push(...stepRecords);
 
@@ -258,6 +266,39 @@ export function assembleTurn(journalEvents, options = {}) {
 }
 
 // ─── Transcript Directory Scanning ───
+
+function readTranscriptTexts(transcriptPath) {
+  if (!transcriptPath || String(transcriptPath) === 'None') return null;
+  try {
+    if (!fs.existsSync(transcriptPath)) return null;
+    const content = fs.readFileSync(transcriptPath, 'utf-8');
+    const lines = content.trim().split('\n').filter(Boolean);
+    let lastUserText = null;
+    let lastAssistantText = null;
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line);
+        if (entry.role === 'user' && entry.message?.content) {
+          const parts = entry.message.content
+            .filter(p => p.type === 'text' && p.text)
+            .map(p => p.text.replace(/<\/?user_query>\n?/g, '').trim())
+            .filter(Boolean);
+          if (parts.length > 0) lastUserText = parts.join('');
+        }
+        if (entry.role === 'assistant' && entry.message?.content) {
+          const parts = entry.message.content
+            .filter(p => p.type === 'text' && p.text)
+            .map(p => p.text);
+          if (parts.length > 0) lastAssistantText = parts.join('');
+        }
+      } catch { /* skip unparseable lines */ }
+    }
+    if (!lastUserText && !lastAssistantText) return null;
+    return { userPrompt: lastUserText, assistantResponse: lastAssistantText };
+  } catch {
+    return null;
+  }
+}
 
 function scanSubagentDir(transcriptPath) {
   if (!transcriptPath || String(transcriptPath) === 'None') return [];
@@ -403,14 +444,15 @@ function buildParentSteps(events, ctx) {
 
     else if (ev.hook_event === 'afterAgentResponse') {
       if (currentStepId !== null && currentStepHasTools) {
-        // lastStepEndTs stays at previous tool's end time (already updated by postToolUse)
-        // Do NOT set it to afterAgentResponse's time — that would make req == resp → 0ms LLM
         openNewStep(ev, false, null);
         currentLlmResponse = buildLlmResponseWithToken(ev, ctx, currentStepId, 'text');
         if (flushPendingTools(currentStepId)) currentStepHasTools = true;
       } else if (currentStepId !== null) {
         if (currentLlmResponse) {
-          appendPart(currentLlmResponse, 'text', ev.text);
+          // If transcript text already provided the response, just merge tokens
+          if (!ctx.transcriptResponseText) {
+            appendPart(currentLlmResponse, 'text', ev.text);
+          }
           mergeTokens(currentLlmResponse, ev);
         } else {
           currentLlmResponse = buildLlmResponseWithToken(ev, ctx, currentStepId, 'text');
@@ -555,6 +597,10 @@ function buildLlmRequestWithTs(reqTs, ev, ctx, stepId, userPrompt, prevToolResul
 }
 
 function buildLlmResponse(ev, ctx, stepId, partType) {
+  // On Windows, use transcript text to replace Cursor's codepage-garbled response
+  const responseText = (ctx.transcriptResponseText && ev.hook_event === 'afterAgentResponse')
+    ? ctx.transcriptResponseText
+    : ev.text;
   const rec = applyPolicy({
     time_unix_nano: eventTs(ev),
     observed_time_unix_nano: eventTs(ev),
@@ -566,8 +612,8 @@ function buildLlmResponse(ev, ctx, stepId, partType) {
     'gen_ai.provider.name': inferProvider(ev.model || ctx.model),
     'gen_ai.request.model': resolveModel(ev.model || ctx.model),
     'gen_ai.response.model': resolveModel(ev.model || ctx.model),
-    'gen_ai.output.messages': ev.text
-      ? [{ role: 'assistant', parts: [{ type: partType, content: ev.text }] }]
+    'gen_ai.output.messages': responseText
+      ? [{ role: 'assistant', parts: [{ type: partType, content: responseText }] }]
       : [{ role: 'assistant', parts: [] }],
     'agent.cursor.hook_event_name': ev.hook_event,
     'agent.cursor.reasoning_observed_at': partType === 'reasoning' ? ev._journal_ts : undefined,


### PR DESCRIPTION
## Summary

- On Chinese Windows, Cursor IDE corrupts non-ASCII text in hook payloads through the system codepage (GB18030)
- Both user input and AI response are garbled in `afterAgentResponse`/`beforeSubmitPrompt` events
- Fix: on `stop` event, read the Cursor transcript file (which is always valid UTF-8) and use its user/assistant text to replace garbled content
- Also strip UTF-8 BOM in cursor PS1 hook and remove the ineffective GBK reversal logic

## Test plan

- [x] Deploy to Windows machine with Chinese locale
- [x] Send Chinese message in Cursor, verify output JSONL has correct Chinese in both `input.messages_delta` and `output.messages`
- [x] Verify transcript file is read correctly via debug logging
- [ ] Non-Windows platforms should be unaffected (transcript reading is gated by `process.platform === 'win32'`)