### PR TITLE
fix(deploy): avoid SIGPIPE when previewing package contents

### DIFF
--- a/deploy/package-opensource.sh
+++ b/deploy/package-opensource.sh
@@ -138,7 +138,7 @@ echo "    ✅ $ZIP_OUTPUT_PATH ($ZIP_SIZE)"
 # ── Summary ──
 echo ""
 echo "==> Contents:"
-tar -tzf "$OUTPUT_PATH" | head -20
+tar -tzf "$OUTPUT_PATH" | sed -n '1,20p'
 echo "    ... (truncated)"
 echo ""
 echo "Done."


### PR DESCRIPTION
The script deploy/package-opensource.sh enables strict mode via set -euo pipefail.

At the end of the script, the command tar -tzf "$OUTPUT_PATH" | head -20 is executed.

In Linux environments, head -20 closes the pipe immediately after printing the first 20 lines. This sends a SIGPIPE signal to the upstream tar process, making tar exit with code 141.

Due to set -o pipefail, the entire pipeline returns a non-zero exit code, which triggers set -e to terminate the whole script and results in the build failure.