### PR TITLE
docs: add Qoder for JetBrains to Supported Agents matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Pilot is designed to answer practical questions:
 | OpenCode      | Plugin injection          | Yes          | Yes        | Yes         | Yes                       |
 | Qoder         | Hook                      | Yes          | Yes        | Yes         | Yes                       |
 | Qoder CN      | Hook                      | Yes          | Yes        | Yes         | Yes                       |
+| Qoder for JetBrains | Detection-only      | Yes          | Yes        | Yes         | Yes                       |
 | Qoder CLI     | Hook / session polling    | Yes          | Yes        | Yes         | Yes                       |
 | Qoder Work    | Hook / local data polling | Yes          | Yes        | Yes         | Yes                       |
 | Qoder Work CN | Hook / local data polling | Yes          | Yes        | Yes         | Yes                       |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -39,10 +39,12 @@ Pilot 主要帮助回答这些问题：
 | OpenCode | 插件注入 | Yes | Yes | Yes | Yes |
 | Qoder | Hook | Yes | Yes | Yes | Yes |
 | Qoder CN | Hook | Yes | Yes | Yes | Yes |
-| Qoder CLI | Hook / session polling | Yes | Yes | No | Yes |
-| Qoder Work | Hook / 本地数据轮询 | Yes | Yes | No | Yes |
-| Qoder Work CN | Hook / 本地数据轮询 | Yes | Yes | No | Yes |
+| Qoder for JetBrains | 自动检测 | Yes | Yes | Yes | Yes |
+| Qoder CLI | Hook / session polling | Yes | Yes | Yes | Yes |
+| Qoder Work | Hook / 本地数据轮询 | Yes | Yes | Yes | Yes |
+| Qoder Work CN | Hook / 本地数据轮询 | Yes | Yes | Yes | Yes |
 | Qwen Code CLI | Hook | Yes | Yes | Yes | Yes |
+| Wukong | CLI API 轮询 | Yes | Yes | Yes | Yes |
 
 Agent 定义位于 `agents.d/`。如需接入新的 Agent，请参考 [新 Agent 接入](docs/zh-CN/agent-onboarding.md)。
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -16,7 +16,7 @@ Use these IDs in installer options, `agent-control.json`, and `config.json`.
 | OpenCode | `opencode` | Plugin injection. |
 | Qoder | `qoder` | Hook integration. |
 | Qoder CN | `qoder-cn` | Hook integration. |
-| Qoder for JetBrains | `qoder-jetbrains` | Detection-only; shares Qoder's hook/DB pipeline. |
+| Qoder for JetBrains | `qoder-jetbrains` | Detection-only deploy ID. Agent gating uses `qoder` in `agent-control.json`; content policy uses `qoder-idea` in `config.json`. |
 | Qoder CLI | `qoder` | Shares the Qoder agent definition and uses hook/session sources. |
 | Qoder Work | `qoder-work` | Hook and local data sources. |
 | Qoder Work CN | `qoder-work-cn` | Hook and local data sources. |

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -16,6 +16,7 @@ Use these IDs in installer options, `agent-control.json`, and `config.json`.
 | OpenCode | `opencode` | Plugin injection. |
 | Qoder | `qoder` | Hook integration. |
 | Qoder CN | `qoder-cn` | Hook integration. |
+| Qoder for JetBrains | `qoder-jetbrains` | Detection-only; shares Qoder's hook/DB pipeline. |
 | Qoder CLI | `qoder` | Shares the Qoder agent definition and uses hook/session sources. |
 | Qoder Work | `qoder-work` | Hook and local data sources. |
 | Qoder Work CN | `qoder-work-cn` | Hook and local data sources. |

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -28,6 +28,7 @@ LoongSuite Pilot runs on a developer machine and collects telemetry from support
 | OpenCode | Plugin injection | Yes | Yes | Yes | Yes |
 | Qoder | Hook | Yes | Yes | Yes | Yes |
 | Qoder CN | Hook | Yes | Yes | Yes | Yes |
+| Qoder for JetBrains | Detection-only | Yes | Yes | Yes | Yes |
 | Qoder CLI | Hook / session polling | Yes | Yes | Yes | Yes |
 | Qoder Work | Hook / local data polling | Yes | Yes | Yes | Yes |
 | Qoder Work CN | Hook / local data polling | Yes | Yes | Yes | Yes |

--- a/docs/zh-CN/agents.md
+++ b/docs/zh-CN/agents.md
@@ -16,6 +16,7 @@
 | OpenCode | `opencode` | 插件注入。 |
 | Qoder | `qoder` | Hook 集成。 |
 | Qoder CN | `qoder-cn` | Hook 集成。 |
+| Qoder for JetBrains | `qoder-jetbrains` | 自动检测；复用 Qoder 的 Hook/DB 管线。 |
 | Qoder CLI | `qoder` | 复用 Qoder Agent 定义，使用 Hook / session 数据源。 |
 | Qoder Work | `qoder-work` | Hook 和本地数据源。 |
 | Qoder Work CN | `qoder-work-cn` | Hook 和本地数据源。 |

--- a/docs/zh-CN/agents.md
+++ b/docs/zh-CN/agents.md
@@ -16,7 +16,7 @@
 | OpenCode | `opencode` | 插件注入。 |
 | Qoder | `qoder` | Hook 集成。 |
 | Qoder CN | `qoder-cn` | Hook 集成。 |
-| Qoder for JetBrains | `qoder-jetbrains` | 自动检测；复用 Qoder 的 Hook/DB 管线。 |
+| Qoder for JetBrains | `qoder-jetbrains` | 部署/检测专用 ID。`agent-control.json` 中采集开关为 `qoder`；`config.json` 中内容策略为 `qoder-idea`。 |
 | Qoder CLI | `qoder` | 复用 Qoder Agent 定义，使用 Hook / session 数据源。 |
 | Qoder Work | `qoder-work` | Hook 和本地数据源。 |
 | Qoder Work CN | `qoder-work-cn` | Hook 和本地数据源。 |

--- a/docs/zh-CN/overview.md
+++ b/docs/zh-CN/overview.md
@@ -28,6 +28,7 @@ LoongSuite Pilot 运行在开发者本机，用于采集支持的 AI Coding Agen
 | OpenCode | 插件注入 | Yes | Yes | Yes | Yes |
 | Qoder | Hook | Yes | Yes | Yes | Yes |
 | Qoder CN | Hook | Yes | Yes | Yes | Yes |
+| Qoder for JetBrains | 自动检测 | Yes | Yes | Yes | Yes |
 | Qoder CLI | Hook / session polling | Yes | Yes | Yes | Yes |
 | Qoder Work | Hook / 本地数据轮询 | Yes | Yes | Yes | Yes |
 | Qoder Work CN | Hook / 本地数据轮询 | Yes | Yes | Yes | Yes |


### PR DESCRIPTION
## Summary

Qoder for JetBrains (`agents.d/qoder-jetbrains.json`) was merged as a first-class data source in #45 but was never added to the Supported Agents documentation table across any file.

Additionally, commit c4cec30 (docs: update supported agents matrix #55) updated **README.md** and **docs/** but skipped **README.zh-CN.md**, leaving the Chinese README out of sync.

## Changes

### 1. Add Qoder for JetBrains (all 6 files)

| File | Change |
|------|--------|
| `README.md` | +1 row in Supported Agents table |
| `README.zh-CN.md` | +1 row in 支持的 Agent table |
| `docs/overview.md` | +1 row in Supported Agents table |
| `docs/zh-CN/overview.md` | +1 row in 支持的 Agent table |
| `docs/agents.md` | +1 row in Agent ID table (`qoder-jetbrains`) |
| `docs/zh-CN/agents.md` | +1 row in Agent ID table (`qoder-jetbrains`) |

Capabilities: Trace ✅ · Log ✅ · Token Usage ✅ · Conversation/Tool Calls ✅ · Integration: detection-only

### 2. Fix README.zh-CN.md sync gap (missed by #55)

| Agent | Field | Was | Now |
|-------|-------|-----|-----|
| Qoder CLI | Token Usage | No | Yes |
| Qoder Work | Token Usage | No | Yes |
| Qoder Work CN | Token Usage | No | Yes |
| Wukong | (entire row) | missing | added |

## Evidence

- `agents.d/qoder-jetbrains.json` — detection-only deploy mode, JetBrains plugin glob detection
- `src/types/client-type.ts` — `QoderIdea` / `QoderIdeaHook` ClientType entries
- `src/inputs/qoder-trace/qoder-trace-input.ts` — `inferTurnVariant()` routes `qoder-idea` turns to `enrichIdeTurn()`
- `src/inputs/qoder-trace/sqlite-token-reader.ts` — reads `~/.qoder/shared_client/` DB for IntelliJ sessions
- Commit #45 (`635ca74`): *"add Qoder for JetBrains as a first-class data source"*

## Checklist

- [x] Documentation only — no code changes
- [x] All 6 doc files updated consistently
- [x] zh-CN README synced with EN README