### PR TITLE
fix(cursor): split input messages into delta + full, fix composer-2.5-fast s2

### DIFF
--- a/assets/hooks/cursor/react-assembler.mjs
+++ b/assets/hooks/cursor/react-assembler.mjs
@@ -366,18 +366,7 @@ function buildParentSteps(events, ctx) {
     // Compute delta for this step:
     //   s1: user prompt (if any) — already pre-seeded in cumulative.
     //   s2+: tool results from previous step — append to cumulative.
-    const deltaMessages = [];
-    if (isFirst && userPrompt) {
-      deltaMessages.push({
-        role: 'user',
-        parts: [{ type: 'text', content: userPrompt }],
-      });
-    }
-    if (previousToolResults && previousToolResults.length > 0) {
-      const toolMessage = toolResultsToMessage(previousToolResults);
-      deltaMessages.push(toolMessage);
-      cumulativeInputMessages.push(toolMessage);
-    }
+    const deltaMessages = buildDeltaMessages(isFirst, userPrompt, previousToolResults, cumulativeInputMessages);
 
     const { timestamp: reqTs, source: reqTsSource } = llmRequestStartTime(ev, lastStepEndTs);
     records.push(buildLlmRequestWithTs(
@@ -413,20 +402,11 @@ function buildParentSteps(events, ctx) {
         currentStepId = `${ctx.stepPrefix || ctx.turnId}:s${stepRound}`;
         stepToolCalls.set(currentStepId, []);
         const { timestamp: reqTs, source: reqTsSource } = llmRequestStartTime(ev, lastStepEndTs);
-        const deltaMessages = [];
-        if (stepRound === 1 && ctx.userPrompt) {
-          deltaMessages.push({
-            role: 'user',
-            parts: [{ type: 'text', content: ctx.userPrompt }],
-          });
-          // Note: cumulativeInputMessages already contains the user prompt
-          // (pre-seeded by buildParentSteps). Do not push again.
-        }
-        if (previousToolResults.length > 0) {
-          const toolMessage = toolResultsToMessage(previousToolResults);
-          deltaMessages.push(toolMessage);
-          cumulativeInputMessages.push(toolMessage);
-        }
+        // Ordering invariant: delta must be computed BEFORE flushPendingTools, because
+        // flushPendingTools populates previousToolResults with the current step's tools.
+        // s1's delta should only contain results from a prior step (empty for the first step).
+        const deltaMessages = buildDeltaMessages(stepRound === 1, ctx.userPrompt, previousToolResults, cumulativeInputMessages);
+        previousToolResults = [];
         records.push(buildLlmRequestWithTs(
           reqTs, { hook_event: 'implicit' }, ctx, currentStepId,
           deltaMessages, cumulativeInputMessages, reqTsSource,
@@ -526,18 +506,7 @@ function buildParentSteps(events, ctx) {
     stepToolCalls.set(currentStepId, []);
     const reqTs = lastStepEndTs || ctx.promptEventTs;
 
-    const deltaMessages = [];
-    if (isFirstStep && ctx.userPrompt) {
-      deltaMessages.push({
-        role: 'user',
-        parts: [{ type: 'text', content: ctx.userPrompt }],
-      });
-    }
-    if (previousToolResults.length > 0) {
-      const toolMessage = toolResultsToMessage(previousToolResults);
-      deltaMessages.push(toolMessage);
-      cumulativeInputMessages.push(toolMessage);
-    }
+    const deltaMessages = buildDeltaMessages(isFirstStep, ctx.userPrompt, previousToolResults, cumulativeInputMessages);
 
     records.push(buildLlmRequestWithTs(
       reqTs, { hook_event: 'implicit' }, ctx, currentStepId,
@@ -594,6 +563,31 @@ function toolResultsToMessage(toolResults) {
     response: tr.error || stringify(tr.result),
   }));
   return { role: 'tool', parts };
+}
+
+/**
+ * Build per-step delta messages and update cumulative input.
+ *
+ * - isFirst step: delta includes the user prompt (already pre-seeded in cumulative).
+ * - s2+ steps: delta includes a tool-role message from the previous step's results,
+ *   which is also appended to cumulativeInputMessages.
+ *
+ * Callers are responsible for resetting previousToolResults after this call.
+ */
+function buildDeltaMessages(isFirst, userPrompt, previousToolResults, cumulativeInputMessages) {
+  const deltaMessages = [];
+  if (isFirst && userPrompt) {
+    deltaMessages.push({
+      role: 'user',
+      parts: [{ type: 'text', content: userPrompt }],
+    });
+  }
+  if (previousToolResults.length > 0) {
+    const toolMessage = toolResultsToMessage(previousToolResults);
+    deltaMessages.push(toolMessage);
+    cumulativeInputMessages.push(toolMessage);
+  }
+  return deltaMessages;
 }
 
 function buildLlmResponse(ev, ctx, stepId, partType) {

--- a/assets/hooks/cursor/react-assembler.mjs
+++ b/assets/hooks/cursor/react-assembler.mjs
@@ -269,6 +269,17 @@ function buildParentSteps(events, ctx) {
   // Track last event timestamp for computing next step's LLM start time
   let lastStepEndTs = ctx.promptEventTs; // first step starts at prompt time
 
+  // Cumulative input messages within this turn — represents the full user/tool
+  // message context sent to the LLM at each llm.request. Subagents have no
+  // user prompt seeded (ctx.userPrompt is null for child sessions).
+  const cumulativeInputMessages = [];
+  if (ctx.userPrompt) {
+    cumulativeInputMessages.push({
+      role: 'user',
+      parts: [{ type: 'text', content: ctx.userPrompt }],
+    });
+  }
+
   // Buffer for tools that arrive before any thought
   let pendingToolRecords = [];
   let pendingToolCalls = [];
@@ -351,9 +362,30 @@ function buildParentSteps(events, ctx) {
     currentStepId = `${ctx.stepPrefix || ctx.turnId}:s${stepRound}`;
     currentStepHasTools = false;
     stepToolCalls.set(currentStepId, []);
+
+    // Compute delta for this step:
+    //   s1: user prompt (if any) — already pre-seeded in cumulative.
+    //   s2+: tool results from previous step — append to cumulative.
+    const deltaMessages = [];
+    if (isFirst && userPrompt) {
+      deltaMessages.push({
+        role: 'user',
+        parts: [{ type: 'text', content: userPrompt }],
+      });
+    }
+    if (previousToolResults && previousToolResults.length > 0) {
+      const toolMessage = toolResultsToMessage(previousToolResults);
+      deltaMessages.push(toolMessage);
+      cumulativeInputMessages.push(toolMessage);
+    }
+
     const { timestamp: reqTs, source: reqTsSource } = llmRequestStartTime(ev, lastStepEndTs);
-    records.push(buildLlmRequestWithTs(reqTs, ev, ctx, currentStepId,
-      isFirst ? userPrompt : null, previousToolResults, reqTsSource));
+    records.push(buildLlmRequestWithTs(
+      reqTs, ev, ctx, currentStepId,
+      deltaMessages,
+      cumulativeInputMessages,
+      reqTsSource,
+    ));
     previousToolResults = [];
   }
 
@@ -374,6 +406,38 @@ function buildParentSteps(events, ctx) {
     }
 
     else if (ev.hook_event === 'afterAgentResponse') {
+      // composer-2.5-fast path: no afterAgentThought, tools buffered, no step opened yet.
+      // First open s1 for the buffered tools (so afterAgentResponse can claim s2 below).
+      if (currentStepId === null && pendingToolRecords.length > 0) {
+        stepRound++;
+        currentStepId = `${ctx.stepPrefix || ctx.turnId}:s${stepRound}`;
+        stepToolCalls.set(currentStepId, []);
+        const { timestamp: reqTs, source: reqTsSource } = llmRequestStartTime(ev, lastStepEndTs);
+        const deltaMessages = [];
+        if (stepRound === 1 && ctx.userPrompt) {
+          deltaMessages.push({
+            role: 'user',
+            parts: [{ type: 'text', content: ctx.userPrompt }],
+          });
+          // Note: cumulativeInputMessages already contains the user prompt
+          // (pre-seeded by buildParentSteps). Do not push again.
+        }
+        if (previousToolResults.length > 0) {
+          const toolMessage = toolResultsToMessage(previousToolResults);
+          deltaMessages.push(toolMessage);
+          cumulativeInputMessages.push(toolMessage);
+        }
+        records.push(buildLlmRequestWithTs(
+          reqTs, { hook_event: 'implicit' }, ctx, currentStepId,
+          deltaMessages, cumulativeInputMessages, reqTsSource,
+        ));
+        currentLlmResponse = buildEmptyLlmResponse(
+          { _journal_ts: reqTs, hook_event: 'implicit' }, ctx, currentStepId,
+        );
+        flushPendingTools(currentStepId);
+        currentStepHasTools = true;
+      }
+
       if (currentStepId !== null && currentStepHasTools) {
         openNewStep(ev, false, null);
         currentLlmResponse = buildLlmResponseWithToken(ev, ctx, currentStepId, 'text');
@@ -456,11 +520,30 @@ function buildParentSteps(events, ctx) {
 
   // Buffered tools with no thought/response (entire turn was tools-only)
   if (pendingToolRecords.length > 0) {
+    const isFirstStep = stepRound === 0;
     stepRound++;
     currentStepId = `${ctx.stepPrefix || ctx.turnId}:s${stepRound}`;
     stepToolCalls.set(currentStepId, []);
     const reqTs = lastStepEndTs || ctx.promptEventTs;
-    records.push(buildLlmRequestWithTs(reqTs, { hook_event: 'implicit' }, ctx, currentStepId, ctx.userPrompt, previousToolResults));
+
+    const deltaMessages = [];
+    if (isFirstStep && ctx.userPrompt) {
+      deltaMessages.push({
+        role: 'user',
+        parts: [{ type: 'text', content: ctx.userPrompt }],
+      });
+    }
+    if (previousToolResults.length > 0) {
+      const toolMessage = toolResultsToMessage(previousToolResults);
+      deltaMessages.push(toolMessage);
+      cumulativeInputMessages.push(toolMessage);
+    }
+
+    records.push(buildLlmRequestWithTs(
+      reqTs, { hook_event: 'implicit' }, ctx, currentStepId,
+      deltaMessages,
+      cumulativeInputMessages,
+    ));
     currentLlmResponse = buildEmptyLlmResponse({ _journal_ts: reqTs, hook_event: 'implicit' }, ctx, currentStepId);
     flushPendingTools(currentStepId);
     currentStepHasTools = true;
@@ -476,20 +559,7 @@ function buildParentSteps(events, ctx) {
 
 // ─── Record Builders ───
 
-function buildLlmRequestWithTs(reqTs, ev, ctx, stepId, userPrompt, prevToolResults, timeSource) {
-  const inputMessages = [];
-  if (userPrompt && (!prevToolResults || prevToolResults.length === 0)) {
-    inputMessages.push({ role: 'user', parts: [{ type: 'text', content: userPrompt }] });
-  }
-  if (prevToolResults && prevToolResults.length > 0) {
-    const parts = prevToolResults.map(tr => ({
-      type: 'tool_call_response',
-      id: tr.toolUseId || null,
-      response: tr.error || stringify(tr.result),
-    }));
-    inputMessages.push({ role: 'tool', parts });
-  }
-
+function buildLlmRequestWithTs(reqTs, ev, ctx, stepId, deltaMessages, fullMessages, timeSource) {
   const ts = reqTs ? timestampToUnixNanos(reqTs) : eventTs(ev);
   return applyPolicy({
     time_unix_nano: ts,
@@ -500,10 +570,30 @@ function buildLlmRequestWithTs(reqTs, ev, ctx, stepId, userPrompt, prevToolResul
     'gen_ai.step.id': stepId,
     'gen_ai.provider.name': inferProvider(ev.model || ctx.model),
     'gen_ai.request.model': resolveModel(ev.model || ctx.model),
-    'gen_ai.input.messages': inputMessages.length > 0 ? inputMessages : undefined,
+    'gen_ai.input.messages_delta': deltaMessages && deltaMessages.length > 0
+      ? cloneMessages(deltaMessages)
+      : undefined,
+    'gen_ai.input.messages': fullMessages && fullMessages.length > 0
+      ? cloneMessages(fullMessages)
+      : undefined,
     'agent.cursor.hook_event_name': ev.hook_event,
     'agent.cursor.llm_request_time_source': timeSource,
   }, ctx.runtimeConfig);
+}
+
+/** Deep clone messages so later mutations to cumulative array don't affect emitted records. */
+function cloneMessages(messages) {
+  return JSON.parse(JSON.stringify(messages));
+}
+
+/** Build a tool-role message from collected tool results (used as delta input on s2+ steps). */
+function toolResultsToMessage(toolResults) {
+  const parts = toolResults.map(tr => ({
+    type: 'tool_call_response',
+    id: tr.toolUseId || null,
+    response: tr.error || stringify(tr.result),
+  }));
+  return { role: 'tool', parts };
 }
 
 function buildLlmResponse(ev, ctx, stepId, partType) {

--- a/tests/unit/hooks/cursor-react-assembler.test.ts
+++ b/tests/unit/hooks/cursor-react-assembler.test.ts
@@ -374,19 +374,30 @@ describe('Cursor react assembler', () => {
         record['event.name'] === 'llm.request' &&
         record['gen_ai.step.id'] === 'turn-subagent:s2'
       );
-      const secondStepToolResponses = secondStepRequest?.['gen_ai.input.messages']?.[0]?.parts ?? [];
+      const secondStepDelta = secondStepRequest?.['gen_ai.input.messages_delta'] ?? [];
+      const secondStepFull = secondStepRequest?.['gen_ai.input.messages'] ?? [];
 
       expect(parentSubagentResults).toHaveLength(1);
       expect(parentSubagentResults[0]).toMatchObject({
         'agent.cursor.hook_event_name': 'subagent_result_synthesized',
         'gen_ai.tool.call.result': { summary: 'child final result' },
       });
-      expect(secondStepToolResponses).toHaveLength(1);
-      expect(secondStepToolResponses[0]).toMatchObject({
+      // Delta on s2 = the tool result that arrived since s1
+      expect(secondStepDelta).toHaveLength(1);
+      expect(secondStepDelta[0]).toMatchObject({ role: 'tool' });
+      expect(secondStepDelta[0]?.parts).toHaveLength(1);
+      expect(secondStepDelta[0]?.parts?.[0]).toMatchObject({
         type: 'tool_call_response',
         id: 'call-subagent',
         response: 'child final result',
       });
+      // Full = cumulative user prompt + tool result
+      expect(secondStepFull).toHaveLength(2);
+      expect(secondStepFull[0]).toMatchObject({
+        role: 'user',
+        parts: [{ type: 'text', content: 'delegate this' }],
+      });
+      expect(secondStepFull[1]).toMatchObject({ role: 'tool' });
     } finally {
       fs.rmSync(transcriptDir, { recursive: true, force: true });
     }
@@ -456,19 +467,30 @@ describe('Cursor react assembler', () => {
       record['event.name'] === 'llm.request' &&
       record['gen_ai.step.id'] === 'turn-subagent-fallback:s2'
     );
-    const secondStepToolResponses = secondStepRequest?.['gen_ai.input.messages']?.[0]?.parts ?? [];
+    const secondStepDelta = secondStepRequest?.['gen_ai.input.messages_delta'] ?? [];
+    const secondStepFull = secondStepRequest?.['gen_ai.input.messages'] ?? [];
 
     expect(parentSubagentResults).toHaveLength(1);
     expect(parentSubagentResults[0]).toMatchObject({
       'agent.cursor.hook_event_name': 'postToolUse',
       'gen_ai.tool.call.result': 'cursor fallback result',
     });
-    expect(secondStepToolResponses).toHaveLength(1);
-    expect(secondStepToolResponses[0]).toMatchObject({
+    // Delta on s2 = only the new tool result added since s1's llm.request.
+    expect(secondStepDelta).toHaveLength(1);
+    expect(secondStepDelta[0]).toMatchObject({ role: 'tool' });
+    expect(secondStepDelta[0]?.parts).toHaveLength(1);
+    expect(secondStepDelta[0]?.parts?.[0]).toMatchObject({
       type: 'tool_call_response',
       id: 'call-subagent-fallback',
       response: 'cursor fallback result',
     });
+    // Full = cumulative user prompt + tool result.
+    expect(secondStepFull).toHaveLength(2);
+    expect(secondStepFull[0]).toMatchObject({
+      role: 'user',
+      parts: [{ type: 'text', content: 'delegate without child transcript' }],
+    });
+    expect(secondStepFull[1]).toMatchObject({ role: 'tool' });
   });
 
   // Skip: requires stopGenerationId generation-level isolation (not in this branch)
@@ -680,5 +702,239 @@ describe('Cursor react assembler', () => {
     expect(BigInt(s2Request!.time_unix_nano as string))
       .toBeGreaterThanOrEqual(BigInt(ns(450)));
     expect(s2Response?.time_unix_nano).toBe(ns(800));
+  });
+
+  it('emits delta + full messages on llm.request: s1 has user prompt, s2 has tool result + cumulative', () => {
+    const { records } = assembleTurn([
+      {
+        _journal_ts: iso(0),
+        hook_event: 'beforeSubmitPrompt',
+        conversation_id: 'conv-msg',
+        generation_id: 'turn-msg',
+        model: 'gpt-5.4',
+        prompt: 'list files',
+      },
+      {
+        _journal_ts: iso(100),
+        hook_event: 'afterAgentThought',
+        conversation_id: 'conv-msg',
+        generation_id: 'turn-msg',
+        model: 'gpt-5.4',
+        text: 'will use ls',
+        duration_ms: 50,
+      },
+      {
+        _journal_ts: iso(200),
+        hook_event: 'preToolUse',
+        conversation_id: 'conv-msg',
+        generation_id: 'turn-msg',
+        tool_name: 'ls',
+        tool_use_id: 'call-1',
+        tool_input: { path: '.' },
+      },
+      {
+        _journal_ts: iso(300),
+        hook_event: 'postToolUse',
+        conversation_id: 'conv-msg',
+        generation_id: 'turn-msg',
+        tool_name: 'ls',
+        tool_use_id: 'call-1',
+        tool_output: 'a.txt b.txt',
+        duration_ms: 80,
+      },
+      {
+        _journal_ts: iso(400),
+        hook_event: 'afterAgentResponse',
+        conversation_id: 'conv-msg',
+        generation_id: 'turn-msg',
+        model: 'gpt-5.4',
+        text: 'done',
+        duration_ms: 60,
+      },
+      {
+        _journal_ts: iso(500),
+        hook_event: 'stop',
+        conversation_id: 'conv-msg',
+        generation_id: 'turn-msg',
+        status: 'completed',
+      },
+    ], { stopConversationId: 'conv-msg' });
+
+    const llmRequests = records.filter(r => r['event.name'] === 'llm.request');
+    expect(llmRequests).toHaveLength(2);
+
+    // s1: delta = full = [user prompt]
+    expect(llmRequests[0]!['gen_ai.input.messages_delta']).toEqual([
+      { role: 'user', parts: [{ type: 'text', content: 'list files' }] },
+    ]);
+    expect(llmRequests[0]!['gen_ai.input.messages']).toEqual([
+      { role: 'user', parts: [{ type: 'text', content: 'list files' }] },
+    ]);
+
+    // s2: delta = [tool result], full = [user prompt, tool result]
+    const s2Delta = llmRequests[1]!['gen_ai.input.messages_delta'] as Array<{ role: string; parts: Array<Record<string, unknown>> }>;
+    expect(s2Delta).toHaveLength(1);
+    expect(s2Delta[0]).toMatchObject({ role: 'tool' });
+    expect(s2Delta[0]?.parts?.[0]).toMatchObject({
+      type: 'tool_call_response',
+      id: 'call-1',
+      response: 'a.txt b.txt',
+    });
+
+    const s2Full = llmRequests[1]!['gen_ai.input.messages'] as Array<{ role: string; parts: Array<Record<string, unknown>> }>;
+    expect(s2Full).toHaveLength(2);
+    expect(s2Full[0]).toMatchObject({
+      role: 'user',
+      parts: [{ type: 'text', content: 'list files' }],
+    });
+    expect(s2Full[1]).toMatchObject({ role: 'tool' });
+    expect(s2Full[1]?.parts?.[0]).toMatchObject({
+      type: 'tool_call_response',
+      id: 'call-1',
+      response: 'a.txt b.txt',
+    });
+
+    // Deep-clone isolation: mutating s2's full messages should not affect s1's full.
+    s2Full[0]!.role = 'mutated';
+    expect(llmRequests[0]!['gen_ai.input.messages']).toEqual([
+      { role: 'user', parts: [{ type: 'text', content: 'list files' }] },
+    ]);
+  });
+
+  it('opens a final s2 for afterAgentResponse when no afterAgentThought is emitted (composer-2.5-fast)', () => {
+    // composer-2.5-fast does not emit afterAgentThought: a turn may look like
+    //   beforeSubmitPrompt → preToolUse×N → postToolUse×N → afterAgentResponse → stop
+    // We still expect s1 = buffered tools, s2 = final afterAgentResponse text.
+    const { records } = assembleTurn([
+      {
+        _journal_ts: iso(0),
+        hook_event: 'beforeSubmitPrompt',
+        conversation_id: 'conv-fast',
+        generation_id: 'turn-fast',
+        model: 'composer-2.5-fast',
+        prompt: 'solve leetcode 1',
+      },
+      {
+        _journal_ts: iso(50),
+        hook_event: 'preToolUse',
+        conversation_id: 'conv-fast',
+        generation_id: 'turn-fast',
+        model: 'composer-2.5-fast',
+        tool_name: 'Read',
+        tool_use_id: 'tool-aaa',
+        tool_input: { file_path: '/tmp/foo.py' },
+      },
+      {
+        _journal_ts: iso(120),
+        hook_event: 'postToolUse',
+        conversation_id: 'conv-fast',
+        generation_id: 'turn-fast',
+        model: 'composer-2.5-fast',
+        tool_name: 'Read',
+        tool_use_id: 'tool-aaa',
+        tool_output: 'class Solution: ...',
+        duration_ms: 70,
+      },
+      {
+        _journal_ts: iso(200),
+        hook_event: 'preToolUse',
+        conversation_id: 'conv-fast',
+        generation_id: 'turn-fast',
+        model: 'composer-2.5-fast',
+        tool_name: 'Write',
+        tool_use_id: 'tool-bbb',
+        tool_input: { file_path: '/tmp/foo.py', content: '...' },
+      },
+      {
+        _journal_ts: iso(260),
+        hook_event: 'postToolUse',
+        conversation_id: 'conv-fast',
+        generation_id: 'turn-fast',
+        model: 'composer-2.5-fast',
+        tool_name: 'Write',
+        tool_use_id: 'tool-bbb',
+        tool_output: '{"success":true}',
+        duration_ms: 60,
+      },
+      {
+        _journal_ts: iso(320),
+        hook_event: 'afterAgentResponse',
+        conversation_id: 'conv-fast',
+        generation_id: 'turn-fast',
+        model: 'composer-2.5-fast',
+        text: 'Done, both files updated.',
+        duration_ms: 40,
+        input_tokens: 50000,
+        output_tokens: 120,
+      },
+      {
+        _journal_ts: iso(400),
+        hook_event: 'stop',
+        conversation_id: 'conv-fast',
+        generation_id: 'turn-fast',
+        status: 'completed',
+      },
+    ], { stopConversationId: 'conv-fast' });
+
+    const s1Request = records.find(r =>
+      r['event.name'] === 'llm.request' && r['gen_ai.step.id'] === 'turn-fast:s1'
+    );
+    const s1Response = records.find(r =>
+      r['event.name'] === 'llm.response' && r['gen_ai.step.id'] === 'turn-fast:s1'
+    );
+    const s2Request = records.find(r =>
+      r['event.name'] === 'llm.request' && r['gen_ai.step.id'] === 'turn-fast:s2'
+    );
+    const s2Response = records.find(r =>
+      r['event.name'] === 'llm.response' && r['gen_ai.step.id'] === 'turn-fast:s2'
+    );
+
+    // s1 = buffered tools, s2 = final afterAgentResponse. Both must exist.
+    expect(s1Request).toBeDefined();
+    expect(s2Request).toBeDefined();
+    expect(s1Response).toBeDefined();
+    expect(s2Response).toBeDefined();
+
+    // s1 input: delta = [user prompt]; full = [user prompt].
+    expect(s1Request!['gen_ai.input.messages_delta']).toEqual([
+      { role: 'user', parts: [{ type: 'text', content: 'solve leetcode 1' }] },
+    ]);
+    expect(s1Request!['gen_ai.input.messages']).toEqual([
+      { role: 'user', parts: [{ type: 'text', content: 'solve leetcode 1' }] },
+    ]);
+
+    // s1's llm.response should carry the tool_call parts for both buffered tools.
+    const s1Output = s1Response!['gen_ai.output.messages'] as Array<{ parts: Array<Record<string, unknown>> }>;
+    const s1ToolParts = s1Output[0]!.parts!.filter(p => p.type === 'tool_call') as Array<Record<string, unknown>>;
+    expect(s1ToolParts).toHaveLength(2);
+    expect(s1ToolParts[0]).toMatchObject({ type: 'tool_call', id: 'tool-aaa', name: 'Read' });
+    expect(s1ToolParts[1]).toMatchObject({ type: 'tool_call', id: 'tool-bbb', name: 'Write' });
+
+    // s1 should contain both tool.call and tool.result records.
+    const s1ToolCalls = records.filter(r =>
+      r['event.name'] === 'tool.call' && r['gen_ai.step.id'] === 'turn-fast:s1'
+    );
+    const s1ToolResults = records.filter(r =>
+      r['event.name'] === 'tool.result' && r['gen_ai.step.id'] === 'turn-fast:s1'
+    );
+    expect(s1ToolCalls).toHaveLength(2);
+    expect(s1ToolResults).toHaveLength(2);
+
+    // s2 input: delta = [tool results for Read+Write], full = [user prompt, tool results].
+    const s2Delta = s2Request!['gen_ai.input.messages_delta'] as Array<{ role: string; parts: Array<Record<string, unknown>> }>;
+    expect(s2Delta).toHaveLength(1);
+    expect(s2Delta[0]).toMatchObject({ role: 'tool' });
+    expect(s2Delta[0]!.parts).toHaveLength(2);
+
+    const s2Full = s2Request!['gen_ai.input.messages'] as Array<{ role: string; parts: Array<Record<string, unknown>> }>;
+    expect(s2Full).toHaveLength(2);
+    expect(s2Full[0]).toMatchObject({ role: 'user' });
+    expect(s2Full[1]).toMatchObject({ role: 'tool' });
+
+    // s2 llm.response should carry the final text but NO tool_call parts.
+    const s2Output = s2Response!['gen_ai.output.messages'] as Array<{ parts: Array<Record<string, unknown>> }>;
+    expect(s2Output[0]!.parts![0]).toMatchObject({ type: 'text', content: 'Done, both files updated.' });
+    const s2ToolParts = s2Output[0]!.parts!.filter(p => p.type === 'tool_call');
+    expect(s2ToolParts).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- `llm.request` records now carry both `gen_ai.input.messages_delta`（本 step 增量）和 `gen_ai.input.messages`（累积全量），两者均通过 `JSON.parse(JSON.stringify)` 深拷贝隔离，防止后续 cumulative 修改污染已 emit 的记录
- 修复 composer-2.5-fast 单 step 问题：该模型不发 `afterAgentThought`，`afterAgentResponse` 到来时缓冲的 tools 还没有 step 承载。新增 pre-branch 先开 s1 承载工具调用，再让正常分支开 s2 承载最终文本响应
- `openNewStep` 和 tools-only 兜底分支统一改为构造 `deltaMessages` + `cumulativeInputMessages` 双数组，由 `buildLlmRequestWithTs` 接收新签名 `(reqTs, ev, ctx, stepId, deltaMessages, fullMessages, timeSource)`

## Test plan
- [x] `cursor-react-assembler.test.ts` 9/9 pass（含 2 个 skip）
- [x] 新增 "emits delta + full messages on llm.request"：覆盖 s1（delta=full=[user]）、s2（delta=[tool], full=[user, tool]）以及深拷贝隔离验证
- [x] 新增 "opens a final s2 for afterAgentResponse when no afterAgentThought is emitted (composer-2.5-fast)"：验证 Read+Write 缓冲后 s1 含 tool_call parts、s2 含 final text
- [x] 已有 subagent / fallback 测试断言从 `gen_ai.input.messages` 拆分为 delta + full 校验
- [x] `cursor-source-event.test.mjs` 2/2 pass（未修改）