### PR TITLE
feat(sls): add user-agent header to all SLS transport paths

### DIFF
--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -199,6 +199,7 @@ export class Orchestrator extends EventEmitter {
         configDir: path.join(this.dataDir, 'configs', 'local'),
         stateDir: path.join(this.dataDir, 'state', 'file-collection'),
         failedLogDir: path.join(this.dataDir, 'logs', 'file-collection-failed'),
+        dataDir: this.dataDir,
       });
       await this.fileCollectionManager.start();
     } else {
@@ -365,7 +366,7 @@ export class Orchestrator extends EventEmitter {
     if (otlpTraceCfg?.enabled) {
       try {
         const { OtlpTraceFlusher } = await import('../flushers/otlp-trace-flusher.js');
-        const r = new OtlpTraceFlusher(otlpTraceCfg);
+        const r = new OtlpTraceFlusher({ ...otlpTraceCfg, dataDir: this.dataDir });
         flushers.push(r);
       } catch (err) {
         logger.warn('OtlpTraceFlusher unavailable, skipping', { error: String(err) });

--- a/src/file-collection/file-collection-manager.ts
+++ b/src/file-collection/file-collection-manager.ts
@@ -16,6 +16,7 @@ export class FileCollectionManager {
   private readonly configDir: string;
   private readonly stateDir: string;
   private readonly failedLogDir: string;
+  private readonly dataDir: string;
   private readonly pipelines: Map<string, FilePipeline> = new Map();
   private readonly configHashes: Map<string, string> = new Map();
   private watcher: fs.FSWatcher | null = null;
@@ -29,6 +30,7 @@ export class FileCollectionManager {
     this.configDir = opts.configDir;
     this.stateDir = opts.stateDir;
     this.failedLogDir = opts.failedLogDir;
+    this.dataDir = opts.dataDir;
   }
 
   async start(): Promise<void> {
@@ -251,6 +253,7 @@ export class FileCollectionManager {
         config,
         stateDir: this.stateDir,
         failedLogDir: this.failedLogDir,
+        dataDir: this.dataDir,
       });
       await pipeline.start();
       this.pipelines.set(config.configName, pipeline);

--- a/src/file-collection/file-pipeline.ts
+++ b/src/file-collection/file-pipeline.ts
@@ -56,6 +56,7 @@ export class FilePipeline {
       flusher,
       opts.config.configName,
       opts.failedLogDir,
+      opts.dataDir,
     );
 
     this.fileWatcher = new FileWatcher();

--- a/src/file-collection/file-sls-sender.ts
+++ b/src/file-collection/file-sls-sender.ts
@@ -1,4 +1,3 @@
-import * as os from 'node:os';
 import type { FileSlsFlusherConfig } from './types.js';
 import {
   postWebtracking,
@@ -6,21 +5,9 @@ import {
   type SlsTransportConfig,
 } from '../flushers/sls-transport.js';
 import { createLogger } from '../utils/logger.js';
+import { LOCAL_IP, buildUserAgent } from '../utils/network-utils.js';
 
 const logger = createLogger('FileSlsSender');
-
-function getLocalIp(): string {
-  const interfaces = os.networkInterfaces();
-  for (const addrs of Object.values(interfaces)) {
-    if (!addrs) continue;
-    for (const addr of addrs) {
-      if (addr.family === 'IPv4' && !addr.internal) return addr.address;
-    }
-  }
-  return '127.0.0.1';
-}
-
-const LOCAL_IP = getLocalIp();
 
 const DEFAULT_FLUSH_INTERVAL_MS = 2000;
 const DEFAULT_BATCH_SIZE = 4000;
@@ -38,11 +25,13 @@ export class FileSlsSender {
   private flushing = false;
   private readonly flushIntervalMs: number;
   private readonly batchSize: number;
+  private readonly userAgent: string;
 
   constructor(
     flusherConfig: FileSlsFlusherConfig,
     configName: string,
     failedLogDir: string,
+    dataDir: string,
   ) {
     const endpoint = /^https?:\/\//.test(flusherConfig.Endpoint)
       ? flusherConfig.Endpoint
@@ -57,6 +46,7 @@ export class FileSlsSender {
     this.failedLogDir = failedLogDir;
     this.flushIntervalMs = DEFAULT_FLUSH_INTERVAL_MS;
     this.batchSize = DEFAULT_BATCH_SIZE;
+    this.userAgent = buildUserAgent(dataDir);
   }
 
   start(): void {
@@ -111,6 +101,7 @@ export class FileSlsSender {
                 topic: this.configName,
                 source: LOCAL_IP,
                 tags: { __path__: filePath },
+                userAgent: this.userAgent,
               }).then(() => ({ ok: true as const })),
             ),
           );

--- a/src/file-collection/types.ts
+++ b/src/file-collection/types.ts
@@ -52,10 +52,12 @@ export interface FileCollectionManagerOptions {
   configDir: string;
   stateDir: string;
   failedLogDir: string;
+  dataDir: string;
 }
 
 export interface FilePipelineOptions {
   config: FileCollectionConfig;
   stateDir: string;
   failedLogDir: string;
+  dataDir: string;
 }

--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -20,11 +20,10 @@ import { BaseFlusher } from './base-flusher.js';
 import { normalizeAgentType } from '../utils/agent-type-normalize.js';
 import { resolveAgentSystem } from '../normalization/agent-system-map.js';
 import { createLogger } from '../utils/logger.js';
-import { appendLine, ensureDir, getTodayDateString } from '../utils/fs-utils.js';
+import { appendLine, ensureDir, getTodayDateString, readInstalledVersion } from '../utils/fs-utils.js';
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
-import { readFileSync } from 'node:fs';
 
 const logger = createLogger('otlp-trace-flusher');
 
@@ -68,17 +67,6 @@ function resolveEndpointUrl(raw: string): string {
   return url;
 }
 
-function getPilotVersion(): string {
-  try {
-    const pkg = JSON.parse(
-      readFileSync(new URL('../../package.json', import.meta.url), 'utf-8'),
-    );
-    return pkg.version ?? 'unknown';
-  } catch {
-    return 'unknown';
-  }
-}
-
 const DEFAULT_MAX_EXPORT_BATCH_BYTES = 10 * 1024 * 1024; // 10 MB
 
 function estimateSpanSize(span: ReadableSpan): number {
@@ -105,7 +93,7 @@ export class OtlpTraceFlusher extends BaseFlusher {
   private readonly agentConvertStates = new Map<string, AgentConvertState>();
   private readonly agentExportStates = new Map<string, AgentExportState>();
   private readonly instanceId = randomUUID();
-  private readonly pilotVersion = getPilotVersion();
+  private readonly pilotVersion: string;
   private readonly resolvedEndpointUrl: string;
   private readonly debugDir: string;
   private readonly failedDir: string;
@@ -130,9 +118,11 @@ export class OtlpTraceFlusher extends BaseFlusher {
       throw new Error('[otlp-trace-flusher] config.serviceName is required when enabled');
     }
     this.cfg = cfg;
+    const dataDir = cfg.dataDir ?? os.homedir() + '/.loongsuite-pilot';
+    this.pilotVersion = readInstalledVersion(dataDir);
     this.resolvedEndpointUrl = resolveEndpointUrl(cfg.endpoint);
-    this.debugDir = path.join(os.homedir(), '.loongsuite-pilot', 'logs', 'otlp-debug');
-    this.failedDir = path.join(os.homedir(), '.loongsuite-pilot', 'logs', 'otlp-failed');
+    this.debugDir = path.join(dataDir, 'logs', 'otlp-debug');
+    this.failedDir = path.join(dataDir, 'logs', 'otlp-failed');
 
     if (cfg.captureMessageContent !== false) {
       process.env.OTEL_SEMCONV_STABILITY_OPT_IN ??= 'gen_ai_latest_experimental';

--- a/src/flushers/sls-flusher.ts
+++ b/src/flushers/sls-flusher.ts
@@ -11,6 +11,7 @@ import { createLogger } from '../utils/logger.js';
 import { appendLine, ensureDir } from '../utils/fs-utils.js';
 import { formatTime } from '../utils/time-utils.js';
 import { normalizeAgentType } from '../utils/agent-type-normalize.js';
+import { LOCAL_IP, buildUserAgent } from '../utils/network-utils.js';
 import * as path from 'node:path';
 import {
   HttpError,
@@ -24,18 +25,6 @@ import {
   RETRYABLE_STATUS_CODES,
 } from './sls-transport.js';
 
-function getLocalIp(): string {
-  const interfaces = os.networkInterfaces();
-  for (const addrs of Object.values(interfaces)) {
-    if (!addrs) continue;
-    for (const addr of addrs) {
-      if (addr.family === 'IPv4' && !addr.internal) return addr.address;
-    }
-  }
-  return '127.0.0.1';
-}
-
-const LOCAL_IP = getLocalIp();
 const HOSTNAME = os.hostname();
 
 const BATCH_MAX_SIZE = 20;
@@ -74,12 +63,14 @@ export class SlsFlusher extends BaseFlusher {
   private alarmManager: AlarmManager | null = null;
 
   private readonly serviceName: string;
+  private readonly userAgent: string;
 
   constructor(config: SlsFlusherConfig, dataDir: string) {
     super();
     this.config = config;
     this.failedLogDir = path.join(dataDir, 'sls-failed-logs');
     this.serviceName = config.serviceNamePrefix || '';
+    this.userAgent = buildUserAgent(dataDir);
     for (const ep of config.endpoints) {
       this.endpointCounters.set(ep.name, {
         inEntries: 0, inBytes: 0, outEntries: 0, outFailed: 0,
@@ -104,6 +95,7 @@ export class SlsFlusher extends BaseFlusher {
         accessKeyId: endpoint.accessKeyId ?? '',
         accessKeySecret: endpoint.accessKeySecret ?? '',
         endpoint: endpoint.endpoint,
+        userAgent: this.userAgent,
       } as any);
       this.akClients.set(endpoint.name, client);
     }
@@ -323,6 +315,7 @@ export class SlsFlusher extends BaseFlusher {
             'x-log-apiversion': '0.6.0',
             'x-log-bodyrawsize': String(Buffer.byteLength(raw)),
             'Content-Type': 'application/json',
+            'user-agent': this.userAgent,
           },
           body: raw,
           signal: AbortSignal.timeout(WEBTRACKING_TIMEOUT_MS),
@@ -430,6 +423,7 @@ export class SlsFlusher extends BaseFlusher {
               topic,
               source: LOCAL_IP,
               tags: { __hostname__: HOSTNAME },
+              userAgent: this.userAgent,
             },
           );
         }

--- a/src/flushers/sls-transport.ts
+++ b/src/flushers/sls-transport.ts
@@ -31,6 +31,7 @@ export interface PostWebtrackingOptions {
   topic?: string;
   source?: string;
   tags?: Record<string, string>;
+  userAgent?: string;
 }
 
 export function splitForWebtracking(
@@ -122,6 +123,7 @@ async function postWebtrackingChunk(
           'x-log-apiversion': '0.6.0',
           'x-log-bodyrawsize': String(Buffer.byteLength(raw)),
           'Content-Type': 'application/json',
+          ...(opts?.userAgent ? { 'user-agent': opts.userAgent } : {}),
         },
         body: raw,
         signal: AbortSignal.timeout(timeoutMs),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -98,6 +98,7 @@ export interface OtlpTraceFlusherConfig {
   turnIdleTimeoutMs?: number;
   maxExportBatchBytes?: number;
   compression?: 'none' | 'gzip';
+  dataDir?: string;
 }
 
 export type SlsMode = 'ak' | 'webtracking';

--- a/src/utils/network-utils.ts
+++ b/src/utils/network-utils.ts
@@ -1,4 +1,5 @@
 import * as os from 'node:os';
+import { readInstalledVersion } from './fs-utils.js';
 
 export function resolveLocalIp(): string {
   const interfaces = os.networkInterfaces();
@@ -10,4 +11,11 @@ export function resolveLocalIp(): string {
     }
   }
   return '127.0.0.1';
+}
+
+export const LOCAL_IP = resolveLocalIp();
+
+export function buildUserAgent(dataDir: string): string {
+  const version = readInstalledVersion(dataDir);
+  return `loongsuite-pilot/${version} (${os.type()}; ${os.release()}; ${os.arch()}) ip/${LOCAL_IP}`;
 }

--- a/tests/unit/flushers/sls-flusher.dual-write.test.ts
+++ b/tests/unit/flushers/sls-flusher.dual-write.test.ts
@@ -30,6 +30,7 @@ vi.mock('../../../src/utils/fs-utils.js', () => ({
   appendLine: (...args: unknown[]) => mockAppendLine(...args),
   ensureDir: (...args: unknown[]) => mockEnsureDir(...args),
   getTodayDateString: () => '2026-04-27',
+  readInstalledVersion: () => '0.0.0-test',
 }));
 
 vi.mock('../../../src/utils/logger.js', () => ({

--- a/tests/unit/flushers/sls-flusher.test.ts
+++ b/tests/unit/flushers/sls-flusher.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../../src/utils/fs-utils.js', () => ({
   appendLine: (...args: unknown[]) => mockAppendLine(...args),
   ensureDir: (...args: unknown[]) => mockEnsureDir(...args),
   getTodayDateString: () => '2026-04-27',
+  readInstalledVersion: () => '0.0.0-test',
 }));
 
 vi.mock('../../../src/utils/logger.js', () => ({


### PR DESCRIPTION
## Summary

- Add `user-agent` header (`loongsuite-pilot/{version} ({os}; {release}; {arch}) ip/{ip}`) to all SLS data transport paths: AK mode (`@alicloud/log` SDK), inline webtracking `fetch`, and `postWebtracking` transport layer
- Extract shared `buildUserAgent(dataDir)` and `LOCAL_IP` into `src/utils/network-utils.ts` to eliminate duplicated IP/version resolution across `sls-flusher.ts`, `file-sls-sender.ts`, and `sls-transport.ts`
- Use `readInstalledVersion(dataDir)` for robust version resolution in bundled deployments (replaces unreliable `import.meta.url`-based `package.json` lookup)
- Thread `dataDir` through Orchestrator → FileCollectionManager → FilePipeline → FileSlsSender call chain

## Changed Files

- `src/utils/network-utils.ts` — add `buildUserAgent()` and `LOCAL_IP` exports
- `src/flushers/sls-flusher.ts` — use shared `buildUserAgent()`, set `userAgent` in AK client constructor and webtracking fetch headers
- `src/flushers/sls-transport.ts` — add optional `userAgent` field to `PostWebtrackingOptions`, apply to fetch headers
- `src/file-collection/file-sls-sender.ts` — use shared `LOCAL_IP` and `buildUserAgent()`
- `src/file-collection/types.ts` — add `dataDir` to `FileCollectionManagerOptions` and `FilePipelineOptions`
- `src/file-collection/file-collection-manager.ts` — thread `dataDir`
- `src/file-collection/file-pipeline.ts` — thread `dataDir` to `FileSlsSender`
- `src/core/orchestrator.ts` — pass `dataDir` to `FileCollectionManager` and `OtlpTraceFlusher`
- `src/types/index.ts` — add `dataDir` to `OtlpTraceFlusherConfig`
- `src/flushers/otlp-trace-flusher.ts` — use `readInstalledVersion(dataDir)` instead of `getPilotVersion()`

## Test Plan

- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] Verify `user-agent` header appears in SLS requests via debug logging
- [ ] Verify version resolves correctly in bundled deployment (`~/.loongsuite-pilot/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)