### PR TITLE
fix(initd): avoid root-owned pid/log files blocking service start

### DIFF
--- a/scripts/loongsuite-pilot.sh
+++ b/scripts/loongsuite-pilot.sh
@@ -1102,6 +1102,8 @@ _write_initd_script() {
     local log_file="$target_home/.loongsuite-pilot/logs/loongsuite-pilot-service.log"
     local config_file="$target_home/.loongsuite-pilot/config.json"
     local script_path="/etc/init.d/$daemon_name"
+    local daemon_group
+    daemon_group=$(id -gn "$target_user" 2>/dev/null || echo "$target_user")
 
     local tmp_script
     tmp_script=$(mktemp)
@@ -1119,6 +1121,7 @@ _write_initd_script() {
 # chkconfig: 2345 90 10
 
 DAEMON_USER="USER_PLACEHOLDER"
+DAEMON_GROUP="GROUP_PLACEHOLDER"
 DAEMON_HOME="HOME_PLACEHOLDER"
 DAEMON_BIN="BIN_PLACEHOLDER"
 DAEMON_NAME="DAEMON_NAME_PLACEHOLDER"
@@ -1145,8 +1148,7 @@ do_start() {
             --background --make-pidfile --pidfile "$PID_FILE" \
             --exec "$DAEMON_BIN" -- run \
             >>"$LOG_FILE" 2>&1
-        chmod 666 "$LOG_FILE"
-        chmod 666 "$PID_FILE"
+        chown "$DAEMON_USER:$DAEMON_GROUP" "$LOG_FILE" "$PID_FILE"
     else
         su - "$DAEMON_USER" -c "
             export AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'
@@ -1208,6 +1210,7 @@ INITEOF
 
     sed -i.bak \
         -e "s|USER_PLACEHOLDER|${target_user}|g" \
+        -e "s|GROUP_PLACEHOLDER|${daemon_group}|g" \
         -e "s|HOME_PLACEHOLDER|${target_home}|g" \
         -e "s|BIN_PLACEHOLDER|${daemon_bin}|g" \
         -e "s|DAEMON_NAME_PLACEHOLDER|${daemon_name}|g" \
@@ -1231,6 +1234,8 @@ _write_initd_updater_script() {
     local log_file="$target_home/.loongsuite-pilot/logs/loongsuite-pilot-updater.log"
     local config_file="$target_home/.loongsuite-pilot/config.json"
     local script_path="/etc/init.d/$daemon_name"
+    local daemon_group
+    daemon_group=$(id -gn "$target_user" 2>/dev/null || echo "$target_user")
 
     local tmp_script
     tmp_script=$(mktemp)
@@ -1248,6 +1253,7 @@ _write_initd_updater_script() {
 # chkconfig: 2345 91 9
 
 DAEMON_USER="USER_PLACEHOLDER"
+DAEMON_GROUP="GROUP_PLACEHOLDER"
 DAEMON_HOME="HOME_PLACEHOLDER"
 DAEMON_BIN="BIN_PLACEHOLDER"
 DAEMON_NAME="DAEMON_NAME_PLACEHOLDER"
@@ -1274,8 +1280,7 @@ do_start() {
             --background --make-pidfile --pidfile "$PID_FILE" \
             --exec "$DAEMON_BIN" -- run-updater \
             >>"$LOG_FILE" 2>&1
-        chmod 666 "$LOG_FILE"
-        chmod 666 "$PID_FILE"
+        chown "$DAEMON_USER:$DAEMON_GROUP" "$LOG_FILE" "$PID_FILE"
     else
         su - "$DAEMON_USER" -c "
             export AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'
@@ -1337,6 +1342,7 @@ INITEOF
 
     sed -i.bak \
         -e "s|USER_PLACEHOLDER|${target_user}|g" \
+        -e "s|GROUP_PLACEHOLDER|${daemon_group}|g" \
         -e "s|HOME_PLACEHOLDER|${target_home}|g" \
         -e "s|BIN_PLACEHOLDER|${daemon_bin}|g" \
         -e "s|DAEMON_NAME_PLACEHOLDER|${daemon_name}|g" \

--- a/scripts/loongsuite-pilot.sh
+++ b/scripts/loongsuite-pilot.sh
@@ -1145,6 +1145,8 @@ do_start() {
             --background --make-pidfile --pidfile "$PID_FILE" \
             --exec "$DAEMON_BIN" -- run \
             >>"$LOG_FILE" 2>&1
+        chmod 666 "$LOG_FILE"
+        chmod 666 "$PID_FILE"
     else
         su - "$DAEMON_USER" -c "
             export AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'
@@ -1272,6 +1274,8 @@ do_start() {
             --background --make-pidfile --pidfile "$PID_FILE" \
             --exec "$DAEMON_BIN" -- run-updater \
             >>"$LOG_FILE" 2>&1
+        chmod 666 "$LOG_FILE"
+        chmod 666 "$PID_FILE"
     else
         su - "$DAEMON_USER" -c "
             export AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'


### PR DESCRIPTION
###  Background

When installing the service on Linux with --system-service, the installer falls back to generating init.d scripts if systemd is unavailable. The init.d script is usually executed as root and uses start-stop-daemon --chuid <user> to start loongsuite-pilot as a regular user.
However, when start-stop-daemon is used with --make-pidfile --pidfile ..., loongsuite-pilot.pid and the redirected service log loongsuite-pilot-service.log may be created by root first. The actual loongsuite-pilot run process then starts as the regular user and attempts to write to the same PID file, which can fail due to insufficient permissions. As a result, the service exits and cannot be started.

### Problem

1. Run loongsuite-pilot start --system-service
2. The environment falls back to init.d
3. The init.d script is executed as root
4. The PID file or service log file is created by root
5. The collector/updater process starts as a regular user
6. The regular user cannot write to the same PID/log file
7. The service fails to start

### Changes

1. Adjust the generated init.d collector script to prevent root-owned loongsuite-pilot.pid / loongsuite-pilot-service.log files from blocking writes by the regular user process.
8. Apply the same fix to the init.d updater script for loongsuite-pilot-updater.pid / loongsuite-pilot-updater.log.
9. The change only affects the init.d fallback path and does not affect systemd, launchd, or user-level nohup startup paths.