### PR TITLE
fix(codex): do not add `version` field to Codex hooks.json

### DIFF
--- a/src/deployment/hook-strategy.ts
+++ b/src/deployment/hook-strategy.ts
@@ -275,15 +275,23 @@ export class HookStrategy implements DeployStrategy {
 
   /**
    * Ensure the settings file exists with a valid structure.
-   * Handles Cursor's hooks.json which needs a `version` field.
+   * Cursor's hooks.json requires a `version` field; Codex's does NOT
+   * (Codex uses `#[serde(deny_unknown_fields)]` and only allows `hooks`).
    */
   private async ensureSettingsFile(settingsPath: string): Promise<void> {
+    const isHooksJson = settingsPath.endsWith('hooks.json');
+    const needsVersion = isHooksJson && settingsPath.includes('.cursor');
+
     const existing = await readJsonFile<Record<string, unknown>>(settingsPath);
     if (!existing) {
-      if (settingsPath.endsWith('hooks.json')) {
-        await writeJsonFile(settingsPath, { version: 1, hooks: {} });
+      if (isHooksJson) {
+        const initial: Record<string, unknown> = { hooks: {} };
+        if (needsVersion) {
+          initial.version = 1;
+        }
+        await writeJsonFile(settingsPath, initial);
       }
-    } else if (settingsPath.endsWith('hooks.json') && existing.version === undefined) {
+    } else if (needsVersion && existing.version === undefined) {
       existing.version = 1;
       await writeJsonFile(settingsPath, existing);
     }

--- a/tests/unit/deployment/hook-strategy.test.ts
+++ b/tests/unit/deployment/hook-strategy.test.ts
@@ -145,21 +145,68 @@ describe('HookStrategy', () => {
 
       expect(writeJsonFile).toHaveBeenCalledWith(
         '/home/.test/hooks.json',
+        { hooks: {} },
+      );
+    });
+
+    it('creates settings file with version for Cursor hooks.json', async () => {
+      vi.mocked(readJsonFile).mockResolvedValue(null);
+      mockHookManager.isHookInstalled.mockResolvedValue(false);
+      mockHookManager.installHook.mockResolvedValue(true);
+
+      const def = makeDef({
+        hook: {
+          settingsPath: '/home/.cursor/hooks.json',
+          events: ['Stop'],
+          hookCommand: '/opt/pilot/hooks/test.sh',
+          format: 'flat',
+        },
+      });
+      await strategy.deploy(def);
+
+      expect(writeJsonFile).toHaveBeenCalledWith(
+        '/home/.cursor/hooks.json',
         { version: 1, hooks: {} },
       );
     });
 
-    it('adds version field to existing hooks.json without one', async () => {
+    it('adds version field to existing Cursor hooks.json without one', async () => {
       vi.mocked(readJsonFile).mockResolvedValue({ hooks: {} });
       mockHookManager.isHookInstalled.mockResolvedValue(false);
       mockHookManager.installHook.mockResolvedValue(true);
 
-      await strategy.deploy(makeDef());
+      const def = makeDef({
+        hook: {
+          settingsPath: '/home/.cursor/hooks.json',
+          events: ['Stop'],
+          hookCommand: '/opt/pilot/hooks/test.sh',
+          format: 'flat',
+        },
+      });
+      await strategy.deploy(def);
 
       expect(writeJsonFile).toHaveBeenCalledWith(
-        '/home/.test/hooks.json',
+        '/home/.cursor/hooks.json',
         { version: 1, hooks: {} },
       );
+    });
+
+    it('does not add version to Codex hooks.json', async () => {
+      vi.mocked(readJsonFile).mockResolvedValue({ hooks: {} });
+      mockHookManager.isHookInstalled.mockResolvedValue(false);
+      mockHookManager.installHook.mockResolvedValue(true);
+
+      const def = makeDef({
+        hook: {
+          settingsPath: '/home/.codex/hooks.json',
+          events: ['Stop'],
+          hookCommand: '/opt/pilot/hooks/test.sh',
+          format: 'nested',
+        },
+      });
+      await strategy.deploy(def);
+
+      expect(writeJsonFile).not.toHaveBeenCalled();
     });
 
     it('does not overwrite version on existing hooks.json that already has one', async () => {
@@ -167,7 +214,15 @@ describe('HookStrategy', () => {
       mockHookManager.isHookInstalled.mockResolvedValue(false);
       mockHookManager.installHook.mockResolvedValue(true);
 
-      await strategy.deploy(makeDef());
+      const def = makeDef({
+        hook: {
+          settingsPath: '/home/.cursor/hooks.json',
+          events: ['Stop'],
+          hookCommand: '/opt/pilot/hooks/test.sh',
+          format: 'flat',
+        },
+      });
+      await strategy.deploy(def);
 
       expect(writeJsonFile).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary

- Codex 的 `hooks.json` 使用 `#[serde(deny_unknown_fields)]`，根级别只允许 `hooks` 字段
- `ensureSettingsFile` 之前对所有 `hooks.json` 路径统一添加 `version: 1`，导致 Codex 解析失败：`unknown field 'version', expected 'hooks'`
- 修复：仅对包含 `.cursor` 的路径添加 `version` 字段，Codex/其他 agent 的 `hooks.json` 不再注入该字段

## Changes

- `src/deployment/hook-strategy.ts`: `ensureSettingsFile` 增加 `needsVersion` 判断（仅 `.cursor` 路径）
- `tests/unit/deployment/hook-strategy.test.ts`: 新增 Cursor / Codex 分别的测试用例，覆盖有无 version 的场景

## Test plan

- [x] `npx vitest run tests/unit/deployment/hook-strategy.test.ts` — 18 tests passed
- [ ] 手动验证：删除 `~/.codex/hooks.json` 中的 `version` 后 Codex 不再报 parse error
- [ ] 手动验证：Cursor 部署仍正常写入 `version: 1`


Made with [Cursor](https://cursor.com)