### PR TITLE
fix(hooks): use rawCommand flag to skip -File path quoting for Qoder agents

### DIFF
--- a/agents.d/qoder-cn.json
+++ b/agents.d/qoder-cn.json
@@ -11,7 +11,8 @@
     "events": ["Stop", "PreToolUse", "PostToolUse", "UserPromptSubmit"],
     "hookCommand": "$PILOT_DATA/hooks/qodercn-loongsuite-pilot-hook.sh",
     "format": "nested",
-    "matcher": "*"
+    "matcher": "*",
+    "rawCommand": true
   },
   "input": {
     "type": "hook-jsonl",

--- a/agents.d/qoder.json
+++ b/agents.d/qoder.json
@@ -12,6 +12,7 @@
     "hookCommand": "$PILOT_DATA/hooks/qoder-loongsuite-pilot-hook.sh qoder",
     "format": "nested",
     "matcher": "*",
+    "rawCommand": true,
     "replaceHookCommands": ["$PILOT_DATA/hooks/qoder-loongsuite-pilot-hook.sh qoder-cli"]
   },
   "input": {

--- a/src/deployment/hook-strategy.ts
+++ b/src/deployment/hook-strategy.ts
@@ -32,13 +32,14 @@ function eventToSubcommand(event: string): string {
  * piping to work correctly.  Bare `.ps1` paths fail to receive stdin when
  * spawned through cmd.exe / child_process.
  */
-function wrapPs1Command(cmd: string): string {
+function wrapPs1Command(cmd: string, raw?: boolean): string {
   if (process.platform !== 'win32') return cmd;
   const parts = cmd.split(' ');
   const script = parts[0];
   if (!script.endsWith('.ps1')) return cmd;
   const args = parts.slice(1).join(' ');
-  const wrapped = `powershell -NoProfile -ExecutionPolicy Bypass -File "${script}"`;
+  const scriptRef = raw ? script : `"${script}"`;
+  const wrapped = `powershell -NoProfile -ExecutionPolicy Bypass -File ${scriptRef}`;
   return args ? `${wrapped} ${args}` : wrapped;
 }
 
@@ -50,8 +51,9 @@ function formatHookCommand(
   hookCommand: string,
   event: string,
   style: AgentHookConfig['eventSubcommand'],
+  raw?: boolean,
 ): string {
-  const cmd = wrapPs1Command(hookCommand);
+  const cmd = wrapPs1Command(hookCommand, raw);
   if (style === 'kebab-case') {
     return `${cmd} ${eventToSubcommand(event)}`;
   }
@@ -266,7 +268,9 @@ export class HookStrategy implements DeployStrategy {
       agentId: def.id,
       settingsPath: hookConfig.settingsPath,
       hookJsonPath: ['hooks', event],
-      hookCommand: formatHookCommand(hookConfig.hookCommand, event, hookConfig.eventSubcommand),
+      hookCommand: formatHookCommand(
+        hookConfig.hookCommand, event, hookConfig.eventSubcommand, hookConfig.rawCommand,
+      ),
       matcher: hookConfig.matcher,
       useNestedFormat: hookConfig.format === 'nested',
       replaceHookCommands: hookConfig.replaceHookCommands,

--- a/src/types/deployment.ts
+++ b/src/types/deployment.ts
@@ -52,6 +52,12 @@ export interface AgentHookConfig {
    * trust hash 也用同样字符串，保证一致性。
    */
   eventSubcommand?: 'kebab-case';
+  /**
+   * If true, omit quotes around the -File path on Windows.
+   * Use for agents whose hook executor does direct spawn (not shell),
+   * where the quoted path in -File "..." would become literal characters.
+   */
+  rawCommand?: boolean;
 }
 
 export interface PluginSourceConfig {


### PR DESCRIPTION
## Summary

Qoder's hook executor uses direct spawn (not shell), so the quoted path in `-File "..."` becomes literal characters on Windows. 

- Add `rawCommand` field to `AgentHookConfig` — when true, omits quotes around the `-File` path in the powershell wrapper
- Set `rawCommand: true` on `qoder` and `qoder-cn` agent definitions
- Other agents (claude-code, codex, cursor, etc.) are unaffected

## Test plan

- [ ] Deploy on Windows, verify `~/.qoder/settings.json` hook command has unquoted `-File` path
- [ ] Verify other agents' settings.json are unchanged (still quoted)
- [ ] Run qoder hook on Windows and confirm it executes successfully