### PR TITLE
fix(qoder-work): fix extractText dropping user query and interrupt causing spurious turns

### DIFF
--- a/assets/hooks/qoderwork-hook-processor.mjs
+++ b/assets/hooks/qoderwork-hook-processor.mjs
@@ -448,4 +448,6 @@ function resolveQoderWorkProjectDir(sandboxCwd, agentId) {
   return sandboxCwd;
 }
 
+export { extractText, isSystemInjection, isToolResult, splitIntoTurns };
+
 main().catch(() => { /* fail-open */ });

--- a/assets/hooks/qoderwork-hook-processor.mjs
+++ b/assets/hooks/qoderwork-hook-processor.mjs
@@ -141,7 +141,9 @@ function splitIntoTurns(contentRows) {
 
 function isSystemInjection(row) {
   const text = extractText(row).trimStart();
-  return text.startsWith('<command-message>') || text.startsWith('<command-name>');
+  return text.startsWith('<command-message>')
+    || text.startsWith('<command-name>')
+    || text.startsWith('[Request interrupted');
 }
 
 function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, cwd) {
@@ -399,10 +401,12 @@ function extractText(row) {
   const content = msg.content;
   if (typeof content === 'string') return content;
   if (Array.isArray(content)) {
+    const parts = [];
     for (const block of content) {
-      if (block.type === 'text') return block.text || '';
-      if (typeof block === 'string') return block;
+      if (block.type === 'text' && block.text) parts.push(block.text);
+      else if (typeof block === 'string') parts.push(block);
     }
+    return parts.join('\n');
   }
   return '';
 }

--- a/tests/unit/hooks/qoderwork-hook-processor.test.mjs
+++ b/tests/unit/hooks/qoderwork-hook-processor.test.mjs
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractText,
+  isSystemInjection,
+  isToolResult,
+  splitIntoTurns,
+} from '../../../assets/hooks/qoderwork-hook-processor.mjs';
+
+describe('extractText', () => {
+  it('returns string content directly', () => {
+    expect(extractText({ message: { content: 'hello' } })).toBe('hello');
+  });
+
+  it('returns empty string for missing message', () => {
+    expect(extractText({})).toBe('');
+  });
+
+  it('extracts single text block', () => {
+    const row = { message: { content: [{ type: 'text', text: 'user query' }] } };
+    expect(extractText(row)).toBe('user query');
+  });
+
+  it('concatenates multiple text blocks with newline', () => {
+    const row = {
+      message: {
+        content: [
+          { type: 'text', text: 'first' },
+          { type: 'tool_use', id: 't1', name: 'shell', input: {} },
+          { type: 'text', text: 'second' },
+        ],
+      },
+    };
+    expect(extractText(row)).toBe('first\nsecond');
+  });
+
+  it('handles plain string blocks in content array', () => {
+    const row = { message: { content: ['plain string'] } };
+    expect(extractText(row)).toBe('plain string');
+  });
+
+  it('skips text blocks with empty text', () => {
+    const row = {
+      message: {
+        content: [
+          { type: 'text', text: '' },
+          { type: 'text', text: 'actual' },
+        ],
+      },
+    };
+    expect(extractText(row)).toBe('actual');
+  });
+});
+
+describe('isSystemInjection', () => {
+  it('detects <command-message> prefix', () => {
+    const row = { message: { content: [{ type: 'text', text: '<command-message>do something</command-message>' }] } };
+    expect(isSystemInjection(row)).toBe(true);
+  });
+
+  it('detects <command-name> prefix', () => {
+    const row = { message: { content: [{ type: 'text', text: '<command-name>run</command-name>' }] } };
+    expect(isSystemInjection(row)).toBe(true);
+  });
+
+  it('detects [Request interrupted prefix', () => {
+    const row = { message: { content: [{ type: 'text', text: '[Request interrupted by user for new message]' }] } };
+    expect(isSystemInjection(row)).toBe(true);
+  });
+
+  it('detects injection with leading whitespace', () => {
+    const row = { message: { content: [{ type: 'text', text: '  [Request interrupted by user]' }] } };
+    expect(isSystemInjection(row)).toBe(true);
+  });
+
+  it('returns false for normal user text', () => {
+    const row = { message: { content: [{ type: 'text', text: 'how do I build a multi-turn scenario?' }] } };
+    expect(isSystemInjection(row)).toBe(false);
+  });
+});
+
+describe('isToolResult', () => {
+  it('returns true for tool_result content', () => {
+    const row = { message: { content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }] } };
+    expect(isToolResult(row)).toBe(true);
+  });
+
+  it('returns false for text content', () => {
+    const row = { message: { content: [{ type: 'text', text: 'hello' }] } };
+    expect(isToolResult(row)).toBe(false);
+  });
+});
+
+describe('splitIntoTurns', () => {
+  it('splits on user messages, keeps tool_results and injections in current turn', () => {
+    const rows = [
+      { type: 'user', message: { content: [{ type: 'text', text: 'question 1' }] } },
+      { type: 'assistant', message: { content: [{ type: 'text', text: 'answer 1' }] } },
+      { type: 'user', message: { content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }] } },
+      { type: 'user', message: { content: [{ type: 'text', text: '[Request interrupted by user]' }] } },
+      { type: 'user', message: { content: [{ type: 'text', text: 'question 2' }] } },
+      { type: 'assistant', message: { content: [{ type: 'text', text: 'answer 2' }] } },
+    ];
+    const turns = splitIntoTurns(rows);
+    expect(turns).toHaveLength(2);
+    expect(turns[0]).toHaveLength(4);
+    expect(turns[1]).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- **extractText**: Changed from returning only the first text block to concatenating all text blocks. QoderWork puts system prompt and user query in separate `text` blocks within `message.content`; the old `for…return` pattern returned on the first block (system prompt), losing the actual user question.
- **isSystemInjection**: Added `[Request interrupted` pattern so that interrupt messages don't start a spurious new turn.

## Test plan
- [x] Verified on Windows machine with live QoderWork sessions
- [x] Confirmed user queries now appear in collected data
- [x] Confirmed `[Request interrupted` messages no longer split turns