### PR TITLE
fix(hooks): disable debug logging in hook processors

### DIFF
--- a/assets/hooks/shared/hook-processor-base.mjs
+++ b/assets/hooks/shared/hook-processor-base.mjs
@@ -13,7 +13,7 @@ import {
   loadHookRuntimeConfig,
 } from '../agent-event-normalizer.mjs';
 
-const ENABLE_LOGGING = true;
+const ENABLE_LOGGING = false;
 export const HOOKS_DIR = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 export const LOONGSUITE_PILOT_LOGS_BASE_DIR = (() => {
   const configured = process.env.LOONGSUITE_PILOT_DATA_DIR;


### PR DESCRIPTION
## Summary
- Turn off `ENABLE_LOGGING` in `hook-processor-base.mjs` to stop writing debug logs to `~/.loongsuite-pilot/logs/*/debug/` on every hook invocation
- Debug logs are written unconditionally on every Stop hook event, producing unnecessary disk I/O in production environments

## Test plan
- [ ] Deploy to a test environment and verify no new debug log files are created under `~/.loongsuite-pilot/logs/*/debug/`
- [ ] Verify hook transcript processing (history JSONL) still works correctly