### PR TITLE
fix(opencode): preserve turnSeq + pre-create plugin-inject log dirs

### DIFF
--- a/assets/plugins/opencode/plugin.mjs
+++ b/assets/plugins/opencode/plugin.mjs
@@ -183,13 +183,14 @@ function writeError(source, err) {
 // ---------------------------------------------------------------------------
 
 const sessions = new Map();
+const sessionTurnSeqs = new Map();
 
 function getSession(sessionID) {
   if (!sessionID) return null;
   let s = sessions.get(sessionID);
   if (!s) {
     s = {
-      turnSeq: 0,
+      turnSeq: sessionTurnSeqs.get(sessionID) || 0,
       currentTurn: null,
       systemPrompt: null,
       systemInstructionsParts: null,
@@ -211,6 +212,14 @@ function getSession(sessionID) {
 }
 
 function clearSession(sessionID) {
+  const s = sessions.get(sessionID);
+  if (s) {
+    sessionTurnSeqs.set(sessionID, s.turnSeq);
+    if (sessionTurnSeqs.size > MAX_SESSIONS) {
+      const oldest = sessionTurnSeqs.keys().next().value;
+      sessionTurnSeqs.delete(oldest);
+    }
+  }
   sessions.delete(sessionID);
 }
 

--- a/assets/plugins/opencode/plugin.mjs
+++ b/assets/plugins/opencode/plugin.mjs
@@ -214,6 +214,7 @@ function getSession(sessionID) {
 function clearSession(sessionID) {
   const s = sessions.get(sessionID);
   if (s) {
+    sessionTurnSeqs.delete(sessionID);
     sessionTurnSeqs.set(sessionID, s.turnSeq);
     if (sessionTurnSeqs.size > MAX_SESSIONS) {
       const oldest = sessionTurnSeqs.keys().next().value;

--- a/assets/plugins/opencode/plugin.mjs
+++ b/assets/plugins/opencode/plugin.mjs
@@ -190,7 +190,7 @@ function getSession(sessionID) {
   let s = sessions.get(sessionID);
   if (!s) {
     s = {
-      turnSeq: sessionTurnSeqs.get(sessionID) || 0,
+      turnSeq: sessionTurnSeqs.get(sessionID) ?? 0,
       currentTurn: null,
       systemPrompt: null,
       systemInstructionsParts: null,

--- a/assets/plugins/opencode/plugin.mjs
+++ b/assets/plugins/opencode/plugin.mjs
@@ -205,7 +205,7 @@ function getSession(sessionID) {
     sessions.set(sessionID, s);
     if (sessions.size > MAX_SESSIONS) {
       const oldest = sessions.keys().next().value;
-      sessions.delete(oldest);
+      clearSession(oldest);
     }
   }
   return s;

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -857,9 +857,11 @@ export class Orchestrator extends EventEmitter {
     );
 
     // --- OpenCode Log (event_t plugin JSONL) ---
-    const opencodeLogDir = path.join(this.dataDir, 'logs', 'opencode');
-    // Pre-create log dir so fs.watch in AgentDiscoveryService succeeds immediately,
+    // Plugin-inject agents (opencode, qwen-code-cli) don't create their log dirs
+    // during hook deployment (unlike cursor/claude/codex whose shell hooks mkdir -p).
+    // Pre-create here so fs.watch in AgentDiscoveryService succeeds immediately,
     // avoiding a 5-minute polling fallback delay after fresh install with --purge.
+    const opencodeLogDir = path.join(this.dataDir, 'logs', 'opencode');
     await ensureDir(opencodeLogDir);
     const opencodeLogInput = new OpenCodeLogInput({
       stateStore: this.stateStore,

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -858,6 +858,9 @@ export class Orchestrator extends EventEmitter {
 
     // --- OpenCode Log (event_t plugin JSONL) ---
     const opencodeLogDir = path.join(this.dataDir, 'logs', 'opencode');
+    // Pre-create log dir so fs.watch in AgentDiscoveryService succeeds immediately,
+    // avoiding a 5-minute polling fallback delay after fresh install with --purge.
+    await ensureDir(opencodeLogDir);
     const opencodeLogInput = new OpenCodeLogInput({
       stateStore: this.stateStore,
       logDir: opencodeLogDir,
@@ -878,6 +881,8 @@ export class Orchestrator extends EventEmitter {
 
     // --- Qwen Code CLI Log (transcript-driven hook JSONL) ---
     const qwenCodeCliLogDir = path.join(this.dataDir, 'logs', 'qwen-code-cli');
+    // Pre-create log dir so fs.watch in AgentDiscoveryService succeeds immediately.
+    await ensureDir(qwenCodeCliLogDir);
     const qwenCodeCliLogInput = new QwenCodeCliLogInput({
       stateStore: this.stateStore,
       logDir: qwenCodeCliLogDir,

--- a/tests/unit/hooks/opencode-plugin-session.test.mjs
+++ b/tests/unit/hooks/opencode-plugin-session.test.mjs
@@ -1,0 +1,142 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const PLUGIN_PATH = path.resolve(
+  fileURLToPath(import.meta.url),
+  '../../../../assets/plugins/opencode/plugin.mjs',
+);
+
+/**
+ * Extract session management functions from plugin.mjs for unit testing.
+ * Since the plugin exports only the default hook object, we re-implement
+ * the session logic here mirroring the source to test the invariants.
+ */
+
+const MAX_SESSIONS = 100;
+
+function createSessionManager() {
+  const sessions = new Map();
+  const sessionTurnSeqs = new Map();
+
+  function getSession(sessionID) {
+    if (!sessionID) return null;
+    let s = sessions.get(sessionID);
+    if (!s) {
+      s = {
+        turnSeq: sessionTurnSeqs.get(sessionID) || 0,
+        currentTurn: null,
+      };
+      sessions.set(sessionID, s);
+      if (sessions.size > MAX_SESSIONS) {
+        const oldest = sessions.keys().next().value;
+        clearSession(oldest);
+      }
+    }
+    return s;
+  }
+
+  function clearSession(sessionID) {
+    const s = sessions.get(sessionID);
+    if (s) {
+      sessionTurnSeqs.delete(sessionID);
+      sessionTurnSeqs.set(sessionID, s.turnSeq);
+      if (sessionTurnSeqs.size > MAX_SESSIONS) {
+        const oldest = sessionTurnSeqs.keys().next().value;
+        sessionTurnSeqs.delete(oldest);
+      }
+    }
+    sessions.delete(sessionID);
+  }
+
+  function simulateTurn(sessionID) {
+    const session = getSession(sessionID);
+    session.turnSeq += 1;
+    const turnId = `${sessionID}:t${session.turnSeq}`;
+    session.currentTurn = { turnId };
+    return turnId;
+  }
+
+  return { getSession, clearSession, simulateTurn, sessions, sessionTurnSeqs };
+}
+
+describe('opencode plugin session turnSeq persistence', () => {
+  let mgr;
+
+  beforeEach(() => {
+    mgr = createSessionManager();
+  });
+
+  it('restores turnSeq after session.idle clears the session', () => {
+    const t1 = mgr.simulateTurn('ses_A');
+    expect(t1).toBe('ses_A:t1');
+
+    mgr.clearSession('ses_A');
+
+    const t2 = mgr.simulateTurn('ses_A');
+    expect(t2).toBe('ses_A:t2');
+  });
+
+  it('turnSeq remains monotonic across multiple idle cycles', () => {
+    const results = [];
+    for (let i = 1; i <= 5; i++) {
+      const turnId = mgr.simulateTurn('ses_B');
+      results.push(turnId);
+      mgr.clearSession('ses_B');
+    }
+
+    expect(results).toEqual([
+      'ses_B:t1',
+      'ses_B:t2',
+      'ses_B:t3',
+      'ses_B:t4',
+      'ses_B:t5',
+    ]);
+  });
+
+  it('LRU eviction in getSession preserves turnSeq via clearSession', () => {
+    for (let i = 0; i < MAX_SESSIONS; i++) {
+      const s = mgr.getSession(`ses_fill_${i}`);
+      s.turnSeq = 10;
+    }
+    expect(mgr.sessions.size).toBe(MAX_SESSIONS);
+
+    mgr.getSession('ses_new');
+    expect(mgr.sessions.size).toBe(MAX_SESSIONS);
+
+    expect(mgr.sessionTurnSeqs.get('ses_fill_0')).toBe(10);
+
+    const s = mgr.getSession('ses_fill_0');
+    expect(s.turnSeq).toBe(10);
+  });
+
+  it('sessionTurnSeqs LRU updates key recency on re-save', () => {
+    for (let i = 0; i < MAX_SESSIONS; i++) {
+      const s = mgr.getSession(`ses_lru_${i}`);
+      s.turnSeq = i + 1;
+      mgr.clearSession(`ses_lru_${i}`);
+    }
+    expect(mgr.sessionTurnSeqs.size).toBe(MAX_SESSIONS);
+
+    const s = mgr.getSession('ses_lru_0');
+    s.turnSeq = 99;
+    mgr.clearSession('ses_lru_0');
+
+    mgr.getSession('ses_lru_new');
+    mgr.getSession('ses_lru_new').turnSeq = 1;
+    mgr.clearSession('ses_lru_new');
+
+    expect(mgr.sessionTurnSeqs.has('ses_lru_0')).toBe(true);
+  });
+
+  it('different sessions have independent turnSeq counters', () => {
+    expect(mgr.simulateTurn('ses_X')).toBe('ses_X:t1');
+    expect(mgr.simulateTurn('ses_Y')).toBe('ses_Y:t1');
+    expect(mgr.simulateTurn('ses_X')).toBe('ses_X:t2');
+
+    mgr.clearSession('ses_X');
+    expect(mgr.simulateTurn('ses_X')).toBe('ses_X:t3');
+    expect(mgr.simulateTurn('ses_Y')).toBe('ses_Y:t2');
+  });
+});


### PR DESCRIPTION
## Summary

- Fix OpenCode plugin `clearSession()` wiping `turnSeq` on every `session.idle`, causing all subsequent conversations to reuse `gen_ai.turn.id = ses_xxx:t1`
- This led to the OTLP trace flusher dropping 2nd+ conversations as "late arrivals" for an already-flushed turn key
- Persist `turnSeq` in a separate LRU-bounded map (`sessionTurnSeqs`) so the counter monotonically increases within a process lifetime
- Pre-create log directories for plugin-inject agents (opencode, qwen-code-cli) to avoid 5-minute discovery delay after fresh install

## Root Cause

1. `session.idle` fires between conversations → `clearSession()` deletes the entire session object
2. Next `getSession()` creates a fresh session with `turnSeq: 0` → `handleChatMessage` increments to 1 → always generates `ses_xxx:t1`
3. Flusher's `flushedTurnKeys` set already contains `turn:ses_xxx:t1` from the first conversation → subsequent events are dropped
4. (Secondary) After `--purge` reinstall, plugin-inject agent log dirs don't exist → `fs.watch` fails → 5min polling fallback

## Test plan

- [x] Trigger 3+ conversations in a single OpenCode session
- [x] Verify `~/.loongsuite-pilot/logs/opencode/` shows distinct `gen_ai.turn.id` values (`:t1`, `:t2`, `:t3`)
- [x] Verify `~/.loongsuite-pilot/logs/otlp-debug/` produces 3 separate traces with unique trace IDs
- [x] Unit tests pass: `vitest run tests/unit/hooks/opencode-plugin-session.test.mjs` (5 tests)