### PR TITLE
fix(qoder-work): merge trace timing and transcript fixes

### DIFF
--- a/assets/hooks/qoderwork-hook-processor.mjs
+++ b/assets/hooks/qoderwork-hook-processor.mjs
@@ -141,7 +141,9 @@ function splitIntoTurns(contentRows) {
 
 function isSystemInjection(row) {
   const text = extractText(row).trimStart();
-  return text.startsWith('<command-message>') || text.startsWith('<command-name>');
+  return text.startsWith('<command-message>') ||
+    text.startsWith('<command-name>') ||
+    text.startsWith('<system-reminder>');
 }
 
 function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, cwd) {
@@ -152,7 +154,7 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
 
   // User-hook event (no step.id, no model — per §5 of EVENT_LOG_TO_TRACE_SPEC)
   if (userRow) {
-    const userText = extractText(userRow);
+    const userText = stripSystemReminders(extractText(userRow));
     if (userText) {
       records.push(buildRecord({
         'event.name': 'llm.request',
@@ -169,14 +171,22 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
     }
   }
 
-  // Group assistant rows by parentUuid — each group = one LLM call
+  // Group assistant rows by tool_result boundaries — each group = one LLM call.
+  // Reason: QoderWork sometimes splits one LLM response across multiple assistant
+  // rows with different parentUuids (e.g. thinking row + separate tool_use row).
+  // groupByParentUuid would wrongly split these into multiple "steps" and break
+  // timing (the second half would incorrectly inherit the tool_result's ts as
+  // llm.request time). Tool_result boundaries are the semantically correct split
+  // since the LLM only receives tool outputs and issues a new response at those points.
   const assistantRows = turnRows.filter(r => r.type === 'assistant');
   const toolResultRows = turnRows.filter(r => r.type === 'user' && isToolResult(r));
 
-  const llmGroups = groupByParentUuid(assistantRows);
+  const llmGroups = groupAssistantRowsByToolResults(turnRows);
 
-  const userText = userRow ? extractText(userRow) : '';
+  const userText = userRow ? stripSystemReminders(extractText(userRow)) : '';
+  const userTs = userRow ? timestampToUnixNanos(userRow.timestamp) : undefined;
   let prevToolCalls = []; // tool_call ids from previous step, for building tool_result delta
+  let prevStepLastToolResultTs = undefined; // 上一个 step 最后一个 tool_result 的 nano ts，用于本 step llm.request 时间
 
   let stepCounter = 0;
   for (const group of llmGroups) {
@@ -208,17 +218,38 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
       }
     }
 
-    const stepRecords = buildStepEvents(group, toolResultRows, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, stepCounter === llmGroups.length, inputDelta, cwd);
+    // llm.request time:
+    //   step 1 = user input ts (user message arrival, a reasonable proxy for LLM start)
+    //   step N>1 = 上一个 step 最后一个 tool_result ts (工具返回后模型立刻开始处理)
+    // 否则用 assistant 行写盘时间会导致 LLM span 退化为 0ms（thinking/tool_use 同毫秒批量 flush）
+    const llmRequestTs = stepCounter === 1 ? userTs : prevStepLastToolResultTs;
+
+    const stepRecords = buildStepEvents(group, toolResultRows, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, stepCounter === llmGroups.length, inputDelta, cwd, llmRequestTs);
     records.push(...stepRecords);
 
     // Collect this step's tool_calls for next step's input delta
     prevToolCalls = [];
+    let lastToolResultTsInStep = undefined;
     for (const row of group) {
       const msg = row.message || {};
       const content = Array.isArray(msg.content) ? msg.content : [];
       for (const b of content) {
-        if (b.type === 'tool_use') prevToolCalls.push({ id: b.id, name: b.name });
+        if (b.type === 'tool_use') {
+          prevToolCalls.push({ id: b.id, name: b.name });
+          // 找到本 step 该 tool_use 对应的 tool_result 行，记录 ts；多 tool 场景保留最后一个
+          const trRow = toolResultRows.find(r => {
+            const c = Array.isArray(r.message?.content) ? r.message.content : [];
+            return c.some(bl => bl.type === 'tool_result' && bl.tool_use_id === b.id);
+          });
+          if (trRow?.timestamp) {
+            const nano = timestampToUnixNanos(trRow.timestamp);
+            if (nano) lastToolResultTsInStep = nano;
+          }
+        }
       }
+    }
+    if (lastToolResultTsInStep) {
+      prevStepLastToolResultTs = lastToolResultTsInStep;
     }
   }
 
@@ -247,10 +278,53 @@ function groupByParentUuid(assistantRows) {
   return groups;
 }
 
-function buildStepEvents(group, toolResultRows, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, isLastStep, inputDelta, cwd) {
+/**
+ * Group consecutive assistant rows between tool_result boundaries.
+ *
+ * Each group represents ONE LLM response. A tool_result row marks the
+ * boundary because it delivers a tool's output back to the model — the
+ * next assistant row is the start of the model's next response.
+ *
+ * Why not parentUuid: QoderWork occasionally emits a single LLM response
+ * as multiple assistant rows with different parentUuids (e.g. a thinking
+ * row + a separate tool_use row). Using parentUuid would incorrectly
+ * split them into multiple "steps", and a "prev tool_result ts as
+ * llm.request start" rule would then attribute the tool's execution time
+ * to the second half's LLM time.
+ */
+function groupAssistantRowsByToolResults(turnRows) {
+  const groups = [];
+  let current = [];
+
+  for (const row of turnRows) {
+    if (row.type === 'assistant') {
+      current.push(row);
+    } else if (row.type === 'user' && isToolResult(row)) {
+      if (current.length > 0) {
+        groups.push(current);
+        current = [];
+      }
+    }
+    // Non-assistant non-tool_result user rows (the prompt) are ignored here;
+    // they don't end an LLM-response group.
+  }
+  if (current.length > 0) groups.push(current);
+  return groups;
+}
+
+function buildStepEvents(group, toolResultRows, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, isLastStep, inputDelta, cwd, llmRequestTs) {
   const records = [];
   const firstRow = group[0];
   const lastRow = group[group.length - 1];
+
+  // thinking 行的 ts 用作 llm.response 时间（模型完成输出的真实时刻）；
+  // 没有 thinking 时回退到 lastRow.timestamp（与现有行为一致）
+  const thinkingRow = group.find(r => {
+    const content = Array.isArray(r.message?.content) ? r.message.content : [];
+    const firstType = content[0]?.type;
+    return firstType === 'thinking' || r.content_type === 'thinking';
+  });
+  const llmResponseTs = timestampToUnixNanos(thinkingRow ? thinkingRow.timestamp : lastRow.timestamp);
 
   // Determine response.id from parentUuid
   const responseId = firstRow.parentUuid || firstRow.uuid;
@@ -293,7 +367,7 @@ function buildStepEvents(group, toolResultRows, stepId, turnId, sessionId, userI
     'gen_ai.provider.name': providerName,
     'gen_ai.request.model': 'auto',
     'user.id': userId,
-    time_unix_nano: timestampToUnixNanos(firstRow.timestamp),
+    time_unix_nano: llmRequestTs || timestampToUnixNanos(firstRow.timestamp),
     observed_time_unix_nano: observedTs,
     version,
   };
@@ -317,7 +391,7 @@ function buildStepEvents(group, toolResultRows, stepId, turnId, sessionId, userI
       'gen_ai.response.finish_reasons': [finishReason],
       'user.id': userId,
       'gen_ai.output.messages': [{ role: 'assistant', parts: outputParts, finish_reason: finishReason }],
-      time_unix_nano: timestampToUnixNanos(lastRow.timestamp),
+      time_unix_nano: llmResponseTs,
       observed_time_unix_nano: observedTs,
       version,
     }, firstRow, runtimeConfig, cwd));
@@ -405,6 +479,17 @@ function extractText(row) {
     }
   }
   return '';
+}
+
+/**
+ * Strip <system-reminder>...</system-reminder> blocks from user message text.
+ * QoderWork injects these for context (timezone, MCP tools, memory diffs) into
+ * the user role message. They are not real user input and should not be emitted
+ * as gen_ai.input.messages_delta — they add noise, leak private context (MEMORY),
+ * and produce empty "user turns" when the message is purely system-reminder.
+ */
+function stripSystemReminders(text) {
+  return text.replace(/<system-reminder>[\s\S]*?<\/system-reminder>\s*/g, '').trim();
 }
 
 /**

--- a/assets/hooks/qoderwork-hook-processor.mjs
+++ b/assets/hooks/qoderwork-hook-processor.mjs
@@ -113,7 +113,7 @@ function processTranscript(parsed, sessionId, agentId, runtimeConfig, cwd) {
   const turns = splitIntoTurns(contentRows);
 
   for (const turn of turns) {
-    const turnId = crypto.randomUUID();
+    const turnId = getTurnIdForRows(turn);
     const turnRecords = buildTurnEvents(turn, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, cwd);
     records.push(...turnRecords);
   }
@@ -139,11 +139,19 @@ function splitIntoTurns(contentRows) {
   return turns;
 }
 
+function getTurnIdForRows(turnRows) {
+  const promptRow = turnRows.find(r => r.type === 'user' && !isToolResult(r));
+  return promptRow?.promptId || promptRow?.uuid || crypto.randomUUID();
+}
+
 function isSystemInjection(row) {
   const text = extractText(row).trimStart();
-  return text.startsWith('<command-message>') ||
+  if (text.startsWith('<command-message>') ||
     text.startsWith('<command-name>') ||
-    text.startsWith('<system-reminder>');
+    text.startsWith('[SYSTEM: This is an automated background review task')) {
+    return true;
+  }
+  return text.startsWith('<system-reminder>') && !extractPromptText(row);
 }
 
 function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, cwd) {
@@ -151,12 +159,15 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
 
   // Find the user prompt
   const userRow = turnRows.find(r => r.type === 'user' && !isToolResult(r));
+  const promptId = userRow?.promptId || turnId;
+  const turnMetadata = promptId ? { 'agent.qoderwork.promptId': promptId } : {};
 
   // User-hook event (no step.id, no model — per §5 of EVENT_LOG_TO_TRACE_SPEC)
   if (userRow) {
-    const userText = stripSystemReminders(extractText(userRow));
+    const userText = extractPromptText(userRow);
     if (userText) {
       records.push(buildRecord({
+        ...turnMetadata,
         'event.name': 'llm.request',
         'gen_ai.turn.id': turnId,
         'gen_ai.session.id': sessionId,
@@ -183,7 +194,7 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
 
   const llmGroups = groupAssistantRowsByToolResults(turnRows);
 
-  const userText = userRow ? stripSystemReminders(extractText(userRow)) : '';
+  const userText = userRow ? extractPromptText(userRow) : '';
   const userTs = userRow ? timestampToUnixNanos(userRow.timestamp) : undefined;
   let prevToolCalls = []; // tool_call ids from previous step, for building tool_result delta
   let prevStepLastToolResultTs = undefined; // 上一个 step 最后一个 tool_result 的 nano ts，用于本 step llm.request 时间
@@ -224,7 +235,7 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
     // 否则用 assistant 行写盘时间会导致 LLM span 退化为 0ms（thinking/tool_use 同毫秒批量 flush）
     const llmRequestTs = stepCounter === 1 ? userTs : prevStepLastToolResultTs;
 
-    const stepRecords = buildStepEvents(group, toolResultRows, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, stepCounter === llmGroups.length, inputDelta, cwd, llmRequestTs);
+    const stepRecords = buildStepEvents(group, toolResultRows, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, stepCounter === llmGroups.length, inputDelta, cwd, llmRequestTs, turnMetadata);
     records.push(...stepRecords);
 
     // Collect this step's tool_calls for next step's input delta
@@ -312,7 +323,7 @@ function groupAssistantRowsByToolResults(turnRows) {
   return groups;
 }
 
-function buildStepEvents(group, toolResultRows, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, isLastStep, inputDelta, cwd, llmRequestTs) {
+function buildStepEvents(group, toolResultRows, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, isLastStep, inputDelta, cwd, llmRequestTs, turnMetadata = {}) {
   const records = [];
   const firstRow = group[0];
   const lastRow = group[group.length - 1];
@@ -359,6 +370,7 @@ function buildStepEvents(group, toolResultRows, stepId, turnId, sessionId, userI
 
   // llm.request for this step (with input.messages_delta per EVENT_LOG_TO_TRACE_SPEC §3.2)
   const llmRequestFields = {
+    ...turnMetadata,
     'event.name': 'llm.request',
     'gen_ai.step.id': stepId,
     'gen_ai.turn.id': turnId,
@@ -379,6 +391,7 @@ function buildStepEvents(group, toolResultRows, stepId, turnId, sessionId, userI
   // llm.response (merged multi-parts)
   if (outputParts.length > 0) {
     records.push(buildRecord({
+      ...turnMetadata,
       'event.name': 'llm.response',
       'gen_ai.step.id': stepId,
       'gen_ai.turn.id': turnId,
@@ -400,6 +413,7 @@ function buildStepEvents(group, toolResultRows, stepId, turnId, sessionId, userI
   // tool.call + tool.result events
   for (const tc of toolCalls) {
     records.push(buildRecord({
+      ...turnMetadata,
       'event.name': 'tool.call',
       'gen_ai.step.id': stepId,
       'gen_ai.turn.id': turnId,
@@ -425,6 +439,7 @@ function buildStepEvents(group, toolResultRows, stepId, turnId, sessionId, userI
       const resultBlock = resultContent.find(b => b.tool_use_id === tc.id);
       const resultText = typeof resultBlock?.content === 'string' ? resultBlock.content : JSON.stringify(resultBlock?.content);
       records.push(buildRecord({
+        ...turnMetadata,
         'event.name': 'tool.result',
         'gen_ai.step.id': stepId,
         'gen_ai.turn.id': turnId,
@@ -482,14 +497,53 @@ function extractText(row) {
 }
 
 /**
- * Strip <system-reminder>...</system-reminder> blocks from user message text.
+ * Extract the human prompt text from QoderWork's mixed user message payload.
+ *
+ * QoderWork can place runtime context in the user role, either as a separate
+ * text block before the prompt or inline after/around it. Keep the user's text
+ * outside those wrappers, but drop the injected context itself.
+ */
+function extractPromptText(row) {
+  const msg = row.message || {};
+  const content = msg.content;
+  const textBlocks = [];
+  if (typeof content === 'string') {
+    textBlocks.push(content);
+  } else if (Array.isArray(content)) {
+    for (const block of content) {
+      if (typeof block === 'string') {
+        textBlocks.push(block);
+      } else if (block?.type === 'text' && typeof block.text === 'string') {
+        textBlocks.push(block.text);
+      }
+    }
+  }
+
+  const cleaned = textBlocks
+    .map(cleanPromptText)
+    .filter(Boolean);
+  return cleaned.join('\n\n');
+}
+
+/**
+ * Strip injected context wrappers from one text block while preserving text
+ * outside the wrappers, e.g. "<user-selected-text>...</user-selected-text> 讲讲这个".
+ *
  * QoderWork injects these for context (timezone, MCP tools, memory diffs) into
  * the user role message. They are not real user input and should not be emitted
  * as gen_ai.input.messages_delta — they add noise, leak private context (MEMORY),
  * and produce empty "user turns" when the message is purely system-reminder.
  */
-function stripSystemReminders(text) {
-  return text.replace(/<system-reminder>[\s\S]*?<\/system-reminder>\s*/g, '').trim();
+function cleanPromptText(text) {
+  const value = String(text || '');
+  if (/^\s*<(?:command-message|command-name)>/.test(value)) return '';
+  return value
+    .replace(/^\[SYSTEM: This is an automated background review task[\s\S]*$/g, '')
+    .replace(/<system-reminder>[\s\S]*?<\/system-reminder>\s*/g, ' ')
+    .replace(/<user-selected-text>[\s\S]*?<\/user-selected-text>\s*/g, ' ')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
 }
 
 /**

--- a/assets/hooks/qoderwork-hook-processor.mjs
+++ b/assets/hooks/qoderwork-hook-processor.mjs
@@ -126,7 +126,7 @@ function splitIntoTurns(contentRows) {
   let currentTurn = [];
 
   for (const row of contentRows) {
-    if (row.type === 'user' && !isToolResult(row) && !isSystemInjection(row)) {
+    if (isPromptRow(row)) {
       if (currentTurn.length > 0) {
         turns.push(currentTurn);
       }
@@ -139,8 +139,12 @@ function splitIntoTurns(contentRows) {
   return turns;
 }
 
+function isPromptRow(row) {
+  return row.type === 'user' && !isToolResult(row) && !isSystemInjection(row);
+}
+
 function getTurnIdForRows(turnRows) {
-  const promptRow = turnRows.find(r => r.type === 'user' && !isToolResult(r));
+  const promptRow = turnRows.find(isPromptRow);
   return promptRow?.promptId || promptRow?.uuid || crypto.randomUUID();
 }
 
@@ -164,7 +168,7 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
   const records = [];
 
   // Find the user prompt
-  const userRow = turnRows.find(r => r.type === 'user' && !isToolResult(r) && !isSystemInjection(r));
+  const userRow = turnRows.find(isPromptRow);
   const promptId = userRow?.promptId || turnId;
   const turnMetadata = promptId ? { 'agent.qoderwork.promptId': promptId } : {};
 
@@ -197,6 +201,15 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
   // since the LLM only receives tool outputs and issues a new response at those points.
   const assistantRows = turnRows.filter(r => r.type === 'assistant');
   const toolResultRows = turnRows.filter(r => r.type === 'user' && isToolResult(r));
+  const toolResultsByUseId = new Map();
+  for (const row of toolResultRows) {
+    const content = Array.isArray(row.message?.content) ? row.message.content : [];
+    for (const block of content) {
+      if (block.type === 'tool_result' && block.tool_use_id && !toolResultsByUseId.has(block.tool_use_id)) {
+        toolResultsByUseId.set(block.tool_use_id, { row, block });
+      }
+    }
+  }
 
   const llmGroups = groupAssistantRowsByToolResults(turnRows);
 
@@ -219,13 +232,9 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
     } else if (prevToolCalls.length > 0) {
       const toolParts = [];
       for (const tc of prevToolCalls) {
-        const matchingResult = toolResultRows.find(r => {
-          const content = Array.isArray(r.message?.content) ? r.message.content : [];
-          return content.some(b => b.type === 'tool_result' && b.tool_use_id === tc.id);
-        });
+        const matchingResult = toolResultsByUseId.get(tc.id);
         if (matchingResult) {
-          const resultContent = Array.isArray(matchingResult.message?.content) ? matchingResult.message.content : [];
-          const resultBlock = resultContent.find(b => b.tool_use_id === tc.id);
+          const resultBlock = matchingResult.block;
           const resultText = typeof resultBlock?.content === 'string' ? resultBlock.content : JSON.stringify(resultBlock?.content);
           toolParts.push({ type: 'tool_call_response', id: tc.id, response: resultText });
         }
@@ -241,7 +250,7 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
     // 否则用 assistant 行写盘时间会导致 LLM span 退化为 0ms（thinking/tool_use 同毫秒批量 flush）
     const llmRequestTs = stepCounter === 1 ? userTs : prevStepLastToolResultTs;
 
-    const stepRecords = buildStepEvents(group, toolResultRows, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, stepCounter === llmGroups.length, inputDelta, cwd, llmRequestTs, turnMetadata);
+    const stepRecords = buildStepEvents(group, toolResultsByUseId, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, stepCounter === llmGroups.length, inputDelta, cwd, llmRequestTs, turnMetadata);
     records.push(...stepRecords);
 
     // Collect this step's tool_calls for next step's input delta
@@ -254,12 +263,9 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
         if (b.type === 'tool_use') {
           prevToolCalls.push({ id: b.id, name: b.name });
           // 找到本 step 该 tool_use 对应的 tool_result 行，记录 ts；多 tool 场景保留最后一个
-          const trRow = toolResultRows.find(r => {
-            const c = Array.isArray(r.message?.content) ? r.message.content : [];
-            return c.some(bl => bl.type === 'tool_result' && bl.tool_use_id === b.id);
-          });
-          if (trRow?.timestamp) {
-            const nano = timestampToUnixNanos(trRow.timestamp);
+          const matchingResult = toolResultsByUseId.get(b.id);
+          if (matchingResult?.row.timestamp) {
+            const nano = timestampToUnixNanos(matchingResult.row.timestamp);
             if (nano) lastToolResultTsInStep = nano;
           }
         }
@@ -329,7 +335,7 @@ function groupAssistantRowsByToolResults(turnRows) {
   return groups;
 }
 
-function buildStepEvents(group, toolResultRows, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, isLastStep, inputDelta, cwd, llmRequestTs, turnMetadata = {}) {
+function buildStepEvents(group, toolResultsByUseId, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, isLastStep, inputDelta, cwd, llmRequestTs, turnMetadata = {}) {
   const records = [];
   const firstRow = group[0];
   const lastRow = group[group.length - 1];
@@ -451,13 +457,9 @@ function buildStepEvents(group, toolResultRows, stepId, turnId, sessionId, userI
     }, firstRow, runtimeConfig, cwd));
 
     // Find matching tool_result
-    const matchingResult = toolResultRows.find(r => {
-      const content = Array.isArray(r.message?.content) ? r.message.content : [];
-      return content.some(b => b.type === 'tool_result' && b.tool_use_id === tc.id);
-    });
+    const matchingResult = toolResultsByUseId.get(tc.id);
     if (matchingResult) {
-      const resultContent = Array.isArray(matchingResult.message?.content) ? matchingResult.message.content : [];
-      const resultBlock = resultContent.find(b => b.tool_use_id === tc.id);
+      const { row: resultRow, block: resultBlock } = matchingResult;
       const resultText = typeof resultBlock?.content === 'string' ? resultBlock.content : JSON.stringify(resultBlock?.content);
       records.push(buildRecord({
         ...turnMetadata,
@@ -472,10 +474,10 @@ function buildStepEvents(group, toolResultRows, stepId, turnId, sessionId, userI
         'gen_ai.tool.call.result': resultText,
         'tool.result.status': resultBlock?.is_error ? 'failure' : 'success',
         'user.id': userId,
-        time_unix_nano: timestampToUnixNanos(matchingResult.timestamp),
+        time_unix_nano: timestampToUnixNanos(resultRow.timestamp),
         observed_time_unix_nano: observedTs,
         version,
-      }, matchingResult, runtimeConfig, cwd));
+      }, resultRow, runtimeConfig, cwd));
     }
   }
 
@@ -556,6 +558,6 @@ function resolveQoderWorkProjectDir(sandboxCwd, agentId) {
   return sandboxCwd;
 }
 
-export { extractText, isSystemInjection, isToolResult, splitIntoTurns };
+export { extractText, getTurnIdForRows, isSystemInjection, isToolResult, splitIntoTurns };
 
 main().catch(() => { /* fail-open */ });

--- a/assets/hooks/qoderwork-hook-processor.mjs
+++ b/assets/hooks/qoderwork-hook-processor.mjs
@@ -368,7 +368,22 @@ function buildStepEvents(group, toolResultRows, stepId, turnId, sessionId, userI
 
   const finishReason = toolCalls.length > 0 ? 'tool_calls' : (isLastStep ? 'end_turn' : 'stop');
 
-  // llm.request for this step (with input.messages_delta per EVENT_LOG_TO_TRACE_SPEC §3.2)
+  // llm.request for this step.
+  //
+  // Field choice: gen_ai.input.messages (NOT messages_delta).
+  //
+  // The converter (@loongsuite/otel-util-genai) treats messages_delta as a
+  // turn-level accumulator: when an LLM pair only has messages_delta, it
+  // concatenates ALL prior pairs' deltas to build the LLM span's input.
+  // For QoderWork that means tool_call_response would grow across steps
+  // (step 1: 0 results, step 2: 1, step 3: 2, ...) — wrong for an LLM
+  // span which should show what THIS llm call received.
+  //
+  // Writing to messages (treated as "full") makes the converter use the
+  // value directly without accumulation. We still emit per-step incremental
+  // content, matching Codex's pattern. ENTRY/AGENT spans collect input from
+  // the user-hook event (no step.id, still messages_delta) above, so this
+  // change does not affect the turn-level overview spans.
   const llmRequestFields = {
     ...turnMetadata,
     'event.name': 'llm.request',
@@ -384,7 +399,7 @@ function buildStepEvents(group, toolResultRows, stepId, turnId, sessionId, userI
     version,
   };
   if (inputDelta) {
-    llmRequestFields['gen_ai.input.messages_delta'] = inputDelta;
+    llmRequestFields['gen_ai.input.messages'] = inputDelta;
   }
   records.push(buildRecord(llmRequestFields, firstRow, runtimeConfig, cwd));
 

--- a/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
+++ b/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
@@ -1,15 +1,24 @@
 import * as crypto from 'node:crypto';
+import { createReadStream } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import { createInterface } from 'node:readline';
 import { ClientType, CollectionMethod } from '../../types/index.js';
 import type { AgentActivityEntry } from '../../types/index.js';
 import { BaseInput, type InputOptions } from '../base/base-input.js';
 import { enrichCanonicalEntryWithGit } from '../../normalization/enrich-git-context.js';
 import { resolveHome, directoryExists, ensureDir } from '../../utils/fs-utils.js';
 import { getTodayDateString } from '../../utils/fs-utils.js';
+import {
+  parseSdkLogLine,
+  resolveQoderWorkRoot,
+  type SdkEvent,
+} from '../qoder-work-log/qoder-work-log-input.js';
 
 const NANO_PER_MILLI = 1_000_000n;
 const SEGMENT_TIMING_TOLERANCE_MS = 5 * 60 * 1000;
+const SDK_TOKEN_MATCH_TOLERANCE_MS = 5 * 1000;
+const SEGMENT_STATE_TTL_MS = 60 * 60 * 1000;
 
 /**
  * QoderWork TraceInput — hook JSONL + segments enrichment.
@@ -33,6 +42,7 @@ export class QoderWorkTraceInput extends BaseInput {
 
   private readonly logDir: string;
   private readonly segmentsRoot: string;
+  private readonly sdkLogDir: string;
   private readonly logPrefix = 'qoder-work';
 
   // Per-session in-memory state for segment enrichment
@@ -43,14 +53,21 @@ export class QoderWorkTraceInput extends BaseInput {
   // Per-session set of turn_ids known to be subagent. We only filter LLM calls
   // whose turn_id is in this set. A turn_id absent from the set is treated as
   // main (covers the rare case where turn.started is split across files).
-  private readonly subagentTurns: Map<string, Set<string>> = new Map();
+  private readonly subagentTurns: Map<string, Map<string, number>> = new Map();
   // Per-session in-flight LLM pairs (request seen, response not yet seen).
   private readonly inFlightPairs: Map<string, Map<string, InFlightPair>> = new Map();
+  // Legacy SDK fallback is token-only. It must never change timing or model.
+  private readonly sdkTokenPairs: Map<string, SdkTokenPair[]> = new Map();
+  private readonly sdkInFlightMessages: Map<string, SdkInFlightMessage> = new Map();
+  // The encoded workspace directory is a fast path; session-id lookup handles
+  // writer encoding changes and non-POSIX workspace paths.
+  private readonly segmentDirBySession: Map<string, CachedSegmentDir> = new Map();
 
   constructor(opts: QoderWorkTraceInputOptions) {
     super({ ...opts, pollIntervalMs: opts.pollIntervalMs ?? 30_000 });
     this.logDir = opts.logDir ?? resolveHome('~/.loongsuite-pilot/logs/qoder-work/history');
     this.segmentsRoot = opts.segmentsRoot ?? resolveHome('~/.qoderwork/logs/sessions');
+    this.sdkLogDir = opts.sdkLogDir ?? resolveQoderWorkSdkLogDir();
   }
 
   static async checkAvailability(): Promise<boolean> {
@@ -69,52 +86,57 @@ export class QoderWorkTraceInput extends BaseInput {
   }
 
   protected async collect(): Promise<AgentActivityEntry[]> {
-    // 1. Hook JSONL — primary source of structure.
-    const { entries: rawEntries, isFirstRun } = await this.readHookJsonl();
-    if (rawEntries.length === 0) return [];
+    try {
+      // Read legacy SDK logs only for token compatibility. Segment data remains
+      // authoritative for LLM/tool timing and model attribution.
+      await this.readSdkTokenState();
 
-    // A fresh collector must not replay a whole pre-existing daily hook log.
-    // The hook writes each turn contiguously, so the last group is the only
-    // current conversation worth exporting from a first-run baseline.
-    const allTurnGroups = this.groupByTurn(rawEntries);
-    const entries = isFirstRun
-      ? [...allTurnGroups.values()].at(-1) ?? []
-      : rawEntries;
-    if (isFirstRun) {
-      const state = this.getState();
-      const extra = state.extra && typeof state.extra === 'object'
-        ? state.extra as Record<string, unknown>
-        : {};
-      this.setState({
-        extra: { ...extra, qoderWorkTurnCount: allTurnGroups.size },
-      });
-    }
+      // 1. Hook JSONL — primary source of structure.
+      const { entries: rawEntries, isFirstRun, turnCount } = await this.readHookJsonl();
+      if (rawEntries.length === 0) return [];
 
-    // 2. Discover the (sessionId, cwd) pairs we have entries for, then read
-    //    fresh segments for each. Lazily — sessions absent from hook batch
-    //    don't trigger segment IO.
-    const sessionCwd = this.collectSessionCwd(entries);
-    for (const [sessionId, cwd] of sessionCwd) {
-      await this.readSegmentsForSession(sessionId, cwd);
-    }
-
-    // 3. Group → enrich → emit.
-    const turnGroups = this.groupByTurn(entries);
-    const allEntries: AgentActivityEntry[] = [];
-    for (const [, turnEntries] of turnGroups) {
-      this.enrichTurn(turnEntries);
-      this.injectTraceId(turnEntries);
-      for (const entry of turnEntries) {
-        await enrichCanonicalEntryWithGit(
-          entry as Record<string, unknown>,
-          entry as Record<string, unknown>,
-          'qoder-work',
-        );
+      // A fresh collector must not replay a whole pre-existing daily hook log.
+      const allTurnGroups = this.groupByTurn(rawEntries);
+      const entries = isFirstRun
+        ? [...allTurnGroups.values()].at(-1) ?? []
+        : rawEntries;
+      if (isFirstRun) {
+        const state = this.getState();
+        const extra = state.extra && typeof state.extra === 'object'
+          ? state.extra as Record<string, unknown>
+          : {};
+        this.setState({
+          extra: { ...extra, qoderWorkTurnCount: turnCount ?? allTurnGroups.size },
+        });
       }
-      allEntries.push(...turnEntries);
-    }
 
-    return allEntries;
+      // 2. Discover the (sessionId, cwd) pairs we have entries for, then read
+      //    fresh segments for each. Lazily — sessions absent from hook batch
+      //    don't trigger segment IO.
+      const sessionCwd = this.collectSessionCwd(entries);
+      for (const [sessionId, cwd] of sessionCwd) {
+        await this.readSegmentsForSession(sessionId, cwd);
+      }
+
+      // 3. Group → enrich → emit.
+      const turnGroups = this.groupByTurn(entries);
+      const allEntries: AgentActivityEntry[] = [];
+      for (const [, turnEntries] of turnGroups) {
+        this.enrichTurn(turnEntries);
+        this.injectTraceId(turnEntries);
+        for (const entry of turnEntries) {
+          await enrichCanonicalEntryWithGit(
+            entry as Record<string, unknown>,
+            entry as Record<string, unknown>,
+            'qoder-work',
+          );
+        }
+        allEntries.push(...turnEntries);
+      }
+      return allEntries;
+    } finally {
+      this.evictStaleState();
+    }
   }
 
   // ─── Hook JSONL reading ────────────────────────────────────────────────────
@@ -145,20 +167,20 @@ export class QoderWorkTraceInput extends BaseInput {
       && Object.hasOwn(state.extra, 'qoderWorkTurnCount');
     const isFirstRun = offset === 0 && !hasFirstRunMarker;
 
+    if (isFirstRun) {
+      return this.readFirstRunHookBaseline(logFile, logFileName, stat.size);
+    }
+
     const handle = await fs.open(logFile, 'r');
     const entries: AgentActivityEntry[] = [];
     try {
       const maxReadSize = 16 * 1024 * 1024;
-      // The baseline must see the true last turn even when the history file
-      // exceeds the normal incremental read cap. It runs only once per state.
-      const readSize = isFirstRun
-        ? stat.size - offset
-        : Math.min(stat.size - offset, maxReadSize);
+      const readSize = Math.min(stat.size - offset, maxReadSize);
       const buf = Buffer.alloc(readSize);
       await handle.read(buf, 0, readSize, offset);
       let text = buf.toString('utf-8');
       let consumedBytes = readSize;
-      if (!isFirstRun && readSize < stat.size - offset) {
+      if (readSize < stat.size - offset) {
         const lastNL = text.lastIndexOf('\n');
         if (lastNL >= 0) { text = text.substring(0, lastNL); consumedBytes = Buffer.byteLength(text, 'utf-8') + 1; }
       }
@@ -180,6 +202,40 @@ export class QoderWorkTraceInput extends BaseInput {
     return { entries, isFirstRun };
   }
 
+  private async readFirstRunHookBaseline(
+    logFile: string,
+    logFileName: string,
+    fileSize: number,
+  ): Promise<HookJsonlBatch> {
+    let latestTurnId: string | undefined;
+    let latestTurnEntries: AgentActivityEntry[] = [];
+    let turnCount = 0;
+    const reader = createInterface({
+      input: createReadStream(logFile, { encoding: 'utf-8' }),
+      crlfDelay: Infinity,
+    });
+
+    for await (const line of reader) {
+      if (!line.trim()) continue;
+      try {
+        const record = JSON.parse(line) as AgentActivityEntry;
+        if (!record['event.name']) continue;
+        const turnId = String(record['gen_ai.turn.id'] ?? 'unknown');
+        if (turnId !== latestTurnId) {
+          latestTurnId = turnId;
+          latestTurnEntries = [];
+          turnCount++;
+        }
+        latestTurnEntries.push(record);
+      } catch {
+        this.logger.warn('invalid JSONL line');
+      }
+    }
+
+    this.setState({ lastFile: logFileName, lastOffset: fileSize });
+    return { entries: latestTurnEntries, isFirstRun: true, turnCount };
+  }
+
   // ─── Segments reading ──────────────────────────────────────────────────────
 
   private collectSessionCwd(entries: AgentActivityEntry[]): Map<string, string> {
@@ -192,14 +248,18 @@ export class QoderWorkTraceInput extends BaseInput {
     return map;
   }
 
-  /** Encode a workspace cwd into the qoderwork sessions directory name. */
+  /**
+   * QoderWork 1.0.21 on macOS writes this form. Keep it as a fast path, then
+   * resolve by session id below so a writer/platform encoding change does not
+   * silently disable timing enrichment.
+   */
   private encodeWorkspace(cwd: string): string {
     return cwd.replace(/\//g, '-').replace(/\./g, '-');
   }
 
   private async readSegmentsForSession(sessionId: string, cwd: string): Promise<void> {
-    const ws = this.encodeWorkspace(cwd);
-    const segDir = path.join(this.segmentsRoot, ws, sessionId, 'segments');
+    const segDir = await this.resolveSegmentsDir(sessionId, cwd);
+    if (!segDir) return;
 
     let files: string[];
     try {
@@ -215,6 +275,37 @@ export class QoderWorkTraceInput extends BaseInput {
     for (const filePath of files) {
       await this.readSegmentsFile(sessionId, filePath);
     }
+  }
+
+  private async resolveSegmentsDir(sessionId: string, cwd: string): Promise<string | undefined> {
+    const cached = this.segmentDirBySession.get(sessionId);
+    if (cached) {
+      cached.seenAtMs = Date.now();
+      return cached.path;
+    }
+
+    const preferred = path.join(this.segmentsRoot, this.encodeWorkspace(cwd), sessionId, 'segments');
+    if (await isDirectory(preferred)) {
+      this.segmentDirBySession.set(sessionId, { path: preferred, seenAtMs: Date.now() });
+      return preferred;
+    }
+
+    let workspaceDirs: import('node:fs').Dirent[];
+    try {
+      workspaceDirs = await fs.readdir(this.segmentsRoot, { withFileTypes: true });
+    } catch {
+      return undefined;
+    }
+
+    for (const workspaceDir of workspaceDirs) {
+      if (!workspaceDir.isDirectory()) continue;
+      const candidate = path.join(this.segmentsRoot, workspaceDir.name, sessionId, 'segments');
+      if (await isDirectory(candidate)) {
+        this.segmentDirBySession.set(sessionId, { path: candidate, seenAtMs: Date.now() });
+        return candidate;
+      }
+    }
+    return undefined;
   }
 
   private async readSegmentsFile(sessionId: string, filePath: string): Promise<void> {
@@ -273,12 +364,13 @@ export class QoderWorkTraceInput extends BaseInput {
   }
 
   private handleSegmentEvent(sessionId: string, event: SegmentEvent): void {
+    const seenAtMs = Date.now();
     switch (event.type) {
       case 'turn.started': {
         if (event.turn_id && (event.data?.is_subagent === true || isIgnoredSegmentTurn(event.turn_id))) {
-          let set = this.subagentTurns.get(sessionId);
-          if (!set) { set = new Set(); this.subagentTurns.set(sessionId, set); }
-          set.add(event.turn_id);
+          const turns = this.subagentTurns.get(sessionId) ?? new Map<string, number>();
+          turns.set(event.turn_id, seenAtMs);
+          this.subagentTurns.set(sessionId, turns);
         }
         return;
       }
@@ -294,6 +386,7 @@ export class QoderWorkTraceInput extends BaseInput {
           turnId: event.turn_id,
           startNano,
           model: event.data?.model || '',
+          seenAtMs,
         });
         return;
       }
@@ -312,6 +405,8 @@ export class QoderWorkTraceInput extends BaseInput {
           startNano: inFlight.startNano,
           endNano,
           model: event.data?.model || inFlight.model || '',
+          usage: extractSegmentUsage(event.data),
+          seenAtMs,
         });
         this.segmentPairs.set(sessionId, list);
         return;
@@ -323,8 +418,9 @@ export class QoderWorkTraceInput extends BaseInput {
         const nano = isoToNano(event.ts);
         if (!nano) return;
         const timings = this.segmentToolTimings.get(sessionId) ?? new Map<string, SegmentToolTiming>();
-        const existing = timings.get(event.tool_call_id) ?? { turnId: event.turn_id };
+        const existing = timings.get(event.tool_call_id) ?? { turnId: event.turn_id, seenAtMs };
         existing.turnId = event.turn_id;
+        existing.seenAtMs = seenAtMs;
         if (event.data?.tool_name) existing.toolName = String(event.data.tool_name);
         if (event.type === 'tool.requested') {
           existing.requestedNano = nano;
@@ -360,6 +456,7 @@ export class QoderWorkTraceInput extends BaseInput {
         if (!stepEntries) continue;
         const request = stepEntries.find(e => e['event.name'] === 'llm.request');
         const response = stepEntries.find(e => e['event.name'] === 'llm.response');
+        let hasSegmentUsage = false;
         if (request && response) {
           const pair = this.takeSegmentPair(sessionId, turnId, request, response);
           if (pair) {
@@ -376,7 +473,9 @@ export class QoderWorkTraceInput extends BaseInput {
                 }
               }
             }
+            hasSegmentUsage = this.applyUsage(response, pair.usage);
           }
+          if (!hasSegmentUsage) this.applySdkTokenUsage(sessionId, request, response);
         }
 
         this.applySegmentToolTiming(sessionId, stepEntries);
@@ -405,6 +504,178 @@ export class QoderWorkTraceInput extends BaseInput {
           (e as Record<string, unknown>)['time_unix_nano'] = capNano;
         }
       }
+    }
+  }
+
+  private applyUsage(response: AgentActivityEntry, usage: TokenUsage): boolean {
+    const inputTokens = positiveNumber(usage.inputTokens);
+    const outputTokens = positiveNumber(usage.outputTokens);
+    const cacheReadTokens = positiveNumber(usage.cacheReadInputTokens);
+    const cacheCreationTokens = positiveNumber(usage.cacheCreationInputTokens);
+    if (!inputTokens && !outputTokens && !cacheReadTokens && !cacheCreationTokens) return false;
+
+    const target = response as Record<string, unknown>;
+    if (inputTokens) target['gen_ai.usage.input_tokens'] = inputTokens;
+    if (outputTokens) target['gen_ai.usage.output_tokens'] = outputTokens;
+    if (inputTokens || outputTokens) target['gen_ai.usage.total_tokens'] = (inputTokens ?? 0) + (outputTokens ?? 0);
+    if (cacheReadTokens) target['gen_ai.usage.cache_read.input_tokens'] = cacheReadTokens;
+    if (cacheCreationTokens) target['gen_ai.usage.cache_creation.input_tokens'] = cacheCreationTokens;
+    return true;
+  }
+
+  private applySdkTokenUsage(
+    sessionId: string,
+    request: AgentActivityEntry,
+    response: AgentActivityEntry,
+  ): void {
+    const requestNano = request['time_unix_nano'] as string | undefined;
+    const requestMs = nanoToMillis(requestNano);
+    if (requestMs === undefined) return;
+
+    const pairs = this.sdkTokenPairs.get(sessionId);
+    if (!pairs?.length) return;
+    let index = -1;
+    let smallestDelta = Number.POSITIVE_INFINITY;
+    for (let i = 0; i < pairs.length; i++) {
+      const delta = Math.abs(pairs[i].startMs - requestMs);
+      if (delta <= SDK_TOKEN_MATCH_TOLERANCE_MS && delta < smallestDelta) {
+        index = i;
+        smallestDelta = delta;
+      }
+    }
+    if (index < 0) return;
+
+    const [pair] = pairs.splice(index, 1);
+    if (pairs.length === 0) this.sdkTokenPairs.delete(sessionId);
+    this.applyUsage(response, pair);
+  }
+
+  // ─── SDK token compatibility ─────────────────────────────────────────────
+
+  private async readSdkTokenState(): Promise<void> {
+    for (const filePath of await this.discoverSdkLogFiles()) {
+      await this.readSdkTokenFile(filePath);
+    }
+  }
+
+  private async discoverSdkLogFiles(): Promise<string[]> {
+    let sessionDirs: import('node:fs').Dirent[];
+    try {
+      sessionDirs = await fs.readdir(this.sdkLogDir, { withFileTypes: true });
+    } catch {
+      return [];
+    }
+
+    const files: string[] = [];
+    for (const dir of sessionDirs) {
+      if (!dir.isDirectory()) continue;
+      const sessionDir = path.join(this.sdkLogDir, dir.name);
+      const mainLog = path.join(sessionDir, 'main.log');
+      if (await isFile(mainLog)) {
+        files.push(mainLog);
+        continue;
+      }
+      const legacyDir = path.join(sessionDir, 'main');
+      try {
+        const legacyFiles = await fs.readdir(legacyDir, { withFileTypes: true });
+        for (const file of legacyFiles) {
+          if (file.isFile() && file.name.startsWith('sdk-') && file.name.endsWith('.log')) {
+            files.push(path.join(legacyDir, file.name));
+          }
+        }
+      } catch {
+        // The directory can be created after the session directory appears.
+      }
+    }
+    return files.sort();
+  }
+
+  private async readSdkTokenFile(filePath: string): Promise<void> {
+    const stateKey = `${this.id}:sdk-token:${filePath}`;
+    let stat;
+    try {
+      stat = await fs.stat(filePath);
+    } catch {
+      return;
+    }
+    const currentInode = (stat as unknown as { ino: number }).ino;
+    const previous = this.stateStore.get(stateKey);
+    const previousInode = (previous.extra as { inode?: number } | undefined)?.inode;
+    if (previousInode !== undefined && previousInode !== currentInode) {
+      this.stateStore.setOffset(stateKey, 0);
+    }
+
+    let offset = previousInode !== undefined && previousInode !== currentInode
+      ? 0
+      : this.stateStore.getOffset(stateKey);
+    if (offset > 0 && stat.size < offset) offset = 0;
+    if (stat.size <= offset) {
+      this.stateStore.update(stateKey, { extra: { inode: currentInode } });
+      return;
+    }
+
+    const handle = await fs.open(filePath, 'r');
+    let text = '';
+    try {
+      const readSize = Math.min(stat.size - offset, 16 * 1024 * 1024);
+      const buffer = Buffer.alloc(readSize);
+      await handle.read(buffer, 0, readSize, offset);
+      text = buffer.toString('utf-8');
+      let consumedBytes = readSize;
+      if (readSize < stat.size - offset) {
+        const lastNewLine = text.lastIndexOf('\n');
+        if (lastNewLine >= 0) {
+          text = text.substring(0, lastNewLine);
+          consumedBytes = Buffer.byteLength(text, 'utf-8') + 1;
+        }
+      }
+      this.stateStore.setOffset(stateKey, offset + consumedBytes);
+      this.stateStore.update(stateKey, { extra: { inode: currentInode } });
+    } finally {
+      await handle.close();
+    }
+
+    for (const line of text.split('\n')) {
+      if (!line.trim()) continue;
+      const event = parseSdkLogLine(line);
+      if (event) this.handleSdkTokenEvent(event);
+    }
+  }
+
+  private handleSdkTokenEvent(event: SdkEvent): void {
+    const seenAtMs = Date.now();
+    if (event.kind === 'message_start') {
+      if (!event.sessionId) return;
+      this.sdkInFlightMessages.set(event.sessionId, { startMs: event.ts, seenAtMs });
+      return;
+    }
+    if (event.kind !== 'message_delta') return;
+    if (!event.sessionId) return;
+    const inFlight = this.sdkInFlightMessages.get(event.sessionId);
+    if (!inFlight) return;
+    this.sdkInFlightMessages.delete(event.sessionId);
+    const pairs = this.sdkTokenPairs.get(event.sessionId) ?? [];
+    pairs.push({
+      startMs: inFlight.startMs,
+      inputTokens: event.inputTokens,
+      outputTokens: event.outputTokens,
+      seenAtMs,
+    });
+    this.sdkTokenPairs.set(event.sessionId, pairs);
+  }
+
+  private evictStaleState(): void {
+    const cutoff = Date.now() - SEGMENT_STATE_TTL_MS;
+    evictMapValues(this.segmentPairs, pair => pair.seenAtMs >= cutoff);
+    evictNestedMapValues(this.segmentToolTimings, timing => timing.seenAtMs >= cutoff);
+    evictNestedMapValues(this.subagentTurns, seenAtMs => seenAtMs >= cutoff);
+    evictNestedMapValues(this.inFlightPairs, pair => pair.seenAtMs >= cutoff);
+    evictMapValues(this.sdkTokenPairs, pair => pair.seenAtMs >= cutoff);
+    for (const [sessionId, message] of this.sdkInFlightMessages) {
+      if (message.seenAtMs < cutoff) this.sdkInFlightMessages.delete(sessionId);
+    }
+    for (const [sessionId, cachedDir] of this.segmentDirBySession) {
+      if (cachedDir.seenAtMs < cutoff) this.segmentDirBySession.delete(sessionId);
     }
   }
 
@@ -515,11 +786,13 @@ export class QoderWorkTraceInput extends BaseInput {
 export interface QoderWorkTraceInputOptions extends InputOptions {
   logDir?: string;
   segmentsRoot?: string;
+  sdkLogDir?: string;
 }
 
 interface HookJsonlBatch {
   entries: AgentActivityEntry[];
   isFirstRun: boolean;
+  turnCount?: number;
 }
 
 interface SegmentEvent {
@@ -540,6 +813,7 @@ interface InFlightPair {
   turnId: string;
   startNano: string;
   model: string;
+  seenAtMs: number;
 }
 
 interface SegmentLlmPair {
@@ -547,6 +821,8 @@ interface SegmentLlmPair {
   startNano: string;
   endNano: string;
   model: string;
+  usage: TokenUsage;
+  seenAtMs: number;
 }
 
 interface SegmentToolTiming {
@@ -554,12 +830,94 @@ interface SegmentToolTiming {
   toolName?: string;
   requestedNano?: string;
   finishedNano?: string;
+  seenAtMs: number;
+}
+
+interface TokenUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadInputTokens?: number;
+  cacheCreationInputTokens?: number;
+}
+
+interface SdkTokenPair extends TokenUsage {
+  startMs: number;
+  seenAtMs: number;
+}
+
+interface SdkInFlightMessage {
+  startMs: number;
+  seenAtMs: number;
+}
+
+interface CachedSegmentDir {
+  path: string;
+  seenAtMs: number;
 }
 
 function isoToNano(iso: string): string | undefined {
   const ms = Date.parse(iso);
   if (Number.isNaN(ms)) return undefined;
   return String(BigInt(ms) * 1_000_000n);
+}
+
+function extractSegmentUsage(data: SegmentEvent['data']): TokenUsage {
+  return {
+    inputTokens: positiveNumber(data?.input_tokens),
+    outputTokens: positiveNumber(data?.output_tokens),
+    cacheReadInputTokens: positiveNumber(data?.cache_read_input_tokens),
+    cacheCreationInputTokens: positiveNumber(data?.cache_creation_input_tokens),
+  };
+}
+
+function positiveNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function nanoToMillis(nano: string | undefined): number | undefined {
+  if (!nano) return undefined;
+  try {
+    return Number(BigInt(nano) / NANO_PER_MILLI);
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveQoderWorkSdkLogDir(): string {
+  return path.join(resolveQoderWorkRoot(), 'logs');
+}
+
+async function isDirectory(candidate: string): Promise<boolean> {
+  try {
+    return (await fs.stat(candidate)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function isFile(candidate: string): Promise<boolean> {
+  try {
+    return (await fs.stat(candidate)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function evictMapValues<T>(map: Map<string, T[]>, keep: (value: T) => boolean): void {
+  for (const [key, values] of map) {
+    const retained = values.filter(keep);
+    if (retained.length === 0) map.delete(key);
+    else map.set(key, retained);
+  }
+}
+
+function evictNestedMapValues<T>(map: Map<string, Map<string, T>>, keep: (value: T) => boolean): void {
+  for (const [sessionId, values] of map) {
+    for (const [key, value] of values) {
+      if (!keep(value)) values.delete(key);
+    }
+    if (values.size === 0) map.delete(sessionId);
+  }
 }
 
 function isIgnoredSegmentTurn(turnId: string): boolean {

--- a/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
+++ b/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
@@ -8,6 +8,9 @@ import { enrichCanonicalEntryWithGit } from '../../normalization/enrich-git-cont
 import { resolveHome, directoryExists, ensureDir } from '../../utils/fs-utils.js';
 import { getTodayDateString } from '../../utils/fs-utils.js';
 
+const NANO_PER_MILLI = 1_000_000n;
+const SEGMENT_TIMING_TOLERANCE_MS = 5 * 60 * 1000;
+
 /**
  * QoderWork TraceInput — hook JSONL + segments enrichment.
  *
@@ -35,6 +38,8 @@ export class QoderWorkTraceInput extends BaseInput {
   // Per-session in-memory state for segment enrichment
   // Key: sessionId. Value: FIFO of LLM pairs from main-turn segments.
   private readonly segmentPairs: Map<string, SegmentLlmPair[]> = new Map();
+  // Per-session tool timing from segments, keyed by tool_call_id.
+  private readonly segmentToolTimings: Map<string, Map<string, SegmentToolTiming>> = new Map();
   // Per-session set of turn_ids known to be subagent. We only filter LLM calls
   // whose turn_id is in this set. A turn_id absent from the set is treated as
   // main (covers the rare case where turn.started is split across files).
@@ -244,7 +249,7 @@ export class QoderWorkTraceInput extends BaseInput {
   private handleSegmentEvent(sessionId: string, event: SegmentEvent): void {
     switch (event.type) {
       case 'turn.started': {
-        if (event.turn_id && event.data?.is_subagent === true) {
+        if (event.turn_id && (event.data?.is_subagent === true || isIgnoredSegmentTurn(event.turn_id))) {
           let set = this.subagentTurns.get(sessionId);
           if (!set) { set = new Set(); this.subagentTurns.set(sessionId, set); }
           set.add(event.turn_id);
@@ -254,12 +259,13 @@ export class QoderWorkTraceInput extends BaseInput {
       case 'model.request.started': {
         if (!event.turn_id || !event.request_id || !event.ts) return;
         // Skip subagent LLM calls — hook transcript only carries main agent.
-        if (this.subagentTurns.get(sessionId)?.has(event.turn_id)) return;
+        if (this.shouldSkipSegmentTurn(sessionId, event.turn_id)) return;
         const startNano = isoToNano(event.ts);
         if (!startNano) return;
         let m = this.inFlightPairs.get(sessionId);
         if (!m) { m = new Map(); this.inFlightPairs.set(sessionId, m); }
         m.set(event.request_id, {
+          turnId: event.turn_id,
           startNano,
           model: event.data?.model || '',
         });
@@ -267,7 +273,7 @@ export class QoderWorkTraceInput extends BaseInput {
       }
       case 'model.response.completed': {
         if (!event.turn_id || !event.request_id || !event.ts) return;
-        if (this.subagentTurns.get(sessionId)?.has(event.turn_id)) return;
+        if (this.shouldSkipSegmentTurn(sessionId, event.turn_id)) return;
         const inFlightForSession = this.inFlightPairs.get(sessionId);
         const inFlight = inFlightForSession?.get(event.request_id);
         if (!inFlight) return; // orphan response (e.g. resumed mid-stream)
@@ -276,6 +282,7 @@ export class QoderWorkTraceInput extends BaseInput {
         if (!endNano) return;
         const list = this.segmentPairs.get(sessionId) ?? [];
         list.push({
+          turnId: inFlight.turnId,
           startNano: inFlight.startNano,
           endNano,
           model: event.data?.model || inFlight.model || '',
@@ -283,54 +290,71 @@ export class QoderWorkTraceInput extends BaseInput {
         this.segmentPairs.set(sessionId, list);
         return;
       }
+      case 'tool.requested':
+      case 'tool.execution.finished': {
+        if (!event.turn_id || !event.tool_call_id || !event.ts) return;
+        if (this.shouldSkipSegmentTurn(sessionId, event.turn_id)) return;
+        const nano = isoToNano(event.ts);
+        if (!nano) return;
+        const timings = this.segmentToolTimings.get(sessionId) ?? new Map<string, SegmentToolTiming>();
+        const existing = timings.get(event.tool_call_id) ?? { turnId: event.turn_id };
+        existing.turnId = event.turn_id;
+        if (event.data?.tool_name) existing.toolName = String(event.data.tool_name);
+        if (event.type === 'tool.requested') {
+          existing.requestedNano = nano;
+        } else {
+          existing.finishedNano = nano;
+        }
+        timings.set(event.tool_call_id, existing);
+        this.segmentToolTimings.set(sessionId, timings);
+        return;
+      }
       default:
         return;
     }
+  }
+
+  private shouldSkipSegmentTurn(sessionId: string, turnId: string): boolean {
+    return isIgnoredSegmentTurn(turnId) || this.subagentTurns.get(sessionId)?.has(turnId) === true;
   }
 
   // ─── Enrichment ─────────────────────────────────────────────────────────────
 
   private enrichTurn(entries: AgentActivityEntry[]): void {
     const sessionId = entries.find(e => e['gen_ai.session.id'])?.['gen_ai.session.id'] as string | undefined;
+    const turnId = entries.find(e => e['gen_ai.turn.id'])?.['gen_ai.turn.id'] as string | undefined;
 
     const steps = this.groupByStep(entries);
     const stepOrder = [...steps.keys()].filter((k): k is string => k !== undefined);
 
     // Apply segment-derived timing + model to each step in transcript order.
     if (sessionId) {
-      const buffer = this.segmentPairs.get(sessionId);
       for (const stepId of stepOrder) {
         const stepEntries = steps.get(stepId);
         if (!stepEntries) continue;
         const request = stepEntries.find(e => e['event.name'] === 'llm.request');
         const response = stepEntries.find(e => e['event.name'] === 'llm.response');
-        if (!request || !response) continue;
+        if (request && response) {
+          const pair = this.takeSegmentPair(sessionId, turnId, request, response);
+          if (pair) {
+            (request as Record<string, unknown>)['time_unix_nano'] = pair.startNano;
+            (response as Record<string, unknown>)['time_unix_nano'] = pair.endNano;
 
-        const pair = buffer?.length ? buffer.shift() : undefined;
-        if (!pair) continue;
-
-        (request as Record<string, unknown>)['time_unix_nano'] = pair.startNano;
-        (response as Record<string, unknown>)['time_unix_nano'] = pair.endNano;
-
-        if (pair.model) {
-          for (const e of stepEntries) {
-            if (!e['gen_ai.request.model'] || e['gen_ai.request.model'] === 'auto') {
-              (e as Record<string, unknown>)['gen_ai.request.model'] = pair.model;
-            }
-            if (e['event.name'] === 'llm.response') {
-              (e as Record<string, unknown>)['gen_ai.response.model'] = pair.model;
+            if (pair.model) {
+              for (const e of stepEntries) {
+                if (!e['gen_ai.request.model'] || e['gen_ai.request.model'] === 'auto') {
+                  (e as Record<string, unknown>)['gen_ai.request.model'] = pair.model;
+                }
+                if (e['event.name'] === 'llm.response') {
+                  (e as Record<string, unknown>)['gen_ai.response.model'] = pair.model;
+                }
+              }
             }
           }
         }
 
-        // tool.call carries no native timestamp from segments; align to llm.response.
-        for (const e of stepEntries) {
-          if (e['event.name'] === 'tool.call') {
-            (e as Record<string, unknown>)['time_unix_nano'] = pair.endNano;
-          }
-        }
+        this.applySegmentToolTiming(sessionId, stepEntries);
       }
-      if (buffer && buffer.length === 0) this.segmentPairs.delete(sessionId);
     }
 
     // Defensive STEP overlap clamp: ensure tool.result of step N doesn't exceed
@@ -356,6 +380,75 @@ export class QoderWorkTraceInput extends BaseInput {
         }
       }
     }
+  }
+
+  private takeSegmentPair(
+    sessionId: string,
+    turnId: string | undefined,
+    request: AgentActivityEntry,
+    response: AgentActivityEntry,
+  ): SegmentLlmPair | undefined {
+    const buffer = this.segmentPairs.get(sessionId);
+    if (!buffer?.length) return undefined;
+
+    let idx = turnId ? buffer.findIndex(pair => pair.turnId === turnId) : -1;
+    if (idx < 0) {
+      idx = buffer.findIndex(pair => this.isSegmentPairCompatible(pair, request, response));
+    }
+    if (idx < 0) return undefined;
+
+    const [pair] = buffer.splice(idx, 1);
+    if (buffer.length === 0) this.segmentPairs.delete(sessionId);
+    return pair;
+  }
+
+  private isSegmentPairCompatible(
+    pair: SegmentLlmPair,
+    request: AgentActivityEntry,
+    response: AgentActivityEntry,
+  ): boolean {
+    const requestNano = request['time_unix_nano'] as string | undefined;
+    const responseNano = response['time_unix_nano'] as string | undefined;
+    if (!requestNano || !responseNano) return false;
+    return isWithinTolerance(pair.startNano, requestNano, SEGMENT_TIMING_TOLERANCE_MS)
+      && isWithinTolerance(pair.endNano, responseNano, SEGMENT_TIMING_TOLERANCE_MS);
+  }
+
+  private applySegmentToolTiming(sessionId: string, stepEntries: AgentActivityEntry[]): void {
+    const timings = this.segmentToolTimings.get(sessionId);
+    if (!timings?.size) return;
+
+    const usedCallIds = new Set<string>();
+    for (const entry of stepEntries) {
+      const eventName = entry['event.name'];
+      if (eventName !== 'tool.call' && eventName !== 'tool.result') continue;
+      const callId = entry['gen_ai.tool.call.id'] as string | undefined;
+      if (!callId) continue;
+      const timing = timings.get(callId);
+      if (!timing) continue;
+
+      if (eventName === 'tool.call' && timing.requestedNano) {
+        (entry as Record<string, unknown>)['time_unix_nano'] = timing.requestedNano;
+        usedCallIds.add(callId);
+      } else if (eventName === 'tool.result' && timing.finishedNano) {
+        (entry as Record<string, unknown>)['time_unix_nano'] = timing.finishedNano;
+        usedCallIds.add(callId);
+      }
+    }
+
+    for (const callId of usedCallIds) {
+      const timing = timings.get(callId);
+      const hasCallEntry = stepEntries.some(entry =>
+        entry['event.name'] === 'tool.call' && entry['gen_ai.tool.call.id'] === callId
+      );
+      const hasResultEntry = stepEntries.some(entry =>
+        entry['event.name'] === 'tool.result' && entry['gen_ai.tool.call.id'] === callId
+      );
+      if (hasCallEntry && hasResultEntry && timing?.requestedNano && timing.finishedNano) {
+        timings.delete(callId);
+      }
+    }
+    if (timings.size === 0) this.segmentToolTimings.delete(sessionId);
   }
 
   private groupByStep(entries: AgentActivityEntry[]): Map<string | undefined, AgentActivityEntry[]> {
@@ -403,26 +496,51 @@ interface SegmentEvent {
   type?: string;
   turn_id?: string;
   request_id?: string;
+  tool_call_id?: string;
   data?: {
     model?: string;
     is_subagent?: boolean;
+    tool_name?: string;
     [key: string]: unknown;
   };
 }
 
 interface InFlightPair {
+  turnId: string;
   startNano: string;
   model: string;
 }
 
 interface SegmentLlmPair {
+  turnId: string;
   startNano: string;
   endNano: string;
   model: string;
+}
+
+interface SegmentToolTiming {
+  turnId: string;
+  toolName?: string;
+  requestedNano?: string;
+  finishedNano?: string;
 }
 
 function isoToNano(iso: string): string | undefined {
   const ms = Date.parse(iso);
   if (Number.isNaN(ms)) return undefined;
   return String(BigInt(ms) * 1_000_000n);
+}
+
+function isIgnoredSegmentTurn(turnId: string): boolean {
+  return turnId.startsWith('qoderwork-memory-sink');
+}
+
+function isWithinTolerance(leftNano: string, rightNano: string, toleranceMs: number): boolean {
+  try {
+    const delta = BigInt(leftNano) - BigInt(rightNano);
+    const abs = delta < 0n ? -delta : delta;
+    return abs <= BigInt(toleranceMs) * NANO_PER_MILLI;
+  } catch {
+    return false;
+  }
 }

--- a/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
+++ b/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
@@ -1,6 +1,5 @@
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs/promises';
-import * as os from 'node:os';
 import * as path from 'node:path';
 import { ClientType, CollectionMethod } from '../../types/index.js';
 import type { AgentActivityEntry } from '../../types/index.js';
@@ -8,35 +7,21 @@ import { BaseInput, type InputOptions } from '../base/base-input.js';
 import { enrichCanonicalEntryWithGit } from '../../normalization/enrich-git-context.js';
 import { resolveHome, directoryExists, ensureDir } from '../../utils/fs-utils.js';
 import { getTodayDateString } from '../../utils/fs-utils.js';
-import { parseSdkLogLine, type SdkEvent } from '../qoder-work-log/qoder-work-log-input.js';
-
-const BUFFER_TTL_MS = 24 * 60 * 60 * 1000;
-
-export interface QoderWorkTraceInputOptions extends InputOptions {
-  logDir?: string;
-  sdkLogDir?: string;
-}
-
-interface SdkMessageData {
-  messageId: string;
-  sessionId: string;
-  startTimeMs: number;
-  endTimeMs: number;
-  inputTokens: number;
-  outputTokens: number;
-  stopReason: string;
-  complete: boolean;
-  createdAtMs: number; // 用于 eviction
-}
 
 /**
- * QoderWork CN TraceInput — multi-source merge.
+ * QoderWork TraceInput — hook JSONL + segments enrichment.
  *
- * Reads hook JSONL (messages + structure, produced by the rewritten
- * qoderwork-hook-processor.mjs) and SDK log (tokens from message_delta).
- * Merges tokens into the hook's llm.response events, injects trace_id.
+ * Pipeline:
+ *   1. Read hook processor's JSONL output (`logs/qoder-work/history/...`) —
+ *      this owns event structure (turn/step ids, message deltas, ordering).
+ *   2. Read QoderWork session segments (`~/.qoderwork/logs/sessions/<ws>/<sid>/segments/*.jsonl`) —
+ *      these own precise LLM timing and resolved model names.
+ *   3. Match each hook step's (llm.request, llm.response) with one segment
+ *      `model.request.started`/`model.response.completed` pair via per-session FIFO.
+ *      Subagent turns are skipped — hook transcript only contains main agent
+ *      conversation, so segment subagent LLM calls would mis-align the FIFO.
  *
- * When enabled, supersedes qoder-work-hook / qoder-work-log / qoder-work-sqlite.
+ * Outputs `AgentActivityEntry[]` with shared trace_id per turn.
  */
 export class QoderWorkTraceInput extends BaseInput {
   readonly id = 'qoder-work-trace';
@@ -44,21 +29,23 @@ export class QoderWorkTraceInput extends BaseInput {
   readonly collectionMethod = CollectionMethod.HookJsonl;
 
   private readonly logDir: string;
-  private readonly sdkLogDir: string;
+  private readonly segmentsRoot: string;
   private readonly logPrefix = 'qoder-work';
 
-  // SDK log 状态机缓冲 — 实例级持久化，跨 collect() 周期存活
-  private sdkMessageBuffer: Map<string, SdkMessageData[]> = new Map();
-  private sdkInFlightMessages: Map<string, SdkMessageData> = new Map();
-
-  // Model policy 按文件路径隔离，防止不同 SDK 进程的 model 交叉污染
-  private fileModelPolicies: Map<string, { chat: string; compact: string; scene: string }> = new Map();
-  private currentModelPolicy: { chat: string; compact: string; scene: string } = { chat: '', compact: '', scene: '' };
+  // Per-session in-memory state for segment enrichment
+  // Key: sessionId. Value: FIFO of LLM pairs from main-turn segments.
+  private readonly segmentPairs: Map<string, SegmentLlmPair[]> = new Map();
+  // Per-session set of turn_ids known to be subagent. We only filter LLM calls
+  // whose turn_id is in this set. A turn_id absent from the set is treated as
+  // main (covers the rare case where turn.started is split across files).
+  private readonly subagentTurns: Map<string, Set<string>> = new Map();
+  // Per-session in-flight LLM pairs (request seen, response not yet seen).
+  private readonly inFlightPairs: Map<string, Map<string, InFlightPair>> = new Map();
 
   constructor(opts: QoderWorkTraceInputOptions) {
     super({ ...opts, pollIntervalMs: opts.pollIntervalMs ?? 30_000 });
     this.logDir = opts.logDir ?? resolveHome('~/.loongsuite-pilot/logs/qoder-work/history');
-    this.sdkLogDir = opts.sdkLogDir ?? resolveQoderWorkSdkLogDir();
+    this.segmentsRoot = opts.segmentsRoot ?? resolveHome('~/.qoderwork/logs/sessions');
   }
 
   static async checkAvailability(): Promise<boolean> {
@@ -68,7 +55,7 @@ export class QoderWorkTraceInput extends BaseInput {
   static getWatchPaths(): string[] {
     return [
       resolveHome('~/.loongsuite-pilot/logs/qoder-work/history'),
-      resolveQoderWorkSdkLogDir(),
+      resolveHome('~/.qoderwork/logs/sessions'),
     ];
   }
 
@@ -77,17 +64,20 @@ export class QoderWorkTraceInput extends BaseInput {
   }
 
   protected async collect(): Promise<AgentActivityEntry[]> {
-    // 1. 读取 SDK log 状态（token + timing + model），积累到实例级缓冲
-    await this.readSdkLogState();
-
-    // 2. 读取 hook JSONL 条目
+    // 1. Hook JSONL — primary source of structure.
     const rawEntries = await this.readHookJsonl();
     if (rawEntries.length === 0) return [];
 
-    // 3. 按 turn.id 分组
-    const turnGroups = this.groupByTurn(rawEntries);
+    // 2. Discover the (sessionId, cwd) pairs we have entries for, then read
+    //    fresh segments for each. Lazily — sessions absent from hook batch
+    //    don't trigger segment IO.
+    const sessionCwd = this.collectSessionCwd(rawEntries);
+    for (const [sessionId, cwd] of sessionCwd) {
+      await this.readSegmentsForSession(sessionId, cwd);
+    }
 
-    // 4. 对每个 turn 进行全量 enrichment（token + timing + model + git context）
+    // 3. Group → enrich → emit.
+    const turnGroups = this.groupByTurn(rawEntries);
     const allEntries: AgentActivityEntry[] = [];
     for (const [, turnEntries] of turnGroups) {
       this.enrichTurn(turnEntries);
@@ -101,9 +91,6 @@ export class QoderWorkTraceInput extends BaseInput {
       }
       allEntries.push(...turnEntries);
     }
-
-    // 5. 清理超过 24 小时未消费的缓冲条目
-    this.evictStaleBuffers();
 
     return allEntries;
   }
@@ -162,246 +149,193 @@ export class QoderWorkTraceInput extends BaseInput {
     return entries;
   }
 
-  // ─── SDK Log state reading ──────────────────────────────────────────────────
+  // ─── Segments reading ──────────────────────────────────────────────────────
 
-  private async readSdkLogState(): Promise<void> {
-    const stateKey = `${this.id}:sdk-log`;
+  private collectSessionCwd(entries: AgentActivityEntry[]): Map<string, string> {
+    const map = new Map<string, string>();
+    for (const e of entries) {
+      const sid = e['gen_ai.session.id'] as string | undefined;
+      const cwd = e['agent.qoderwork.cwd'] as string | undefined;
+      if (sid && cwd && !map.has(sid)) map.set(sid, cwd);
+    }
+    return map;
+  }
 
-    let logFiles: string[];
+  /** Encode a workspace cwd into the qoderwork sessions directory name. */
+  private encodeWorkspace(cwd: string): string {
+    return cwd.replace(/\//g, '-').replace(/\./g, '-');
+  }
+
+  private async readSegmentsForSession(sessionId: string, cwd: string): Promise<void> {
+    const ws = this.encodeWorkspace(cwd);
+    const segDir = path.join(this.segmentsRoot, ws, sessionId, 'segments');
+
+    let files: string[];
     try {
-      logFiles = await this.discoverSdkLogFiles();
+      const dirEntries = await fs.readdir(segDir, { withFileTypes: true });
+      files = dirEntries
+        .filter(d => d.isFile() && d.name.endsWith('.jsonl'))
+        .map(d => path.join(segDir, d.name))
+        .sort(); // filename starts with ISO timestamp → sort = chronological
+    } catch {
+      return; // no segments dir for this session yet
+    }
+
+    for (const filePath of files) {
+      await this.readSegmentsFile(sessionId, filePath);
+    }
+  }
+
+  private async readSegmentsFile(sessionId: string, filePath: string): Promise<void> {
+    const fileStateKey = `${this.id}:seg:${filePath}`;
+
+    let stat;
+    try {
+      stat = await fs.stat(filePath);
     } catch {
       return;
     }
 
-    for (const filePath of logFiles) {
-      // 恢复该文件的 model policy 快照，防止跨文件污染
-      this.currentModelPolicy = this.fileModelPolicies.get(filePath)
-        ?? { chat: '', compact: '', scene: '' };
+    const prevState = this.stateStore.get(fileStateKey);
+    const prevInode = (prevState.extra as { inode?: number } | undefined)?.inode;
+    const currentInode = (stat as unknown as { ino: number }).ino;
 
-      const fileStateKey = `${stateKey}:${filePath}`;
-      let stat;
-      try { stat = await fs.stat(filePath); } catch { continue; }
+    if (prevInode !== undefined && prevInode !== currentInode) {
+      this.stateStore.setOffset(fileStateKey, 0);
+      this.stateStore.update(fileStateKey, { extra: { inode: currentInode } });
+    } else if (prevInode === undefined) {
+      this.stateStore.update(fileStateKey, { extra: { inode: currentInode } });
+    }
 
-      const prevState = this.stateStore.get(fileStateKey);
-      const prevInode = prevState.extra?.inode as number | undefined;
-      const currentInode = (stat as unknown as { ino: number }).ino;
-      let cachedSig: string | undefined;
+    let offset = this.stateStore.getOffset(fileStateKey);
+    if (offset > 0 && stat.size < offset) offset = 0; // truncated
+    if (stat.size <= offset) return;
 
-      if (prevInode !== undefined && prevInode !== currentInode) {
-        this.stateStore.setOffset(fileStateKey, 0);
-        cachedSig = await computeFileSignature(filePath);
-        this.stateStore.update(fileStateKey, { extra: { inode: currentInode, signatureHash: cachedSig } });
-      } else if (prevInode === undefined) {
-        cachedSig = await computeFileSignature(filePath);
-        this.stateStore.update(fileStateKey, { extra: { inode: currentInode, signatureHash: cachedSig } });
+    const handle = await fs.open(filePath, 'r');
+    try {
+      const maxReadSize = 16 * 1024 * 1024;
+      const readSize = Math.min(stat.size - offset, maxReadSize);
+      const buf = Buffer.alloc(readSize);
+      await handle.read(buf, 0, readSize, offset);
+      let text = buf.toString('utf-8');
+
+      let consumedBytes = readSize;
+      if (readSize < stat.size - offset) {
+        const lastNL = text.lastIndexOf('\n');
+        if (lastNL >= 0) { text = text.substring(0, lastNL); consumedBytes = Buffer.byteLength(text, 'utf-8') + 1; }
       }
+      this.stateStore.setOffset(fileStateKey, offset + consumedBytes);
+      this.stateStore.update(fileStateKey, { extra: { inode: currentInode } });
 
-      let offset = this.stateStore.getOffset(fileStateKey);
-      if (offset > 0 && stat.size < offset) {
-        this.logger.info('SDK log truncated or rotated, resetting offset', { file: filePath });
-        offset = 0;
-        this.stateStore.setOffset(fileStateKey, 0);
-      }
-
-      // Signature-based rotation detection: handles inode reuse on tmpfs (Linux CI)
-      if (offset > 0 && stat.size > 0) {
-        const currentSig = cachedSig ?? await computeFileSignature(filePath);
-        cachedSig = currentSig;
-        const prevSig = prevState.extra?.signatureHash as string | undefined;
-        if (prevSig && currentSig && prevSig !== currentSig) {
-          this.logger.info('SDK log content signature changed (inode reused), resetting offset', { file: filePath });
-          offset = 0;
-          this.stateStore.setOffset(fileStateKey, 0);
+      for (const line of text.split('\n')) {
+        if (!line.trim()) continue;
+        try {
+          const event = JSON.parse(line) as SegmentEvent;
+          this.handleSegmentEvent(sessionId, event);
+        } catch {
+          this.logger.warn('invalid segments JSONL line');
         }
       }
-      if (stat.size <= offset) {
-        this.fileModelPolicies.set(filePath, { ...this.currentModelPolicy });
-        continue;
-      }
-
-      const handle = await fs.open(filePath, 'r');
-      try {
-        const readSize = Math.min(stat.size - offset, 16 * 1024 * 1024);
-        const buf = Buffer.alloc(readSize);
-        await handle.read(buf, 0, readSize, offset);
-        let text = buf.toString('utf-8');
-
-        let consumedBytes = readSize;
-        if (readSize < stat.size - offset) {
-          const lastNL = text.lastIndexOf('\n');
-          if (lastNL >= 0) { text = text.substring(0, lastNL); consumedBytes = Buffer.byteLength(text, 'utf-8') + 1; }
-        }
-        this.stateStore.setOffset(fileStateKey, offset + consumedBytes);
-        const sig = cachedSig ?? await computeFileSignature(filePath);
-        this.stateStore.update(fileStateKey, { extra: { inode: currentInode, signatureHash: sig } });
-
-        for (const line of text.split('\n')) {
-          if (!line.trim()) continue;
-          const event = parseSdkLogLine(line);
-          if (!event) continue;
-          this.handleSdkEvent(event);
-        }
-      } finally {
-        await handle.close();
-      }
-
-      // 保存该文件处理后的 model policy 快照
-      this.fileModelPolicies.set(filePath, { ...this.currentModelPolicy });
+    } finally {
+      await handle.close();
     }
   }
 
-  private handleSdkEvent(event: SdkEvent): void {
-    switch (event.kind) {
-      case 'set_model_policy':
-        if (event.chatModel) this.currentModelPolicy.chat = event.chatModel;
-        if (event.compactModel) this.currentModelPolicy.compact = event.compactModel;
-        if (event.sceneModel) this.currentModelPolicy.scene = event.sceneModel;
-        return;
-
-      case 'message_start': {
-        const existing = this.sdkInFlightMessages.get(event.sessionId);
-        if (existing) {
-          this.logger.debug('overwriting incomplete in-flight message', {
-            droppedMessageId: existing.messageId,
-            sessionId: event.sessionId,
-          });
+  private handleSegmentEvent(sessionId: string, event: SegmentEvent): void {
+    switch (event.type) {
+      case 'turn.started': {
+        if (event.turn_id && event.data?.is_subagent === true) {
+          let set = this.subagentTurns.get(sessionId);
+          if (!set) { set = new Set(); this.subagentTurns.set(sessionId, set); }
+          set.add(event.turn_id);
         }
-        const msg: SdkMessageData = {
-          messageId: event.messageId,
-          sessionId: event.sessionId,
-          startTimeMs: event.ts,
-          endTimeMs: 0,
-          inputTokens: 0,
-          outputTokens: 0,
-          stopReason: '',
-          complete: false,
-          createdAtMs: Date.now(),
-        };
-        this.sdkInFlightMessages.set(event.sessionId, msg);
         return;
       }
-
-      case 'message_delta': {
-        const inFlight = this.sdkInFlightMessages.get(event.sessionId);
-        if (!inFlight) return;
-        inFlight.endTimeMs = event.ts;
-        inFlight.inputTokens = event.inputTokens;
-        inFlight.outputTokens = event.outputTokens;
-        inFlight.stopReason = event.stopReason;
-        inFlight.complete = true;
-        // 移入完成缓冲
-        this.sdkInFlightMessages.delete(event.sessionId);
-        const list = this.sdkMessageBuffer.get(event.sessionId) ?? [];
-        list.push(inFlight);
-        this.sdkMessageBuffer.set(event.sessionId, list);
+      case 'model.request.started': {
+        if (!event.turn_id || !event.request_id || !event.ts) return;
+        // Skip subagent LLM calls — hook transcript only carries main agent.
+        if (this.subagentTurns.get(sessionId)?.has(event.turn_id)) return;
+        const startNano = isoToNano(event.ts);
+        if (!startNano) return;
+        let m = this.inFlightPairs.get(sessionId);
+        if (!m) { m = new Map(); this.inFlightPairs.set(sessionId, m); }
+        m.set(event.request_id, {
+          startNano,
+          model: event.data?.model || '',
+        });
         return;
       }
-
-      // message_stop / 其他事件类型不需要特殊处理
+      case 'model.response.completed': {
+        if (!event.turn_id || !event.request_id || !event.ts) return;
+        if (this.subagentTurns.get(sessionId)?.has(event.turn_id)) return;
+        const inFlightForSession = this.inFlightPairs.get(sessionId);
+        const inFlight = inFlightForSession?.get(event.request_id);
+        if (!inFlight) return; // orphan response (e.g. resumed mid-stream)
+        inFlightForSession!.delete(event.request_id);
+        const endNano = isoToNano(event.ts);
+        if (!endNano) return;
+        const list = this.segmentPairs.get(sessionId) ?? [];
+        list.push({
+          startNano: inFlight.startNano,
+          endNano,
+          model: event.data?.model || inFlight.model || '',
+        });
+        this.segmentPairs.set(sessionId, list);
+        return;
+      }
       default:
         return;
     }
   }
 
-  private async discoverSdkLogFiles(): Promise<string[]> {
-    const files: string[] = [];
-    let entries;
-    try {
-      entries = await fs.readdir(this.sdkLogDir, { withFileTypes: true });
-    } catch {
-      return files;
-    }
-
-    for (const dir of entries) {
-      if (!dir.isDirectory()) continue;
-      const sessionPath = path.join(this.sdkLogDir, dir.name);
-      const mainLogPath = path.join(sessionPath, 'main.log');
-      try {
-        const st = await fs.stat(mainLogPath);
-        if (st.isFile()) { files.push(mainLogPath); continue; }
-      } catch { /* fall through */ }
-      const mainDir = path.join(sessionPath, 'main');
-      let subEntries;
-      try { subEntries = await fs.readdir(mainDir, { withFileTypes: true }); } catch { continue; }
-      for (const entry of subEntries) {
-        if (entry.isFile() && entry.name.startsWith('sdk-') && entry.name.endsWith('.log')) {
-          files.push(path.join(mainDir, entry.name));
-        }
-      }
-    }
-    return files.sort();
-  }
-
   // ─── Enrichment ─────────────────────────────────────────────────────────────
 
   private enrichTurn(entries: AgentActivityEntry[]): void {
-    const sessionId = entries.find(e => e['gen_ai.session.id'])?.['gen_ai.session.id'] as string || '';
-    if (!sessionId) return;
+    const sessionId = entries.find(e => e['gen_ai.session.id'])?.['gen_ai.session.id'] as string | undefined;
 
-    const buffer = this.sdkMessageBuffer.get(sessionId);
     const steps = this.groupByStep(entries);
     const stepOrder = [...steps.keys()].filter((k): k is string => k !== undefined);
 
-    for (const [stepId, stepEntries] of steps) {
-      if (!stepId) continue;
+    // Apply segment-derived timing + model to each step in transcript order.
+    if (sessionId) {
+      const buffer = this.segmentPairs.get(sessionId);
+      for (const stepId of stepOrder) {
+        const stepEntries = steps.get(stepId);
+        if (!stepEntries) continue;
+        const request = stepEntries.find(e => e['event.name'] === 'llm.request');
+        const response = stepEntries.find(e => e['event.name'] === 'llm.response');
+        if (!request || !response) continue;
 
-      const response = stepEntries.find(e => e['event.name'] === 'llm.response');
-      const request = stepEntries.find(e => e['event.name'] === 'llm.request');
-      if (!response) continue;
+        const pair = buffer?.length ? buffer.shift() : undefined;
+        if (!pair) continue;
 
-      // FIFO 消费一个 SdkMessageData
-      const sdkData = buffer?.length ? buffer.shift() : undefined;
-      if (sdkData) {
-        // Token enrichment — only set when SDK reports non-zero values.
-        // QoderWork message_delta always carries positive token counts;
-        // 0 means the SDK event was malformed, so we skip to avoid
-        // overwriting with misleading zeros.
-        if (sdkData.inputTokens > 0) {
-          (response as Record<string, unknown>)['gen_ai.usage.input_tokens'] = sdkData.inputTokens;
-        }
-        if (sdkData.outputTokens > 0) {
-          (response as Record<string, unknown>)['gen_ai.usage.output_tokens'] = sdkData.outputTokens;
-        }
-        if (sdkData.inputTokens > 0 || sdkData.outputTokens > 0) {
-          (response as Record<string, unknown>)['gen_ai.usage.total_tokens'] =
-            (sdkData.inputTokens || 0) + (sdkData.outputTokens || 0);
-        }
+        (request as Record<string, unknown>)['time_unix_nano'] = pair.startNano;
+        (response as Record<string, unknown>)['time_unix_nano'] = pair.endNano;
 
-        // Timing enrichment — 用 SDK log 的精确时间戳覆盖 hook 的粗粒度时间戳
-        if (sdkData.startTimeMs > 0 && request) {
-          (request as Record<string, unknown>)['time_unix_nano'] = String(BigInt(sdkData.startTimeMs) * 1_000_000n);
-        }
-        if (sdkData.endTimeMs > 0) {
-          const endNano = String(BigInt(sdkData.endTimeMs) * 1_000_000n);
-          (response as Record<string, unknown>)['time_unix_nano'] = endNano;
-          // tool.call 时间戳跟随 response（LLM 声明 tool_use 的时刻）
+        if (pair.model) {
           for (const e of stepEntries) {
-            if (e['event.name'] === 'tool.call') {
-              (e as Record<string, unknown>)['time_unix_nano'] = endNano;
+            if (!e['gen_ai.request.model'] || e['gen_ai.request.model'] === 'auto') {
+              (e as Record<string, unknown>)['gen_ai.request.model'] = pair.model;
+            }
+            if (e['event.name'] === 'llm.response') {
+              (e as Record<string, unknown>)['gen_ai.response.model'] = pair.model;
             }
           }
         }
-      }
 
-      // Model enrichment — uses currentModelPolicy which reflects the last
-      // processed SDK log file. This assumes a single active QoderWork process
-      // (single SDK log directory). If multiple workspaces run in parallel in
-      // the future, model policy should be keyed by sessionId instead.
-      const resolvedModel = this.resolveModel();
-      if (resolvedModel && resolvedModel !== 'unknown') {
+        // tool.call carries no native timestamp from segments; align to llm.response.
         for (const e of stepEntries) {
-          if (!e['gen_ai.request.model'] || e['gen_ai.request.model'] === 'auto') {
-            (e as Record<string, unknown>)['gen_ai.request.model'] = resolvedModel;
-          }
-          if (e['event.name'] === 'llm.response') {
-            (e as Record<string, unknown>)['gen_ai.response.model'] = resolvedModel;
+          if (e['event.name'] === 'tool.call') {
+            (e as Record<string, unknown>)['time_unix_nano'] = pair.endNano;
           }
         }
       }
+      if (buffer && buffer.length === 0) this.segmentPairs.delete(sessionId);
     }
 
-    // Fix STEP overlap: cap tool.result 时间戳使其不超过下一个 step 的 llm.request 开始时间
+    // Defensive STEP overlap clamp: ensure tool.result of step N doesn't exceed
+    // llm.request of step N+1. Hook is already monotonic; segments enrichment
+    // shouldn't break that, but we keep this guard for edge cases.
     for (let i = 0; i < stepOrder.length - 1; i++) {
       const currentStepEntries = steps.get(stepOrder[i]);
       const nextStepEntries = steps.get(stepOrder[i + 1]);
@@ -422,16 +356,6 @@ export class QoderWorkTraceInput extends BaseInput {
         }
       }
     }
-
-    // 清理空 buffer
-    if (buffer && buffer.length === 0) {
-      this.sdkMessageBuffer.delete(sessionId);
-    }
-  }
-
-  private resolveModel(): string {
-    const policy = this.currentModelPolicy;
-    return policy.chat || policy.scene || policy.compact || '';
   }
 
   private groupByStep(entries: AgentActivityEntry[]): Map<string | undefined, AgentActivityEntry[]> {
@@ -443,24 +367,6 @@ export class QoderWorkTraceInput extends BaseInput {
       groups.set(stepId, group);
     }
     return groups;
-  }
-
-  private evictStaleBuffers(): void {
-    const now = Date.now();
-    for (const [sessionId, list] of this.sdkMessageBuffer) {
-      const filtered = list.filter(m => now - m.createdAtMs < BUFFER_TTL_MS);
-      if (filtered.length === 0) {
-        this.sdkMessageBuffer.delete(sessionId);
-      } else if (filtered.length < list.length) {
-        this.sdkMessageBuffer.set(sessionId, filtered);
-      }
-    }
-    // 同时清理停滞的 in-flight messages
-    for (const [sessionId, msg] of this.sdkInFlightMessages) {
-      if (now - msg.createdAtMs > BUFFER_TTL_MS) {
-        this.sdkInFlightMessages.delete(sessionId);
-      }
-    }
   }
 
   // ─── Trace ID injection ────────────────────────────────────────────────────
@@ -487,31 +393,36 @@ export class QoderWorkTraceInput extends BaseInput {
   }
 }
 
-const SIGNATURE_BYTES = 1024;
-
-async function computeFileSignature(filePath: string): Promise<string> {
-  let handle;
-  try {
-    handle = await fs.open(filePath, 'r');
-    const buf = Buffer.alloc(SIGNATURE_BYTES);
-    const { bytesRead } = await handle.read(buf, 0, SIGNATURE_BYTES, 0);
-    if (bytesRead === 0) return '';
-    return crypto.createHash('md5').update(buf.subarray(0, bytesRead)).digest('hex');
-  } catch {
-    return '';
-  } finally {
-    await handle?.close();
-  }
+export interface QoderWorkTraceInputOptions extends InputOptions {
+  logDir?: string;
+  segmentsRoot?: string;
 }
 
-function resolveQoderWorkSdkLogDir(): string {
-  if (process.platform === 'darwin') {
-    return resolveHome('~/Library/Application Support/QoderWork/logs');
-  }
-  if (process.platform === 'win32') {
-    return path.join(process.env.APPDATA ?? path.join(os.homedir(), 'AppData', 'Roaming'), 'QoderWork', 'logs');
-  }
-  const xdg = process.env.XDG_CONFIG_HOME;
-  if (xdg) return path.join(xdg, 'QoderWork', 'logs');
-  return resolveHome('~/.config/QoderWork/logs');
+interface SegmentEvent {
+  ts?: string;
+  type?: string;
+  turn_id?: string;
+  request_id?: string;
+  data?: {
+    model?: string;
+    is_subagent?: boolean;
+    [key: string]: unknown;
+  };
+}
+
+interface InFlightPair {
+  startNano: string;
+  model: string;
+}
+
+interface SegmentLlmPair {
+  startNano: string;
+  endNano: string;
+  model: string;
+}
+
+function isoToNano(iso: string): string | undefined {
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return undefined;
+  return String(BigInt(ms) * 1_000_000n);
 }

--- a/tests/unit/hooks/qoderwork-hook-processor.test.mjs
+++ b/tests/unit/hooks/qoderwork-hook-processor.test.mjs
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   extractText,
+  getTurnIdForRows,
   isSystemInjection,
   isToolResult,
   splitIntoTurns,
@@ -95,6 +96,24 @@ describe('isSystemInjection', () => {
   it('returns false for normal user text', () => {
     const row = { message: { content: [{ type: 'text', text: 'how do I build a multi-turn scenario?' }] } };
     expect(isSystemInjection(row)).toBe(false);
+  });
+});
+
+describe('getTurnIdForRows', () => {
+  it('uses the same real prompt row as turn event construction', () => {
+    const systemReminder = {
+      type: 'user',
+      uuid: 'system-row-id',
+      message: { content: [{ type: 'text', text: '<system-reminder>runtime context</system-reminder>' }] },
+    };
+    const prompt = {
+      type: 'user',
+      uuid: 'prompt-row-id',
+      promptId: 'real-prompt-id',
+      message: { content: [{ type: 'text', text: 'implement the requested change' }] },
+    };
+
+    expect(getTurnIdForRows([systemReminder, prompt])).toBe('real-prompt-id');
   });
 });
 

--- a/tests/unit/hooks/qoderwork/hook-processor.test.mjs
+++ b/tests/unit/hooks/qoderwork/hook-processor.test.mjs
@@ -58,7 +58,7 @@ function readJsonlRecords() {
 function inputContents(records) {
   return records
     .filter((r) => r['event.name'] === 'llm.request')
-    .flatMap((r) => r['gen_ai.input.messages_delta'] ?? [])
+    .flatMap((r) => r['gen_ai.input.messages'] ?? r['gen_ai.input.messages_delta'] ?? [])
     .flatMap((m) => m.parts ?? [])
     .filter((p) => p.type === 'text')
     .map((p) => p.content);

--- a/tests/unit/hooks/qoderwork/hook-processor.test.mjs
+++ b/tests/unit/hooks/qoderwork/hook-processor.test.mjs
@@ -1,0 +1,171 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROCESSOR = path.resolve(__dirname, '../../../../assets/hooks/qoderwork-hook-processor.mjs');
+const AGENT_ID = 'qoder-work-test';
+const LOG_PREFIX = 'qoder-work';
+const LINE_RECORD = path.resolve(__dirname, '../../../../assets/hooks/.line_records.qoder-work-test.json');
+
+let DATA_DIR;
+let TRANSCRIPT;
+
+beforeEach(() => {
+  DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'qoderwork-hook-test-'));
+  TRANSCRIPT = path.join(DATA_DIR, 'transcript.jsonl');
+  try { fs.rmSync(LINE_RECORD, { force: true }); } catch {}
+});
+
+afterEach(() => {
+  try { fs.rmSync(DATA_DIR, { recursive: true, force: true }); } catch {}
+  try { fs.rmSync(LINE_RECORD, { force: true }); } catch {}
+});
+
+function writeTranscript(records) {
+  fs.writeFileSync(TRANSCRIPT, records.map((r) => JSON.stringify(r)).join('\n') + '\n', 'utf-8');
+}
+
+function runHook(sessionId) {
+  return spawnSync('node', [PROCESSOR, '--agent-id', AGENT_ID, '--log-prefix', LOG_PREFIX], {
+    input: JSON.stringify({
+      session_id: sessionId,
+      transcript_path: TRANSCRIPT,
+      cwd: '/tmp/qoderwork-test',
+    }),
+    env: { ...process.env, LOONGSUITE_PILOT_DATA_DIR: DATA_DIR },
+    encoding: 'utf-8',
+    timeout: 10_000,
+  });
+}
+
+function readJsonlRecords() {
+  const dir = path.join(DATA_DIR, 'logs', AGENT_ID, 'history');
+  if (!fs.existsSync(dir)) return [];
+  const records = [];
+  for (const f of fs.readdirSync(dir).filter((x) => x.endsWith('.jsonl'))) {
+    const content = fs.readFileSync(path.join(dir, f), 'utf-8');
+    for (const line of content.split('\n')) {
+      if (line.trim()) records.push(JSON.parse(line));
+    }
+  }
+  return records;
+}
+
+function inputContents(records) {
+  return records
+    .filter((r) => r['event.name'] === 'llm.request')
+    .flatMap((r) => r['gen_ai.input.messages_delta'] ?? [])
+    .flatMap((m) => m.parts ?? [])
+    .filter((p) => p.type === 'text')
+    .map((p) => p.content);
+}
+
+function baseRows(userContent) {
+  return [
+    {
+      type: 'user',
+      uuid: 'user-1',
+      timestamp: '2026-06-18T01:35:54.477Z',
+      message: { role: 'user', content: userContent },
+      sessionId: 'sess-1',
+      userType: 'external',
+      isSidechain: false,
+    },
+    {
+      type: 'assistant',
+      uuid: 'assistant-1',
+      parentUuid: 'user-1',
+      timestamp: '2026-06-18T01:35:56.477Z',
+      message: {
+        role: 'assistant',
+        id: 'msg-1',
+        content: [{ type: 'text', text: 'done' }],
+        stop_reason: 'end_turn',
+      },
+      sessionId: 'sess-1',
+      isSidechain: false,
+    },
+  ];
+}
+
+describe('qoderwork-hook-processor user prompt extraction', () => {
+  test('uses transcript promptId as the stable turn id', () => {
+    writeTranscript(baseRows([
+      { type: 'text', text: '你先搜索力扣565题' },
+    ]).map((row) => row.type === 'user' ? { ...row, promptId: 'prompt-turn-565' } : row));
+
+    const result = runHook('sess-prompt-id');
+    expect(result.status).toBe(0);
+
+    const records = readJsonlRecords();
+    expect(records.length).toBeGreaterThan(0);
+    expect(records.map((r) => r['gen_ai.turn.id'])).toEqual(records.map(() => 'prompt-turn-565'));
+    expect(records.filter((r) => r['gen_ai.step.id']).map((r) => r['gen_ai.step.id'])).toEqual(
+      records.filter((r) => r['gen_ai.step.id']).map(() => 'prompt-turn-565:s1'),
+    );
+    expect(records.map((r) => r['agent.qoderwork.promptId'])).toEqual(records.map(() => 'prompt-turn-565'));
+  });
+
+  test('uses the later text block when the first block is only system-reminder', () => {
+    writeTranscript(baseRows([
+      { type: 'text', text: '<system-reminder>\nUser environment\n</system-reminder>' },
+      { type: 'text', text: '你先搜索力扣560题，然后在本地创建一个py文件解决这道题，只需解决这一题' },
+    ]));
+
+    const result = runHook('sess-system-first');
+    expect(result.status).toBe(0);
+
+    expect(inputContents(readJsonlRecords())).toEqual([
+      '你先搜索力扣560题，然后在本地创建一个py文件解决这道题，只需解决这一题',
+      '你先搜索力扣560题，然后在本地创建一个py文件解决这道题，只需解决这一题',
+    ]);
+  });
+
+  test('removes selected text context and keeps the user question outside the tag', () => {
+    writeTranscript(baseRows([
+      { type: 'text', text: '<user-selected-text> Trace-Metrics 关联字段 </user-selected-text> 讲讲这个' },
+    ]));
+
+    const result = runHook('sess-selected-text');
+    expect(result.status).toBe(0);
+
+    expect(inputContents(readJsonlRecords())).toEqual(['讲讲这个', '讲讲这个']);
+  });
+
+  test('strips system-reminder suffix from an otherwise normal prompt', () => {
+    writeTranscript(baseRows([
+      { type: 'text', text: '帮我安装qodercli <system-reminder>User environment</system-reminder>' },
+    ]));
+
+    const result = runHook('sess-system-suffix');
+    expect(result.status).toBe(0);
+
+    expect(inputContents(readJsonlRecords())).toEqual(['帮我安装qodercli', '帮我安装qodercli']);
+  });
+
+  test('keeps text outside both selected-text and system-reminder wrappers', () => {
+    writeTranscript(baseRows([
+      { type: 'text', text: '<user-selected-text> sudo cp old new </user-selected-text> 这一步不是已经做了吗 <system-reminder>User environment</system-reminder>' },
+    ]));
+
+    const result = runHook('sess-selected-system');
+    expect(result.status).toBe(0);
+
+    expect(inputContents(readJsonlRecords())).toEqual(['这一步不是已经做了吗', '这一步不是已经做了吗']);
+  });
+
+  test('does not treat command-message injections as user prompt text', () => {
+    writeTranscript(baseRows([
+      { type: 'text', text: '<command-message>init</command-message>' },
+    ]));
+
+    const result = runHook('sess-command-message');
+    expect(result.status).toBe(0);
+
+    expect(inputContents(readJsonlRecords())).toEqual([]);
+  });
+});

--- a/tests/unit/inputs/qoder-work-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-work-trace-input.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -11,6 +11,7 @@ describe('QoderWorkTraceInput', () => {
   let tmpRoot: string;
   let hookLogDir: string;
   let segmentsRoot: string;
+  let sdkLogDir: string;
   let stateStore: MockStateStore;
 
   const TEST_CWD = '/Users/test/.qoderwork/workspace/wsabc';
@@ -20,12 +21,15 @@ describe('QoderWorkTraceInput', () => {
     tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'qoder-work-trace-test-'));
     hookLogDir = path.join(tmpRoot, 'hook-history');
     segmentsRoot = path.join(tmpRoot, 'sessions');
+    sdkLogDir = path.join(tmpRoot, 'sdk-logs');
     await fs.mkdir(hookLogDir, { recursive: true });
     await fs.mkdir(segmentsRoot, { recursive: true });
+    await fs.mkdir(sdkLogDir, { recursive: true });
     stateStore = new MockStateStore();
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     await fs.rm(tmpRoot, { recursive: true, force: true });
   });
 
@@ -34,6 +38,7 @@ describe('QoderWorkTraceInput', () => {
       stateStore: stateStore as any,
       logDir: hookLogDir,
       segmentsRoot,
+      sdkLogDir,
     });
   }
 
@@ -45,14 +50,26 @@ describe('QoderWorkTraceInput', () => {
     return filePath;
   }
 
+  async function writeSdkLog(sessionDir: string, lines: string[]) {
+    const dir = path.join(sdkLogDir, sessionDir);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'main.log'), lines.join('\n') + '\n');
+  }
+
   function segTurnStarted(turnId: string, isSubagent = false, ts = '2026-06-16T10:00:00.000Z') {
     return { ts, type: 'turn.started', turn_id: turnId, data: { is_subagent: isSubagent } };
   }
   function segModelStart(turnId: string, requestId: string, ts: string, model = 'qwork-ultimate') {
     return { ts, type: 'model.request.started', turn_id: turnId, request_id: requestId, data: { model } };
   }
-  function segModelEnd(turnId: string, requestId: string, ts: string, model = 'qwork-ultimate') {
-    return { ts, type: 'model.response.completed', turn_id: turnId, request_id: requestId, data: { model } };
+  function segModelEnd(
+    turnId: string,
+    requestId: string,
+    ts: string,
+    model = 'qwork-ultimate',
+    usage: Record<string, number> = {},
+  ) {
+    return { ts, type: 'model.response.completed', turn_id: turnId, request_id: requestId, data: { model, ...usage } };
   }
   function segToolRequested(turnId: string, toolCallId: string, ts: string, toolName = 'TodoWrite') {
     return { ts, type: 'tool.requested', turn_id: turnId, tool_call_id: toolCallId, data: { tool_name: toolName, args: {} } };
@@ -62,6 +79,23 @@ describe('QoderWorkTraceInput', () => {
   }
   function nano(iso: string) {
     return String(BigInt(Date.parse(iso)) * 1_000_000n);
+  }
+
+  function sdkMessageStart(sessionId: string, messageId: string, iso: string) {
+    return `[${iso}] [INFO] [SDK] [QueryHandler] Received message: stream_event ${JSON.stringify({
+      event: { type: 'message_start', message: { id: messageId } }, session_id: sessionId,
+    })}`;
+  }
+
+  function sdkMessageDelta(sessionId: string, iso: string, inputTokens: number, outputTokens: number) {
+    return `[${iso}] [INFO] [SDK] [QueryHandler] Received message: stream_event ${JSON.stringify({
+      event: {
+        type: 'message_delta',
+        delta: { stop_reason: 'end_turn' },
+        usage: { input_tokens: inputTokens, output_tokens: outputTokens },
+      },
+      session_id: sessionId,
+    })}`;
   }
 
   function todayFileName() {
@@ -191,6 +225,24 @@ describe('QoderWorkTraceInput', () => {
 
     expect(entries.map(entry => entry['event.id'])).toEqual(['only-response']);
     expect(stateStore.get('qoder-work-trace').extra).toMatchObject({ qoderWorkTurnCount: 1 });
+  });
+
+  it('streams a large first-run history and exports only its last turn', async () => {
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const oldEntry = {
+      ...buildHookEntry({ 'event.id': 'large-old', 'gen_ai.turn.id': 'turn-old' }),
+      'agent.qoderwork.padding': 'x'.repeat(17 * 1024 * 1024),
+    };
+    const latestEntry = buildHookEntry({ 'event.id': 'large-latest', 'gen_ai.turn.id': 'turn-latest' });
+    const text = `${JSON.stringify(oldEntry)}\n${JSON.stringify(latestEntry)}\n`;
+    await fs.writeFile(hookFile, text);
+
+    const input = makeInput();
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    expect(entries.map(entry => entry['event.id'])).toEqual(['large-latest']);
+    expect(stateStore.get('qoder-work-trace').lastOffset).toBe(Buffer.byteLength(text));
   });
 
   it('caps tool.result to not exceed next step llm.request', async () => {
@@ -325,6 +377,152 @@ describe('QoderWorkTraceInput', () => {
     expect(reqOut['gen_ai.request.model']).toBe('qwork-ultimate');
     expect(respOut['gen_ai.request.model']).toBe('qwork-ultimate');
     expect(respOut['gen_ai.response.model']).toBe('qwork-ultimate');
+  });
+
+  it('enriches response usage from a matched segment pair', async () => {
+    const sessionId = 'sess-segment-usage';
+    const turnId = 'turn-segment-usage';
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const request = buildHookEntry({
+      'event.id': 'usage-request',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+    });
+    const response = buildHookEntry({
+      'event.id': 'usage-response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+    });
+    await fs.writeFile(hookFile, [request, response].map(entry => JSON.stringify(entry)).join('\n') + '\n');
+    await writeSegments(sessionId, 'usage.jsonl', [
+      segModelStart(turnId, 'usage-request-id', '2026-06-16T10:00:00.000Z'),
+      segModelEnd(turnId, 'usage-request-id', '2026-06-16T10:00:05.000Z', 'qwork-ultimate', {
+        input_tokens: 120,
+        output_tokens: 30,
+        cache_read_input_tokens: 50,
+        cache_creation_input_tokens: 10,
+      }),
+    ]);
+
+    const input = makeInput();
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const enriched = entries.find(entry => entry['event.id'] === 'usage-response')!;
+    expect(enriched['gen_ai.usage.input_tokens']).toBe(120);
+    expect(enriched['gen_ai.usage.output_tokens']).toBe(30);
+    expect(enriched['gen_ai.usage.total_tokens']).toBe(150);
+    expect(enriched['gen_ai.usage.cache_read.input_tokens']).toBe(50);
+    expect(enriched['gen_ai.usage.cache_creation.input_tokens']).toBe(10);
+  });
+
+  it('uses SDK token data only when the matched segment has no usage', async () => {
+    const sessionId = 'sess-sdk-usage';
+    const turnId = 'turn-sdk-usage';
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const request = buildHookEntry({
+      'event.id': 'sdk-request',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: nano('2026-06-16T10:00:00.000Z'),
+    });
+    const response = buildHookEntry({
+      'event.id': 'sdk-response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: nano('2026-06-16T10:00:05.000Z'),
+    });
+    await fs.writeFile(hookFile, [request, response].map(entry => JSON.stringify(entry)).join('\n') + '\n');
+    await writeSdkLog('sdk-session', [
+      sdkMessageStart(sessionId, 'sdk-message-1', '2026-06-16T10:00:00.000Z'),
+      sdkMessageDelta(sessionId, '2026-06-16T10:00:05.000Z', 321, 45),
+    ]);
+
+    const input = makeInput();
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const enriched = entries.find(entry => entry['event.id'] === 'sdk-response')!;
+    expect(enriched['gen_ai.usage.input_tokens']).toBe(321);
+    expect(enriched['gen_ai.usage.output_tokens']).toBe(45);
+    expect(enriched['gen_ai.usage.total_tokens']).toBe(366);
+    expect(enriched.time_unix_nano).toBe(nano('2026-06-16T10:00:05.000Z'));
+  });
+
+  it('falls back to locating segment directories by session id', async () => {
+    const sessionId = 'sess-segment-directory-fallback';
+    const turnId = 'turn-segment-directory-fallback';
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const request = buildHookEntry({
+      'event.id': 'fallback-request',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+    });
+    const response = buildHookEntry({
+      'event.id': 'fallback-response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+    });
+    await fs.writeFile(hookFile, [request, response].map(entry => JSON.stringify(entry)).join('\n') + '\n');
+    const fallbackDir = path.join(segmentsRoot, 'writer-format-changed', sessionId, 'segments');
+    await fs.mkdir(fallbackDir, { recursive: true });
+    await fs.writeFile(path.join(fallbackDir, 'fallback.jsonl'), [
+      segModelStart(turnId, 'fallback-request-id', '2026-06-16T10:00:00.000Z'),
+      segModelEnd(turnId, 'fallback-request-id', '2026-06-16T10:00:05.000Z', 'qwork-fallback'),
+    ].map(entry => JSON.stringify(entry)).join('\n') + '\n');
+
+    const input = makeInput();
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    expect(entries.find(entry => entry['event.id'] === 'fallback-response')?.['gen_ai.response.model'])
+      .toBe('qwork-fallback');
+  });
+
+  it('evicts stale segment state even when no later hook entries arrive', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-16T10:00:00.000Z'));
+    const sessionId = 'sess-stale-segment';
+    const turnId = 'turn-stale-segment';
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const toolCall = buildHookEntry({
+      'event.id': 'stale-tool-call',
+      'event.name': 'tool.call' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      'gen_ai.tool.call.id': 'stale-tool',
+    });
+    await fs.writeFile(hookFile, JSON.stringify(toolCall) + '\n');
+    await writeSegments(sessionId, 'stale.jsonl', [
+      segTurnStarted('stale-subagent', true),
+      segModelStart(turnId, 'stale-request', '2026-06-16T10:00:00.000Z'),
+      segModelEnd(turnId, 'stale-request', '2026-06-16T10:00:01.000Z'),
+      segToolRequested(turnId, 'stale-tool', '2026-06-16T10:00:00.100Z'),
+    ]);
+
+    const input = makeInput();
+    await startAndCollect(input);
+    expect((input as any).segmentPairs.size).toBe(1);
+    expect((input as any).subagentTurns.size).toBe(1);
+
+    vi.advanceTimersByTime(60 * 60 * 1000 + 1);
+    await triggerCycle(input);
+    await input.stop();
+
+    expect((input as any).segmentPairs.size).toBe(0);
+    expect((input as any).segmentToolTimings.size).toBe(0);
+    expect((input as any).subagentTurns.size).toBe(0);
+    expect((input as any).inFlightPairs.size).toBe(0);
   });
 
   it('skips subagent LLM pairs when matching to hook steps', async () => {

--- a/tests/unit/inputs/qoder-work-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-work-trace-input.test.ts
@@ -54,6 +54,15 @@ describe('QoderWorkTraceInput', () => {
   function segModelEnd(turnId: string, requestId: string, ts: string, model = 'qwork-ultimate') {
     return { ts, type: 'model.response.completed', turn_id: turnId, request_id: requestId, data: { model } };
   }
+  function segToolRequested(turnId: string, toolCallId: string, ts: string, toolName = 'TodoWrite') {
+    return { ts, type: 'tool.requested', turn_id: turnId, tool_call_id: toolCallId, data: { tool_name: toolName, args: {} } };
+  }
+  function segToolFinished(turnId: string, toolCallId: string, ts: string, toolName = 'TodoWrite') {
+    return { ts, type: 'tool.execution.finished', turn_id: turnId, tool_call_id: toolCallId, data: { tool_name: toolName, status: 'success' } };
+  }
+  function nano(iso: string) {
+    return String(BigInt(Date.parse(iso)) * 1_000_000n);
+  }
 
   function todayFileName() {
     const d = new Date();
@@ -227,9 +236,9 @@ describe('QoderWorkTraceInput', () => {
 
     // Segment: main turn, one LLM pair from 2026-06-16T10:00:00.000Z to 10:00:05.000Z
     await writeSegments(sessionId, 'run1.jsonl', [
-      segTurnStarted('seg-turn-X', false),
-      segModelStart('seg-turn-X', 'req-X', '2026-06-16T10:00:00.000Z', 'qwork-ultimate'),
-      segModelEnd('seg-turn-X', 'req-X', '2026-06-16T10:00:05.000Z', 'qwork-ultimate'),
+      segTurnStarted('hook-turn-1', false),
+      segModelStart('hook-turn-1', 'req-X', '2026-06-16T10:00:00.000Z', 'qwork-ultimate'),
+      segModelEnd('hook-turn-1', 'req-X', '2026-06-16T10:00:05.000Z', 'qwork-ultimate'),
     ]);
 
     const input = makeInput();
@@ -275,9 +284,9 @@ describe('QoderWorkTraceInput', () => {
       segTurnStarted('sub-turn', true),
       segModelStart('sub-turn', 'sub-req', '2026-06-16T09:00:00.000Z', 'qwork-fast'),
       segModelEnd('sub-turn', 'sub-req', '2026-06-16T09:00:01.000Z', 'qwork-fast'),
-      segTurnStarted('main-turn', false),
-      segModelStart('main-turn', 'main-req', '2026-06-16T10:00:00.000Z', 'qwork-ultimate'),
-      segModelEnd('main-turn', 'main-req', '2026-06-16T10:00:05.000Z', 'qwork-ultimate'),
+      segTurnStarted('hook-turn-1', false),
+      segModelStart('hook-turn-1', 'main-req', '2026-06-16T10:00:00.000Z', 'qwork-ultimate'),
+      segModelEnd('hook-turn-1', 'main-req', '2026-06-16T10:00:05.000Z', 'qwork-ultimate'),
     ]);
 
     const input = makeInput();
@@ -317,13 +326,13 @@ describe('QoderWorkTraceInput', () => {
     await fs.writeFile(hookFile, lines.map(l => JSON.stringify(l)).join('\n') + '\n');
 
     await writeSegments(sessionId, 'run1.jsonl', [
-      segTurnStarted('seg-turn-A', false),
-      segModelStart('seg-turn-A', 'r1', '2026-06-16T10:00:00.000Z'),
-      segModelEnd('seg-turn-A', 'r1', '2026-06-16T10:00:01.000Z'),
-      segModelStart('seg-turn-A', 'r2', '2026-06-16T10:00:02.000Z'),
-      segModelEnd('seg-turn-A', 'r2', '2026-06-16T10:00:03.000Z'),
-      segModelStart('seg-turn-A', 'r3', '2026-06-16T10:00:04.000Z'),
-      segModelEnd('seg-turn-A', 'r3', '2026-06-16T10:00:05.000Z'),
+      segTurnStarted(turnId, false),
+      segModelStart(turnId, 'r1', '2026-06-16T10:00:00.000Z'),
+      segModelEnd(turnId, 'r1', '2026-06-16T10:00:01.000Z'),
+      segModelStart(turnId, 'r2', '2026-06-16T10:00:02.000Z'),
+      segModelEnd(turnId, 'r2', '2026-06-16T10:00:03.000Z'),
+      segModelStart(turnId, 'r3', '2026-06-16T10:00:04.000Z'),
+      segModelEnd(turnId, 'r3', '2026-06-16T10:00:05.000Z'),
     ]);
 
     const input = makeInput();
@@ -336,6 +345,161 @@ describe('QoderWorkTraceInput', () => {
     expect(s1Resp.time_unix_nano).toBe(String(BigInt(Date.parse('2026-06-16T10:00:01.000Z')) * 1_000_000n));
     expect(s2Resp.time_unix_nano).toBe(String(BigInt(Date.parse('2026-06-16T10:00:03.000Z')) * 1_000_000n));
     expect(s3Resp.time_unix_nano).toBe(String(BigInt(Date.parse('2026-06-16T10:00:05.000Z')) * 1_000_000n));
+  });
+
+  it('matches segment timing by turn id and uses segment tool timing without consuming background pairs', async () => {
+    const sessionId = 'sess-background-pair';
+    const turnId = 'prompt-real-turn';
+    const toolCallId = 'tool-call-real';
+    const hookFile = path.join(hookLogDir, todayFileName());
+
+    const step1Req = buildHookEntry({
+      'event.id': 's1-req',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      'agent.qoderwork.promptId': turnId,
+      time_unix_nano: nano('2026-06-18T02:37:42.905Z'),
+    });
+    const step1Resp = buildHookEntry({
+      'event.id': 's1-resp',
+      'event.name': 'llm.response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      'agent.qoderwork.promptId': turnId,
+      time_unix_nano: nano('2026-06-18T02:38:05.180Z'),
+    });
+    const step1ToolCall = buildHookEntry({
+      'event.id': 's1-tool-call',
+      'event.name': 'tool.call' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      'gen_ai.tool.call.id': toolCallId,
+      'agent.qoderwork.promptId': turnId,
+      time_unix_nano: nano('2026-06-18T02:38:05.180Z'),
+    });
+    const step1ToolResult = buildHookEntry({
+      'event.id': 's1-tool-result',
+      'event.name': 'tool.result' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      'gen_ai.tool.call.id': toolCallId,
+      'agent.qoderwork.promptId': turnId,
+      time_unix_nano: nano('2026-06-18T02:38:06.722Z'),
+    });
+    const step2Req = buildHookEntry({
+      'event.id': 's2-req',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s2`,
+      'agent.qoderwork.promptId': turnId,
+      time_unix_nano: nano('2026-06-18T02:38:06.722Z'),
+    });
+    const step2Resp = buildHookEntry({
+      'event.id': 's2-resp',
+      'event.name': 'llm.response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s2`,
+      'agent.qoderwork.promptId': turnId,
+      time_unix_nano: nano('2026-06-18T02:38:11.107Z'),
+    });
+
+    await fs.writeFile(hookFile, [
+      step1Req,
+      step1Resp,
+      step1ToolCall,
+      step1ToolResult,
+      step2Req,
+      step2Resp,
+    ].map(l => JSON.stringify(l)).join('\n') + '\n');
+
+    await writeSegments(sessionId, 'run1.jsonl', [
+      segModelStart('qoderwork-memory-sink-fork-qoderwork-memory-sink', 'memory-1', '2026-06-18T09:39:42.866+08:00'),
+      segModelEnd('qoderwork-memory-sink-fork-qoderwork-memory-sink', 'memory-1', '2026-06-18T09:39:50.736+08:00'),
+      segModelStart(turnId, 'real-1', '2026-06-18T10:37:43.032+08:00'),
+      segToolRequested(turnId, toolCallId, '2026-06-18T10:38:05.093+08:00'),
+      segModelEnd(turnId, 'real-1', '2026-06-18T10:38:05.168+08:00'),
+      segToolFinished(turnId, toolCallId, '2026-06-18T10:38:06.616+08:00'),
+      segModelStart(turnId, 'real-2', '2026-06-18T10:38:06.840+08:00'),
+      segModelEnd(turnId, 'real-2', '2026-06-18T10:38:11.107+08:00'),
+    ]);
+
+    const input = makeInput();
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    expect(entries.find(e => e['event.id'] === 's1-req')!.time_unix_nano).toBe(nano('2026-06-18T10:37:43.032+08:00'));
+    expect(entries.find(e => e['event.id'] === 's1-resp')!.time_unix_nano).toBe(nano('2026-06-18T10:38:05.168+08:00'));
+    expect(entries.find(e => e['event.id'] === 's1-tool-call')!.time_unix_nano).toBe(nano('2026-06-18T10:38:05.093+08:00'));
+    expect(entries.find(e => e['event.id'] === 's1-tool-result')!.time_unix_nano).toBe(nano('2026-06-18T10:38:06.616+08:00'));
+    expect(entries.find(e => e['event.id'] === 's2-req')!.time_unix_nano).toBe(nano('2026-06-18T10:38:06.840+08:00'));
+    expect(entries.find(e => e['event.id'] === 's2-resp')!.time_unix_nano).toBe(nano('2026-06-18T10:38:11.107+08:00'));
+  });
+
+  it('retains segment tool timing when tool.call and tool.result arrive in separate batches', async () => {
+    const sessionId = 'sess-split-tool';
+    const turnId = 'prompt-split-tool';
+    const toolCallId = 'tool-call-split';
+    const hookFile = path.join(hookLogDir, todayFileName());
+
+    const req = buildHookEntry({
+      'event.id': 'req',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: nano('2026-06-18T02:00:00.000Z'),
+    });
+    const resp = buildHookEntry({
+      'event.id': 'resp',
+      'event.name': 'llm.response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: nano('2026-06-18T02:00:05.000Z'),
+    });
+    const toolCall = buildHookEntry({
+      'event.id': 'tool-call',
+      'event.name': 'tool.call' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      'gen_ai.tool.call.id': toolCallId,
+      time_unix_nano: nano('2026-06-18T02:00:05.100Z'),
+    });
+    const toolResult = buildHookEntry({
+      'event.id': 'tool-result',
+      'event.name': 'tool.result' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      'gen_ai.tool.call.id': toolCallId,
+      time_unix_nano: nano('2026-06-18T02:00:06.900Z'),
+    });
+
+    await fs.writeFile(hookFile, [req, resp, toolCall].map(l => JSON.stringify(l)).join('\n') + '\n');
+    await writeSegments(sessionId, 'run1.jsonl', [
+      segModelStart(turnId, 'r1', '2026-06-18T10:00:00.000+08:00'),
+      segToolRequested(turnId, toolCallId, '2026-06-18T10:00:05.050+08:00'),
+      segModelEnd(turnId, 'r1', '2026-06-18T10:00:05.200+08:00'),
+      segToolFinished(turnId, toolCallId, '2026-06-18T10:00:06.700+08:00'),
+    ]);
+
+    const input = makeInput();
+    const firstBatch = await startAndCollect(input);
+    expect(firstBatch.find(e => e['event.id'] === 'tool-call')!.time_unix_nano).toBe(nano('2026-06-18T10:00:05.050+08:00'));
+
+    await fs.appendFile(hookFile, JSON.stringify(toolResult) + '\n');
+    const secondBatch = await triggerCycle(input);
+    await input.stop();
+
+    expect(secondBatch.find(e => e['event.id'] === 'tool-result')!.time_unix_nano).toBe(nano('2026-06-18T10:00:06.700+08:00'));
   });
 
   it('keeps hook timing when segments are unavailable', async () => {
@@ -369,7 +533,7 @@ describe('QoderWorkTraceInput', () => {
     expect(respOut.time_unix_nano).toBe('1700001000000000000');
   });
 
-  it('aligns tool.call timestamp to segment llm.response', async () => {
+  it('keeps hook tool.call timestamp when segments have no tool.requested event', async () => {
     const sessionId = 'sess-tc';
     const hookFile = path.join(hookLogDir, todayFileName());
 
@@ -400,18 +564,17 @@ describe('QoderWorkTraceInput', () => {
     await fs.writeFile(hookFile, [JSON.stringify(req), JSON.stringify(resp), JSON.stringify(toolCall)].join('\n') + '\n');
 
     await writeSegments(sessionId, 'run1.jsonl', [
-      segTurnStarted('seg-turn', false),
-      segModelStart('seg-turn', 'r1', '2026-06-16T10:00:00.000Z'),
-      segModelEnd('seg-turn', 'r1', '2026-06-16T10:00:05.000Z'),
+      segTurnStarted('turn-tc', false),
+      segModelStart('turn-tc', 'r1', '2026-06-16T10:00:00.000Z'),
+      segModelEnd('turn-tc', 'r1', '2026-06-16T10:00:05.000Z'),
     ]);
 
     const input = makeInput();
     const entries = await startAndCollect(input);
     await input.stop();
 
-    const endNano = String(BigInt(Date.parse('2026-06-16T10:00:05.000Z')) * 1_000_000n);
     const tcOut = entries.find(e => e['event.id'] === 'tc')!;
-    expect(tcOut.time_unix_nano).toBe(endNano);
+    expect(tcOut.time_unix_nano).toBe('999999999999000000');
   });
 });
 

--- a/tests/unit/inputs/qoder-work-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-work-trace-input.test.ts
@@ -10,17 +10,19 @@ import { MockStateStore } from '../../helpers/mock-state-store.js';
 describe('QoderWorkTraceInput', () => {
   let tmpRoot: string;
   let hookLogDir: string;
-  let sdkLogDir: string;
+  let segmentsRoot: string;
   let stateStore: MockStateStore;
+
+  const TEST_CWD = '/Users/test/.qoderwork/workspace/wsabc';
+  const TEST_CWD_ENCODED = '-Users-test--qoderwork-workspace-wsabc';
 
   beforeEach(async () => {
     tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'qoder-work-trace-test-'));
     hookLogDir = path.join(tmpRoot, 'hook-history');
-    sdkLogDir = path.join(tmpRoot, 'sdk-logs');
+    segmentsRoot = path.join(tmpRoot, 'sessions');
     await fs.mkdir(hookLogDir, { recursive: true });
-    await fs.mkdir(sdkLogDir, { recursive: true });
+    await fs.mkdir(segmentsRoot, { recursive: true });
     stateStore = new MockStateStore();
-    sdkLineCounter = 0;
   });
 
   afterEach(async () => {
@@ -31,8 +33,26 @@ describe('QoderWorkTraceInput', () => {
     return new QoderWorkTraceInput({
       stateStore: stateStore as any,
       logDir: hookLogDir,
-      sdkLogDir,
+      segmentsRoot,
     });
+  }
+
+  async function writeSegments(sessionId: string, runFile: string, lines: object[]) {
+    const segDir = path.join(segmentsRoot, TEST_CWD_ENCODED, sessionId, 'segments');
+    await fs.mkdir(segDir, { recursive: true });
+    const filePath = path.join(segDir, runFile);
+    await fs.writeFile(filePath, lines.map(l => JSON.stringify(l)).join('\n') + '\n');
+    return filePath;
+  }
+
+  function segTurnStarted(turnId: string, isSubagent = false, ts = '2026-06-16T10:00:00.000Z') {
+    return { ts, type: 'turn.started', turn_id: turnId, data: { is_subagent: isSubagent } };
+  }
+  function segModelStart(turnId: string, requestId: string, ts: string, model = 'qwork-ultimate') {
+    return { ts, type: 'model.request.started', turn_id: turnId, request_id: requestId, data: { model } };
+  }
+  function segModelEnd(turnId: string, requestId: string, ts: string, model = 'qwork-ultimate') {
+    return { ts, type: 'model.response.completed', turn_id: turnId, request_id: requestId, data: { model } };
   }
 
   function todayFileName() {
@@ -50,37 +70,10 @@ describe('QoderWorkTraceInput', () => {
       'gen_ai.agent.type': ClientType.QoderWork,
       'gen_ai.output.messages': '[{"role":"assistant","parts":[{"type":"reasoning","content":"thinking"},{"type":"text","content":"hello"}]}]',
       'agent.source': 'qoder-transcript-hook',
+      'agent.qoderwork.cwd': TEST_CWD,
       time_unix_nano: '1780000000000000000',
       ...overrides,
     } as AgentActivityEntry;
-  }
-
-  let sdkLineCounter = 0;
-
-  function buildSdkMessageStartLine(sessionId: string, messageId: string, ts?: string): string {
-    const timestamp = ts ?? new Date(Date.now() + sdkLineCounter * 1000).toISOString();
-    sdkLineCounter++;
-    return `[${timestamp}] [INFO] [SDK] [QueryHandler] Received message: stream_event {"event":{"message":{"id":"${messageId}"},"type":"message_start"},"session_id":"${sessionId}","type":"stream_event","uuid":"uuid-${sdkLineCounter}"}`;
-  }
-
-  function buildSdkMessageDeltaLine(sessionId: string, inputTokens: number, outputTokens: number, ts?: string): string {
-    const timestamp = ts ?? new Date(Date.now() + sdkLineCounter * 1000).toISOString();
-    sdkLineCounter++;
-    return `[${timestamp}] [INFO] [SDK] [QueryHandler] Received message: stream_event {"event":{"delta":{"stop_reason":"end_turn"},"type":"message_delta","usage":{"input_tokens":${inputTokens},"output_tokens":${outputTokens}}},"session_id":"${sessionId}","type":"stream_event","uuid":"uuid-${sdkLineCounter}"}`;
-  }
-
-  function buildSdkModelPolicyLine(chatModel: string, ts?: string): string {
-    const timestamp = ts ?? new Date(Date.now() + sdkLineCounter * 1000).toISOString();
-    sdkLineCounter++;
-    return `[${timestamp}] [INFO] [SDK] [QueryHandler] Sending control request: set_model_policy {"requestId":"rq-1","request":{"type":"control","request_id":"rq-1","request":{"subtype":"set_model_policy","chat":{"model":"${chatModel}"},"compact":{"model":"auto"},"scene_model":{"model":"auto"}}}}`;
-  }
-
-  // 生成一对 message_start + message_delta 行
-  function buildSdkMessagePair(sessionId: string, messageId: string, inputTokens: number, outputTokens: number, startTs?: string, endTs?: string): string[] {
-    return [
-      buildSdkMessageStartLine(sessionId, messageId, startTs),
-      buildSdkMessageDeltaLine(sessionId, inputTokens, outputTokens, endTs),
-    ];
   }
 
   it('has correct identity', () => {
@@ -122,317 +115,73 @@ describe('QoderWorkTraceInput', () => {
     await input.stop();
   });
 
-  it('enriches each step llm.response with its own tokens from SDK log', async () => {
-    const sessionId = 'sess-token-test';
-    const hookFile = path.join(hookLogDir, todayFileName());
-    const resp1 = buildHookEntry({ 'event.id': 'r1', 'gen_ai.session.id': sessionId, 'gen_ai.turn.id': 'turn-1', 'gen_ai.step.id': 'turn-1:s1' });
-    const resp2 = buildHookEntry({ 'event.id': 'r2', 'gen_ai.session.id': sessionId, 'gen_ai.turn.id': 'turn-1', 'gen_ai.step.id': 'turn-1:s2' });
-    await fs.writeFile(hookFile, [JSON.stringify(resp1), JSON.stringify(resp2)].join('\n') + '\n');
-
-    // SDK log: 2 message pairs for 2 steps
-    const sessionDir = path.join(sdkLogDir, '202606041000');
-    await fs.mkdir(sessionDir, { recursive: true });
-    const sdkFile = path.join(sessionDir, 'main.log');
-    const lines = [
-      ...buildSdkMessagePair(sessionId, 'msg-1', 5000, 200),
-      ...buildSdkMessagePair(sessionId, 'msg-2', 3000, 100),
-    ];
-    await fs.writeFile(sdkFile, lines.join('\n') + '\n');
-
-    const input = makeInput();
-    const entries = await startAndCollect(input);
-    await input.stop();
-
-    const responses = entries.filter(e => e['event.name'] === 'llm.response');
-    expect(responses.length).toBe(2);
-    // Step 1 gets first SDK message
-    expect(responses[0]['gen_ai.usage.input_tokens']).toBe(5000);
-    expect(responses[0]['gen_ai.usage.output_tokens']).toBe(200);
-    expect(responses[0]['gen_ai.usage.total_tokens']).toBe(5200);
-    // Step 2 gets second SDK message
-    expect(responses[1]['gen_ai.usage.input_tokens']).toBe(3000);
-    expect(responses[1]['gen_ai.usage.output_tokens']).toBe(100);
-    expect(responses[1]['gen_ai.usage.total_tokens']).toBe(3100);
-  });
-
-  it('handles SDK log inode rotation', async () => {
-    const sessionId = 'sess-rotate';
-    const hookFile = path.join(hookLogDir, todayFileName());
-    const resp = buildHookEntry({ 'gen_ai.session.id': sessionId, 'gen_ai.turn.id': 'turn-1' });
-    await fs.writeFile(hookFile, JSON.stringify(resp) + '\n');
-
-    const sessionDir = path.join(sdkLogDir, '202606041000');
-    await fs.mkdir(sessionDir, { recursive: true });
-    const sdkFile = path.join(sessionDir, 'main.log');
-    const lines1 = buildSdkMessagePair(sessionId, 'msg-r1', 1000, 50);
-    await fs.writeFile(sdkFile, lines1.join('\n') + '\n');
-
-    const input = makeInput();
-    const batch1 = await startAndCollect(input);
-    expect(batch1[0]['gen_ai.usage.input_tokens']).toBe(1000);
-
-    // Simulate rotation: rename old file first then create new one.
-    // Keep old file alive during creation to prevent inode reuse on Linux.
-    const oldSdkFile = sdkFile + '.old';
-    await fs.rename(sdkFile, oldSdkFile);
-    const lines2 = buildSdkMessagePair(sessionId, 'msg-r2', 2000, 100);
-    await fs.writeFile(sdkFile, lines2.join('\n') + '\n');
-    await fs.rm(oldSdkFile);
-
-    // Write new hook entry
-    const resp2 = buildHookEntry({ 'event.id': 'r2', 'gen_ai.session.id': sessionId, 'gen_ai.turn.id': 'turn-2' });
-    await fs.appendFile(hookFile, JSON.stringify(resp2) + '\n');
-
-    const batch2 = await triggerCycle(input);
-    const responses2 = batch2.filter(e => e['event.name'] === 'llm.response');
-    expect(responses2[0]['gen_ai.usage.input_tokens']).toBe(2000);
-    await input.stop();
-  });
-
-  it('enriches each step independently across multi-step turn (tool_use scenario)', async () => {
-    const sessionId = 'sess-multi-step';
-    const hookFile = path.join(hookLogDir, todayFileName());
-    // Turn 1: 2 steps
-    const resp1 = buildHookEntry({ 'event.id': 'r1', 'gen_ai.session.id': sessionId, 'gen_ai.turn.id': 'turn-1', 'gen_ai.step.id': 'turn-1:s1' });
-    const resp2 = buildHookEntry({ 'event.id': 'r2', 'gen_ai.session.id': sessionId, 'gen_ai.turn.id': 'turn-1', 'gen_ai.step.id': 'turn-1:s2' });
-    // Turn 2: 1 step
-    const resp3 = buildHookEntry({ 'event.id': 'r3', 'gen_ai.session.id': sessionId, 'gen_ai.turn.id': 'turn-2', 'gen_ai.step.id': 'turn-2:s1' });
-    await fs.writeFile(hookFile, [JSON.stringify(resp1), JSON.stringify(resp2), JSON.stringify(resp3)].join('\n') + '\n');
-
-    // SDK log: 3 message pairs (one per LLM call / step)
-    const sessionDir = path.join(sdkLogDir, '202606041000');
-    await fs.mkdir(sessionDir, { recursive: true });
-    const sdkFile = path.join(sessionDir, 'main.log');
-    const lines = [
-      ...buildSdkMessagePair(sessionId, 'msg-1', 1000, 50),
-      ...buildSdkMessagePair(sessionId, 'msg-2', 2000, 100),
-      ...buildSdkMessagePair(sessionId, 'msg-3', 3000, 150),
-    ];
-    await fs.writeFile(sdkFile, lines.join('\n') + '\n');
-
-    const input = makeInput();
-    const entries = await startAndCollect(input);
-    await input.stop();
-
-    const turn1Responses = entries.filter(e => e['gen_ai.turn.id'] === 'turn-1' && e['event.name'] === 'llm.response');
-    const turn2Responses = entries.filter(e => e['gen_ai.turn.id'] === 'turn-2' && e['event.name'] === 'llm.response');
-
-    // Turn 1, step 1: own tokens
-    expect(turn1Responses[0]['gen_ai.usage.input_tokens']).toBe(1000);
-    expect(turn1Responses[0]['gen_ai.usage.output_tokens']).toBe(50);
-    expect(turn1Responses[0]['gen_ai.usage.total_tokens']).toBe(1050);
-    // Turn 1, step 2: own tokens
-    expect(turn1Responses[1]['gen_ai.usage.input_tokens']).toBe(2000);
-    expect(turn1Responses[1]['gen_ai.usage.output_tokens']).toBe(100);
-    expect(turn1Responses[1]['gen_ai.usage.total_tokens']).toBe(2100);
-
-    // Turn 2: gets its own token, NOT leaked from turn 1
-    expect(turn2Responses[0]['gen_ai.usage.input_tokens']).toBe(3000);
-    expect(turn2Responses[0]['gen_ai.usage.output_tokens']).toBe(150);
-    expect(turn2Responses[0]['gen_ai.usage.total_tokens']).toBe(3150);
-  });
-
-  it('persists SDK message buffer across collect() cycles', async () => {
-    const sessionId = 'sess-cross-cycle';
+  it('caps tool.result to not exceed next step llm.request', async () => {
+    // Step 1 has a long-running tool whose result ts overshoots step 2's
+    // llm.request. The clamp prevents STEP spans from overlapping.
+    const sessionId = 'sess-cap';
+    const turnId = 'turn-cap';
     const hookFile = path.join(hookLogDir, todayFileName());
 
-    // Cycle 1: SDK log arrives but no hook JSONL yet
-    const sessionDir = path.join(sdkLogDir, '202606041000');
-    await fs.mkdir(sessionDir, { recursive: true });
-    const sdkFile = path.join(sessionDir, 'main.log');
-    const sdkLines = buildSdkMessagePair(sessionId, 'msg-cc', 4000, 250);
-    await fs.writeFile(sdkFile, sdkLines.join('\n') + '\n');
-
-    const input = makeInput();
-    const batch1 = await startAndCollect(input);
-    expect(batch1.length).toBe(0);
-
-    // Cycle 2: hook JSONL arrives — should find buffered SDK data
-    const resp = buildHookEntry({ 'gen_ai.session.id': sessionId, 'gen_ai.turn.id': 'turn-1' });
-    await fs.writeFile(hookFile, JSON.stringify(resp) + '\n');
-
-    const batch2 = await triggerCycle(input);
-    await input.stop();
-
-    expect(batch2.length).toBe(1);
-    expect(batch2[0]['gen_ai.usage.input_tokens']).toBe(4000);
-    expect(batch2[0]['gen_ai.usage.output_tokens']).toBe(250);
-  });
-
-  it('enriches timing from SDK log message_start/message_delta', async () => {
-    const sessionId = 'sess-timing';
-    const hookFile = path.join(hookLogDir, todayFileName());
-
-    // Hook entry with request + response in same step
-    const request = buildHookEntry({
-      'event.id': 'req-1',
+    const step1Req = buildHookEntry({
+      'event.id': 's1-req',
       'event.name': 'llm.request' as any,
       'gen_ai.session.id': sessionId,
-      'gen_ai.turn.id': 'turn-1',
-      'gen_ai.step.id': 'turn-1:s1',
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: '1000000000000000000', // t=1000s
     });
-    const response = buildHookEntry({
-      'event.id': 'resp-1',
+    const step1Resp = buildHookEntry({
+      'event.id': 's1-resp',
       'event.name': 'llm.response',
       'gen_ai.session.id': sessionId,
-      'gen_ai.turn.id': 'turn-1',
-      'gen_ai.step.id': 'turn-1:s1',
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: '1010000000000000000', // t=1010s
     });
-    await fs.writeFile(hookFile, [JSON.stringify(request), JSON.stringify(response)].join('\n') + '\n');
-
-    // SDK log with precise timestamps
-    const startTs = '2026-06-04T10:00:01.000Z';
-    const endTs = '2026-06-04T10:00:05.500Z';
-    const sessionDir = path.join(sdkLogDir, '202606041000');
-    await fs.mkdir(sessionDir, { recursive: true });
-    const sdkFile = path.join(sessionDir, 'main.log');
-    const sdkLines = buildSdkMessagePair(sessionId, 'msg-t1', 1000, 50, startTs, endTs);
-    await fs.writeFile(sdkFile, sdkLines.join('\n') + '\n');
-
-    const input = makeInput();
-    const entries = await startAndCollect(input);
-    await input.stop();
-
-    const req = entries.find(e => e['event.name'] === 'llm.request');
-    const resp = entries.find(e => e['event.name'] === 'llm.response');
-    // request 时间戳应被覆盖为 message_start 的时间
-    expect(req!.time_unix_nano).toBe(String(BigInt(Date.parse(startTs)) * 1_000_000n));
-    // response 时间戳应被覆盖为 message_delta 的时间
-    expect(resp!.time_unix_nano).toBe(String(BigInt(Date.parse(endTs)) * 1_000_000n));
-    // 确保 duration > 0
-    expect(BigInt(resp!.time_unix_nano)).toBeGreaterThan(BigInt(req!.time_unix_nano));
-  });
-
-  it('enriches model from SDK log set_model_policy', async () => {
-    const sessionId = 'sess-model';
-    const hookFile = path.join(hookLogDir, todayFileName());
-    const resp = buildHookEntry({
+    const step1Tool = buildHookEntry({
+      'event.id': 's1-tool',
+      'event.name': 'tool.result' as any,
       'gen_ai.session.id': sessionId,
-      'gen_ai.turn.id': 'turn-1',
-      'gen_ai.request.model': 'auto',
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: '1500000000000000000', // t=1500s (overshoots s2)
     });
-    await fs.writeFile(hookFile, JSON.stringify(resp) + '\n');
-
-    // SDK log with model policy
-    const sessionDir = path.join(sdkLogDir, '202606041000');
-    await fs.mkdir(sessionDir, { recursive: true });
-    const sdkFile = path.join(sessionDir, 'main.log');
-    const lines = [
-      buildSdkModelPolicyLine('qwork-ultimate'),
-      ...buildSdkMessagePair(sessionId, 'msg-m1', 1000, 50),
-    ];
-    await fs.writeFile(sdkFile, lines.join('\n') + '\n');
-
-    const input = makeInput();
-    const entries = await startAndCollect(input);
-    await input.stop();
-
-    expect(entries[0]['gen_ai.request.model']).toBe('qwork-ultimate');
-    expect(entries[0]['gen_ai.response.model']).toBe('qwork-ultimate');
-  });
-
-  it('gracefully degrades when SDK log has no message_delta', async () => {
-    const sessionId = 'sess-no-delta';
-    const hookFile = path.join(hookLogDir, todayFileName());
-    const resp = buildHookEntry({
-      'gen_ai.session.id': sessionId,
-      'gen_ai.turn.id': 'turn-1',
-      'gen_ai.request.model': 'auto',
-    });
-    await fs.writeFile(hookFile, JSON.stringify(resp) + '\n');
-
-    // SDK log with only message_start (no message_delta)
-    const sessionDir = path.join(sdkLogDir, '202606041000');
-    await fs.mkdir(sessionDir, { recursive: true });
-    const sdkFile = path.join(sessionDir, 'main.log');
-    await fs.writeFile(sdkFile, buildSdkMessageStartLine(sessionId, 'msg-orphan') + '\n');
-
-    const input = makeInput();
-    const entries = await startAndCollect(input);
-    await input.stop();
-
-    // Should not crash; model stays 'auto' since no policy line, tokens undefined
-    expect(entries.length).toBe(1);
-    expect(entries[0]['gen_ai.request.model']).toBe('auto');
-    expect(entries[0]['gen_ai.usage.input_tokens']).toBeUndefined();
-  });
-
-  it('isolates model policy per SDK log file', async () => {
-    const sessionId = 'sess-iso';
-    const hookFile = path.join(hookLogDir, todayFileName());
-    const resp = buildHookEntry({
-      'gen_ai.session.id': sessionId,
-      'gen_ai.turn.id': 'turn-1',
-      'gen_ai.request.model': 'auto',
-    });
-    await fs.writeFile(hookFile, JSON.stringify(resp) + '\n');
-
-    // File 1: sets model to qwork-ultimate
-    const sessionDir1 = path.join(sdkLogDir, '202606041000');
-    await fs.mkdir(sessionDir1, { recursive: true });
-    const sdkFile1 = path.join(sessionDir1, 'main.log');
-    await fs.writeFile(sdkFile1, buildSdkModelPolicyLine('qwork-ultimate') + '\n');
-
-    // File 2: sets different model, has the actual message pair
-    const sessionDir2 = path.join(sdkLogDir, '202606041001');
-    await fs.mkdir(sessionDir2, { recursive: true });
-    const sdkFile2 = path.join(sessionDir2, 'main.log');
-    const lines = [
-      buildSdkModelPolicyLine('qwork-standard'),
-      ...buildSdkMessagePair(sessionId, 'msg-iso', 500, 25),
-    ];
-    await fs.writeFile(sdkFile2, lines.join('\n') + '\n');
-
-    const input = makeInput();
-    const entries = await startAndCollect(input);
-    await input.stop();
-
-    // The last file processed sets currentModelPolicy, so model should be from file 2
-    expect(entries[0]['gen_ai.request.model']).toBe('qwork-standard');
-  });
-
-  it('enriches tool.call timestamps with response time', async () => {
-    const sessionId = 'sess-tool-ts';
-    const hookFile = path.join(hookLogDir, todayFileName());
-
-    const request = buildHookEntry({
-      'event.id': 'req-t1',
+    const step2Req = buildHookEntry({
+      'event.id': 's2-req',
       'event.name': 'llm.request' as any,
       'gen_ai.session.id': sessionId,
-      'gen_ai.turn.id': 'turn-1',
-      'gen_ai.step.id': 'turn-1:s1',
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s2`,
+      time_unix_nano: '1200000000000000000', // t=1200s
     });
-    const response = buildHookEntry({
-      'event.id': 'resp-t1',
+    const step2Resp = buildHookEntry({
+      'event.id': 's2-resp',
       'event.name': 'llm.response',
       'gen_ai.session.id': sessionId,
-      'gen_ai.turn.id': 'turn-1',
-      'gen_ai.step.id': 'turn-1:s1',
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s2`,
+      time_unix_nano: '1210000000000000000',
     });
-    const toolCall = buildHookEntry({
-      'event.id': 'tc-t1',
-      'event.name': 'tool.call' as any,
-      'gen_ai.session.id': sessionId,
-      'gen_ai.turn.id': 'turn-1',
-      'gen_ai.step.id': 'turn-1:s1',
-    });
-    await fs.writeFile(hookFile, [JSON.stringify(request), JSON.stringify(response), JSON.stringify(toolCall)].join('\n') + '\n');
 
-    const endTs = '2026-06-04T10:00:05.500Z';
-    const sessionDir = path.join(sdkLogDir, '202606041000');
-    await fs.mkdir(sessionDir, { recursive: true });
-    const sdkFile = path.join(sessionDir, 'main.log');
-    const sdkLines = buildSdkMessagePair(sessionId, 'msg-tc', 1000, 50, undefined, endTs);
-    await fs.writeFile(sdkFile, sdkLines.join('\n') + '\n');
+    await fs.writeFile(hookFile, [
+      JSON.stringify(step1Req),
+      JSON.stringify(step1Resp),
+      JSON.stringify(step1Tool),
+      JSON.stringify(step2Req),
+      JSON.stringify(step2Resp),
+    ].join('\n') + '\n');
 
     const input = makeInput();
     const entries = await startAndCollect(input);
     await input.stop();
 
-    const tc = entries.find(e => e['event.name'] === 'tool.call');
-    const resp = entries.find(e => e['event.name'] === 'llm.response');
-    expect(tc!.time_unix_nano).toBe(String(BigInt(Date.parse(endTs)) * 1_000_000n));
-    expect(tc!.time_unix_nano).toBe(resp!.time_unix_nano);
+    const clamped = entries.find(e => e['event.id'] === 's1-tool');
+    expect(clamped).toBeDefined();
+    // tool.result ts must be clamped to just before step 2's llm.request (1200s - 1ms)
+    expect(clamped!.time_unix_nano).toBe('1199999999999000000');
+    // Non-tool entries stay untouched
+    expect(entries.find(e => e['event.id'] === 's1-resp')!.time_unix_nano).toBe('1010000000000000000');
+    expect(entries.find(e => e['event.id'] === 's2-req')!.time_unix_nano).toBe('1200000000000000000');
   });
 
   it('assigns unique trace_id per turn group', async () => {
@@ -451,6 +200,219 @@ describe('QoderWorkTraceInput', () => {
     expect(entries[1].trace_id).toBe(traceA);
     expect(entries[2].trace_id).not.toBe(traceA);
   });
+
+  it('overrides llm.request/response time and model from segments', async () => {
+    const sessionId = 'sess-seg';
+    const hookFile = path.join(hookLogDir, todayFileName());
+
+    const req = buildHookEntry({
+      'event.id': 'req',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': 'hook-turn-1',
+      'gen_ai.step.id': 'hook-turn-1:s1',
+      'gen_ai.request.model': 'auto',
+      time_unix_nano: '1000000000000000000',
+    });
+    const resp = buildHookEntry({
+      'event.id': 'resp',
+      'event.name': 'llm.response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': 'hook-turn-1',
+      'gen_ai.step.id': 'hook-turn-1:s1',
+      'gen_ai.request.model': 'auto',
+      time_unix_nano: '1000010000000000000',
+    });
+    await fs.writeFile(hookFile, [JSON.stringify(req), JSON.stringify(resp)].join('\n') + '\n');
+
+    // Segment: main turn, one LLM pair from 2026-06-16T10:00:00.000Z to 10:00:05.000Z
+    await writeSegments(sessionId, 'run1.jsonl', [
+      segTurnStarted('seg-turn-X', false),
+      segModelStart('seg-turn-X', 'req-X', '2026-06-16T10:00:00.000Z', 'qwork-ultimate'),
+      segModelEnd('seg-turn-X', 'req-X', '2026-06-16T10:00:05.000Z', 'qwork-ultimate'),
+    ]);
+
+    const input = makeInput();
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const startNano = String(BigInt(Date.parse('2026-06-16T10:00:00.000Z')) * 1_000_000n);
+    const endNano = String(BigInt(Date.parse('2026-06-16T10:00:05.000Z')) * 1_000_000n);
+
+    const reqOut = entries.find(e => e['event.id'] === 'req')!;
+    const respOut = entries.find(e => e['event.id'] === 'resp')!;
+    expect(reqOut.time_unix_nano).toBe(startNano);
+    expect(respOut.time_unix_nano).toBe(endNano);
+    expect(reqOut['gen_ai.request.model']).toBe('qwork-ultimate');
+    expect(respOut['gen_ai.request.model']).toBe('qwork-ultimate');
+    expect(respOut['gen_ai.response.model']).toBe('qwork-ultimate');
+  });
+
+  it('skips subagent LLM pairs when matching to hook steps', async () => {
+    const sessionId = 'sess-sub';
+    const hookFile = path.join(hookLogDir, todayFileName());
+
+    const req = buildHookEntry({
+      'event.id': 'req',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': 'hook-turn-1',
+      'gen_ai.step.id': 'hook-turn-1:s1',
+      time_unix_nano: '1000000000000000000',
+    });
+    const resp = buildHookEntry({
+      'event.id': 'resp',
+      'event.name': 'llm.response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': 'hook-turn-1',
+      'gen_ai.step.id': 'hook-turn-1:s1',
+      time_unix_nano: '1000010000000000000',
+    });
+    await fs.writeFile(hookFile, [JSON.stringify(req), JSON.stringify(resp)].join('\n') + '\n');
+
+    // Segments: subagent LLM (should be ignored) THEN main LLM
+    await writeSegments(sessionId, 'run1.jsonl', [
+      segTurnStarted('sub-turn', true),
+      segModelStart('sub-turn', 'sub-req', '2026-06-16T09:00:00.000Z', 'qwork-fast'),
+      segModelEnd('sub-turn', 'sub-req', '2026-06-16T09:00:01.000Z', 'qwork-fast'),
+      segTurnStarted('main-turn', false),
+      segModelStart('main-turn', 'main-req', '2026-06-16T10:00:00.000Z', 'qwork-ultimate'),
+      segModelEnd('main-turn', 'main-req', '2026-06-16T10:00:05.000Z', 'qwork-ultimate'),
+    ]);
+
+    const input = makeInput();
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const respOut = entries.find(e => e['event.id'] === 'resp')!;
+    // Should consume the MAIN turn pair, not the subagent one
+    expect(respOut['gen_ai.response.model']).toBe('qwork-ultimate');
+    expect(respOut.time_unix_nano).toBe(String(BigInt(Date.parse('2026-06-16T10:00:05.000Z')) * 1_000_000n));
+  });
+
+  it('matches multiple hook steps to multiple segment pairs in FIFO order', async () => {
+    const sessionId = 'sess-multi';
+    const turnId = 'hook-turn-multi';
+    const hookFile = path.join(hookLogDir, todayFileName());
+
+    const lines: AgentActivityEntry[] = [];
+    for (let i = 1; i <= 3; i++) {
+      lines.push(buildHookEntry({
+        'event.id': `s${i}-req`,
+        'event.name': 'llm.request' as any,
+        'gen_ai.session.id': sessionId,
+        'gen_ai.turn.id': turnId,
+        'gen_ai.step.id': `${turnId}:s${i}`,
+        time_unix_nano: '1000000000000000000',
+      }));
+      lines.push(buildHookEntry({
+        'event.id': `s${i}-resp`,
+        'event.name': 'llm.response',
+        'gen_ai.session.id': sessionId,
+        'gen_ai.turn.id': turnId,
+        'gen_ai.step.id': `${turnId}:s${i}`,
+        time_unix_nano: '1000010000000000000',
+      }));
+    }
+    await fs.writeFile(hookFile, lines.map(l => JSON.stringify(l)).join('\n') + '\n');
+
+    await writeSegments(sessionId, 'run1.jsonl', [
+      segTurnStarted('seg-turn-A', false),
+      segModelStart('seg-turn-A', 'r1', '2026-06-16T10:00:00.000Z'),
+      segModelEnd('seg-turn-A', 'r1', '2026-06-16T10:00:01.000Z'),
+      segModelStart('seg-turn-A', 'r2', '2026-06-16T10:00:02.000Z'),
+      segModelEnd('seg-turn-A', 'r2', '2026-06-16T10:00:03.000Z'),
+      segModelStart('seg-turn-A', 'r3', '2026-06-16T10:00:04.000Z'),
+      segModelEnd('seg-turn-A', 'r3', '2026-06-16T10:00:05.000Z'),
+    ]);
+
+    const input = makeInput();
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const s1Resp = entries.find(e => e['event.id'] === 's1-resp')!;
+    const s2Resp = entries.find(e => e['event.id'] === 's2-resp')!;
+    const s3Resp = entries.find(e => e['event.id'] === 's3-resp')!;
+    expect(s1Resp.time_unix_nano).toBe(String(BigInt(Date.parse('2026-06-16T10:00:01.000Z')) * 1_000_000n));
+    expect(s2Resp.time_unix_nano).toBe(String(BigInt(Date.parse('2026-06-16T10:00:03.000Z')) * 1_000_000n));
+    expect(s3Resp.time_unix_nano).toBe(String(BigInt(Date.parse('2026-06-16T10:00:05.000Z')) * 1_000_000n));
+  });
+
+  it('keeps hook timing when segments are unavailable', async () => {
+    const sessionId = 'sess-no-seg';
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const req = buildHookEntry({
+      'event.id': 'req',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': 'turn-x',
+      'gen_ai.step.id': 'turn-x:s1',
+      time_unix_nano: '1700000000000000000',
+    });
+    const resp = buildHookEntry({
+      'event.id': 'resp',
+      'event.name': 'llm.response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': 'turn-x',
+      'gen_ai.step.id': 'turn-x:s1',
+      time_unix_nano: '1700001000000000000',
+    });
+    await fs.writeFile(hookFile, [JSON.stringify(req), JSON.stringify(resp)].join('\n') + '\n');
+
+    const input = makeInput();
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const reqOut = entries.find(e => e['event.id'] === 'req')!;
+    const respOut = entries.find(e => e['event.id'] === 'resp')!;
+    expect(reqOut.time_unix_nano).toBe('1700000000000000000');
+    expect(respOut.time_unix_nano).toBe('1700001000000000000');
+  });
+
+  it('aligns tool.call timestamp to segment llm.response', async () => {
+    const sessionId = 'sess-tc';
+    const hookFile = path.join(hookLogDir, todayFileName());
+
+    const req = buildHookEntry({
+      'event.id': 'req',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': 'turn-tc',
+      'gen_ai.step.id': 'turn-tc:s1',
+      time_unix_nano: '1000000000000000000',
+    });
+    const resp = buildHookEntry({
+      'event.id': 'resp',
+      'event.name': 'llm.response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': 'turn-tc',
+      'gen_ai.step.id': 'turn-tc:s1',
+      time_unix_nano: '1000010000000000000',
+    });
+    const toolCall = buildHookEntry({
+      'event.id': 'tc',
+      'event.name': 'tool.call' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': 'turn-tc',
+      'gen_ai.step.id': 'turn-tc:s1',
+      time_unix_nano: '999999999999000000',
+    });
+    await fs.writeFile(hookFile, [JSON.stringify(req), JSON.stringify(resp), JSON.stringify(toolCall)].join('\n') + '\n');
+
+    await writeSegments(sessionId, 'run1.jsonl', [
+      segTurnStarted('seg-turn', false),
+      segModelStart('seg-turn', 'r1', '2026-06-16T10:00:00.000Z'),
+      segModelEnd('seg-turn', 'r1', '2026-06-16T10:00:05.000Z'),
+    ]);
+
+    const input = makeInput();
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const endNano = String(BigInt(Date.parse('2026-06-16T10:00:05.000Z')) * 1_000_000n);
+    const tcOut = entries.find(e => e['event.id'] === 'tc')!;
+    expect(tcOut.time_unix_nano).toBe(endNano);
+  });
 });
 
 async function startAndCollect(input: any): Promise<AgentActivityEntry[]> {
@@ -464,7 +426,6 @@ async function triggerCycle(input: any): Promise<AgentActivityEntry[]> {
   const entries: AgentActivityEntry[] = [];
   const handler = (batch: AgentActivityEntry[]) => { entries.push(...batch); };
   input.on('entries', handler);
-  // Access protected collect via bracket notation
   const result = await input['collect']();
   if (result && result.length > 0) {
     entries.push(...result);


### PR DESCRIPTION
## 背景

QoderWork 的 Hook JSONL 负责 turn/step 结构，session segment JSONL 才包含可靠的 LLM 与工具真实时间。此前重新部署后，checkpoint 为初始状态时会重放当日历史 trace；另外 transcript 多 text block、中断记录及 LLM/tool 时序仍存在采集偏差。

## 保留 PR #42 的思想

本 PR 以已合入的 #42 为基础，并保留其两项核心修复：

- `extractText()` 拼接所有 text block（以换行分隔），避免首个 block 是 system-reminder 时真实用户问题被丢弃。
- 将 `[Request interrupted ...]` 识别为系统注入，不将中断记录切分成新的 turn。

同时保留一个仅用于 turn 分类的纯 `<system-reminder>` 判断：纯注入上下文不会切新 turn；携带真实提问时仍完整、原样输出，不改写 prompt 内容。

## 本 PR 额外修复

- 使用 `~/.qoderwork/logs/sessions/**/segments/*.jsonl` 的 `model.request.started` / `model.response.completed` 修正 LLM 时长和 resolved model，使用 `tool.requested` / `tool.execution.finished` 修正工具时长；过滤 subagent 与 memory-sink 事件。
- 以 transcript `promptId` 生成稳定 turn id；每步写入独立 `gen_ai.input.messages`，避免 converter 对 delta 累积。
- 首次运行时流式扫描当日 hook JSONL，仅上报最后一个 turn，并将 offset 推到文件末尾，避免重装或重启后的历史全量回放。
- `getTurnIdForRows()` 与 turn event 构建共用真实 prompt 过滤条件，防止纯 system-reminder 导致 turn id 与 prompt id 不一致。
- segment response 有非零 usage 时优先写入 `gen_ai.usage.*`（包含 cache read/creation）；仅在 segment usage 缺失时，从旧 SDK 日志按 session 和 5 秒请求时间窗口一对一补 token。SDK fallback 不会修改时间、模型或工具事件。
- 为 segment、工具、subagent、in-flight、SDK token 与目录缓存状态增加一小时 TTL 清理；即使当前没有新 hook 数据也会执行驱逐。
- workspace 路径编码保留已验证的快速路径，并按 session id 回退查找 segment 目录，降低 writer 编码变化或跨平台路径带来的静默降级风险。
- 预建 `tool_use_id -> tool_result` 索引，将工具结果关联从嵌套线性扫描改为 O(1) 查找。

## 范围

改动限定在 QoderWork Hook 与 `QoderWorkTraceInput`，未修改公共 Input/StateStore 基类。

## 验证

- `npm test`：111 files passed，1135 passed / 2 skipped
- `npm run typecheck`

## 回归覆盖

- 多 text block、纯/混合 system-reminder、selected text、command-message、interrupted turn。
- segment LLM/tool 时序、模型补全、subagent 过滤、跨批次工具事件。
- segment usage 优先、SDK token-only fallback、目录编码回退、状态 TTL 驱逐。
- 首次多 turn 仅上报最后一个、首次单 turn、超过 16 MiB 的首次历史、后续 append 增量上报。