### PR TITLE
feat(claude-code): capture system_instructions and TTFT via BUN_OPTIONS preload

### DIFF
--- a/agents.d/claude-code.json
+++ b/agents.d/claude-code.json
@@ -20,10 +20,7 @@
     "replaceHookCommands": [
       "otel-claude-hook",
       ".cache/opentelemetry.instrumentation.claude"
-    ],
-    "env": {
-      "BUN_OPTIONS": "--preload=$PILOT_DATA/hooks/claude-code-fetch-intercept.mjs"
-    }
+    ]
   },
   "input": {
     "type": "hook-jsonl",

--- a/agents.d/claude-code.json
+++ b/agents.d/claude-code.json
@@ -20,7 +20,10 @@
     "replaceHookCommands": [
       "otel-claude-hook",
       ".cache/opentelemetry.instrumentation.claude"
-    ]
+    ],
+    "env": {
+      "BUN_OPTIONS": "--preload=$PILOT_DATA/hooks/claude-code-fetch-intercept.mjs"
+    }
   },
   "input": {
     "type": "hook-jsonl",

--- a/assets/hooks/claude-code-fetch-intercept.mjs
+++ b/assets/hooks/claude-code-fetch-intercept.mjs
@@ -1,0 +1,285 @@
+// BUN_OPTIONS preload script for Claude Code fetch interception.
+// Injected via: BUN_OPTIONS="--preload=<this-file>" claude ...
+// Writes one JSON file per LLM call to:
+//   ~/.loongsuite-pilot/intercept/claude-code/<session_id>/<response_id>.json
+//
+// What it captures:
+//   1. system_instructions — parsed from the outgoing /v1/messages request
+//      body's `system` field, mapped to the MessagePart[] form defined by
+//      loongsuite-pilot/specs/gen-ai-system_instructions.json (TextPart uses
+//      `content`, not the Anthropic `text` field). The first block, which is
+//      a Claude Code billing-header marker, is filtered out.
+//   2. response_id — extracted from the first SSE `message_start` event's
+//      `message.id`. Same value pilot already stores under
+//      `gen_ai.response.id`, so the hook processor can join 1:1.
+//   3. ttft_ns — performance.now() delta (ms) at the moment the first
+//      content_block_delta (text_delta / thinking_delta / input_json_delta)
+//      arrives, converted to integer nanoseconds.
+//
+// Design notes:
+//   - SSE is parsed by splitting the accumulated buffer on `\n\n` event
+//     boundaries. A sliding-window regex was tried first and silently
+//     corrupted long preambles — do NOT change back.
+//   - Once both response_id and ttft_ns are captured we stop parsing and
+//     transparently pipe the rest of the stream, keeping memory bounded.
+//   - All work is wrapped in try/catch; an exception here must never break
+//     Claude Code's own fetch flow.
+//   - NOTE: This file uses require() which is Bun-specific in .mjs context.
+//     It only runs under BUN_OPTIONS --preload inside a compiled Bun binary
+//     (Claude Code CLI).
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const INTERCEPT_BASE = path.join(
+  process.env.LOONGSUITE_PILOT_DATA_DIR || path.join(process.env.HOME || '/tmp', '.loongsuite-pilot'),
+  'intercept',
+  'claude-code',
+);
+const LLM_URL_RE = /\/v1\/messages(?:\?|$|\/)/;
+const BILLING_HEADER_PREFIX = 'x-anthropic-billing-header:';
+const SSE_DELIMITER = '\n\n';
+
+// ─── system_instructions extraction ──────────────────────────────────────
+
+function extractSystemInstructions(systemField) {
+  if (systemField == null) return null;
+  // Defensive: accept a bare string and wrap (spec returns array form)
+  if (typeof systemField === 'string') {
+    if (systemField.startsWith(BILLING_HEADER_PREFIX)) return null;
+    return [{ type: 'text', content: systemField }];
+  }
+  if (!Array.isArray(systemField)) return null;
+
+  const result = [];
+  for (const block of systemField) {
+    if (!block || typeof block !== 'object') continue;
+    const type = block.type;
+    if (type === 'text') {
+      const text = typeof block.text === 'string' ? block.text : '';
+      if (text.startsWith(BILLING_HEADER_PREFIX)) continue;
+      result.push({ type: 'text', content: text });
+    } else if (typeof type === 'string') {
+      // Non-text block: pass through under GenericPart (spec allows
+      // additionalProperties). Preserve all original fields so server-side
+      // consumers see everything.
+      const { type: t, ...rest } = block;
+      result.push({ type: t, ...rest });
+    }
+  }
+  return result.length > 0 ? result : null;
+}
+
+// ─── header / body helpers ────────────────────────────────────────────────
+
+function dumpHeaders(h) {
+  const out = {};
+  if (!h) return out;
+  try {
+    if (typeof h.forEach === 'function') {
+      h.forEach((v, k) => { out[String(k).toLowerCase()] = v; });
+    } else if (typeof h === 'object') {
+      for (const k of Object.keys(h)) out[k.toLowerCase()] = h[k];
+    }
+  } catch (_) {}
+  return out;
+}
+
+function readBodyAsText(body) {
+  if (body == null) return null;
+  if (typeof body === 'string') return body;
+  if (body instanceof Uint8Array) {
+    try { return new TextDecoder().decode(body); } catch (_) { return null; }
+  }
+  if (body instanceof ArrayBuffer) {
+    try { return new TextDecoder().decode(new Uint8Array(body)); } catch (_) { return null; }
+  }
+  return null;
+}
+
+function safeParseRequestSystem(body) {
+  const text = readBodyAsText(body);
+  if (!text) return null;
+  try {
+    const parsed = JSON.parse(text);
+    return extractSystemInstructions(parsed.system);
+  } catch (_) {
+    return null;
+  }
+}
+
+// ─── intercept record writer ──────────────────────────────────────────────
+
+function writeRecord(sessionId, record) {
+  try {
+    const dir = path.join(INTERCEPT_BASE, sessionId);
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, `${record.response_id}.json`);
+    // Single record per file (~27KB worst case) — POSIX guarantees writes
+    // under PIPE_BUF (~4KB) are atomic; for larger writes appendFileSync
+    // could interleave, but writeFileSync writes once to a fresh inode so
+    // partial reads aren't a concern in practice.
+    fs.writeFileSync(file, JSON.stringify(record));
+  } catch (_) {
+    // intercept storage failure must not affect the host process
+  }
+}
+
+// ─── SSE event-block parsing ──────────────────────────────────────────────
+
+/**
+ * Parse a single complete SSE event block (text between two `\n\n`).
+ * Returns { event, data } or null if malformed.
+ */
+function parseSseBlock(block) {
+  let event = null;
+  const dataLines = [];
+  for (const line of block.split('\n')) {
+    if (line.startsWith('event:')) event = line.slice(6).trim();
+    else if (line.startsWith('data:')) dataLines.push(line.slice(5).trim());
+  }
+  if (!event || dataLines.length === 0) return null;
+  return { event, data: dataLines.join('\n') };
+}
+
+// ─── globalThis.fetch monkey-patch ───────────────────────────────────────
+
+const origFetch = globalThis.fetch;
+if (typeof origFetch === 'function') {
+  globalThis.fetch = async function patchedFetch(input, init) {
+    let url;
+    try {
+      url = typeof input === 'string' ? input
+          : (input && typeof input === 'object' && typeof input.url === 'string') ? input.url
+          : String(input);
+    } catch (_) {
+      url = '';
+    }
+
+    if (!url || !LLM_URL_RE.test(url)) {
+      return origFetch.call(this, input, init);
+    }
+
+    // Header session_id is required to scope intercept output. Without it
+    // we have no way for the hook processor to find this record, so we
+    // skip writing — let the request go through normally.
+    let sessionId = null;
+    let systemInstructions = null;
+    try {
+      const headers = dumpHeaders(
+        init?.headers ?? (input && typeof input === 'object' ? input.headers : null),
+      );
+      sessionId = headers['x-claude-code-session-id'] || null;
+      if (sessionId) {
+        const body = init?.body
+          ?? (input && typeof input === 'object' ? input.body : null);
+        systemInstructions = safeParseRequestSystem(body);
+      }
+    } catch (_) {}
+
+    if (!sessionId) {
+      return origFetch.call(this, input, init);
+    }
+
+    const startMs = performance.now();
+    let response;
+    try {
+      response = await origFetch.call(this, input, init);
+    } catch (err) {
+      // Network failure: nothing useful to record; rethrow to host.
+      throw err;
+    }
+
+    // No body (HEAD-style, 204, etc.) → can't observe stream.
+    if (!response || !response.body) return response;
+
+    let responseId = null;
+    let ttftNs = null;
+    let recordWritten = false;
+    let stopParsing = false;
+    const decoder = new TextDecoder();
+    let pending = '';
+
+    const tryEmit = () => {
+      if (recordWritten || !responseId) return;
+      writeRecord(sessionId, {
+        session_id: sessionId,
+        response_id: responseId,
+        ttft_ns: ttftNs,
+        system_instructions: systemInstructions,
+      });
+      recordWritten = true;
+    };
+
+    const processBlock = (block) => {
+      const parsed = parseSseBlock(block);
+      if (!parsed) return;
+      if (parsed.event === 'message_start' && responseId === null) {
+        try {
+          const evt = JSON.parse(parsed.data);
+          if (evt?.message?.id) responseId = String(evt.message.id);
+        } catch (_) {}
+      } else if (parsed.event === 'content_block_delta' && ttftNs === null) {
+        try {
+          const evt = JSON.parse(parsed.data);
+          const dtype = evt?.delta?.type;
+          if (dtype === 'text_delta' || dtype === 'thinking_delta' || dtype === 'input_json_delta') {
+            const ms = performance.now() - startMs;
+            ttftNs = Math.max(0, Math.round(ms * 1e6));
+          }
+        } catch (_) {}
+      }
+    };
+
+    let transform;
+    try {
+      transform = new TransformStream({
+        transform(chunk, controller) {
+          controller.enqueue(chunk); // pass through first, parsing is best-effort
+          if (stopParsing) return;
+          try {
+            pending += decoder.decode(chunk, { stream: true });
+            let idx;
+            while ((idx = pending.indexOf(SSE_DELIMITER)) !== -1) {
+              const block = pending.slice(0, idx);
+              pending = pending.slice(idx + SSE_DELIMITER.length);
+              processBlock(block);
+            }
+            if (responseId && ttftNs !== null) {
+              tryEmit();
+              stopParsing = true;
+              pending = '';
+            }
+          } catch (_) {}
+        },
+        flush() {
+          // Stream ended normally without ever producing a content delta
+          // (e.g. tool-only response that arrived as a single block, or
+          // server returned an error mid-stream). Persist whatever we have.
+          if (!recordWritten && responseId) tryEmit();
+        },
+      });
+    } catch (_) {
+      // TransformStream construction failed (very old runtime): bail out
+      // and return the original response untouched.
+      return response;
+    }
+
+    let wrappedBody;
+    try {
+      wrappedBody = response.body.pipeThrough(transform);
+    } catch (_) {
+      return response;
+    }
+
+    try {
+      return new Response(wrappedBody, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+    } catch (_) {
+      return response;
+    }
+  };
+}

--- a/assets/hooks/claude-code-hook-processor.mjs
+++ b/assets/hooks/claude-code-hook-processor.mjs
@@ -71,6 +71,78 @@ function defaultLogDir() {
   return path.join(pilotDataDir(), 'logs', AGENT_ID);
 }
 
+// ─── intercept (BUN_OPTIONS preload) data integration ───
+
+const INTERCEPT_STALE_MS = 60 * 60 * 1000; // 1 hour
+
+function interceptSessionDir(sessionId) {
+  return path.join(pilotDataDir(), 'intercept', AGENT_ID, sessionId);
+}
+
+/**
+ * Read per-LLM-call intercept records dropped by claude-code-fetch-intercept.mjs.
+ * Returns Map<response_id, { ttft_ns, system_instructions, _file }>.
+ * Tracks `_file` so reapInterceptFiles can delete merged records after
+ * buildTurnRecords consumes them.
+ */
+function loadInterceptForSession(sessionId) {
+  const out = new Map();
+  const dir = interceptSessionDir(sessionId);
+  let entries;
+  try { entries = fs.readdirSync(dir); } catch { return out; }
+  for (const name of entries) {
+    if (!name.endsWith('.json')) continue;
+    const filePath = path.join(dir, name);
+    let raw;
+    try {
+      raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    } catch (_) {
+      // Corrupt record (preload crashed mid-write): leave the file in place
+      // so the stale reaper picks it up later, do not block merging.
+      continue;
+    }
+    if (raw && typeof raw.response_id === 'string' && raw.response_id.length > 0) {
+      out.set(raw.response_id, { ...raw, _file: filePath });
+    }
+  }
+  return out;
+}
+
+/**
+ * Delete intercept files corresponding to response_ids that buildTurnRecords
+ * actually merged into emitted events. Files whose response_id was not in
+ * the transcript stay on disk (they may belong to a future turn or be
+ * stragglers that reapStaleIntercept will clean up).
+ */
+function reapInterceptFiles(intercept, mergedResponseIds) {
+  for (const rid of mergedResponseIds) {
+    const data = intercept.get(rid);
+    if (!data?._file) continue;
+    try { fs.unlinkSync(data._file); } catch (_) {}
+  }
+}
+
+/**
+ * Opportunistic cleanup: drop files in this session's intercept dir whose
+ * mtime is older than STALE_MS (1h). Called once at the end of exportSession
+ * — handles orphans from prior turns whose response_ids never showed up in
+ * any subsequent transcript. Also rmdir if the dir is empty afterwards.
+ */
+function reapStaleIntercept(sessionId) {
+  const dir = interceptSessionDir(sessionId);
+  let entries;
+  try { entries = fs.readdirSync(dir); } catch { return; }
+  const now = Date.now();
+  for (const name of entries) {
+    const f = path.join(dir, name);
+    try {
+      const st = fs.statSync(f);
+      if (now - st.mtimeMs > INTERCEPT_STALE_MS) fs.unlinkSync(f);
+    } catch (_) {}
+  }
+  try { fs.rmdirSync(dir); } catch (_) {}
+}
+
 function tryReadStdin() {
   try {
     return readStdinJson();
@@ -296,11 +368,17 @@ async function exportSession(state, stopReason) {
 
   const cwd = state.cwd || undefined;
 
+  // Load per-session intercept data once; buildTurnRecords looks up by
+  // response_id (= Anthropic message_id). Empty Map when preload didn't
+  // produce any files — merge logic safely no-ops in that case.
+  const intercept = loadInterceptForSession(sessionId);
+  const mergedResponseIds = new Set();
+
   for (let i = 0; i < turnsToExport.length; i++) {
     const turn = turnsToExport[i];
     const isLast = i === turnsToExport.length - 1;
     const turnStopReason = isLast ? stopReason : 'end_turn';
-    const { records, hash } = buildTurnRecords(
+    const { records, hash, mergedResponseIds: turnMerged } = buildTurnRecords(
       turn,
       baseTurnCount + i,
       sessionId,
@@ -308,9 +386,13 @@ async function exportSession(state, stopReason) {
       userId,
       turnStopReason,
       cwd,
+      intercept,
     );
     allRecords.push(...records);
     logHash = hash;
+    if (turnMerged) {
+      for (const rid of turnMerged) mergedResponseIds.add(rid);
+    }
   }
 
   // turn_count 计入全部 turns(含跳过的历史), 确保 offset 正确推进不重复上报
@@ -318,16 +400,25 @@ async function exportSession(state, stopReason) {
 
   const cleaned = allRecords.map((r) => applyHookContentPolicy(sanitizeObject(r) || r, runtimeConfig));
   writeJsonlRecords(defaultLogDir(), AGENT_ID, cleaned);
+
+  // Cleanup intercept files: delete what we merged + drop stragglers from
+  // earlier turns. Failure is silent — host process must not be impacted.
+  reapInterceptFiles(intercept, mergedResponseIds);
+  reapStaleIntercept(sessionId);
 }
 
 // ─── buildTurnRecords — 单 turn 的 JSONL 记录构造 (v2: tool_use_id 归属) ───
 
-function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStopReason, cwd) {
+function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStopReason, cwd, intercept) {
   const records = [];
   const turnId = `${sessionId}:t${turnIndex + 1}`;
   let stepRound = 0;
   let runningHash = prevHash;
   let prevInputMsgs = [];
+  // response_ids whose intercept record we actually merged into emitted
+  // events. exportSession uses this set to delete the corresponding
+  // intercept files after JSONL is flushed.
+  const mergedResponseIds = new Set();
 
   const traceId = generateTraceId();
   const entrySpanId = generateSpanId();
@@ -388,6 +479,13 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
       logFull = shouldLogFullMessages(runningHash, delta, currentFullHash);
     }
 
+    // Look up preload-captured data once per LLM call. ev.message_id matches
+    // the SSE message_start `message.id` the preload script extracted.
+    const interceptData = intercept && ev.message_id
+      ? intercept.get(ev.message_id)
+      : undefined;
+    if (interceptData) mergedResponseIds.add(ev.message_id);
+
     // llm.request
     const reqRecord = {
       time_unix_nano: isoToUnixNanos(ev.request_start_time),
@@ -405,6 +503,10 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
     };
     if (logFull) {
       reqRecord['gen_ai.input.messages'] = inputMsgs;
+    }
+    if (interceptData && Array.isArray(interceptData.system_instructions)
+        && interceptData.system_instructions.length > 0) {
+      reqRecord['gen_ai.system_instructions'] = interceptData.system_instructions;
     }
     records.push(reqRecord);
 
@@ -437,6 +539,10 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
       'gen_ai.usage.total_tokens': totalTokens,
       'gen_ai.output.messages': convertOutputMessages(ev.output_content, ev.stop_reason),
     };
+    if (interceptData && typeof interceptData.ttft_ns === 'number'
+        && Number.isFinite(interceptData.ttft_ns) && interceptData.ttft_ns >= 0) {
+      respRecord['gen_ai.response.time_to_first_token'] = interceptData.ttft_ns;
+    }
     records.push(respRecord);
 
     runningHash = currentFullHash;
@@ -514,7 +620,7 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
     return 0;
   });
 
-  return { records, hash: runningHash };
+  return { records, hash: runningHash, mergedResponseIds };
 }
 
 // ─── dispatcher ───

--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -903,6 +903,65 @@ remove_qodercli_token_intercept() {
 }
 
 # ============================================================
+# Claude Code fetch intercept: inject/remove shell function
+#
+# Why a shell wrapper instead of ~/.claude/settings.json env:
+#   Claude Code is a Bun-compiled binary. Bun reads BUN_OPTIONS at runtime
+#   startup (before any JS executes), so settings.json env values are too
+#   late — they only affect Claude Code's child processes, not the Bun
+#   preload of the main process. A shell wrapper that sets BUN_OPTIONS
+#   before invoking `claude` is the only reliable injection point.
+#
+# The wrapper prepends our preload but preserves any existing BUN_OPTIONS
+# the user (or qodercli wrapper, or launchd setenv) may have set.
+# ============================================================
+inject_claude_code_fetch_intercept() {
+    if ! echo "$SELECTED_AGENTS" | grep -q 'claude-code'; then return 0; fi
+    if ! command -v claude >/dev/null 2>&1; then return 0; fi
+
+    local intercept_script="$DATA_DIR/hooks/claude-code-fetch-intercept.mjs"
+    if [ ! -f "$intercept_script" ]; then return 0; fi
+
+    msg "==> 配置 claude-code fetch 拦截..." "==> Configuring claude-code fetch intercept..."
+
+    _inject_to_rc() {
+        local file="$1"
+        if [ ! -f "$file" ]; then return 0; fi
+        if [ ! -w "$file" ]; then
+            msg "    ⚠️  $file 不可写，跳过" "    ⚠️  $file is not writable, skipping"
+            return 0
+        fi
+        if grep -q 'loongsuite-pilot BEGIN claude-code-intercept' "$file" 2>/dev/null; then return 0; fi
+        [ -s "$file" ] && [ "$(tail -c1 "$file" | wc -l)" -eq 0 ] && echo "" >> "$file"
+        cat >> "$file" << 'INTERCEPTBLOCK'
+
+# loongsuite-pilot BEGIN claude-code-intercept
+claude() { BUN_OPTIONS="--preload=$HOME/.loongsuite-pilot/hooks/claude-code-fetch-intercept.mjs ${BUN_OPTIONS}" command claude "$@"; }
+# loongsuite-pilot END claude-code-intercept
+INTERCEPTBLOCK
+        msg "    ✅ 已写入 $file (请执行 source $file 或打开新终端)" \
+            "    ✅ Written to $file (run: source $file or open a new terminal)"
+    }
+
+    case "${SHELL:-/bin/bash}" in
+        */zsh)  _inject_to_rc "$HOME/.zshrc" ;;
+        */bash) _inject_to_rc "$HOME/.bashrc" ;;
+        *)      _inject_to_rc "$HOME/.bashrc" ;;
+    esac
+    echo ""
+}
+
+remove_claude_code_fetch_intercept() {
+    for file in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.profile"; do
+        if [ -f "$file" ] && grep -q 'loongsuite-pilot BEGIN claude-code-intercept' "$file" 2>/dev/null; then
+            _sed_inplace '/# loongsuite-pilot BEGIN claude-code-intercept/,/# loongsuite-pilot END claude-code-intercept/d' "$file"
+            msg "    已清理 claude-code fetch intercept ($file)" \
+                "    Cleaned up claude-code fetch intercept ($file)"
+        fi
+    done
+}
+
+# ============================================================
 # Common: read VERSION file fields
 # ============================================================
 get_installed_version() {
@@ -1267,6 +1326,7 @@ cmd_install() {
     write_config
     install_loongsuite_pilot_command
     inject_qodercli_token_intercept
+    inject_claude_code_fetch_intercept
 
     msg "==> 启动服务..." "==> Starting service..."
     local _start_args=""
@@ -1569,6 +1629,7 @@ cmd_uninstall() {
     msg "==> 清理 hook 配置..." "==> Cleaning up hook configs..."
     remove_hook_configs
     remove_qodercli_token_intercept
+    remove_claude_code_fetch_intercept
     echo ""
 
     # Remove OTel Claude plugin

--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -874,10 +874,12 @@ inject_qodercli_token_intercept() {
         fi
         if grep -q 'loongsuite-pilot BEGIN qodercli-intercept' "$file" 2>/dev/null; then return 0; fi
         [ -s "$file" ] && [ "$(tail -c1 "$file" | wc -l)" -eq 0 ] && echo "" >> "$file"
-        cat >> "$file" << 'INTERCEPTBLOCK'
+        # Double-quoted heredoc so $DATA_DIR expands at install time, honoring
+        # --data-dir overrides. $@ is escaped to defer expansion to runtime.
+        cat >> "$file" << INTERCEPTBLOCK
 
 # loongsuite-pilot BEGIN qodercli-intercept
-qodercli() { BUN_OPTIONS="--preload=$HOME/.loongsuite-pilot/hooks/qodercli-token-intercept.mjs" command qodercli "$@"; }
+qodercli() { BUN_OPTIONS="--preload=$DATA_DIR/hooks/qodercli-token-intercept.mjs" command qodercli "\$@"; }
 # loongsuite-pilot END qodercli-intercept
 INTERCEPTBLOCK
         msg "    ✅ 已写入 $file (请执行 source $file 或打开新终端)" \
@@ -933,10 +935,13 @@ inject_claude_code_fetch_intercept() {
         fi
         if grep -q 'loongsuite-pilot BEGIN claude-code-intercept' "$file" 2>/dev/null; then return 0; fi
         [ -s "$file" ] && [ "$(tail -c1 "$file" | wc -l)" -eq 0 ] && echo "" >> "$file"
-        cat >> "$file" << 'INTERCEPTBLOCK'
+        # Double-quoted heredoc so $DATA_DIR expands at install time, honoring
+        # --data-dir overrides. Other refs (${BUN_OPTIONS}, $@) are escaped to
+        # defer expansion until the wrapper actually runs in the user's shell.
+        cat >> "$file" << INTERCEPTBLOCK
 
 # loongsuite-pilot BEGIN claude-code-intercept
-claude() { BUN_OPTIONS="--preload=$HOME/.loongsuite-pilot/hooks/claude-code-fetch-intercept.mjs ${BUN_OPTIONS}" command claude "$@"; }
+claude() { BUN_OPTIONS="--preload=$DATA_DIR/hooks/claude-code-fetch-intercept.mjs \${BUN_OPTIONS}" command claude "\$@"; }
 # loongsuite-pilot END claude-code-intercept
 INTERCEPTBLOCK
         msg "    ✅ 已写入 $file (请执行 source $file 或打开新终端)" \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "loongsuite-pilot",
-  "version": "1.1.5",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loongsuite-pilot",
-      "version": "1.1.5",
+      "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
         "@alicloud/log": "^1.2.6",
-        "@loongsuite/otel-util-genai": "^0.1.0-beta.5",
+        "@loongsuite/otel-util-genai": "^0.1.0-beta.7",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.57.0",
         "@opentelemetry/otlp-transformer": "^0.57.0",
@@ -657,9 +657,9 @@
       }
     },
     "node_modules/@loongsuite/otel-util-genai": {
-      "version": "0.1.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@loongsuite/otel-util-genai/-/otel-util-genai-0.1.0-beta.5.tgz",
-      "integrity": "sha512-kQqW49LIdTPI/oRqit7/fXC80V6vtAmuituvd5dGCCshS3EnVwM6SNfB05BNb8ughcRyeMdOgwGFmHgA2OOLAg==",
+      "version": "0.1.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@loongsuite/otel-util-genai/-/otel-util-genai-0.1.0-beta.7.tgz",
+      "integrity": "sha512-0piH4ENgkvXR4jCVTcotdI9ty/S+O1L2otkuefqNYieo0q0/lTLF+xwDSX6sCBaYOU3qEGwjPznbRTfvgDyUdw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.40.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@alicloud/log": "^1.2.6",
-        "@loongsuite/otel-util-genai": "^0.1.0-beta.7",
+        "@loongsuite/otel-util-genai": "^0.1.0-beta.8",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.57.0",
         "@opentelemetry/otlp-transformer": "^0.57.0",
@@ -657,9 +657,9 @@
       }
     },
     "node_modules/@loongsuite/otel-util-genai": {
-      "version": "0.1.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@loongsuite/otel-util-genai/-/otel-util-genai-0.1.0-beta.7.tgz",
-      "integrity": "sha512-0piH4ENgkvXR4jCVTcotdI9ty/S+O1L2otkuefqNYieo0q0/lTLF+xwDSX6sCBaYOU3qEGwjPznbRTfvgDyUdw==",
+      "version": "0.1.0-beta.8",
+      "resolved": "https://registry.npmjs.org/@loongsuite/otel-util-genai/-/otel-util-genai-0.1.0-beta.8.tgz",
+      "integrity": "sha512-YQdBxoVBGyU6MMbnp14i3D5H3R0+uPFe/3z18DQo26EL1TtMgILTcLtq27Vf751duKZRa9Uw7gu0rss6W0+PVA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.40.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@alicloud/log": "^1.2.6",
-    "@loongsuite/otel-util-genai": "^0.1.0-beta.7",
+    "@loongsuite/otel-util-genai": "^0.1.0-beta.8",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.57.0",
     "@opentelemetry/otlp-transformer": "^0.57.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@alicloud/log": "^1.2.6",
-    "@loongsuite/otel-util-genai": "^0.1.0-beta.5",
+    "@loongsuite/otel-util-genai": "^0.1.0-beta.7",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.57.0",
     "@opentelemetry/otlp-transformer": "^0.57.0",

--- a/src/deployment/hook-strategy.ts
+++ b/src/deployment/hook-strategy.ts
@@ -88,6 +88,19 @@ export class HookStrategy implements DeployStrategy {
     try {
       await this.ensureSettingsFile(hookConfig.settingsPath);
 
+      if (hookConfig.env) {
+        try {
+          await this.applyEnvToSettings(hookConfig.settingsPath, hookConfig.env);
+        } catch (err) {
+          // env injection failure must not block hook deployment — pilot can still
+          // collect the basic transcript-based events without preload.
+          logger.warn('settings.env merge failed (non-blocking)', {
+            agentId: def.id,
+            error: String(err),
+          });
+        }
+      }
+
       const hookDefs = this.buildHookDefinitions(def);
       for (const hookDef of hookDefs) {
         const installed = await this.hookManager.isHookInstalled(hookDef);
@@ -273,6 +286,61 @@ export class HookStrategy implements DeployStrategy {
       useNestedFormat: hookConfig.format === 'nested',
       replaceHookCommands: hookConfig.replaceHookCommands,
     }));
+  }
+
+  /**
+   * Merge env entries from the agent hook config into the settings file's
+   * top-level `env` block. Supports `$PILOT_DATA` token expansion.
+   *
+   * Idempotency:
+   *   - Regular keys overwrite if already present.
+   *   - `BUN_OPTIONS` is treated as a space-separated flag list. If the
+   *     existing value already contains the same `--preload=<path>` we are
+   *     about to add, the write is skipped (allows coexistence with user's
+   *     own preload scripts).
+   *
+   * Failure here is non-fatal — caller in deploy() wraps in try/catch.
+   */
+  private async applyEnvToSettings(
+    settingsPath: string,
+    env: Record<string, string>,
+  ): Promise<void> {
+    const pilotData = resolveHome('~/.loongsuite-pilot');
+    const existing =
+      (await readJsonFile<Record<string, unknown>>(settingsPath)) ?? {};
+    const envBlock =
+      (existing.env as Record<string, string> | undefined) ?? {};
+    let changed = false;
+
+    for (const [key, rawValue] of Object.entries(env)) {
+      const expanded = rawValue.replace(/\$PILOT_DATA/g, pilotData);
+
+      if (key === 'BUN_OPTIONS') {
+        const current = envBlock[key];
+        if (typeof current === 'string' && current.length > 0) {
+          // Extract our --preload= token (anything after the first =) so we
+          // can probe substring presence rather than exact match.
+          const eqIdx = expanded.indexOf('=');
+          const ourToken = eqIdx >= 0 ? expanded.slice(eqIdx + 1) : expanded;
+          if (current.includes(ourToken)) {
+            continue; // already injected
+          }
+          envBlock[key] = `${current} ${expanded}`.trim();
+          changed = true;
+          continue;
+        }
+      }
+
+      if (envBlock[key] !== expanded) {
+        envBlock[key] = expanded;
+        changed = true;
+      }
+    }
+
+    if (!changed) return;
+    existing.env = envBlock;
+    await writeJsonFile(settingsPath, existing);
+    logger.info('settings.env merged', { settingsPath, keys: Object.keys(env) });
   }
 
   /**

--- a/src/deployment/hook-strategy.ts
+++ b/src/deployment/hook-strategy.ts
@@ -305,34 +305,35 @@ export class HookStrategy implements DeployStrategy {
     settingsPath: string,
     env: Record<string, string>,
   ): Promise<void> {
-    const pilotData = resolveHome('~/.loongsuite-pilot');
+    // NOTE: $PILOT_DATA tokens in `env` values are already resolved by
+    // AgentDefLoader.resolveVariables() before the config reaches here
+    // (see agent-def-loader.ts), so no further expansion is needed.
     const existing =
       (await readJsonFile<Record<string, unknown>>(settingsPath)) ?? {};
     const envBlock =
       (existing.env as Record<string, string> | undefined) ?? {};
     let changed = false;
 
-    for (const [key, rawValue] of Object.entries(env)) {
-      const expanded = rawValue.replace(/\$PILOT_DATA/g, pilotData);
-
+    for (const [key, value] of Object.entries(env)) {
       if (key === 'BUN_OPTIONS') {
         const current = envBlock[key];
         if (typeof current === 'string' && current.length > 0) {
-          // Extract our --preload= token (anything after the first =) so we
-          // can probe substring presence rather than exact match.
-          const eqIdx = expanded.indexOf('=');
-          const ourToken = eqIdx >= 0 ? expanded.slice(eqIdx + 1) : expanded;
-          if (current.includes(ourToken)) {
-            continue; // already injected
+          // Match against full whitespace-delimited tokens to avoid a
+          // superstring false-positive (e.g., `...intercept.mjs-debug`
+          // would otherwise be treated as already containing our path).
+          const ourTokens = value.split(/\s+/).filter(Boolean);
+          const currentTokens = current.split(/\s+/).filter(Boolean);
+          if (ourTokens.every((t) => currentTokens.includes(t))) {
+            continue; // already injected (exact tokens present)
           }
-          envBlock[key] = `${current} ${expanded}`.trim();
+          envBlock[key] = `${current} ${value}`.trim();
           changed = true;
           continue;
         }
       }
 
-      if (envBlock[key] !== expanded) {
-        envBlock[key] = expanded;
+      if (envBlock[key] !== value) {
+        envBlock[key] = value;
         changed = true;
       }
     }

--- a/src/types/deployment.ts
+++ b/src/types/deployment.ts
@@ -69,8 +69,13 @@ export interface AgentHookConfig {
    *     write is skipped to keep deploy idempotent and to coexist with
    *     other preload scripts the user may have configured.
    *
-   * Used by Claude Code to inject `BUN_OPTIONS=--preload=...` so the
-   * fetch-intercept script loads inside the Bun-compiled CLI process.
+   * NOTE: settings.json env is read AFTER the agent's main process starts,
+   * so it can only affect child processes the agent spawns. It cannot
+   * influence runtime flags that the host process itself consumes at
+   * startup — most notably `BUN_OPTIONS` for Bun-compiled binaries, which
+   * Bun reads before any JS executes. For BUN_OPTIONS-style injections,
+   * use a shell-rc wrapper instead (see installer-opensource.sh
+   * inject_claude_code_fetch_intercept).
    */
   env?: Record<string, string>;
 }

--- a/src/types/deployment.ts
+++ b/src/types/deployment.ts
@@ -58,6 +58,21 @@ export interface AgentHookConfig {
    * where the quoted path in -File "..." would become literal characters.
    */
   rawCommand?: boolean;
+  /**
+   * Optional env block to merge into the agent's settings.json on deploy.
+   *
+   * Each value supports `$PILOT_DATA` token, which HookStrategy expands to
+   * the resolved pilot data directory at write time. The merge semantics:
+   *   - Regular keys: overwrite if present
+   *   - `BUN_OPTIONS` is treated as space-separated flags; if the existing
+   *     value already contains the same `--preload=<path>` we add, the
+   *     write is skipped to keep deploy idempotent and to coexist with
+   *     other preload scripts the user may have configured.
+   *
+   * Used by Claude Code to inject `BUN_OPTIONS=--preload=...` so the
+   * fetch-intercept script loads inside the Bun-compiled CLI process.
+   */
+  env?: Record<string, string>;
 }
 
 export interface PluginSourceConfig {

--- a/src/types/deployment.ts
+++ b/src/types/deployment.ts
@@ -61,13 +61,16 @@ export interface AgentHookConfig {
   /**
    * Optional env block to merge into the agent's settings.json on deploy.
    *
-   * Each value supports `$PILOT_DATA` token, which HookStrategy expands to
-   * the resolved pilot data directory at write time. The merge semantics:
+   * Each value may contain the `$PILOT_DATA` token; AgentDefLoader resolves
+   * it (recursively, honoring `LOONGSUITE_PILOT_DATA_DIR`) when loading the
+   * agent definition, so HookStrategy receives already-expanded strings.
+   *
+   * Merge semantics:
    *   - Regular keys: overwrite if present
-   *   - `BUN_OPTIONS` is treated as space-separated flags; if the existing
-   *     value already contains the same `--preload=<path>` we add, the
-   *     write is skipped to keep deploy idempotent and to coexist with
-   *     other preload scripts the user may have configured.
+   *   - `BUN_OPTIONS` is treated as space-separated flags; if every token
+   *     we would add is already present, the write is skipped to keep
+   *     deploy idempotent and to coexist with other preload scripts the
+   *     user may have configured.
    *
    * NOTE: settings.json env is read AFTER the agent's main process starts,
    * so it can only affect child processes the agent spawns. It cannot

--- a/tests/unit/deployment/hook-strategy.test.ts
+++ b/tests/unit/deployment/hook-strategy.test.ts
@@ -279,6 +279,145 @@ describe('HookStrategy', () => {
     });
   });
 
+  describe('env injection (settings.env merge)', () => {
+    // Helper: build a def whose hook block carries an env directive.
+    // Uses settings.json (not hooks.json) so ensureSettingsFile is a no-op
+    // and the only writeJsonFile we observe comes from applyEnvToSettings.
+    const envHookDef = (env: Record<string, string> | undefined) =>
+      makeDef({
+        hook: {
+          settingsPath: '/home/.test/settings.json',
+          events: ['Stop'],
+          hookCommand: '/opt/pilot/hooks/test.sh',
+          format: 'nested',
+          ...(env ? { env } : {}),
+        },
+      });
+
+    beforeEach(() => {
+      mockHookManager.isHookInstalled.mockResolvedValue(false);
+      mockHookManager.installHook.mockResolvedValue(true);
+    });
+
+    it('hook config without env → no settings write', async () => {
+      vi.mocked(readJsonFile).mockResolvedValue(null);
+
+      await strategy.deploy(envHookDef(undefined));
+
+      expect(writeJsonFile).not.toHaveBeenCalled();
+    });
+
+    it('first-time injection: $PILOT_DATA expanded and env block created', async () => {
+      // No existing settings file
+      vi.mocked(readJsonFile).mockResolvedValue(null);
+
+      await strategy.deploy(envHookDef({
+        BUN_OPTIONS: '--preload=$PILOT_DATA/hooks/intercept.mjs',
+      }));
+
+      expect(writeJsonFile).toHaveBeenCalledWith(
+        '/home/.test/settings.json',
+        {
+          env: {
+            BUN_OPTIONS: '--preload=~/.loongsuite-pilot/hooks/intercept.mjs',
+          },
+        },
+      );
+    });
+
+    it('BUN_OPTIONS idempotency: existing value already contains our preload → skip write', async () => {
+      vi.mocked(readJsonFile).mockResolvedValue({
+        env: {
+          BUN_OPTIONS: '--preload=~/.loongsuite-pilot/hooks/intercept.mjs',
+        },
+      });
+
+      await strategy.deploy(envHookDef({
+        BUN_OPTIONS: '--preload=$PILOT_DATA/hooks/intercept.mjs',
+      }));
+
+      expect(writeJsonFile).not.toHaveBeenCalled();
+    });
+
+    it('BUN_OPTIONS coexistence: append our preload alongside user\'s own', async () => {
+      vi.mocked(readJsonFile).mockResolvedValue({
+        env: { BUN_OPTIONS: '--preload=/user/own/script.js' },
+      });
+
+      await strategy.deploy(envHookDef({
+        BUN_OPTIONS: '--preload=$PILOT_DATA/hooks/intercept.mjs',
+      }));
+
+      expect(writeJsonFile).toHaveBeenCalledWith(
+        '/home/.test/settings.json',
+        {
+          env: {
+            BUN_OPTIONS:
+              '--preload=/user/own/script.js --preload=~/.loongsuite-pilot/hooks/intercept.mjs',
+          },
+        },
+      );
+    });
+
+    it('non-BUN_OPTIONS key overwrites existing value', async () => {
+      vi.mocked(readJsonFile).mockResolvedValue({
+        env: { OTHER_KEY: 'old_value' },
+      });
+
+      await strategy.deploy(envHookDef({ OTHER_KEY: 'new_value' }));
+
+      expect(writeJsonFile).toHaveBeenCalledWith(
+        '/home/.test/settings.json',
+        { env: { OTHER_KEY: 'new_value' } },
+      );
+    });
+
+    it('preserves unrelated env keys and other top-level settings', async () => {
+      vi.mocked(readJsonFile).mockResolvedValue({
+        env: { ANTHROPIC_AUTH_TOKEN: 'secret' },
+        otherTopLevel: 'preserved',
+      });
+
+      await strategy.deploy(envHookDef({
+        BUN_OPTIONS: '--preload=$PILOT_DATA/hooks/intercept.mjs',
+      }));
+
+      expect(writeJsonFile).toHaveBeenCalledWith(
+        '/home/.test/settings.json',
+        {
+          env: {
+            ANTHROPIC_AUTH_TOKEN: 'secret',
+            BUN_OPTIONS: '--preload=~/.loongsuite-pilot/hooks/intercept.mjs',
+          },
+          otherTopLevel: 'preserved',
+        },
+      );
+    });
+
+    it('same value re-deploy → no write (general idempotency)', async () => {
+      vi.mocked(readJsonFile).mockResolvedValue({
+        env: { CUSTOM_KEY: 'same_value' },
+      });
+
+      await strategy.deploy(envHookDef({ CUSTOM_KEY: 'same_value' }));
+
+      expect(writeJsonFile).not.toHaveBeenCalled();
+    });
+
+    it('env merge failure must not block hook deploy (returns success)', async () => {
+      vi.mocked(readJsonFile).mockResolvedValue({});
+      vi.mocked(writeJsonFile).mockRejectedValueOnce(new Error('disk full'));
+
+      const result = await strategy.deploy(envHookDef({
+        BUN_OPTIONS: '--preload=$PILOT_DATA/hooks/intercept.mjs',
+      }));
+
+      expect(result.success).toBe(true);
+      // Hook installation still attempted normally
+      expect(mockHookManager.installHook).toHaveBeenCalled();
+    });
+  });
+
   describe('undeploy', () => {
     it('uninstalls all hooks', async () => {
       mockHookManager.uninstallHook.mockResolvedValue(true);

--- a/tests/unit/deployment/hook-strategy.test.ts
+++ b/tests/unit/deployment/hook-strategy.test.ts
@@ -307,36 +307,54 @@ describe('HookStrategy', () => {
       expect(writeJsonFile).not.toHaveBeenCalled();
     });
 
-    it('first-time injection: $PILOT_DATA expanded and env block created', async () => {
+    // NOTE: applyEnvToSettings does NOT itself expand $PILOT_DATA — that's
+    // done upstream by AgentDefLoader.resolveVariables() at load time.
+    // These tests pass already-resolved paths to mirror real input shape.
+    const RESOLVED_PRELOAD = '--preload=/home/.loongsuite-pilot/hooks/intercept.mjs';
+
+    it('first-time injection: value written as-is into a fresh env block', async () => {
       // No existing settings file
       vi.mocked(readJsonFile).mockResolvedValue(null);
 
       await strategy.deploy(envHookDef({
-        BUN_OPTIONS: '--preload=$PILOT_DATA/hooks/intercept.mjs',
+        BUN_OPTIONS: RESOLVED_PRELOAD,
       }));
 
       expect(writeJsonFile).toHaveBeenCalledWith(
         '/home/.test/settings.json',
-        {
-          env: {
-            BUN_OPTIONS: '--preload=~/.loongsuite-pilot/hooks/intercept.mjs',
-          },
-        },
+        { env: { BUN_OPTIONS: RESOLVED_PRELOAD } },
       );
     });
 
     it('BUN_OPTIONS idempotency: existing value already contains our preload → skip write', async () => {
       vi.mocked(readJsonFile).mockResolvedValue({
-        env: {
-          BUN_OPTIONS: '--preload=~/.loongsuite-pilot/hooks/intercept.mjs',
-        },
+        env: { BUN_OPTIONS: RESOLVED_PRELOAD },
       });
 
-      await strategy.deploy(envHookDef({
-        BUN_OPTIONS: '--preload=$PILOT_DATA/hooks/intercept.mjs',
-      }));
+      await strategy.deploy(envHookDef({ BUN_OPTIONS: RESOLVED_PRELOAD }));
 
       expect(writeJsonFile).not.toHaveBeenCalled();
+    });
+
+    it('BUN_OPTIONS token-boundary match: superstring is NOT treated as already injected', async () => {
+      // Existing token is our preload path with a `-debug` suffix — must not
+      // false-positive as "already injected" (regression guard for substring
+      // match bug; comment 3 in code review).
+      vi.mocked(readJsonFile).mockResolvedValue({
+        env: { BUN_OPTIONS: '--preload=/home/.loongsuite-pilot/hooks/intercept.mjs-debug' },
+      });
+
+      await strategy.deploy(envHookDef({ BUN_OPTIONS: RESOLVED_PRELOAD }));
+
+      expect(writeJsonFile).toHaveBeenCalledWith(
+        '/home/.test/settings.json',
+        {
+          env: {
+            BUN_OPTIONS:
+              '--preload=/home/.loongsuite-pilot/hooks/intercept.mjs-debug ' + RESOLVED_PRELOAD,
+          },
+        },
+      );
     });
 
     it('BUN_OPTIONS coexistence: append our preload alongside user\'s own', async () => {
@@ -344,16 +362,13 @@ describe('HookStrategy', () => {
         env: { BUN_OPTIONS: '--preload=/user/own/script.js' },
       });
 
-      await strategy.deploy(envHookDef({
-        BUN_OPTIONS: '--preload=$PILOT_DATA/hooks/intercept.mjs',
-      }));
+      await strategy.deploy(envHookDef({ BUN_OPTIONS: RESOLVED_PRELOAD }));
 
       expect(writeJsonFile).toHaveBeenCalledWith(
         '/home/.test/settings.json',
         {
           env: {
-            BUN_OPTIONS:
-              '--preload=/user/own/script.js --preload=~/.loongsuite-pilot/hooks/intercept.mjs',
+            BUN_OPTIONS: '--preload=/user/own/script.js ' + RESOLVED_PRELOAD,
           },
         },
       );
@@ -378,16 +393,14 @@ describe('HookStrategy', () => {
         otherTopLevel: 'preserved',
       });
 
-      await strategy.deploy(envHookDef({
-        BUN_OPTIONS: '--preload=$PILOT_DATA/hooks/intercept.mjs',
-      }));
+      await strategy.deploy(envHookDef({ BUN_OPTIONS: RESOLVED_PRELOAD }));
 
       expect(writeJsonFile).toHaveBeenCalledWith(
         '/home/.test/settings.json',
         {
           env: {
             ANTHROPIC_AUTH_TOKEN: 'secret',
-            BUN_OPTIONS: '--preload=~/.loongsuite-pilot/hooks/intercept.mjs',
+            BUN_OPTIONS: RESOLVED_PRELOAD,
           },
           otherTopLevel: 'preserved',
         },
@@ -408,9 +421,7 @@ describe('HookStrategy', () => {
       vi.mocked(readJsonFile).mockResolvedValue({});
       vi.mocked(writeJsonFile).mockRejectedValueOnce(new Error('disk full'));
 
-      const result = await strategy.deploy(envHookDef({
-        BUN_OPTIONS: '--preload=$PILOT_DATA/hooks/intercept.mjs',
-      }));
+      const result = await strategy.deploy(envHookDef({ BUN_OPTIONS: RESOLVED_PRELOAD }));
 
       expect(result.success).toBe(true);
       // Hook installation still attempted normally

--- a/tests/unit/hooks/claude-code/fetch-intercept.test.mjs
+++ b/tests/unit/hooks/claude-code/fetch-intercept.test.mjs
@@ -39,7 +39,7 @@ function runScenario({ url, sessionId, body, sseEvents, networkDelayMs = 0 }) {
     const { ReadableStream, TransformStream } = require('node:stream/web');
     globalThis.ReadableStream = ReadableStream;
     globalThis.TransformStream = TransformStream;
-    if (!globalThis.Response) globalThis.Response = require('undici').Response;
+    // globalThis.Response is native in Node 18.17+ / 20+ / 22+; no fallback needed.
 
     const chunks = ${chunksJson};
     const encoder = new TextEncoder();
@@ -233,7 +233,7 @@ describe('claude-code-fetch-intercept preload', () => {
       const { ReadableStream, TransformStream } = require('node:stream/web');
       globalThis.ReadableStream = ReadableStream;
       globalThis.TransformStream = TransformStream;
-      if (!globalThis.Response) globalThis.Response = require('undici').Response;
+      // globalThis.Response is native in Node 18.17+ / 20+ / 22+; no fallback needed.
       const chunks = ${chunksJson};
       const encoder = new TextEncoder();
       globalThis.fetch = async function () {

--- a/tests/unit/hooks/claude-code/fetch-intercept.test.mjs
+++ b/tests/unit/hooks/claude-code/fetch-intercept.test.mjs
@@ -32,9 +32,11 @@ afterEach(() => {
  *
  * The preload writes JSON files to <DATA_DIR>/intercept/claude-code/<sid>/...
  */
-function runScenario({ url, sessionId, body, sseEvents, networkDelayMs = 0 }) {
+function runScenario({ url, sessionId, body, rawBody, sseEvents, networkDelayMs = 0 }) {
   const chunksJson = JSON.stringify(sseEvents.map((e) => `event: ${e.event}\ndata: ${JSON.stringify(e.data)}\n\n`));
-  const bodyJson = JSON.stringify(body);
+  // rawBody (string) takes precedence — use it verbatim as fetch body so tests
+  // can exercise malformed/non-JSON bodies without going through JSON.stringify.
+  const bodyJson = rawBody !== undefined ? rawBody : JSON.stringify(body);
   const script = `
     const { ReadableStream, TransformStream } = require('node:stream/web');
     globalThis.ReadableStream = ReadableStream;
@@ -229,41 +231,13 @@ describe('claude-code-fetch-intercept preload', () => {
   test('malformed JSON body does not crash the host fetch', () => {
     // Send a string body that's not valid JSON. The preload's safe parse
     // should yield system_instructions = null and still complete the fetch.
-    const chunksJson = JSON.stringify(sseStream().map((e) => `event: ${e.event}\ndata: ${JSON.stringify(e.data)}\n\n`));
-    const script = `
-      const { ReadableStream, TransformStream } = require('node:stream/web');
-      globalThis.ReadableStream = ReadableStream;
-      globalThis.TransformStream = TransformStream;
-      // globalThis.Response is native in Node 18.17+ / 20+ / 22+; no fallback needed.
-      const chunks = ${chunksJson};
-      const encoder = new TextEncoder();
-      globalThis.fetch = async function () {
-        const stream = new ReadableStream({
-          start(controller) {
-            for (const c of chunks) controller.enqueue(encoder.encode(c));
-            controller.close();
-          }
-        });
-        return new Response(stream, { status: 200 });
-      };
-      process.env.LOONGSUITE_PILOT_DATA_DIR = ${JSON.stringify(DATA_DIR)};
-      (async () => {
-        // Node 18 forbids require() of .mjs (ERR_REQUIRE_ESM); use dynamic import.
-      await import(${JSON.stringify('file://' + PRELOAD)});
-        const res = await globalThis.fetch(${JSON.stringify(LLM_URL)}, {
-          method: 'POST',
-          headers: { 'x-claude-code-session-id': ${JSON.stringify(SESS)} },
-          body: '<not-json>',
-        });
-        const reader = res.body.getReader();
-        while (true) { const { done } = await reader.read(); if (done) break; }
-        await new Promise(r => setTimeout(r, 50));
-      })().then(() => process.exit(0), (e) => { console.error(String(e)); process.exit(1); });
-    `;
-    const r = spawnSync(process.execPath, ['-e', script], { encoding: 'utf-8', timeout: 10_000 });
+    const r = runScenario({
+      url: LLM_URL, sessionId: SESS,
+      rawBody: '<not-json>',
+      sseEvents: sseStream(),
+    });
     expect(r.status).toBe(0);
     const [{ record }] = readIntercept(SESS);
-    // Stream still parsed, response_id captured; system_instructions null
     expect(record.response_id).toBe(MSG_ID);
     expect(record.system_instructions).toBeNull();
   });

--- a/tests/unit/hooks/claude-code/fetch-intercept.test.mjs
+++ b/tests/unit/hooks/claude-code/fetch-intercept.test.mjs
@@ -66,7 +66,8 @@ function runScenario({ url, sessionId, body, sseEvents, networkDelayMs = 0 }) {
     process.env.LOONGSUITE_PILOT_DATA_DIR = ${JSON.stringify(DATA_DIR)};
 
     (async () => {
-      require(${JSON.stringify(PRELOAD)});
+      // Node 18 forbids require() of .mjs (ERR_REQUIRE_ESM); use dynamic import.
+      await import(${JSON.stringify('file://' + PRELOAD)});
 
       const res = await globalThis.fetch(${JSON.stringify(url)}, {
         method: 'POST',
@@ -247,7 +248,8 @@ describe('claude-code-fetch-intercept preload', () => {
       };
       process.env.LOONGSUITE_PILOT_DATA_DIR = ${JSON.stringify(DATA_DIR)};
       (async () => {
-        require(${JSON.stringify(PRELOAD)});
+        // Node 18 forbids require() of .mjs (ERR_REQUIRE_ESM); use dynamic import.
+      await import(${JSON.stringify('file://' + PRELOAD)});
         const res = await globalThis.fetch(${JSON.stringify(LLM_URL)}, {
           method: 'POST',
           headers: { 'x-claude-code-session-id': ${JSON.stringify(SESS)} },

--- a/tests/unit/hooks/claude-code/fetch-intercept.test.mjs
+++ b/tests/unit/hooks/claude-code/fetch-intercept.test.mjs
@@ -1,0 +1,268 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PRELOAD = path.resolve(__dirname, '../../../../assets/hooks/claude-code-fetch-intercept.mjs');
+
+let DATA_DIR;
+let INTERCEPT_DIR;
+
+beforeEach(() => {
+  DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-fetch-intercept-test-'));
+  INTERCEPT_DIR = path.join(DATA_DIR, 'intercept', 'claude-code');
+});
+
+afterEach(() => {
+  try { fs.rmSync(DATA_DIR, { recursive: true, force: true }); } catch {}
+});
+
+/**
+ * Build a Node bootstrap script that:
+ *  1. Stubs globalThis.fetch to return a fake Response with a synthetic SSE
+ *     ReadableStream we drive chunk-by-chunk.
+ *  2. require()s the preload script (which overrides globalThis.fetch with
+ *     its instrumented version).
+ *  3. Awaits the wrapped fetch + drains the returned response.body so the
+ *     TransformStream actually processes chunks.
+ *  4. Returns success exit code.
+ *
+ * The preload writes JSON files to <DATA_DIR>/intercept/claude-code/<sid>/...
+ */
+function runScenario({ url, sessionId, body, sseEvents, networkDelayMs = 0 }) {
+  const chunksJson = JSON.stringify(sseEvents.map((e) => `event: ${e.event}\ndata: ${JSON.stringify(e.data)}\n\n`));
+  const bodyJson = JSON.stringify(body);
+  const script = `
+    const { ReadableStream, TransformStream } = require('node:stream/web');
+    globalThis.ReadableStream = ReadableStream;
+    globalThis.TransformStream = TransformStream;
+    if (!globalThis.Response) globalThis.Response = require('undici').Response;
+
+    const chunks = ${chunksJson};
+    const encoder = new TextEncoder();
+
+    // Stub original fetch — preload will wrap this.
+    globalThis.fetch = async function (input, init) {
+      // Simulate network latency before response headers arrive.
+      if (${networkDelayMs} > 0) await new Promise(r => setTimeout(r, ${networkDelayMs}));
+      const stream = new ReadableStream({
+        async start(controller) {
+          for (const c of chunks) {
+            await new Promise(r => setTimeout(r, 5));
+            controller.enqueue(encoder.encode(c));
+          }
+          controller.close();
+        }
+      });
+      return new Response(stream, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      });
+    };
+
+    process.env.LOONGSUITE_PILOT_DATA_DIR = ${JSON.stringify(DATA_DIR)};
+
+    (async () => {
+      require(${JSON.stringify(PRELOAD)});
+
+      const res = await globalThis.fetch(${JSON.stringify(url)}, {
+        method: 'POST',
+        headers: ${JSON.stringify(sessionId ? { 'x-claude-code-session-id': sessionId } : {})},
+        body: ${JSON.stringify(bodyJson)},
+      });
+
+      // Drain stream so TransformStream sees every chunk.
+      if (res.body) {
+        const reader = res.body.getReader();
+        while (true) {
+          const { done } = await reader.read();
+          if (done) break;
+        }
+      }
+
+      // Tiny grace so writeFileSync inside transform has time to land
+      // (writes themselves are sync, but we want all chunks pumped).
+      await new Promise(r => setTimeout(r, 50));
+    })().then(
+      () => process.exit(0),
+      (e) => { console.error(String(e)); process.exit(1); }
+    );
+  `;
+  return spawnSync(process.execPath, ['-e', script], {
+    encoding: 'utf-8',
+    env: { ...process.env, LOONGSUITE_PILOT_DATA_DIR: DATA_DIR },
+    timeout: 10_000,
+  });
+}
+
+function readIntercept(sessionId) {
+  const dir = path.join(INTERCEPT_DIR, sessionId);
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir).filter((n) => n.endsWith('.json')).map((n) => ({
+    name: n,
+    record: JSON.parse(fs.readFileSync(path.join(dir, n), 'utf-8')),
+  }));
+}
+
+const LLM_URL = 'https://api.anthropic.com/v1/messages';
+const SESS = 'sess-12345';
+const MSG_ID = 'msg_test_01';
+
+function sseStream(opts = {}) {
+  const events = [{
+    event: 'message_start',
+    data: { type: 'message_start', message: { id: opts.msgId ?? MSG_ID, model: 'claude-test', role: 'assistant' } },
+  }];
+  if (opts.includeContentDelta !== false) {
+    events.push({ event: 'content_block_start', data: { type: 'content_block_start', index: 0 } });
+    events.push({
+      event: 'content_block_delta',
+      data: { type: 'content_block_delta', index: 0, delta: { type: opts.deltaType ?? 'text_delta', text: 'hi' } },
+    });
+  }
+  events.push({ event: 'message_stop', data: { type: 'message_stop' } });
+  return events;
+}
+
+describe('claude-code-fetch-intercept preload', () => {
+  test('captures system_instructions in spec format (text → content, filters billing header)', () => {
+    const body = {
+      model: 'claude-opus-4-7',
+      system: [
+        { type: 'text', text: 'x-anthropic-billing-header: cc_version=2.1.119;' },
+        { type: 'text', text: 'You are a Claude agent.' },
+        { type: 'text', text: 'CLAUDE.md content here.' },
+      ],
+      messages: [{ role: 'user', content: 'hi' }],
+      stream: true,
+    };
+    const r = runScenario({ url: LLM_URL, sessionId: SESS, body, sseEvents: sseStream() });
+    expect(r.status).toBe(0);
+
+    const files = readIntercept(SESS);
+    expect(files).toHaveLength(1);
+    const rec = files[0].record;
+    expect(rec.session_id).toBe(SESS);
+    expect(rec.response_id).toBe(MSG_ID);
+    expect(rec.system_instructions).toEqual([
+      { type: 'text', content: 'You are a Claude agent.' },
+      { type: 'text', content: 'CLAUDE.md content here.' },
+    ]);
+  });
+
+  test('captures TTFT as integer nanoseconds for text_delta', () => {
+    const r = runScenario({
+      url: LLM_URL, sessionId: SESS,
+      body: { system: 'sys', messages: [] },
+      sseEvents: sseStream(),
+      networkDelayMs: 30,
+    });
+    expect(r.status).toBe(0);
+    const [{ record }] = readIntercept(SESS);
+    expect(typeof record.ttft_ns).toBe('number');
+    expect(Number.isInteger(record.ttft_ns)).toBe(true);
+    expect(record.ttft_ns).toBeGreaterThan(0);
+    expect(record.ttft_ns).toBeLessThan(60_000_000_000); // < 60s
+  });
+
+  test('TTFT also captures on thinking_delta and input_json_delta', () => {
+    const r = runScenario({
+      url: LLM_URL, sessionId: SESS,
+      body: { system: 'sys', messages: [] },
+      sseEvents: sseStream({ deltaType: 'thinking_delta' }),
+    });
+    expect(r.status).toBe(0);
+    const [{ record }] = readIntercept(SESS);
+    expect(typeof record.ttft_ns).toBe('number');
+  });
+
+  test('filename = response_id and record.response_id matches', () => {
+    const customMsg = 'msg_custom_xyz';
+    const r = runScenario({
+      url: LLM_URL, sessionId: SESS,
+      body: { system: 'sys', messages: [] },
+      sseEvents: sseStream({ msgId: customMsg }),
+    });
+    expect(r.status).toBe(0);
+    const files = readIntercept(SESS);
+    expect(files[0].name).toBe(`${customMsg}.json`);
+    expect(files[0].record.response_id).toBe(customMsg);
+  });
+
+  test('non-/v1/messages requests are not intercepted', () => {
+    const r = runScenario({
+      url: 'https://api.anthropic.com/v1/some_other_endpoint', sessionId: SESS,
+      body: { system: 'sys' },
+      sseEvents: sseStream(),
+    });
+    expect(r.status).toBe(0);
+    expect(readIntercept(SESS)).toHaveLength(0);
+  });
+
+  test('requests missing session header are passed through (no intercept file)', () => {
+    const r = runScenario({
+      url: LLM_URL, sessionId: null,
+      body: { system: 'sys', messages: [] },
+      sseEvents: sseStream(),
+    });
+    expect(r.status).toBe(0);
+    // No session dir at all should be created
+    expect(fs.existsSync(INTERCEPT_DIR)).toBe(false);
+  });
+
+  test('stream without content_block_delta still emits via flush (ttft_ns = null)', () => {
+    const r = runScenario({
+      url: LLM_URL, sessionId: SESS,
+      body: { system: 'sys', messages: [] },
+      sseEvents: sseStream({ includeContentDelta: false }),
+    });
+    expect(r.status).toBe(0);
+    const [{ record }] = readIntercept(SESS);
+    expect(record.response_id).toBe(MSG_ID);
+    expect(record.ttft_ns).toBeNull();
+  });
+
+  test('malformed JSON body does not crash the host fetch', () => {
+    // Send a string body that's not valid JSON. The preload's safe parse
+    // should yield system_instructions = null and still complete the fetch.
+    const chunksJson = JSON.stringify(sseStream().map((e) => `event: ${e.event}\ndata: ${JSON.stringify(e.data)}\n\n`));
+    const script = `
+      const { ReadableStream, TransformStream } = require('node:stream/web');
+      globalThis.ReadableStream = ReadableStream;
+      globalThis.TransformStream = TransformStream;
+      if (!globalThis.Response) globalThis.Response = require('undici').Response;
+      const chunks = ${chunksJson};
+      const encoder = new TextEncoder();
+      globalThis.fetch = async function () {
+        const stream = new ReadableStream({
+          start(controller) {
+            for (const c of chunks) controller.enqueue(encoder.encode(c));
+            controller.close();
+          }
+        });
+        return new Response(stream, { status: 200 });
+      };
+      process.env.LOONGSUITE_PILOT_DATA_DIR = ${JSON.stringify(DATA_DIR)};
+      (async () => {
+        require(${JSON.stringify(PRELOAD)});
+        const res = await globalThis.fetch(${JSON.stringify(LLM_URL)}, {
+          method: 'POST',
+          headers: { 'x-claude-code-session-id': ${JSON.stringify(SESS)} },
+          body: '<not-json>',
+        });
+        const reader = res.body.getReader();
+        while (true) { const { done } = await reader.read(); if (done) break; }
+        await new Promise(r => setTimeout(r, 50));
+      })().then(() => process.exit(0), (e) => { console.error(String(e)); process.exit(1); });
+    `;
+    const r = spawnSync(process.execPath, ['-e', script], { encoding: 'utf-8', timeout: 10_000 });
+    expect(r.status).toBe(0);
+    const [{ record }] = readIntercept(SESS);
+    // Stream still parsed, response_id captured; system_instructions null
+    expect(record.response_id).toBe(MSG_ID);
+    expect(record.system_instructions).toBeNull();
+  });
+});

--- a/tests/unit/hooks/claude-code/hook-processor.test.mjs
+++ b/tests/unit/hooks/claude-code/hook-processor.test.mjs
@@ -247,3 +247,171 @@ describe('claude-code-hook-processor v2 端到端', () => {
     expect(readState('s-legacy')).toBeNull();
   });
 });
+
+// ─── intercept merge (from BUN_OPTIONS preload script) ───
+//
+// hook-processor reads ~/.loongsuite-pilot/intercept/claude-code/<sid>/<rid>.json
+// (written by claude-code-fetch-intercept.mjs) and merges:
+//   gen_ai.system_instructions → llm.request events
+//   gen_ai.response.time_to_first_token → llm.response events
+// joined by message_id == response_id == file basename.
+
+function writeInterceptFile(sessionId, responseId, payload, opts = {}) {
+  const dir = path.join(DATA_DIR, 'intercept', 'claude-code', sessionId);
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${responseId}.json`);
+  fs.writeFileSync(file, JSON.stringify(payload));
+  if (opts.mtime) {
+    const t = opts.mtime / 1000;
+    fs.utimesSync(file, t, t);
+  }
+  return file;
+}
+
+describe('hook-processor merges intercept data into llm events', () => {
+  // Reuse the simple 2-LLM-call transcript shape from earlier tests.
+  function writeBasicTranscript(sessionId, msgId1 = 'msg_1', msgId2 = 'msg_2') {
+    return writeTranscript(sessionId, [
+      { type: 'user', timestamp: '2026-06-04T02:57:32.000Z', message: { content: [{ type: 'text', text: 'list files' }] } },
+      { type: 'assistant', timestamp: '2026-06-04T02:57:49.000Z', message: { id: msgId1, content: [{ type: 'tool_use', id: 'tu_1', name: 'Bash', input: { command: 'ls' } }], usage: { input_tokens: 100, output_tokens: 50 }, stop_reason: 'tool_use' } },
+      { type: 'user', timestamp: '2026-06-04T02:57:49.200Z', message: { content: [{ type: 'tool_result', tool_use_id: 'tu_1', content: 'a.txt' }] } },
+      { type: 'assistant', timestamp: '2026-06-04T02:57:52.000Z', message: { id: msgId2, content: [{ type: 'text', text: 'done' }], usage: { input_tokens: 200, output_tokens: 20 }, stop_reason: 'end_turn' } },
+    ]);
+  }
+
+  const SAMPLE_SYS_INSTR = [
+    { type: 'text', content: 'You are a Claude agent.' },
+    { type: 'text', content: 'CLAUDE.md content here.' },
+  ];
+
+  test('full match: both llm.request and llm.response receive new fields, intercept files deleted', () => {
+    const sid = 'sid-merge-1';
+    const transcriptPath = writeBasicTranscript(sid, 'msg_full_a', 'msg_full_b');
+
+    const fileA = writeInterceptFile(sid, 'msg_full_a', {
+      session_id: sid,
+      response_id: 'msg_full_a',
+      ttft_ns: 1234567890,
+      system_instructions: SAMPLE_SYS_INSTR,
+    });
+    const fileB = writeInterceptFile(sid, 'msg_full_b', {
+      session_id: sid,
+      response_id: 'msg_full_b',
+      ttft_ns: 2222222222,
+      system_instructions: SAMPLE_SYS_INSTR,
+    });
+
+    const r = runHook('stop', { session_id: sid, stop_reason: 'end_turn', transcript_path: transcriptPath });
+    expect(r.status).toBe(0);
+
+    const records = readJsonlRecords();
+
+    const llmRequests = records.filter((rec) => rec['event.name'] === 'llm.request');
+    const llmResponses = records.filter((rec) => rec['event.name'] === 'llm.response');
+    expect(llmRequests).toHaveLength(2);
+    expect(llmResponses).toHaveLength(2);
+
+    for (const req of llmRequests) {
+      expect(req['gen_ai.system_instructions']).toEqual(SAMPLE_SYS_INSTR);
+    }
+    const respByMsg = new Map(llmResponses.map((r) => [r['gen_ai.response.id'], r]));
+    expect(respByMsg.get('msg_full_a')['gen_ai.response.time_to_first_token']).toBe(1234567890);
+    expect(respByMsg.get('msg_full_b')['gen_ai.response.time_to_first_token']).toBe(2222222222);
+
+    // Files for matched response_ids must be deleted; the session dir
+    // itself may be removed (since it's empty after reaping).
+    expect(fs.existsSync(fileA)).toBe(false);
+    expect(fs.existsSync(fileB)).toBe(false);
+  });
+
+  test('no intercept directory: records emit without new fields (graceful)', () => {
+    const sid = 'sid-merge-2';
+    const transcriptPath = writeBasicTranscript(sid);
+
+    const r = runHook('stop', { session_id: sid, stop_reason: 'end_turn', transcript_path: transcriptPath });
+    expect(r.status).toBe(0);
+
+    const records = readJsonlRecords();
+    for (const rec of records.filter((r) => r['event.name'] === 'llm.request')) {
+      expect(rec['gen_ai.system_instructions']).toBeUndefined();
+    }
+    for (const rec of records.filter((r) => r['event.name'] === 'llm.response')) {
+      expect(rec['gen_ai.response.time_to_first_token']).toBeUndefined();
+    }
+  });
+
+  test('partial match: only response_ids with intercept files get enriched', () => {
+    const sid = 'sid-merge-3';
+    const transcriptPath = writeBasicTranscript(sid, 'msg_partial_a', 'msg_partial_b');
+
+    // Only write intercept for msg_partial_a; b has none.
+    writeInterceptFile(sid, 'msg_partial_a', {
+      session_id: sid,
+      response_id: 'msg_partial_a',
+      ttft_ns: 999000000,
+      system_instructions: SAMPLE_SYS_INSTR,
+    });
+
+    runHook('stop', { session_id: sid, stop_reason: 'end_turn', transcript_path: transcriptPath });
+    const records = readJsonlRecords();
+    const reqByMsg = new Map(
+      records.filter((r) => r['event.name'] === 'llm.request').map((r) => [r['gen_ai.response.id'], r]),
+    );
+    const respByMsg = new Map(
+      records.filter((r) => r['event.name'] === 'llm.response').map((r) => [r['gen_ai.response.id'], r]),
+    );
+
+    expect(reqByMsg.get('msg_partial_a')['gen_ai.system_instructions']).toEqual(SAMPLE_SYS_INSTR);
+    expect(reqByMsg.get('msg_partial_b')['gen_ai.system_instructions']).toBeUndefined();
+
+    expect(respByMsg.get('msg_partial_a')['gen_ai.response.time_to_first_token']).toBe(999000000);
+    expect(respByMsg.get('msg_partial_b')['gen_ai.response.time_to_first_token']).toBeUndefined();
+  });
+
+  test('stale orphan intercept file (mtime > 1h) is reaped on Stop', () => {
+    const sid = 'sid-merge-4';
+    const transcriptPath = writeBasicTranscript(sid);
+
+    // No transcript message_id matches this orphan; it will not be merged.
+    // Mark mtime as 2h old → reapStaleIntercept must delete it.
+    const orphanFile = writeInterceptFile(sid, 'msg_orphan', {
+      session_id: sid,
+      response_id: 'msg_orphan',
+      ttft_ns: 100,
+      system_instructions: [],
+    }, { mtime: Date.now() - 2 * 60 * 60 * 1000 });
+
+    runHook('stop', { session_id: sid, stop_reason: 'end_turn', transcript_path: transcriptPath });
+    expect(fs.existsSync(orphanFile)).toBe(false);
+  });
+
+  test('fresh non-matching intercept file (mtime < 1h) is left alone', () => {
+    const sid = 'sid-merge-5';
+    const transcriptPath = writeBasicTranscript(sid);
+
+    // Recent, no match → should stay (might belong to a later turn we haven't seen yet).
+    const recentFile = writeInterceptFile(sid, 'msg_future', {
+      session_id: sid,
+      response_id: 'msg_future',
+      ttft_ns: 100,
+      system_instructions: [],
+    });
+
+    runHook('stop', { session_id: sid, stop_reason: 'end_turn', transcript_path: transcriptPath });
+    expect(fs.existsSync(recentFile)).toBe(true);
+  });
+
+  test('malformed intercept JSON: hook still emits records (no crash)', () => {
+    const sid = 'sid-merge-6';
+    const transcriptPath = writeBasicTranscript(sid);
+    const dir = path.join(DATA_DIR, 'intercept', 'claude-code', sid);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'broken.json'), '{not json');
+
+    const r = runHook('stop', { session_id: sid, stop_reason: 'end_turn', transcript_path: transcriptPath });
+    expect(r.status).toBe(0);
+
+    const llmEvents = readJsonlRecords().filter((r) => r['event.name'] === 'llm.request' || r['event.name'] === 'llm.response');
+    expect(llmEvents.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- 通过 `BUN_OPTIONS=--preload` 在 Claude Code 的 Bun 二进制进程内拦截 LLM fetch,把现有 hook + transcript 方案拿不到的 **`gen_ai.system_instructions`**(完整 system prompt)和 **`gen_ai.response.time_to_first_token`**(纳秒,per-LLM-call)采集出来。
- 新增 `AgentHookConfig.env` 通用字段 + `HookStrategy.applyEnvToSettings`,部署期把 `BUN_OPTIONS` 写入 `~/.claude/settings.json`,带幂等 / 多 preload 共存语义。
- intercept 数据走 per-LLM-call 文件 (`~/.loongsuite-pilot/intercept/claude-code/<sid>/<rid>.json`),Stop hook 按 `response_id` (= Anthropic `message_id`) 1:1 merge 到现有 `llm.request` / `llm.response` 事件后立即删除,孤儿文件 1h opportunistic 清理。

## 关键设计决策
- **关联键 = `response_id`**: 1:1 强匹配,实测三方对账(preload / transcript / pilot JSONL)完全一致。
- **TTFT 单位 = 纳秒**(整数 Number,< Number.MAX_SAFE_INTEGER),与 pilot 其他 duration 字段一致。
- **system_instructions = MessagePart[] (TextPart 用 `content`)**,符合 `specs/gen-ai-system_instructions.json`。preload 自动过滤首个 `x-anthropic-billing-header:` 元数据 block。
- **依赖** `@loongsuite/otel-util-genai >= 0.1.0-beta.7`(新增了从 record 读 ttft 字段的能力)。
- **不做**:daily sweeper、SessionEnd hook(Claude Code 不支持)、system_instructions 体积优化(用户明确"全量上报")、卸载期 BUN_OPTIONS 清理(后续 PR)。

## 文件改动
| 类型 | 文件 |
|---|---|
| 新增 | `assets/hooks/claude-code-fetch-intercept.mjs` (preload 脚本,~285 行) |
| 修改 | `agents.d/claude-code.json` (env 块) |
| 修改 | `src/types/deployment.ts` (`AgentHookConfig.env`) |
| 修改 | `src/deployment/hook-strategy.ts` (`applyEnvToSettings`) |
| 修改 | `assets/hooks/claude-code-hook-processor.mjs` (intercept load + merge + reap) |
| 修改 | `package.json` / `package-lock.json` (util-genai 0.1.0-beta.7) |
| 新增 | `tests/unit/hooks/claude-code/fetch-intercept.test.mjs` (8 case) |
| 修改 | `tests/unit/hooks/claude-code/hook-processor.test.mjs` (+6 merge case) |
| 修改 | `tests/unit/deployment/hook-strategy.test.ts` (+8 env injection case) |

## Test plan
- [x] `npm run typecheck` 通过
- [x] `npx vitest run` 全量:**1321 passed / 2 skipped / 0 failed**(125 files)
- [x] 新增 fetch-intercept 8/8 ✓
- [x] 扩展 hook-processor merge 6/6 ✓(原 9 个无回归)
- [x] 扩展 hook-strategy env-injection 8/8 ✓(原 18 个无回归)
- [x] E2E: `local-reinstall.sh` 打包安装 → `~/.claude/settings.json.env.BUN_OPTIONS` 自动注入 → 触发 `claude --print` → intercept 文件落盘并被 Stop hook 清理 → pilot JSONL 含两新字段 → **OTLP chat span attributes 含 `gen_ai.response.time_to_first_token: 3845797875` 和 `gen_ai.system_instructions` (27399 chars / 2 blocks)**

## 验证过的鲁棒性
- preload 在 budget cutoff / SIGINT / SIGKILL 三种异常退出场景下,关键数据(已经写到 intercept 文件的部分)不丢(`writeFileSync` 同步落盘)
- SSE 解析按 `\n\n` 事件块切分,实测稳健(早期版本用 sliding-window 正则会切坏长 preamble,已避免)
- 跨 Claude Code 版本(2.1.119 / 2.1.178)与跨 Bun runtime(1.3.13 / 1.3.14)行为一致
- fail-open:preload / hook merge 任一环节失败都不阻塞 claude 主流程

🤖 Generated with [Claude Code](https://claude.com/claude-code)