### PR TITLE
fix(qoder): improve LLM boundary detection and token enrichment

### DIFF
--- a/assets/hooks/agent-event-normalizer.mjs
+++ b/assets/hooks/agent-event-normalizer.mjs
@@ -470,7 +470,9 @@ export function buildQoderHookRecord(row, options = {}) {
     'gen_ai.response.model': model,
     'gen_ai.response.id': eventName === 'llm.response' ? getStringValue(message, 'id') : undefined,
     'gen_ai.response.finish_reasons': getStringValue(message, 'stop_reason'),
-    'gen_ai.input.messages_delta': eventName === 'llm.request' ? buildQoderInputMessagesDelta(content) : undefined,
+    'gen_ai.input.messages_delta': eventName === 'llm.request' || (eventName === 'other' && rowType === 'user')
+      ? buildQoderInputMessagesDelta(content)
+      : undefined,
     'gen_ai.output.messages': eventName === 'llm.response' ? buildQoderOutputMessages(content) : undefined,
     'gen_ai.tool.name': eventName === 'tool.call' ? getStringValue(content, 'name') : undefined,
     'gen_ai.tool.call.id': eventName === 'tool.call' || eventName === 'tool.result' ? toolCallId : undefined,
@@ -608,7 +610,7 @@ function inferQoderEventName(rowType, content) {
   const contentType = getStringValue(content, 'type');
   if (contentType === 'tool_result') return 'tool.result';
   if (contentType === 'tool_use') return 'tool.call';
-  return rowType === 'assistant' ? 'llm.response' : 'llm.request';
+  return rowType === 'assistant' ? 'llm.response' : 'other';
 }
 
 function selectDominantContentBlock(rawContent) {

--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -315,6 +315,11 @@ function progressWindowKey(progressEvents, rowMs) {
     }
   }
 
+  // If no start boundary found, this row appears before any progress event.
+  // Return null to let the caller fall back to time-gap grouping, avoiding
+  // incorrect merging of distinct LLM calls that precede the first progress event.
+  if (!startTs) return null;
+
   let endTs = null;
   for (const pe of progressEvents) {
     const peMs = Date.parse(pe.ts) || 0;
@@ -325,7 +330,7 @@ function progressWindowKey(progressEvents, rowMs) {
     }
   }
 
-  return `progress:${startTs || ''}->${endTs || ''}`;
+  return `progress:${startTs}->${endTs || ''}`;
 }
 
 // --- Event Builder -----------------------------------------------------------

--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -216,50 +216,57 @@ async function processTranscript(agentId, logPrefix, transcriptPath, sessionId, 
 
 function buildLlmBoundaries(progressEvents, contentEvents) {
   // Step 1: Group assistant blocks into LLM calls.
-  // Priority: use message.id (CLI variant has it) > fallback to timestamp proximity (IDE variant).
+  // Priority: use message.id (CLI variant has it) > progress window (IDE variant)
+  // > fallback to timestamp proximity when progress events are absent.
   const assistantGroups = [];
   let currentGroup = [];
   let lastTs = null;
-  let lastMessageId = null;
+  let currentKey = null;
+  const hasProgressWindows = progressEvents.some(pe =>
+    pe.hookEvent === 'UserPromptSubmit' || pe.hookEvent === 'PostToolUse' ||
+    pe.hookEvent === 'PreToolUse' || pe.hookEvent === 'Stop'
+  );
+
+  function flushGroup() {
+    if (currentGroup.length > 0) assistantGroups.push(currentGroup);
+    currentGroup = [];
+    lastTs = null;
+    currentKey = null;
+  }
 
   for (const row of contentEvents) {
     if (row.type !== 'assistant') {
-      if (currentGroup.length > 0) {
-        assistantGroups.push(currentGroup);
-        currentGroup = [];
-        lastTs = null;
-        lastMessageId = null;
-      }
+      flushGroup();
       continue;
     }
     const ts = row.timestamp ? Date.parse(row.timestamp) : 0;
     if (!ts) continue;
 
     const messageId = row.message?.id || null;
+    const key = messageId
+      ? `message:${messageId}`
+      : hasProgressWindows
+        ? progressWindowKey(progressEvents, ts)
+        : null;
 
     // Determine if this row starts a new LLM call
     let isNewCall = false;
-    if (messageId && lastMessageId) {
-      // Both have message.id: new call when id changes
-      isNewCall = messageId !== lastMessageId;
-    } else if (!messageId && !lastMessageId) {
-      // Neither has message.id (IDE): use timestamp proximity
+    if (currentGroup.length > 0 && key && currentKey) {
+      isNewCall = key !== currentKey;
+    } else if (currentGroup.length > 0 && !key && !currentKey) {
       isNewCall = lastTs !== null && (ts - lastTs) > 200;
-    } else if (currentGroup.length > 0) {
-      // Mixed (shouldn't happen, but handle gracefully)
+    } else if (currentGroup.length > 0 && key !== currentKey) {
+      // Mixed keyed/unkeyed rows are unusual; keep the old time-gap fallback.
       isNewCall = lastTs !== null && (ts - lastTs) > 200;
     }
 
-    if (isNewCall && currentGroup.length > 0) {
-      assistantGroups.push(currentGroup);
-      currentGroup = [];
-    }
+    if (isNewCall) flushGroup();
 
     currentGroup.push(row);
+    currentKey = key;
     lastTs = ts;
-    if (messageId) lastMessageId = messageId;
   }
-  if (currentGroup.length > 0) assistantGroups.push(currentGroup);
+  flushGroup();
 
   // Step 2: For each assistant group (= one LLM call), find timing from progress
   const boundaries = [];
@@ -298,6 +305,29 @@ function buildLlmBoundaries(progressEvents, contentEvents) {
   return boundaries;
 }
 
+function progressWindowKey(progressEvents, rowMs) {
+  let startTs = null;
+  for (const pe of progressEvents) {
+    const peMs = Date.parse(pe.ts) || 0;
+    if (peMs >= rowMs) break;
+    if (pe.hookEvent === 'PostToolUse' || pe.hookEvent === 'UserPromptSubmit') {
+      startTs = pe.ts;
+    }
+  }
+
+  let endTs = null;
+  for (const pe of progressEvents) {
+    const peMs = Date.parse(pe.ts) || 0;
+    if (peMs <= rowMs) continue;
+    if (pe.hookEvent === 'PreToolUse' || pe.hookEvent === 'Stop') {
+      endTs = pe.ts;
+      break;
+    }
+  }
+
+  return `progress:${startTs || ''}->${endTs || ''}`;
+}
+
 // --- Event Builder -----------------------------------------------------------
 
 function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, turnId, sessionId, agentId, runtimeConfig, cwd) {
@@ -317,7 +347,7 @@ function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, turnId,
       const userHookModel = contentEvents.find(r => r.type === 'assistant' && r.message?.model)?.message?.model || 'unknown';
       records.push({
         'event.id': crypto.randomUUID(),
-        'event.name': 'llm.request',
+        'event.name': 'other',
         'gen_ai.turn.id': turnId,
         'gen_ai.session.id': sessionId,
         'gen_ai.agent.type': agentType,
@@ -609,7 +639,7 @@ function buildLegacyEvents(contentEvents, turnId, sessionId, agentId, runtimeCon
   for (const record of existingRecords) {
     const eventName = record['event.name'];
     const rawType = record['agent.qoder.raw_type'];
-    if (eventName === 'llm.request' && rawType === 'user') continue;
+    if (rawType === 'user') continue;
     if (eventName === 'llm.response') {
       const responseTs = record['time_unix_nano'] || '';
       const tsDiff = lastResponseTs === null ? Infinity : Math.abs(Number(responseTs) - Number(lastResponseTs));

--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -189,19 +189,30 @@ async function processTranscript(agentId, logPrefix, transcriptPath, sessionId, 
     // session_meta, other types: ignored
   }
 
-  // --- Phase 3: Determine LLM call boundaries ---
-  // Use content events (assistant blocks) for boundary detection,
-  // then use progress timestamps for precise timing.
-  const llmBoundaries = buildLlmBoundaries(progressEvents, contentEvents);
-  logDebug(agentId, `Detected ${llmBoundaries.length} LLM call(s)`);
+  // --- Phase 3: Split content events into turns by real user prompts ---
+  // Each real user prompt starts a new turn. Tool results stay attached to the
+  // preceding turn. This ensures each turn gets its own user input instead of
+  // inheriting the first prompt of the whole transcript segment.
+  const turnSegments = splitContentEventsIntoTurns(contentEvents);
+  logDebug(agentId, `Split transcript segment into ${turnSegments.length} turn(s)`);
 
-  // --- Phase 4: Build events using boundaries ---
-  const turnId = crypto.randomUUID();
-  const records = buildEventsFromBoundaries(
-    llmBoundaries, contentEvents, parsed, turnId, sessionId, agentId, runtimeConfig, cwd,
-  );
+  // --- Phase 4: Build events per turn ---
+  const records = [];
+  for (let turnIdx = 0; turnIdx < turnSegments.length; turnIdx++) {
+    const turnContentEvents = turnSegments[turnIdx];
+    const turnId = crypto.randomUUID();
 
-  logDebug(agentId, `Produced ${records.length} events, turn_id=${turnId}`);
+    // Determine LLM call boundaries within this turn.
+    const llmBoundaries = buildLlmBoundaries(progressEvents, turnContentEvents);
+    logDebug(agentId, `Turn ${turnIdx + 1}: detected ${llmBoundaries.length} LLM call(s)`);
+
+    const turnRecords = buildEventsFromBoundaries(
+      llmBoundaries, turnContentEvents, parsed, turnId, sessionId, agentId, runtimeConfig, cwd,
+    );
+    records.push(...turnRecords);
+
+    logDebug(agentId, `Turn ${turnIdx + 1}: produced ${turnRecords.length} events, turn_id=${turnId}`);
+  }
 
   // --- Phase 5: Write to history ---
   const rowsToAppend = records.map(r => JSON.stringify(r));
@@ -586,6 +597,34 @@ function assignContentToBoundaries(boundaries, contentEvents) {
 }
 
 // --- Helpers -----------------------------------------------------------------
+
+/**
+ * Split a list of content events into turns.
+ * Each real user prompt (type === 'user' and not a tool result) starts a new
+ * turn. Tool results and assistant content following a prompt belong to that
+ * turn until the next real user prompt.
+ */
+function splitContentEventsIntoTurns(contentEvents) {
+  const turns = [];
+  let currentTurn = [];
+
+  for (const row of contentEvents) {
+    if (row.type === 'user' && !isToolResult(row)) {
+      if (currentTurn.length > 0) {
+        turns.push(currentTurn);
+      }
+      currentTurn = [row];
+    } else {
+      currentTurn.push(row);
+    }
+  }
+
+  if (currentTurn.length > 0) {
+    turns.push(currentTurn);
+  }
+
+  return turns;
+}
 
 function findPostToolUseTs(boundaries, currentIdx) {
   if (currentIdx + 1 < boundaries.length) {

--- a/src/inputs/qoder-trace/qoder-trace-input.ts
+++ b/src/inputs/qoder-trace/qoder-trace-input.ts
@@ -58,9 +58,10 @@ export class QoderTraceInput extends BaseInput {
     // 2. Group by turn.id
     const turnGroups = this.groupByTurn(rawEntries);
 
-    // 3. Enrich each turn
-    const allEntries: AgentActivityEntry[] = [];
-    for (const [turnId, turnEntries] of turnGroups) {
+    // 3. Enrich each turn. IDE turns are enriched per session so SQLite request_id
+    // ordering can be matched against hook turn ordering without timestamp joins.
+    const ideSessionGroups = new Map<string, AgentActivityEntry[]>();
+    for (const [, turnEntries] of turnGroups) {
       const variant = this.inferTurnVariant(turnEntries);
       const sessionId = this.extractSessionId(turnEntries);
 
@@ -68,17 +69,23 @@ export class QoderTraceInput extends BaseInput {
         const segments = await readSegmentTokensForSession(sessionId);
         enrichCliTurn(turnEntries, segments);
       } else if (variant === 'qoder' && sessionId) {
-        const sqliteRows = await readSqliteTokensForSession(sessionId);
-        enrichIdeTurn(turnEntries, sqliteRows);
+        const sessionEntries = ideSessionGroups.get(sessionId) ?? [];
+        sessionEntries.push(...turnEntries);
+        ideSessionGroups.set(sessionId, sessionEntries);
       }
-
-      // 4. Inject trace_id
-      injectTraceId(turnEntries);
-
-      allEntries.push(...turnEntries);
     }
 
-    return allEntries;
+    for (const [sessionId, sessionEntries] of ideSessionGroups) {
+      const sqliteRows = await readSqliteTokensForSession(sessionId);
+      enrichIdeTurn(sessionEntries, sqliteRows);
+    }
+
+    // 4. Inject trace_id per turn
+    for (const turnEntries of turnGroups.values()) {
+      injectTraceId(turnEntries);
+    }
+
+    return rawEntries;
   }
 
   // ─── Hook JSONL reading (adapted from BaseHookInput) ────────────────────────

--- a/src/inputs/qoder-trace/qoder-trace-input.ts
+++ b/src/inputs/qoder-trace/qoder-trace-input.ts
@@ -103,6 +103,9 @@ export class QoderTraceInput extends BaseInput {
     }
 
     const state = this.getState();
+    // Cold start: no prior state at all (e.g. after redeployment wiped input-state.json).
+    // Day rollover: state.lastFile exists but differs from today's file (normal new-day transition).
+    const isColdStart = !state.lastFile;
     let offset = state.lastFile === logFileName ? (state.lastOffset ?? 0) : 0;
 
     if (offset > 0 && stat.size < offset) {
@@ -112,7 +115,7 @@ export class QoderTraceInput extends BaseInput {
     if (stat.size <= offset) return [];
 
     const handle = await fs.open(logFile, 'r');
-    const entries: AgentActivityEntry[] = [];
+    let entries: AgentActivityEntry[] = [];
     try {
       // NOTE: No MAX_READ_BYTES cap here. Hook JSONL is daily-rotated and typically <100KB/day.
       // If a cap is added in the future, must truncate to last newline to avoid splitting JSONL lines.
@@ -134,6 +137,18 @@ export class QoderTraceInput extends BaseInput {
       }
     } finally {
       await handle.close();
+    }
+
+    // On cold start with multiple turns already in the file, only report the last turn
+    // to avoid replaying full history after a redeployment wipes the state store.
+    if (isColdStart && entries.length > 0) {
+      const turnIds = new Set(entries.map(e => (e['gen_ai.turn.id'] as string) || 'unknown'));
+      if (turnIds.size > 1) {
+        const lastTurnId = entries[entries.length - 1]['gen_ai.turn.id'] as string || 'unknown';
+        const skipped = turnIds.size - 1;
+        this.logger.info('cold start detected, skipping historical turns', { skipped, totalTurns: turnIds.size, keepTurnId: lastTurnId });
+        entries = entries.filter(e => ((e['gen_ai.turn.id'] as string) || 'unknown') === lastTurnId);
+      }
     }
 
     return entries;

--- a/src/inputs/qoder-trace/sqlite-token-reader.ts
+++ b/src/inputs/qoder-trace/sqlite-token-reader.ts
@@ -8,11 +8,14 @@ import { createLogger } from '../../utils/logger.js';
 const logger = createLogger('SqliteTokenReader');
 
 export interface SqliteTokenData {
+  sessionId?: string;
   requestId: string;
+  messageId?: string;
   gmtCreate: number;
   inputTokens: number;
   outputTokens: number;
   cacheReadTokens: number;
+  model?: string;
 }
 
 export async function readSqliteTokensForSession(sessionId: string): Promise<SqliteTokenData[]> {
@@ -20,17 +23,33 @@ export async function readSqliteTokensForSession(sessionId: string): Promise<Sql
   if (!dbPath) return [];
 
   const sql = `
-    SELECT request_id, gmt_create, token_info
-    FROM chat_message
-    WHERE session_id = ?
-      AND role = 'assistant'
-      AND token_info IS NOT NULL
-      AND token_info != ''
-      AND json_valid(token_info)
-    ORDER BY gmt_create ASC
+    SELECT
+      cm.id AS message_id,
+      cm.session_id AS session_id,
+      cm.request_id AS request_id,
+      cm.gmt_create AS gmt_create,
+      cm.token_info AS token_info,
+      cm.model_info AS model_info,
+      cr.extra AS record_extra
+    FROM chat_message cm
+    LEFT JOIN chat_record cr ON cr.request_id = cm.request_id
+    WHERE cm.session_id = ?
+      AND cm.role = 'assistant'
+      AND cm.token_info IS NOT NULL
+      AND cm.token_info != ''
+      AND json_valid(cm.token_info)
+    ORDER BY cm.gmt_create ASC
   `;
 
-  let rows: Array<{ request_id: string; gmt_create: number; token_info: string }>;
+  let rows: Array<{
+    message_id?: string;
+    session_id?: string;
+    request_id: string;
+    gmt_create: number;
+    token_info: string;
+    model_info?: string | null;
+    record_extra?: string | null;
+  }>;
   try {
     rows = await queryReadonly(dbPath, sql, [sessionId]);
   } catch (err) {
@@ -43,11 +62,14 @@ export async function readSqliteTokensForSession(sessionId: string): Promise<Sql
     const info = parseTokenInfo(row.token_info);
     if (!info) continue;
     results.push({
+      sessionId: row.session_id ?? '',
       requestId: row.request_id ?? '',
+      messageId: row.message_id ?? '',
       gmtCreate: row.gmt_create,
       inputTokens: info.promptTokens,
       outputTokens: info.completionTokens,
       cacheReadTokens: info.cachedTokens,
+      model: parseModelKey(row.model_info) ?? parseRecordModelKey(row.record_extra),
     });
   }
   return results;
@@ -84,6 +106,29 @@ function parseTokenInfo(raw: string): { promptTokens: number; completionTokens: 
     return { promptTokens: pt, completionTokens: ct, cachedTokens: cached };
   } catch {
     return null;
+  }
+}
+
+function parseModelKey(raw: string | null | undefined): string | undefined {
+  if (!raw) return undefined;
+  try {
+    const obj = JSON.parse(raw);
+    return typeof obj.model_key === 'string' && obj.model_key.length > 0
+      ? obj.model_key
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseRecordModelKey(raw: string | null | undefined): string | undefined {
+  if (!raw) return undefined;
+  try {
+    const obj = JSON.parse(raw);
+    const key = obj?.modelConfig?.key;
+    return typeof key === 'string' && key.length > 0 ? key : undefined;
+  } catch {
+    return undefined;
   }
 }
 

--- a/src/inputs/qoder-trace/token-enricher.ts
+++ b/src/inputs/qoder-trace/token-enricher.ts
@@ -162,9 +162,11 @@ export function enrichIdeTurn(
   }
   matchedPairs.sort((a, b) => a.gmtCreate - b.gmtCreate);
 
-  // Find the user-boundary entry (llm.request without step_id) for step 1's request time
+  // Find the user-boundary entry for step 1's request time.
+  // The normalizer emits user prompts as 'other' (not 'llm.request'), so match both.
   const userBoundary = entries.find(e =>
-    e['event.name'] === 'llm.request' && !e['gen_ai.step.id'],
+    !e['gen_ai.step.id'] &&
+    (e['event.name'] === 'llm.request' || (e['event.name'] === 'other' && e['gen_ai.input.messages_delta'])),
   );
 
   for (let i = 0; i < matchedPairs.length; i++) {

--- a/src/inputs/qoder-trace/token-enricher.ts
+++ b/src/inputs/qoder-trace/token-enricher.ts
@@ -87,28 +87,19 @@ export function enrichIdeTurn(
 ): void {
   if (sqliteRows.length === 0) return;
 
-  // Level 1: Group SQLite rows by request_id (= turn-level grouping)
-  const requestGroups = new Map<string, SqliteTokenData[]>();
-  for (const row of sqliteRows) {
-    const group = requestGroups.get(row.requestId) ?? [];
-    group.push(row);
-    requestGroups.set(row.requestId, group);
-  }
-
-  // Sort request groups by earliest timestamp
-  const sortedGroups = [...requestGroups.entries()].sort(
-    (a, b) => a[1][0].gmtCreate - b[1][0].gmtCreate,
-  );
-
   // Get all llm.response entries sorted by time
   const responseEntries = entries
     .filter(e => e['event.name'] === 'llm.response')
     .sort((a, b) => extractMs(a) - extractMs(b));
 
-  // Level 2: Within each group, match by closest timestamp
   const used = new Set<AgentActivityEntry>();
   const tokenWritten = new Set<string>();
+  const sortedGroups = groupSqliteRowsByRequest(sqliteRows);
 
+  matchIdeTurnsBySqliteOrder(entries, sortedGroups, used, tokenWritten);
+
+  // Conservative fallback for incomplete SQLite metadata or structurally unmatched responses:
+  // match by close timestamp only, preserving the previous behavior.
   for (const [requestId, group] of sortedGroups) {
     for (const row of group) {
       let bestEntry: AgentActivityEntry | null = null;
@@ -128,12 +119,28 @@ export function enrichIdeTurn(
         (bestEntry as Record<string, unknown>).__matched_gmt_create = row.gmtCreate;
 
         if (!bestEntry['gen_ai.response.id']) {
-          bestEntry['gen_ai.response.id'] = requestId;
+          bestEntry['gen_ai.response.id'] = row.messageId || requestId;
+        }
+        bestEntry['gen_ai.request.id'] = requestId;
+        (bestEntry as Record<string, unknown>)['agent.request_id'] = requestId;
+
+        if (row.model && row.model !== 'unknown') {
+          bestEntry['gen_ai.request.model'] = row.model;
+          bestEntry['gen_ai.response.model'] = row.model;
+          const stepId = bestEntry['gen_ai.step.id'];
+          const req = entries.find(e =>
+            e['event.name'] === 'llm.request' && e['gen_ai.step.id'] === stepId,
+          );
+          if (req) {
+            req['gen_ai.request.id'] = requestId;
+            (req as Record<string, unknown>)['agent.request_id'] = requestId;
+            req['gen_ai.request.model'] = row.model;
+          }
         }
 
         // Each SQLite row = one LLM call. Write token on first match per row.
         // Use composite key (requestId:gmtCreate) to avoid collision if two calls share a millisecond.
-        const dedupeKey = `${row.requestId}:${row.gmtCreate}`;
+        const dedupeKey = sqliteDedupeKey(row);
         if (!tokenWritten.has(dedupeKey)) {
           bestEntry['gen_ai.usage.input_tokens'] = row.inputTokens;
           bestEntry['gen_ai.usage.output_tokens'] = row.outputTokens;
@@ -214,6 +221,134 @@ export function enrichIdeTurn(
     entry['gen_ai.usage.cache_read.input_tokens'] = 0;
   }
 
+}
+
+function groupSqliteRowsByRequest(sqliteRows: SqliteTokenData[]): Array<[string, SqliteTokenData[]]> {
+  const requestGroups = new Map<string, SqliteTokenData[]>();
+  for (const row of sqliteRows) {
+    if (!row.requestId) continue;
+    const group = requestGroups.get(row.requestId) ?? [];
+    group.push(row);
+    requestGroups.set(row.requestId, group);
+  }
+
+  return [...requestGroups.entries()]
+    .map(([requestId, rows]) => [
+      requestId,
+      [...rows].sort((a, b) => a.gmtCreate - b.gmtCreate),
+    ] as [string, SqliteTokenData[]])
+    .sort((a, b) => a[1][0].gmtCreate - b[1][0].gmtCreate);
+}
+
+function matchIdeTurnsBySqliteOrder(
+  entries: AgentActivityEntry[],
+  requestGroups: Array<[string, SqliteTokenData[]]>,
+  used: Set<AgentActivityEntry>,
+  tokenWritten: Set<string>,
+): void {
+  if (requestGroups.length === 0) return;
+  if (!requestGroups.every(([, rows]) => rows.every(row => row.messageId && row.sessionId))) return;
+
+  const sessionId = entries.find(e => typeof e['gen_ai.session.id'] === 'string')?.['gen_ai.session.id'] as string | undefined;
+  const sessionGroups = sessionId
+    ? requestGroups.filter(([, rows]) => rows[0]?.sessionId === sessionId)
+    : requestGroups;
+  if (sessionGroups.length === 0) return;
+
+  const turnGroups = groupEntriesByTurn(entries);
+  if (turnGroups.length === 0) return;
+
+  if (sessionGroups.length < turnGroups.length) {
+    for (const [, turnEntries] of turnGroups) {
+      markLowConfidence(turnEntries, 'request_count_mismatch');
+    }
+    return;
+  }
+
+  const candidateGroups = sessionGroups.slice(sessionGroups.length - turnGroups.length);
+  for (let i = 0; i < turnGroups.length; i++) {
+    const [, turnEntries] = turnGroups[i];
+    const [requestId, sqliteRows] = candidateGroups[i];
+    const responses = turnEntries.filter(e => e['event.name'] === 'llm.response');
+
+    if (responses.length !== sqliteRows.length) {
+      markLowConfidence(turnEntries, 'assistant_count_mismatch');
+      continue;
+    }
+
+    for (let j = 0; j < responses.length; j++) {
+      applySqliteRowToIdeResponse(entries, turnEntries, responses[j], sqliteRows[j], requestId, used, tokenWritten);
+    }
+  }
+}
+
+function groupEntriesByTurn(entries: AgentActivityEntry[]): Array<[string, AgentActivityEntry[]]> {
+  const groups = new Map<string, AgentActivityEntry[]>();
+  for (const entry of entries) {
+    const turnId = entry['gen_ai.turn.id'];
+    if (typeof turnId !== 'string' || turnId.length === 0) continue;
+    const group = groups.get(turnId) ?? [];
+    group.push(entry);
+    groups.set(turnId, group);
+  }
+  return [...groups.entries()].filter(([, group]) => group.some(e => e['event.name'] === 'llm.response'));
+}
+
+function applySqliteRowToIdeResponse(
+  allEntries: AgentActivityEntry[],
+  turnEntries: AgentActivityEntry[],
+  response: AgentActivityEntry,
+  row: SqliteTokenData,
+  requestId: string,
+  used: Set<AgentActivityEntry>,
+  tokenWritten: Set<string>,
+): void {
+  used.add(response);
+  (response as Record<string, unknown>).__matched_gmt_create = row.gmtCreate;
+  response['gen_ai.request.id'] = requestId;
+  (response as Record<string, unknown>)['agent.request_id'] = requestId;
+  response['gen_ai.response.id'] = row.messageId || requestId;
+  (response as Record<string, unknown>)['qoder.match_confidence'] = 'high';
+  (response as Record<string, unknown>)['qoder.match.strategy'] = 'sqlite_request_order';
+
+  if (row.model && row.model !== 'unknown') {
+    response['gen_ai.request.model'] = row.model;
+    response['gen_ai.response.model'] = row.model;
+  }
+
+  const request = findStepRequest(allEntries, response) ?? turnEntries.find(e => e['event.name'] === 'llm.request');
+  if (request) {
+    request['gen_ai.request.id'] = requestId;
+    (request as Record<string, unknown>)['agent.request_id'] = requestId;
+    (request as Record<string, unknown>)['qoder.match_confidence'] = 'high';
+    (request as Record<string, unknown>)['qoder.match.strategy'] = 'sqlite_request_order';
+    if (row.model && row.model !== 'unknown') request['gen_ai.request.model'] = row.model;
+  }
+
+  const dedupeKey = sqliteDedupeKey(row);
+  if (tokenWritten.has(dedupeKey)) return;
+  response['gen_ai.usage.input_tokens'] = row.inputTokens;
+  response['gen_ai.usage.output_tokens'] = row.outputTokens;
+  response['gen_ai.usage.total_tokens'] = row.inputTokens + row.outputTokens;
+  response['gen_ai.usage.cache_read.input_tokens'] = row.cacheReadTokens;
+  tokenWritten.add(dedupeKey);
+}
+
+function findStepRequest(entries: AgentActivityEntry[], response: AgentActivityEntry): AgentActivityEntry | undefined {
+  const stepId = response['gen_ai.step.id'];
+  return entries.find(e => e['event.name'] === 'llm.request' && e['gen_ai.step.id'] === stepId);
+}
+
+function markLowConfidence(entries: AgentActivityEntry[], warning: string): void {
+  for (const entry of entries) {
+    if (entry['event.name'] !== 'llm.request' && entry['event.name'] !== 'llm.response') continue;
+    (entry as Record<string, unknown>)['qoder.match_confidence'] = 'low';
+    (entry as Record<string, unknown>)['qoder.match.warning'] = warning;
+  }
+}
+
+function sqliteDedupeKey(row: SqliteTokenData): string {
+  return row.messageId || `${row.requestId}:${row.gmtCreate}`;
 }
 
 

--- a/tests/integration/hook-jsonl-flow.test.ts
+++ b/tests/integration/hook-jsonl-flow.test.ts
@@ -6,6 +6,7 @@ import { spawnSync } from 'node:child_process';
 import { ClientType } from '../../src/types/index.js';
 import type { AgentActivityEntry } from '../../src/types/index.js';
 import { QoderCliInput } from '../../src/inputs/qoder-cli/qoder-cli-input.js';
+import { QoderTraceInput } from '../../src/inputs/qoder-trace/qoder-trace-input.js';
 import { StateStore } from '../../src/checkpoints/state-store.js';
 import { AgentActivityEntrySchema } from '../contract/agent-activity-schema.js';
 
@@ -425,6 +426,120 @@ describe('Hook JSONL integration flow', () => {
       [llmRequests[0]['gen_ai.step.id'], 'Write'],
       [llmRequests[1]['gen_ai.step.id'], 'Bash'],
     ]);
+  });
+
+  it('QoderTraceInput cold start: only reports last turn when state is empty', async () => {
+    const logDir = path.join(tmpDir, 'logs-cold');
+    await fs.mkdir(logDir, { recursive: true });
+
+    const today = getTodayDateString();
+    const logFile = path.join(logDir, `qoder-${today}.jsonl`);
+
+    // Write 3 turns (historical data present before pilot was deployed)
+    const lines = [
+      // Turn 1 (old)
+      JSON.stringify({
+        'event.name': 'other',
+        'event.id': 'e-1',
+        'gen_ai.turn.id': 'turn-old-1',
+        'gen_ai.session.id': 'sess-1',
+        'gen_ai.agent.type': 'qoder-cli',
+        'gen_ai.input.messages_delta': [{ role: 'user', parts: [{ type: 'text', content: 'old prompt 1' }] }],
+        time_unix_nano: '1780000000000000000',
+        observed_time_unix_nano: '1780000000000000000',
+      }),
+      JSON.stringify({
+        'event.name': 'llm.response',
+        'event.id': 'e-2',
+        'gen_ai.turn.id': 'turn-old-1',
+        'gen_ai.session.id': 'sess-1',
+        'gen_ai.agent.type': 'qoder-cli',
+        'gen_ai.step.id': 'turn-old-1:s1',
+        time_unix_nano: '1780000001000000000',
+        observed_time_unix_nano: '1780000001000000000',
+      }),
+      // Turn 2 (old)
+      JSON.stringify({
+        'event.name': 'other',
+        'event.id': 'e-3',
+        'gen_ai.turn.id': 'turn-old-2',
+        'gen_ai.session.id': 'sess-1',
+        'gen_ai.agent.type': 'qoder-cli',
+        'gen_ai.input.messages_delta': [{ role: 'user', parts: [{ type: 'text', content: 'old prompt 2' }] }],
+        time_unix_nano: '1780000010000000000',
+        observed_time_unix_nano: '1780000010000000000',
+      }),
+      JSON.stringify({
+        'event.name': 'llm.response',
+        'event.id': 'e-4',
+        'gen_ai.turn.id': 'turn-old-2',
+        'gen_ai.session.id': 'sess-1',
+        'gen_ai.agent.type': 'qoder-cli',
+        'gen_ai.step.id': 'turn-old-2:s1',
+        time_unix_nano: '1780000011000000000',
+        observed_time_unix_nano: '1780000011000000000',
+      }),
+      // Turn 3 (latest — should be reported)
+      JSON.stringify({
+        'event.name': 'other',
+        'event.id': 'e-5',
+        'gen_ai.turn.id': 'turn-latest',
+        'gen_ai.session.id': 'sess-1',
+        'gen_ai.agent.type': 'qoder-cli',
+        'gen_ai.input.messages_delta': [{ role: 'user', parts: [{ type: 'text', content: 'latest prompt' }] }],
+        time_unix_nano: '1780000020000000000',
+        observed_time_unix_nano: '1780000020000000000',
+      }),
+      JSON.stringify({
+        'event.name': 'llm.response',
+        'event.id': 'e-6',
+        'gen_ai.turn.id': 'turn-latest',
+        'gen_ai.session.id': 'sess-1',
+        'gen_ai.agent.type': 'qoder-cli',
+        'gen_ai.step.id': 'turn-latest:s1',
+        time_unix_nano: '1780000021000000000',
+        observed_time_unix_nano: '1780000021000000000',
+      }),
+    ];
+    await fs.writeFile(logFile, lines.join('\n') + '\n');
+
+    // Fresh state store (simulates redeployment — no prior offset)
+    const freshStore = new StateStore(path.join(tmpDir, 'cold-state.json'));
+    await freshStore.load();
+
+    const input = new QoderTraceInput({
+      stateStore: freshStore as any,
+      logDir,
+      pollIntervalMs: 60_000,
+    });
+
+    const allEntries: AgentActivityEntry[] = [];
+    input.on('entries', (e: AgentActivityEntry[]) => allEntries.push(...e));
+
+    await input.start();
+    await input.stop();
+
+    // Only the last turn should be reported
+    expect(allEntries.length).toBe(2);
+    expect(allEntries.every(e => e['gen_ai.turn.id'] === 'turn-latest')).toBe(true);
+
+    // Offset should be at end of file
+    await freshStore.save();
+    const state = freshStore.get('qoder-trace');
+    expect(state.lastOffset).toBe((await fs.stat(logFile)).size);
+    expect(state.lastFile).toBe(`qoder-${today}.jsonl`);
+
+    // Subsequent run should not re-emit anything
+    const input2 = new QoderTraceInput({
+      stateStore: freshStore as any,
+      logDir,
+      pollIntervalMs: 60_000,
+    });
+    const newEntries: AgentActivityEntry[] = [];
+    input2.on('entries', (e: AgentActivityEntry[]) => newEntries.push(...e));
+    await input2.start();
+    await input2.stop();
+    expect(newEntries).toHaveLength(0);
   });
 });
 

--- a/tests/integration/hook-jsonl-flow.test.ts
+++ b/tests/integration/hook-jsonl-flow.test.ts
@@ -541,6 +541,96 @@ describe('Hook JSONL integration flow', () => {
     await input2.stop();
     expect(newEntries).toHaveLength(0);
   });
+
+  it('should split multi-turn transcript into separate turns with correct user inputs', async () => {
+    const hookDir = path.join(tmpDir, 'hooks-multi-turn');
+    const dataDir = path.join(tmpDir, 'data-multi-turn');
+    await fs.mkdir(hookDir, { recursive: true });
+    const hookScript = path.join(hookDir, 'qoder-loongsuite-pilot-hook.sh');
+    await fs.copyFile(path.resolve(process.cwd(), 'assets/hooks/qoder-loongsuite-pilot-hook.sh'), hookScript);
+    await fs.copyFile(
+      path.resolve(process.cwd(), 'assets/hooks/qoder-hook-processor.mjs'),
+      path.join(hookDir, 'qoder-hook-processor.mjs'),
+    );
+    await fs.copyFile(
+      path.resolve(process.cwd(), 'assets/hooks/agent-event-normalizer.mjs'),
+      path.join(hookDir, 'agent-event-normalizer.mjs'),
+    );
+    const sharedDir = path.join(hookDir, 'shared');
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.copyFile(
+      path.resolve(process.cwd(), 'assets/hooks/shared/hook-processor-base.mjs'),
+      path.join(sharedDir, 'hook-processor-base.mjs'),
+    );
+    await fs.chmod(hookScript, 0o755);
+
+    const transcriptPath = path.join(tmpDir, 'multi-turn-transcript.jsonl');
+    await fs.writeFile(transcriptPath, [
+      // Turn 1: hello
+      JSON.stringify({
+        type: 'user',
+        timestamp: '2026-06-18T08:00:00.000Z',
+        sessionId: 'sess-multi',
+        message: { role: 'user', content: 'hello' },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        timestamp: '2026-06-18T08:00:01.000Z',
+        sessionId: 'sess-multi',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'Hi there.' }] },
+      }),
+      // Turn 2: leetcode
+      JSON.stringify({
+        type: 'user',
+        timestamp: '2026-06-18T08:01:00.000Z',
+        sessionId: 'sess-multi',
+        message: { role: 'user', content: '完成力扣第143题' },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        timestamp: '2026-06-18T08:01:05.000Z',
+        sessionId: 'sess-multi',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'I\'ll solve leetcode 143.' }] },
+      }),
+      JSON.stringify({
+        type: 'progress',
+        timestamp: '2026-06-18T08:01:10.000Z',
+        data: { hookEvent: 'Stop', hookName: 'Stop' },
+      }),
+      JSON.stringify({
+        type: 'last-prompt',
+        sessionId: 'sess-multi',
+        lastPrompt: '完成力扣第143题',
+      }),
+    ].join('\n') + '\n');
+
+    const result = runQoderHook(hookScript, JSON.stringify({
+      hook_event_name: 'Stop',
+      transcript_path: transcriptPath,
+      session_id: 'sess-multi',
+    }), {
+      LOONGSUITE_PILOT_DATA_DIR: dataDir,
+    });
+    expect(result.status).toBe(0);
+
+    const historyFile = path.join(dataDir, 'logs', 'qoder', 'history', `qoder-${getTodayDateString()}.jsonl`);
+    const records = (await fs.readFile(historyFile, 'utf-8')).trim().split('\n').map(line => JSON.parse(line));
+    const userHookEvents = records.filter(r => r['event.name'] === 'other');
+
+    // Should have two distinct turns
+    expect(userHookEvents).toHaveLength(2);
+    const turnIds = new Set(userHookEvents.map(r => r['gen_ai.turn.id']));
+    expect(turnIds.size).toBe(2);
+
+    // Find the last turn's user input
+    const sortedByTs = userHookEvents.sort((a, b) => Number(a.time_unix_nano) - Number(b.time_unix_nano));
+    expect(sortedByTs[0]['gen_ai.input.messages_delta']).toEqual([
+      { role: 'user', parts: [{ type: 'text', content: 'hello' }] },
+    ]);
+    expect(sortedByTs[1]['gen_ai.input.messages_delta']).toEqual([
+      { role: 'user', parts: [{ type: 'text', content: '完成力扣第143题' }] },
+    ]);
+  });
 });
 
 describe('Cursor hook script integration flow', () => {

--- a/tests/integration/hook-jsonl-flow.test.ts
+++ b/tests/integration/hook-jsonl-flow.test.ts
@@ -269,7 +269,7 @@ describe('Hook JSONL integration flow', () => {
     expect(historyRecord.type).toBeUndefined();
     expect(historyRecord.uuid).toBeUndefined();
     expect(historyRecord.sessionId).toBeUndefined();
-    expect(historyRecord['event.name']).toBe('llm.request');
+    expect(historyRecord['event.name']).toBe('other');
 
     const input = new QoderCliInput({
       stateStore: stateStore as any,
@@ -283,15 +283,148 @@ describe('Hook JSONL integration flow', () => {
     await input.start();
     await input.stop();
 
-    // New processor produces: user-hook (llm.request) + step llm.request + llm.response
+    // New processor produces: user-hook (other) + step llm.request + llm.response
     expect(allEntries.length).toBeGreaterThanOrEqual(1);
-    const userHook = allEntries.find(e => e['event.name'] === 'llm.request' && !e['gen_ai.step.id']);
+    const userHook = allEntries.find(e => e['event.name'] === 'other' && !e['gen_ai.step.id']);
     expect(userHook).toBeDefined();
     expect(userHook).toMatchObject({
-      'event.name': 'llm.request',
+      'event.name': 'other',
       'gen_ai.agent.type': ClientType.QoderCli,
       'gen_ai.session.id': 'sess-hook',
     });
+  });
+
+  it('keeps delayed IDE assistant text and tool_use in the same LLM step', async () => {
+    const hookDir = path.join(tmpDir, 'hooks-delayed-ide');
+    const dataDir = path.join(tmpDir, 'data-delayed-ide');
+    await fs.mkdir(hookDir, { recursive: true });
+    const hookScript = path.join(hookDir, 'qoder-loongsuite-pilot-hook.sh');
+    await fs.copyFile(path.resolve(process.cwd(), 'assets/hooks/qoder-loongsuite-pilot-hook.sh'), hookScript);
+    await fs.copyFile(
+      path.resolve(process.cwd(), 'assets/hooks/qoder-hook-processor.mjs'),
+      path.join(hookDir, 'qoder-hook-processor.mjs'),
+    );
+    await fs.copyFile(
+      path.resolve(process.cwd(), 'assets/hooks/agent-event-normalizer.mjs'),
+      path.join(hookDir, 'agent-event-normalizer.mjs'),
+    );
+    const sharedDir = path.join(hookDir, 'shared');
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.copyFile(
+      path.resolve(process.cwd(), 'assets/hooks/shared/hook-processor-base.mjs'),
+      path.join(sharedDir, 'hook-processor-base.mjs'),
+    );
+    await fs.chmod(hookScript, 0o755);
+
+    const transcriptPath = path.join(tmpDir, 'delayed-ide-transcript.jsonl');
+    await fs.writeFile(transcriptPath, [
+      JSON.stringify({
+        type: 'progress',
+        timestamp: '2026-06-18T09:53:21.156Z',
+        data: { hookEvent: 'UserPromptSubmit', hookName: 'submit' },
+      }),
+      JSON.stringify({
+        type: 'user',
+        timestamp: '2026-06-18T09:53:21.156Z',
+        sessionId: 'sess-delayed-ide',
+        message: { role: 'user', content: [{ type: 'text', text: 'create and test a solution' }] },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        timestamp: '2026-06-18T09:54:08.143Z',
+        sessionId: 'sess-delayed-ide',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'I will create the file.' }] },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        timestamp: '2026-06-18T09:54:08.144Z',
+        sessionId: 'sess-delayed-ide',
+        message: { role: 'assistant', content: [{ type: 'tool_use', id: 'call_write', name: 'Write', input: { file_path: '/tmp/a.py' } }] },
+      }),
+      JSON.stringify({
+        type: 'progress',
+        timestamp: '2026-06-18T09:54:08.495Z',
+        data: { hookEvent: 'PreToolUse', hookName: 'Write' },
+      }),
+      JSON.stringify({
+        type: 'user',
+        timestamp: '2026-06-18T09:54:10.906Z',
+        sessionId: 'sess-delayed-ide',
+        message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'call_write', content: 'created' }] },
+      }),
+      JSON.stringify({
+        type: 'progress',
+        timestamp: '2026-06-18T09:54:11.356Z',
+        data: { hookEvent: 'PostToolUse', hookName: 'Write' },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        timestamp: '2026-06-18T09:54:20.952Z',
+        sessionId: 'sess-delayed-ide',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'Let me run the tests.' }] },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        timestamp: '2026-06-18T09:54:29.523Z',
+        sessionId: 'sess-delayed-ide',
+        message: { role: 'assistant', content: [{ type: 'tool_use', id: 'call_bash', name: 'Bash', input: { command: 'python /tmp/a.py' } }] },
+      }),
+      JSON.stringify({
+        type: 'progress',
+        timestamp: '2026-06-18T09:54:29.937Z',
+        data: { hookEvent: 'PreToolUse', hookName: 'Bash' },
+      }),
+      JSON.stringify({
+        type: 'user',
+        timestamp: '2026-06-18T09:54:30.078Z',
+        sessionId: 'sess-delayed-ide',
+        message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'call_bash', content: 'ok' }] },
+      }),
+      JSON.stringify({
+        type: 'progress',
+        timestamp: '2026-06-18T09:54:30.594Z',
+        data: { hookEvent: 'PostToolUse', hookName: 'Bash' },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        timestamp: '2026-06-18T09:54:40.148Z',
+        sessionId: 'sess-delayed-ide',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'Done.' }] },
+      }),
+      JSON.stringify({
+        type: 'progress',
+        timestamp: '2026-06-18T09:54:40.696Z',
+        data: { hookEvent: 'Stop', hookName: 'Stop' },
+      }),
+      JSON.stringify({
+        type: 'last-prompt',
+        sessionId: 'sess-delayed-ide',
+        lastPrompt: 'create and test a solution',
+      }),
+    ].join('\n') + '\n');
+
+    const result = runQoderHook(hookScript, JSON.stringify({
+      hook_event_name: 'Stop',
+      transcript_path: transcriptPath,
+      session_id: 'sess-delayed-ide',
+    }), {
+      LOONGSUITE_PILOT_DATA_DIR: dataDir,
+    });
+    expect(result.status).toBe(0);
+
+    const historyFile = path.join(dataDir, 'logs', 'qoder', 'history', `qoder-${getTodayDateString()}.jsonl`);
+    const records = (await fs.readFile(historyFile, 'utf-8')).trim().split('\n').map(line => JSON.parse(line));
+    const llmRequests = records.filter(r => r['event.name'] === 'llm.request');
+    const llmResponses = records.filter(r => r['event.name'] === 'llm.response');
+    const toolCalls = records.filter(r => r['event.name'] === 'tool.call');
+
+    expect(llmRequests).toHaveLength(3);
+    expect(llmResponses).toHaveLength(3);
+    expect(new Set(llmRequests.map(r => r['gen_ai.step.id']))).toEqual(new Set(llmResponses.map(r => r['gen_ai.step.id'])));
+    expect(toolCalls.map(r => [r['gen_ai.step.id'], r['gen_ai.tool.name']])).toEqual([
+      [llmRequests[0]['gen_ai.step.id'], 'Write'],
+      [llmRequests[1]['gen_ai.step.id'], 'Bash'],
+    ]);
   });
 });
 

--- a/tests/unit/hooks/agent-event-normalizer.test.mjs
+++ b/tests/unit/hooks/agent-event-normalizer.test.mjs
@@ -246,7 +246,7 @@ describe('asset hook agent event normalizer', () => {
       runtimeConfig: { userId: 'u-qoder', agents: {} },
     });
 
-    expect(record['event.name']).toBe('llm.request');
+    expect(record['event.name']).toBe('other');
     expect(record['gen_ai.request.model']).toBeUndefined();
     expect(record['gen_ai.response.model']).toBeUndefined();
     expect(record['gen_ai.provider.name']).toBe('qwen');

--- a/tests/unit/inputs/qoder-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-trace-input.test.ts
@@ -163,7 +163,144 @@ describe('QoderTraceInput token-enricher', () => {
     });
   });
 
-  describe('enrichIdeTurn (timestamp-based match)', () => {
+  describe('enrichIdeTurn (SQLite structure match)', () => {
+    it('matches IDE turns by session request order and assistant order without timestamp proximity', () => {
+      const entries: AgentActivityEntry[] = [
+        makeEntry({
+          'event.name': 'llm.request',
+          'gen_ai.agent.type': 'qoder',
+          'gen_ai.session.id': 'sess-ide',
+          'gen_ai.turn.id': 'turn-a',
+          'gen_ai.step.id': 'turn-a:s1',
+          'gen_ai.request.model': 'auto',
+          time_unix_nano: '1780000000000000000',
+        } as any),
+        makeEntry({
+          'event.name': 'llm.response',
+          'gen_ai.agent.type': 'qoder',
+          'gen_ai.session.id': 'sess-ide',
+          'gen_ai.turn.id': 'turn-a',
+          'gen_ai.step.id': 'turn-a:s1',
+          'gen_ai.request.model': 'auto',
+          'gen_ai.response.model': 'auto',
+          time_unix_nano: '1780000000000000000',
+        } as any),
+        makeEntry({
+          'event.name': 'llm.request',
+          'gen_ai.agent.type': 'qoder',
+          'gen_ai.session.id': 'sess-ide',
+          'gen_ai.turn.id': 'turn-b',
+          'gen_ai.step.id': 'turn-b:s1',
+          'gen_ai.request.model': 'auto',
+          time_unix_nano: '1780000010000000000',
+        } as any),
+        makeEntry({
+          'event.name': 'llm.response',
+          'gen_ai.agent.type': 'qoder',
+          'gen_ai.session.id': 'sess-ide',
+          'gen_ai.turn.id': 'turn-b',
+          'gen_ai.step.id': 'turn-b:s1',
+          'gen_ai.request.model': 'auto',
+          'gen_ai.response.model': 'auto',
+          time_unix_nano: '1780000010000000000',
+        } as any),
+      ];
+      const sqliteRows: SqliteTokenData[] = [
+        {
+          sessionId: 'sess-ide',
+          requestId: 'request-a',
+          messageId: 'message-a-1',
+          gmtCreate: 1780000100000,
+          inputTokens: 100,
+          outputTokens: 10,
+          cacheReadTokens: 3,
+          model: 'gm51model',
+        },
+        {
+          sessionId: 'sess-ide',
+          requestId: 'request-b',
+          messageId: 'message-b-1',
+          gmtCreate: 1780000200000,
+          inputTokens: 200,
+          outputTokens: 20,
+          cacheReadTokens: 4,
+          model: 'qmodel_latest',
+        },
+      ];
+
+      enrichIdeTurn(entries, sqliteRows);
+
+      expect(entries[0]['gen_ai.request.id']).toBe('request-a');
+      expect((entries[0] as any)['agent.request_id']).toBe('request-a');
+      expect(entries[0]['gen_ai.request.model']).toBe('gm51model');
+      expect(entries[1]['gen_ai.request.id']).toBe('request-a');
+      expect(entries[1]['gen_ai.response.id']).toBe('message-a-1');
+      expect(entries[1]['gen_ai.request.model']).toBe('gm51model');
+      expect(entries[1]['gen_ai.response.model']).toBe('gm51model');
+      expect(entries[1]['gen_ai.usage.input_tokens']).toBe(100);
+
+      expect(entries[2]['gen_ai.request.id']).toBe('request-b');
+      expect(entries[2]['gen_ai.request.model']).toBe('qmodel_latest');
+      expect(entries[3]['gen_ai.response.id']).toBe('message-b-1');
+      expect(entries[3]['gen_ai.response.model']).toBe('qmodel_latest');
+      expect(entries[3]['gen_ai.usage.input_tokens']).toBe(200);
+    });
+
+    it('marks low confidence and avoids structural assignment when assistant counts differ', () => {
+      const entries: AgentActivityEntry[] = [
+        makeEntry({
+          'event.name': 'llm.request',
+          'gen_ai.agent.type': 'qoder',
+          'gen_ai.session.id': 'sess-ide',
+          'gen_ai.turn.id': 'turn-a',
+          'gen_ai.step.id': 'turn-a:s1',
+          'gen_ai.request.model': 'auto',
+          time_unix_nano: '1780000000000000000',
+        } as any),
+        makeEntry({
+          'event.name': 'llm.response',
+          'gen_ai.agent.type': 'qoder',
+          'gen_ai.session.id': 'sess-ide',
+          'gen_ai.turn.id': 'turn-a',
+          'gen_ai.step.id': 'turn-a:s1',
+          'gen_ai.request.model': 'auto',
+          'gen_ai.response.model': 'auto',
+          time_unix_nano: '1780000000000000000',
+        } as any),
+      ];
+      const sqliteRows: SqliteTokenData[] = [
+        {
+          sessionId: 'sess-ide',
+          requestId: 'request-a',
+          messageId: 'message-a-1',
+          gmtCreate: 1780000100000,
+          inputTokens: 100,
+          outputTokens: 10,
+          cacheReadTokens: 3,
+          model: 'gm51model',
+        },
+        {
+          sessionId: 'sess-ide',
+          requestId: 'request-a',
+          messageId: 'message-a-2',
+          gmtCreate: 1780000200000,
+          inputTokens: 200,
+          outputTokens: 20,
+          cacheReadTokens: 4,
+          model: 'gm51model',
+        },
+      ];
+
+      enrichIdeTurn(entries, sqliteRows);
+
+      expect(entries[1]['gen_ai.response.id']).toBeUndefined();
+      expect(entries[1]['gen_ai.response.model']).toBe('auto');
+      expect((entries[1] as any)['qoder.match_confidence']).toBe('low');
+      expect((entries[1] as any)['qoder.match.warning']).toBe('assistant_count_mismatch');
+    });
+  });
+
+  describe('enrichIdeTurn (timestamp-based fallback)', () => {
     it('matches SQLite rows by timestamp within 1000ms', () => {
       const entries: AgentActivityEntry[] = [
         makeEntry({
@@ -185,6 +322,40 @@ describe('QoderTraceInput token-enricher', () => {
       expect(entries[0]['gen_ai.usage.input_tokens']).toBe(24841);
       expect(entries[0]['gen_ai.usage.output_tokens']).toBe(106);
       expect(entries[0]['gen_ai.response.id']).toBe('sqlite-req-1');
+    });
+
+    it('injects SQLite model key into matching IDE request and response entries', () => {
+      const entries: AgentActivityEntry[] = [
+        makeEntry({
+          'event.name': 'llm.request',
+          'gen_ai.agent.type': 'qoder',
+          'gen_ai.step.id': 'turn-1:s1',
+          'gen_ai.request.model': 'auto',
+          time_unix_nano: '1780366977000000000',
+        } as any),
+        makeEntry({
+          'event.name': 'llm.response',
+          'gen_ai.agent.type': 'qoder',
+          'gen_ai.step.id': 'turn-1:s1',
+          'gen_ai.request.model': 'auto',
+          'gen_ai.response.model': 'auto',
+          time_unix_nano: '1780366977467000000',
+        } as any),
+      ];
+      const sqliteRows: SqliteTokenData[] = [{
+        requestId: 'sqlite-req-1',
+        gmtCreate: 1780366977466,
+        inputTokens: 24841,
+        outputTokens: 106,
+        cacheReadTokens: 23741,
+        model: 'gm51model',
+      }];
+
+      enrichIdeTurn(entries, sqliteRows);
+
+      expect(entries[0]['gen_ai.request.model']).toBe('gm51model');
+      expect(entries[1]['gen_ai.request.model']).toBe('gm51model');
+      expect(entries[1]['gen_ai.response.model']).toBe('gm51model');
     });
 
     it('does not match if timestamp difference exceeds 1000ms', () => {


### PR DESCRIPTION
## Summary
- qoder-hook-processor: use progress event windows to detect LLM request/response boundaries more accurately
- agent-event-normalizer: emit user events as `other` instead of `llm.request` to avoid duplicate span creation
- token-enricher: match tokens by SQLite request ordering with confidence tracking
- sqlite-token-reader: extend SqliteTokenData with sessionId/messageId/model fields
- qoder-trace-input: group IDE turns by session before enrichment

## Test plan
- [ ] Run existing unit tests: `npx vitest run tests/unit/hooks/agent-event-normalizer.test.mjs`
- [ ] Run qoder-trace input tests: `npx vitest run tests/unit/inputs/qoder-trace-input.test.ts`
- [ ] Run integration test: `npx vitest run tests/integration/hook-jsonl-flow.test.ts`
- [ ] Verify IDE trace output with real Qoder IDE session