### PR TITLE
fix(codex): skip historical turns on first transcript import

### DIFF
--- a/assets/hooks/codex-hook-processor.mjs
+++ b/assets/hooks/codex-hook-processor.mjs
@@ -320,9 +320,14 @@ async function writeSessionJsonl(state, transcriptData) {
 
   // turn_count 跨 Stop 持久化,确保多 turn session 中 turn_id 递增(不重复 :t1)
   const baseTurnCount = state.turn_count || 0;
+  const baseTranscriptOffset = state.transcript_offset || 0;
+  // 首次运行防护: 新安装/重装后 state 被清空(offset=0, 无 turn_count),
+  // 如果 transcript 包含大量历史 turn, 只上报最后一个(当前对话), 跳过历史。
+  const isFirstRun = !state.turn_count && baseTranscriptOffset === 0;
+  const turnsToExport = isFirstRun && turns.length > 1 ? turns.slice(-1) : turns;
 
-  for (let turnIdx = 0; turnIdx < turns.length; turnIdx++) {
-    const turn = turns[turnIdx];
+  for (let turnIdx = 0; turnIdx < turnsToExport.length; turnIdx++) {
+    const turn = turnsToExport[turnIdx];
     // 主路径:按 turn_id 取本 turn 的 token 事件;fallback 从扁平队列尾部
     let turnTokens = transcriptData?.tokenEventsByTurn?.get(turn.turn_id);
     if (!turnTokens || turnTokens.length === 0) {
@@ -349,6 +354,7 @@ async function writeSessionJsonl(state, transcriptData) {
   }
 
   // 持久化 turn_count(跨 Stop 递增)
+  // turn_count 计入全部 turns(含跳过的历史), 确保 offset 正确推进不重复上报
   state.turn_count = baseTurnCount + turns.length;
 
   const cleaned = allRecords.map((r) => applyHookContentPolicy(sanitizeObject(r) || r, runtimeConfig));

--- a/tests/unit/hooks/codex/hook-processor.test.mjs
+++ b/tests/unit/hooks/codex/hook-processor.test.mjs
@@ -120,6 +120,43 @@ describe('codex-hook-processor 端到端', () => {
     expect(state.transcript_last_token_usage?.inputTokens).toBe(1);
   });
 
+  test('首次接管多 turn transcript 时只导出最后一个 turn 并推进完整进度', () => {
+    writeFakeTranscript([
+      { timestamp: '2026-06-11T10:00:00Z', type: 'session_meta', payload: { model_provider: 'openai' }},
+      { timestamp: '2026-06-11T10:00:01Z', type: 'turn_context', payload: { turn_id: 'old-turn', model: 'gpt-5.5' }},
+      { timestamp: '2026-06-11T10:00:02Z', type: 'event_msg', payload: { type: 'user_message', message: 'old prompt' }},
+      { timestamp: '2026-06-11T10:00:03Z', type: 'event_msg', payload: { type: 'token_count', info: {
+        last_token_usage: { input_tokens: 10, output_tokens: 5, cached_input_tokens: 0, reasoning_output_tokens: 0, total_tokens: 15 },
+      }}},
+      { timestamp: '2026-06-17T10:00:01Z', type: 'turn_context', payload: { turn_id: 'new-turn', model: 'gpt-5.5' }},
+      { timestamp: '2026-06-17T10:00:02Z', type: 'event_msg', payload: { type: 'user_message', message: 'new prompt' }},
+      { timestamp: '2026-06-17T10:00:03Z', type: 'event_msg', payload: { type: 'token_count', info: {
+        last_token_usage: { input_tokens: 20, output_tokens: 6, cached_input_tokens: 0, reasoning_output_tokens: 0, total_tokens: 26 },
+      }}},
+    ]);
+
+    runHook('session-start', { session_id: 'cdx-old-session', model: 'gpt-5.5', source: 'startup', transcript_path: TRANSCRIPT });
+    runHook('stop', { session_id: 'cdx-old-session', turn_id: 'new-turn', last_assistant_message: 'new answer', model: 'gpt-5.5', transcript_path: TRANSCRIPT });
+
+    const records = readJsonl();
+    const promptContents = records
+      .filter((r) => r['event.name'] === 'other')
+      .map((r) => r['gen_ai.input.messages_delta']?.[0]?.parts?.[0]?.content);
+    expect(promptContents).toEqual(['new prompt']);
+
+    const llmResponses = records.filter((r) => r['event.name'] === 'llm.response');
+    expect(llmResponses).toHaveLength(1);
+    expect(llmResponses[0]?.['gen_ai.usage.total_tokens']).toBe(26);
+
+    const state = readState('cdx-old-session');
+    expect(state.turn_count).toBe(2);
+    expect(state.transcript_offset).toBe(fs.statSync(TRANSCRIPT).size);
+
+    const recordsBefore = readJsonl().length;
+    runHook('stop', { session_id: 'cdx-old-session', turn_id: 'new-turn', model: 'gpt-5.5', transcript_path: TRANSCRIPT });
+    expect(readJsonl()).toHaveLength(recordsBefore);
+  });
+
   test('UserPromptSubmit 输出 other 事件,不作为缺少 step/model 的 llm.request', () => {
     writeFakeTranscript([
       { timestamp: '2026-05-27T10:00:00Z', type: 'session_meta', payload: { model_provider: 'openai' }},


### PR DESCRIPTION
## Summary
- Align Codex with Claude Code first-run transcript handling
- On first transcript import with offset=0 and no turn_count, export only the latest turn when multiple turns are parsed
- Still advance turn_count across all parsed turns so skipped history is not replayed
- Add a regression test covering old multi-turn transcript import and repeat stop behavior

## Verification
- npx vitest run tests/unit/hooks/codex/tool-arguments.test.mjs tests/unit/hooks/codex/hook-processor.test.mjs tests/unit/hooks/codex/transcript-parser.test.mjs
- npm run typecheck
- git diff --check