### PR TITLE
refactor: rename INTERNAL_BUILD to PROPRIETARY_BUILD

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -4,7 +4,7 @@ import { copyFile, mkdir } from 'node:fs/promises';
 const isInternal = process.env.BUILD_TYPE === 'internal';
 
 const commonDefine = {
-  '__INTERNAL_BUILD__': String(isInternal),
+  '__PROPRIETARY_BUILD__': String(isInternal),
 };
 
 const internalStubPlugin = {

--- a/build.mjs
+++ b/build.mjs
@@ -1,16 +1,16 @@
 import { build } from 'esbuild';
 import { copyFile, mkdir } from 'node:fs/promises';
 
-const isInternal = process.env.BUILD_TYPE === 'internal';
+const isProprietary = process.env.BUILD_MODE === 'proprietary';
 
 const commonDefine = {
-  '__PROPRIETARY_BUILD__': String(isInternal),
+  '__PROPRIETARY_BUILD__': String(isProprietary),
 };
 
 const internalStubPlugin = {
   name: 'internal-stub',
   setup(b) {
-    if (isInternal) return;
+    if (isProprietary) return;
     b.onResolve({ filter: /\.internal/ }, (args) => ({
       path: args.path,
       namespace: 'internal-stub',

--- a/src/core/build-constants.ts
+++ b/src/core/build-constants.ts
@@ -1,2 +1,2 @@
-declare const __INTERNAL_BUILD__: boolean;
-export const INTERNAL_BUILD = __INTERNAL_BUILD__;
+declare const __PROPRIETARY_BUILD__: boolean;
+export const PROPRIETARY_BUILD = __PROPRIETARY_BUILD__;

--- a/src/internal/sender.ts
+++ b/src/internal/sender.ts
@@ -1,10 +1,10 @@
-import { INTERNAL_BUILD } from '../core/build-constants.js';
+import { PROPRIETARY_BUILD } from '../core/build-constants.js';
 
 let _sendAlarm: (topic: string, data: Record<string, unknown>) => void;
 let _sendStatus: (topic: string, data: Record<string, unknown>) => void;
 let _sendRunningStatus: (data: Record<string, unknown>) => void;
 
-if (INTERNAL_BUILD) {
+if (PROPRIETARY_BUILD) {
   const m = await import('./alarm-sender.internal.js');
   _sendAlarm = m.sendAlarm;
   _sendStatus = m.sendStatus;


### PR DESCRIPTION
## Summary
- Rename `INTERNAL_BUILD` / `__INTERNAL_BUILD__` to `PROPRIETARY_BUILD` / `__PROPRIETARY_BUILD__` across source and build config
- Rename env var `BUILD_TYPE=internal` to `BUILD_MODE=proprietary` in `build.mjs`
- The flag distinguishes proprietary (closed-source) vs open-source builds; the old name was misleading (confused with internal/external deployment targets)

## Changed files
- `build.mjs` — env var and define rename
- `src/core/build-constants.ts` — declaration and export rename
- `src/internal/sender.ts` — import and condition rename

## Test plan
- [ ] `BUILD_MODE=proprietary npm run build` produces bundle with real alarm-sender/statistic code
- [ ] `npm run build` (no BUILD_MODE) produces bundle with stub functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)