### PR TITLE
fix(windows): fix .sh→.ps1 replacement when hookCommand has trailing args

### DIFF
--- a/src/deployment/agent-def-loader.ts
+++ b/src/deployment/agent-def-loader.ts
@@ -126,7 +126,7 @@ export class AgentDefLoader {
     result = resolveHome(result);
 
     if (process.platform === 'win32') {
-      result = result.replace(/\.sh$/, '.ps1');
+      result = result.replace(/\.sh(?=\s|$)/, '.ps1');
     }
     return result;
   }


### PR DESCRIPTION
## Summary
- Fix regex in `agent-def-loader.ts` from `/\.sh$/` to `/\.sh(?=\s|$)/` so that `.sh→.ps1` replacement works when `hookCommand` has trailing arguments (e.g. `hook.sh qoder`)
- Without this fix, on Windows the `.sh` path is written to settings.json as-is, causing the hook to never fire

## Root cause
`qoder.json` defines `hookCommand` as `$PILOT_DATA/hooks/qoder-loongsuite-pilot-hook.sh qoder`. The `$` anchor in the old regex requires `.sh` at the very end of the string, but here `.sh` is followed by ` qoder`, so the replacement silently fails.

## Test plan
- [x] Verified regex handles both cases: `hook.sh` (no args) and `hook.sh qoder` (with args)
- [ ] Deploy to a Windows machine and confirm `~/.qoder/settings.json` gets the `.ps1` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)