### PR TITLE
docs: update supported agents matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ Pilot is designed to answer practical questions:
 | OpenCode      | Plugin injection          | Yes          | Yes        | Yes         | Yes                       |
 | Qoder         | Hook                      | Yes          | Yes        | Yes         | Yes                       |
 | Qoder CN      | Hook                      | Yes          | Yes        | Yes         | Yes                       |
-| Qoder CLI     | Hook / session polling    | Yes          | Yes        | No          | Yes                       |
-| Qoder Work    | Hook / local data polling | Yes          | Yes        | No          | Yes                       |
-| Qoder Work CN | Hook / local data polling | Yes          | Yes        | No          | Yes                       |
+| Qoder CLI     | Hook / session polling    | Yes          | Yes        | Yes         | Yes                       |
+| Qoder Work    | Hook / local data polling | Yes          | Yes        | Yes         | Yes                       |
+| Qoder Work CN | Hook / local data polling | Yes          | Yes        | Yes         | Yes                       |
 | Qwen Code CLI | Hook                      | Yes          | Yes        | Yes         | Yes                       |
+| Wukong        | CLI API polling           | Yes          | Yes        | Yes         | Yes                       |
 
 
 Agent definitions live in `agents.d/`. You can add new agents without changing the deployment framework; see [Agent Onboarding](docs/agent-onboarding.md).

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -20,6 +20,7 @@ Use these IDs in installer options, `agent-control.json`, and `config.json`.
 | Qoder Work | `qoder-work` | Hook and local data sources. |
 | Qoder Work CN | `qoder-work-cn` | Hook and local data sources. |
 | Qwen Code CLI | `qwen-code-cli` | Hook integration; parses qwen-code transcript JSONL on Stop. |
+| Wukong | `wukong` | CLI API polling via local `wukong-cli`. |
 
 ## Choose Agents During Installation
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -28,9 +28,11 @@ LoongSuite Pilot runs on a developer machine and collects telemetry from support
 | OpenCode | Plugin injection | Yes | Yes | Yes | Yes |
 | Qoder | Hook | Yes | Yes | Yes | Yes |
 | Qoder CN | Hook | Yes | Yes | Yes | Yes |
-| Qoder CLI | Hook / session polling | Yes | Yes | No | Yes |
-| Qoder Work | Hook / local data polling | Yes | Yes | No | Yes |
-| Qoder Work CN | Hook / local data polling | Yes | Yes | No | Yes |
+| Qoder CLI | Hook / session polling | Yes | Yes | Yes | Yes |
+| Qoder Work | Hook / local data polling | Yes | Yes | Yes | Yes |
+| Qoder Work CN | Hook / local data polling | Yes | Yes | Yes | Yes |
+| Qwen Code CLI | Hook | Yes | Yes | Yes | Yes |
+| Wukong | CLI API polling | Yes | Yes | Yes | Yes |
 
 ## Data Collected
 

--- a/docs/zh-CN/agents.md
+++ b/docs/zh-CN/agents.md
@@ -20,6 +20,7 @@
 | Qoder Work | `qoder-work` | Hook 和本地数据源。 |
 | Qoder Work CN | `qoder-work-cn` | Hook 和本地数据源。 |
 | Qwen Code CLI | `qwen-code-cli` | Hook 集成；Stop 时解析 qwen-code transcript JSONL。 |
+| Wukong | `wukong` | 通过本地 `wukong-cli` 进行 CLI API 轮询。 |
 
 ## 安装时选择 Agent
 

--- a/docs/zh-CN/overview.md
+++ b/docs/zh-CN/overview.md
@@ -28,9 +28,11 @@ LoongSuite Pilot 运行在开发者本机，用于采集支持的 AI Coding Agen
 | OpenCode | 插件注入 | Yes | Yes | Yes | Yes |
 | Qoder | Hook | Yes | Yes | Yes | Yes |
 | Qoder CN | Hook | Yes | Yes | Yes | Yes |
-| Qoder CLI | Hook / session polling | Yes | Yes | No | Yes |
-| Qoder Work | Hook / 本地数据轮询 | Yes | Yes | No | Yes |
-| Qoder Work CN | Hook / 本地数据轮询 | Yes | Yes | No | Yes |
+| Qoder CLI | Hook / session polling | Yes | Yes | Yes | Yes |
+| Qoder Work | Hook / 本地数据轮询 | Yes | Yes | Yes | Yes |
+| Qoder Work CN | Hook / 本地数据轮询 | Yes | Yes | Yes | Yes |
+| Qwen Code CLI | Hook | Yes | Yes | Yes | Yes |
+| Wukong | CLI API 轮询 | Yes | Yes | Yes | Yes |
 
 ## 采集的数据
 


### PR DESCRIPTION
## Summary
- add Wukong to the supported agents matrix and agent ID docs
- sync Qwen Code CLI into overview docs
- update Qoder CLI, Qoder Work, and Qoder Work CN token usage support to Yes

## Verification
- git diff --check