### PR TITLE
fix(qoder-work): assembler-backed trace pipeline with atomic LLM pairs

### DIFF
--- a/assets/hooks/qoderwork-hook-processor.mjs
+++ b/assets/hooks/qoderwork-hook-processor.mjs
@@ -1,19 +1,41 @@
 #!/usr/bin/env node
 /**
- * Qoder Work hook transcript processor.
+ * Qoder Work hook transcript processor (assembler-driven rewrite).
  *
- * Parses transcript lines, groups assistant blocks by parentUuid
- * (= one LLM call), merges thinking+text+tool_use into unified
- * multi-part responses, assigns turn.id/step.id per spec.
+ * The original implementation was stateless: every Stop hook read the
+ * incremental transcript slice, called `splitIntoTurns()`, and emitted a
+ * full set of records for whatever was visible. That produced two well
+ * documented failure modes:
  *
- * Follows the same architectural pattern as qoder-hook-processor.mjs
- * but adapted for QoderWork's transcript format (no progress events,
- * parentUuid-based grouping).
+ *   1. A Stop fires after the user prompt but before the assistant rows
+ *      land (very common with QoderWork's wave-by-wave Stop). The slice
+ *      contains a user row only → an `llm.request` with no `llm.response`
+ *      ever surfaces in history.
+ *   2. A Stop fires with assistant rows but no preceding user prompt in
+ *      the slice (e.g. a brand-new daily log starting mid-turn). The
+ *      stateless splitter fell back to `crypto.randomUUID()` for the
+ *      turn id, so the turn would never line up with segment data.
+ *
+ * Both stem from missing cross-Hook state. This rewrite introduces a
+ * persistent assembler that owns:
+ *
+ *   - The pending turn (its promptId, accumulated wave rows, pending
+ *     tool calls, and the user input text)
+ *   - A wave finalization rule: emit `llm.request` and `llm.response`
+ *     atomically only when a wave has a non-empty payload
+ *   - A graceful TTL so a partially-consumed turn is eventually dropped
+ *     instead of hanging around forever
+ *
+ * The first event of every turn is emitted with `event.name='other'`
+ * (per EVENT_LOG_TO_TRACE_SPEC.md §5 / §做法 A) so the converter
+ * routes it straight into the ENTRY/AGENT span without spawning a
+ * spurious "user-hook" LLM span.
  */
 
 import path from 'node:path';
 import os from 'node:os';
 import crypto from 'node:crypto';
+import fs from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import {
   parseArgs,
@@ -34,6 +56,25 @@ import {
   sanitizeObject,
   getStringValue,
 } from './agent-event-normalizer.mjs';
+import {
+  ASSEMBLER_DEFAULTS,
+  appendAssistant,
+  bumpStepSeq,
+  clearWave,
+  closePending,
+  dropResolvedToolCalls,
+  evictColdTranscripts,
+  getTranscriptState,
+  isPendingExpired,
+  loadAssemblerState,
+  markUserTextEmitted,
+  openPending,
+  recordPendingToolCalls,
+  resolveNowMs,
+  saveAssemblerState,
+  waveEnded,
+  writeTranscriptState,
+} from './qoderwork-turn-assembler.mjs';
 
 async function main() {
   const { agentId, logPrefix } = parseArgs();
@@ -43,15 +84,43 @@ async function main() {
   const { transcriptPath, sessionId, cwd: rawCwd } = payload;
   const cwd = resolveQoderWorkProjectDir(rawCwd, agentId);
   const runtimeConfig = loadHookRuntimeConfig(path.join(HOOKS_DIR, '..'));
+  const nowMs = resolveNowMs();
+
+  // Always load assembler state, even when there are no new transcript
+  // lines: TTL eviction must still tick over.
+  const assemblerState = loadAssemblerState(agentId);
+  evictColdTranscripts(assemblerState, { nowMs });
+  let perTranscript = getTranscriptState(assemblerState, transcriptPath);
+
+  if (perTranscript.session_id && perTranscript.session_id !== sessionId) {
+    logDebug(agentId, `assembler: session changed (${perTranscript.session_id} → ${sessionId}); reset`);
+    perTranscript = { session_id: sessionId, consumed_line: 0, pending_turn: null, updated_at_ms: nowMs };
+  }
+  perTranscript.session_id = sessionId;
+
+  // TTL eviction for the pending turn — must happen even on empty hooks
+  // so a stale pending doesn't block forever.
+  if (perTranscript.pending_turn && isPendingExpired(perTranscript.pending_turn, { nowMs, ttlMs: ASSEMBLER_DEFAULTS.TTL_MS })) {
+    logDebug(agentId, `assembler: TTL-evicting pending turn ${perTranscript.pending_turn.promptId}`);
+    perTranscript.pending_turn = null;
+  }
 
   const range = getLineRange(agentId, transcriptPath, sessionId);
-  if (!range) return;
+  if (!range) {
+    // Persist any TTL eviction we just did even when there's nothing new.
+    writeTranscriptState(assemblerState, transcriptPath, perTranscript, { nowMs });
+    saveAssemblerState(agentId, assemblerState);
+    return;
+  }
 
   const [startLine, endLine] = range;
   const lines = readTranscriptLines(transcriptPath, startLine, endLine);
   logDebug(agentId, `Read ${lines.length} lines from ${transcriptPath} (range: ${startLine}-${endLine})`);
   if (!lines.length) {
     updateLineRecord(agentId, transcriptPath, sessionId, endLine);
+    perTranscript.consumed_line = endLine;
+    writeTranscriptState(assemblerState, transcriptPath, perTranscript, { nowMs });
+    saveAssemblerState(agentId, assemblerState);
     return;
   }
 
@@ -61,38 +130,57 @@ async function main() {
   }
   if (!parsed.length) {
     updateLineRecord(agentId, transcriptPath, sessionId, endLine);
+    perTranscript.consumed_line = endLine;
+    writeTranscriptState(assemblerState, transcriptPath, perTranscript, { nowMs });
+    saveAssemblerState(agentId, assemblerState);
     return;
   }
 
-  const records = processTranscript(parsed, sessionId, agentId, runtimeConfig, cwd);
-  logDebug(agentId, `Produced ${records.length} events`);
-
-  const rowsToAppend = records.filter(Boolean).map(r => JSON.stringify(r));
-  const success = appendRowsToHistory(agentId, logPrefix, rowsToAppend);
-  if (success) {
-    logDebug(agentId, `Successfully appended ${rowsToAppend.length} rows`);
-    updateLineRecord(agentId, transcriptPath, sessionId, endLine);
-  }
-}
-
-function processTranscript(parsed, sessionId, agentId, runtimeConfig, cwd) {
-  const observedTs = timestampToUnixNanos(Date.now());
-  const records = [];
-
-  // Skip review-copy sessions: QoderWork forks a duplicate transcript with an
-  // appended automated review task. The original session already covers the
-  // user conversation, so processing the copy would produce duplicate traces.
   const isReviewCopy = parsed.some(row =>
     row.type === 'user' &&
     typeof row.message?.content?.[0]?.text === 'string' &&
-    row.message.content[0].text.startsWith('[SYSTEM: This is an automated background review task')
+    row.message.content[0].text.startsWith('[SYSTEM: This is an automated background review task'),
   );
   if (isReviewCopy) {
     logDebug(agentId, `Skipping review-copy session ${sessionId}`);
-    return records;
+    updateLineRecord(agentId, transcriptPath, sessionId, endLine);
+    perTranscript.consumed_line = endLine;
+    writeTranscriptState(assemblerState, transcriptPath, perTranscript, { nowMs });
+    saveAssemblerState(agentId, assemblerState);
+    return;
   }
 
-  // Filter out non-content rows
+  const result = processIncremental({
+    parsed,
+    perTranscript,
+    sessionId,
+    agentId,
+    runtimeConfig,
+    cwd,
+    nowMs,
+  });
+
+  perTranscript = result.perTranscript;
+
+  const rowsToAppend = result.records.filter(Boolean).map(r => JSON.stringify(r));
+  const appendOk = appendRowsToHistory(agentId, logPrefix, rowsToAppend);
+  if (appendOk) {
+    logDebug(agentId, `Successfully appended ${rowsToAppend.length} rows`);
+    updateLineRecord(agentId, transcriptPath, sessionId, endLine);
+    perTranscript.consumed_line = endLine;
+    writeTranscriptState(assemblerState, transcriptPath, perTranscript, { nowMs });
+    saveAssemblerState(agentId, assemblerState);
+  }
+}
+
+// ─── Incremental walker ────────────────────────────────────────────────────
+
+function processIncremental({ parsed, perTranscript, sessionId, agentId, runtimeConfig, cwd, nowMs }) {
+  const observedTs = timestampToUnixNanos(Date.now());
+  const records = [];
+
+  // Filter out non-content rows once. The walker still mutates pending state
+  // inside `state` and emits records into `records`.
   const contentRows = parsed.filter(row => {
     const type = row.type;
     if (!type || type === 'ai-title' || type === 'last-prompt' || type === 'session_meta' || type === 'progress') return false;
@@ -101,265 +189,323 @@ function processTranscript(parsed, sessionId, agentId, runtimeConfig, cwd) {
     return type === 'user' || type === 'assistant';
   });
 
-  if (!contentRows.length) return records;
+  if (contentRows.length === 0) return { perTranscript, records };
 
-  // Determine user info from first row
   const firstRow = contentRows[0];
   const userId = resolveUserId(firstRow, runtimeConfig);
   const providerName = inferProviderName({ 'gen_ai.agent.type': 'qoder-work' });
   const version = getStringValue(firstRow, 'version') || '';
 
-  // Split into turns: each user message (non tool_result) starts a new turn
-  const turns = splitIntoTurns(contentRows);
+  // `resolvedResults` carries tool_results that have been observed but not
+  // yet folded into the next wave's `gen_ai.input.messages`. These live in
+  // memory only — they always belong to the current pending turn and the
+  // turn is held in persisted state, so a Stop hook landing between
+  // tool_result and the next assistant row simply replays the resolution.
+  let pending = perTranscript.pending_turn;
+  let resolvedResults = []; // [{ id, name, resultText, resultTsNano, resultRow }]
 
-  for (const turn of turns) {
-    const turnId = getTurnIdForRows(turn);
-    const turnRecords = buildTurnEvents(turn, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, cwd);
-    records.push(...turnRecords);
+  // Restore resolvedResults from any earlier hook persistence — kept on the
+  // pending turn so we don't lose them when Stop fires between the
+  // tool_result row and the next assistant row.
+  if (pending?.resolvedResults && Array.isArray(pending.resolvedResults)) {
+    resolvedResults = pending.resolvedResults.map((r) => ({ ...r }));
   }
 
-  return records;
-}
-
-function splitIntoTurns(contentRows) {
-  const turns = [];
-  let currentTurn = [];
+  const ctx = {
+    sessionId,
+    userId,
+    providerName,
+    version,
+    observedTs,
+    runtimeConfig,
+    cwd,
+  };
 
   for (const row of contentRows) {
     if (isPromptRow(row)) {
-      if (currentTurn.length > 0) {
-        turns.push(currentTurn);
-      }
-      currentTurn = [row];
-    } else {
-      currentTurn.push(row);
-    }
-  }
-  if (currentTurn.length > 0) turns.push(currentTurn);
-  return turns;
-}
-
-function isPromptRow(row) {
-  return row.type === 'user' && !isToolResult(row) && !isSystemInjection(row);
-}
-
-function getTurnIdForRows(turnRows) {
-  const promptRow = turnRows.find(isPromptRow);
-  return promptRow?.promptId || promptRow?.uuid || crypto.randomUUID();
-}
-
-function isSystemInjection(row) {
-  const text = extractText(row).trimStart();
-  if (text.startsWith('<command-message>') ||
-    text.startsWith('<command-name>') ||
-    text.startsWith('[Request interrupted') ||
-    text.startsWith('[SYSTEM: This is an automated background review task')) {
-    return true;
-  }
-  return isPureSystemReminder(text);
-}
-
-function isPureSystemReminder(text) {
-  return text.startsWith('<system-reminder>')
-    && text.replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, '').trim().length === 0;
-}
-
-function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, cwd) {
-  const records = [];
-
-  // Find the user prompt
-  const userRow = turnRows.find(isPromptRow);
-  const promptId = userRow?.promptId || turnId;
-  const turnMetadata = promptId ? { 'agent.qoderwork.promptId': promptId } : {};
-
-  // User-hook event (no step.id, no model — per §5 of EVENT_LOG_TO_TRACE_SPEC)
-  if (userRow) {
-    const userText = extractText(userRow);
-    if (userText) {
-      records.push(buildRecord({
-        ...turnMetadata,
-        'event.name': 'llm.request',
-        'gen_ai.turn.id': turnId,
-        'gen_ai.session.id': sessionId,
-        'gen_ai.agent.type': 'qoder-work',
-        'gen_ai.provider.name': providerName,
-        'user.id': userId,
-        'gen_ai.input.messages_delta': [{ role: 'user', parts: [{ type: 'text', content: userText }] }],
-        time_unix_nano: timestampToUnixNanos(userRow.timestamp),
-        observed_time_unix_nano: observedTs,
-        version,
-      }, turnRows[0], runtimeConfig, cwd));
-    }
-  }
-
-  // Group assistant rows by tool_result boundaries — each group = one LLM call.
-  // Reason: QoderWork sometimes splits one LLM response across multiple assistant
-  // rows with different parentUuids (e.g. thinking row + separate tool_use row).
-  // groupByParentUuid would wrongly split these into multiple "steps" and break
-  // timing (the second half would incorrectly inherit the tool_result's ts as
-  // llm.request time). Tool_result boundaries are the semantically correct split
-  // since the LLM only receives tool outputs and issues a new response at those points.
-  const assistantRows = turnRows.filter(r => r.type === 'assistant');
-  const toolResultRows = turnRows.filter(r => r.type === 'user' && isToolResult(r));
-  const toolResultsByUseId = new Map();
-  for (const row of toolResultRows) {
-    const content = Array.isArray(row.message?.content) ? row.message.content : [];
-    for (const block of content) {
-      if (block.type === 'tool_result' && block.tool_use_id && !toolResultsByUseId.has(block.tool_use_id)) {
-        toolResultsByUseId.set(block.tool_use_id, { row, block });
-      }
-    }
-  }
-
-  const llmGroups = groupAssistantRowsByToolResults(turnRows);
-
-  const userText = userRow ? extractText(userRow) : '';
-  const userTs = userRow ? timestampToUnixNanos(userRow.timestamp) : undefined;
-  let prevToolCalls = []; // tool_call ids from previous step, for building tool_result delta
-  let prevStepLastToolResultTs = undefined; // 上一个 step 最后一个 tool_result 的 nano ts，用于本 step llm.request 时间
-
-  let stepCounter = 0;
-  for (const group of llmGroups) {
-    stepCounter++;
-    const stepId = `${turnId}:s${stepCounter}`;
-
-    // Build input.messages_delta for this step's llm.request:
-    // - Step 1: user prompt
-    // - Step N>1: previous step's tool results
-    let inputDelta;
-    if (stepCounter === 1 && userText) {
-      inputDelta = [{ role: 'user', parts: [{ type: 'text', content: userText }] }];
-    } else if (prevToolCalls.length > 0) {
-      const toolParts = [];
-      for (const tc of prevToolCalls) {
-        const matchingResult = toolResultsByUseId.get(tc.id);
-        if (matchingResult) {
-          const resultBlock = matchingResult.block;
-          const resultText = typeof resultBlock?.content === 'string' ? resultBlock.content : JSON.stringify(resultBlock?.content);
-          toolParts.push({ type: 'tool_call_response', id: tc.id, response: resultText });
+      // Closing an old pending turn: emit any deferred wave first, then drop
+      // the pending state in favour of a fresh one.
+      if (pending) {
+        const flushed = flushPendingWave({
+          pending,
+          resolvedResults,
+          ctx,
+          waveAssistantRows: pending.currentWaveRows ?? [],
+          finalize: false,
+        });
+        records.push(...flushed.records);
+        pending = flushed.pending;
+        resolvedResults = flushed.resolvedResults;
+        // Whatever rows were in the wave but couldn't be paired are dropped
+        // here; the turn is being replaced by a new prompt.
+        if (pending?.currentWaveRows?.length) {
+          logDebug(agentId, `assembler: dropping ${pending.currentWaveRows.length} unpaired assistant row(s) on prompt change`);
         }
+        pending = closePending(pending, { reason: 'new_prompt', nowMs });
+        pending = null; // closePending returns a snapshot; pending turn is gone
+        resolvedResults = [];
       }
-      if (toolParts.length > 0) {
-        inputDelta = [{ role: 'tool', parts: toolParts }];
+
+      const promptId = row.promptId || row.uuid;
+      if (!promptId) {
+        logDebug(agentId, 'assembler: prompt row has no promptId/uuid; skipped');
+        continue;
       }
-    }
 
-    // llm.request time:
-    //   step 1 = user input ts (user message arrival, a reasonable proxy for LLM start)
-    //   step N>1 = 上一个 step 最后一个 tool_result ts (工具返回后模型立刻开始处理)
-    // 否则用 assistant 行写盘时间会导致 LLM span 退化为 0ms（thinking/tool_use 同毫秒批量 flush）
-    const llmRequestTs = stepCounter === 1 ? userTs : prevStepLastToolResultTs;
+      const userText = extractText(row);
+      const userTimestampNano = timestampToUnixNanos(row.timestamp);
+      pending = openPending({
+        promptId,
+        userText,
+        userTimestampNano,
+        nowMs,
+      });
+      // Cache the source row so subsequent waves can build records pinned to
+      // it (sidechain / userType metadata etc).
+      pending.userRow = sanitizeStoredRow(row);
 
-    const stepRecords = buildStepEvents(group, toolResultsByUseId, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, stepCounter === llmGroups.length, inputDelta, cwd, llmRequestTs, turnMetadata);
-    records.push(...stepRecords);
-
-    // Collect this step's tool_calls for next step's input delta
-    prevToolCalls = [];
-    let lastToolResultTsInStep = undefined;
-    for (const row of group) {
-      const msg = row.message || {};
-      const content = Array.isArray(msg.content) ? msg.content : [];
-      for (const b of content) {
-        if (b.type === 'tool_use') {
-          prevToolCalls.push({ id: b.id, name: b.name });
-          // 找到本 step 该 tool_use 对应的 tool_result 行，记录 ts；多 tool 场景保留最后一个
-          const matchingResult = toolResultsByUseId.get(b.id);
-          if (matchingResult?.row.timestamp) {
-            const nano = timestampToUnixNanos(matchingResult.row.timestamp);
-            if (nano) lastToolResultTsInStep = nano;
-          }
-        }
+      if (userText) {
+        records.push(buildRecord({
+          'event.name': 'other',
+          'agent.qoderwork.event.kind': 'turn_input',
+          'agent.qoderwork.promptId': promptId,
+          'gen_ai.turn.id': pending.turnId,
+          'gen_ai.session.id': ctx.sessionId,
+          'gen_ai.agent.type': 'qoder-work',
+          'gen_ai.provider.name': ctx.providerName,
+          'user.id': ctx.userId,
+          'gen_ai.input.messages_delta': [{ role: 'user', parts: [{ type: 'text', content: userText }] }],
+          time_unix_nano: userTimestampNano,
+          observed_time_unix_nano: ctx.observedTs,
+          version: ctx.version,
+        }, row, ctx.runtimeConfig, ctx.cwd));
+        pending = markUserTextEmitted(pending, { nowMs });
       }
+      continue;
     }
-    if (lastToolResultTsInStep) {
-      prevStepLastToolResultTs = lastToolResultTsInStep;
+
+    if (isToolResult(row)) {
+      if (!pending) {
+        logDebug(agentId, 'assembler: orphan tool_result without a pending turn; skipped');
+        continue;
+      }
+      const handled = handleToolResultRow({
+        row,
+        pending,
+        resolvedResults,
+        ctx,
+        nowMs,
+      });
+      records.push(...handled.records);
+      pending = handled.pending;
+      resolvedResults = handled.resolvedResults;
+      continue;
     }
-  }
 
-  return records;
-}
-
-function groupByParentUuid(assistantRows) {
-  const groups = [];
-  const grouped = new Map();
-  const order = [];
-
-  for (const row of assistantRows) {
-    // randomUUID fallback: rows without parentUuid/uuid are treated as individual LLM calls.
-    // In practice QoderWork always sets parentUuid; this is a defensive fallback only.
-    const parentUuid = row.parentUuid || row.uuid || crypto.randomUUID();
-    if (!grouped.has(parentUuid)) {
-      grouped.set(parentUuid, []);
-      order.push(parentUuid);
-    }
-    grouped.get(parentUuid).push(row);
-  }
-
-  for (const key of order) {
-    groups.push(grouped.get(key));
-  }
-  return groups;
-}
-
-/**
- * Group consecutive assistant rows between tool_result boundaries.
- *
- * Each group represents ONE LLM response. A tool_result row marks the
- * boundary because it delivers a tool's output back to the model — the
- * next assistant row is the start of the model's next response.
- *
- * Why not parentUuid: QoderWork occasionally emits a single LLM response
- * as multiple assistant rows with different parentUuids (e.g. a thinking
- * row + a separate tool_use row). Using parentUuid would incorrectly
- * split them into multiple "steps", and a "prev tool_result ts as
- * llm.request start" rule would then attribute the tool's execution time
- * to the second half's LLM time.
- */
-function groupAssistantRowsByToolResults(turnRows) {
-  const groups = [];
-  let current = [];
-
-  for (const row of turnRows) {
     if (row.type === 'assistant') {
-      current.push(row);
-    } else if (row.type === 'user' && isToolResult(row)) {
-      if (current.length > 0) {
-        groups.push(current);
-        current = [];
+      if (!pending) {
+        logDebug(agentId, 'assembler: orphan assistant row without a pending turn; skipped (no random uuid)');
+        continue;
       }
+      pending = appendAssistant(pending, row, { nowMs });
+      if (waveEnded(row)) {
+        const flushed = flushPendingWave({
+          pending,
+          resolvedResults,
+          ctx,
+          waveAssistantRows: pending.currentWaveRows ?? [],
+          finalize: true,
+          nowMs,
+        });
+        records.push(...flushed.records);
+        pending = flushed.pending;
+        resolvedResults = flushed.resolvedResults;
+      }
+      continue;
     }
-    // Non-assistant non-tool_result user rows (the prompt) are ignored here;
-    // they don't end an LLM-response group.
   }
-  if (current.length > 0) groups.push(current);
-  return groups;
+
+  if (pending) {
+    pending = { ...pending, resolvedResults, updatedAtMs: nowMs };
+    perTranscript.pending_turn = pending;
+  } else {
+    perTranscript.pending_turn = null;
+  }
+  return { perTranscript, records };
 }
 
-function buildStepEvents(group, toolResultsByUseId, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, isLastStep, inputDelta, cwd, llmRequestTs, turnMetadata = {}) {
-  const records = [];
-  const firstRow = group[0];
-  const lastRow = group[group.length - 1];
+// ─── Wave finalization ─────────────────────────────────────────────────────
 
-  // thinking 行的 ts 用作 llm.response 时间（模型完成输出的真实时刻）；
-  // 没有 thinking 时回退到 lastRow.timestamp（与现有行为一致）
-  const thinkingRow = group.find(r => {
+function flushPendingWave({ pending, resolvedResults, ctx, waveAssistantRows, finalize, nowMs }) {
+  if (!pending) return { pending, resolvedResults, records: [] };
+  if (!finalize) {
+    // Closing a pending turn at a prompt boundary: do not emit anything.
+    return { pending, resolvedResults, records: [] };
+  }
+
+  const records = [];
+  const stepSeq = pending.nextStepSeq ?? 1;
+  const stepId = `${pending.turnId}:s${stepSeq}`;
+
+  const { outputParts, toolCalls } = collectOutputParts(waveAssistantRows);
+  if (outputParts.length === 0) {
+    // Defensive: do not emit an unmatched llm.request without payload. Leave
+    // the rows in pending — next hook may bring real content.
+    return { pending, resolvedResults, records };
+  }
+
+  const firstRow = waveAssistantRows[0];
+  const lastRow = waveAssistantRows[waveAssistantRows.length - 1];
+
+  // llm.request for this step:
+  //   step 1 → user prompt timestamp (good proxy for LLM start)
+  //   step N>1 → latest tool_result timestamp from prior step (model
+  //              starts processing the moment its inputs land)
+  let llmRequestTs;
+  let inputDelta;
+  if (stepSeq === 1) {
+    if (pending.userText) {
+      inputDelta = [{ role: 'user', parts: [{ type: 'text', content: pending.userText }] }];
+    }
+    llmRequestTs = pending.userTimestampNano || timestampToUnixNanos(firstRow.timestamp);
+  } else if (resolvedResults.length > 0) {
+    const toolParts = resolvedResults.map((r) => ({
+      type: 'tool_call_response',
+      id: r.id,
+      response: r.resultText,
+    }));
+    inputDelta = [{ role: 'tool', parts: toolParts }];
+    const latestNano = resolvedResults
+      .map((r) => r.resultTsNano)
+      .filter(Boolean)
+      .sort()
+      .at(-1);
+    llmRequestTs = latestNano || timestampToUnixNanos(firstRow.timestamp);
+  } else {
+    llmRequestTs = timestampToUnixNanos(firstRow.timestamp);
+  }
+
+  // llm.response time uses the thinking row when available so the LLM span
+  // tracks the moment the model actually finished generating tokens.
+  const thinkingRow = waveAssistantRows.find((r) => {
     const content = Array.isArray(r.message?.content) ? r.message.content : [];
     const firstType = content[0]?.type;
     return firstType === 'thinking' || r.content_type === 'thinking';
   });
   const llmResponseTs = timestampToUnixNanos(thinkingRow ? thinkingRow.timestamp : lastRow.timestamp);
 
-  // Determine response.id from parentUuid
+  const finishReason = toolCalls.length > 0 ? 'tool_calls' : 'end_turn';
   const responseId = firstRow.parentUuid || firstRow.uuid;
 
-  // Build merged output parts
+  const reqRecord = buildStepLlmRequest({
+    pending,
+    stepId,
+    inputDelta,
+    timeNano: llmRequestTs,
+    ctx,
+    sourceRow: firstRow,
+  });
+  const respRecord = buildStepLlmResponse({
+    pending,
+    stepId,
+    outputParts,
+    finishReason,
+    responseId,
+    timeNano: llmResponseTs,
+    ctx,
+    sourceRow: firstRow,
+  });
+
+  // request and response always emit together — never one without the other.
+  records.push(reqRecord, respRecord);
+
+  // tool.call events are emitted at wave finalization time using the
+  // assistant tool_use row's timestamp. The matching tool.result event is
+  // emitted later (when tool_result actually arrives) and reuses the same
+  // step.id so the converter nests both under the LLM call.
+  for (const tc of toolCalls) {
+    records.push(buildRecord({
+      'agent.qoderwork.promptId': pending.promptId,
+      'event.name': 'tool.call',
+      'gen_ai.step.id': stepId,
+      'gen_ai.turn.id': pending.turnId,
+      'gen_ai.session.id': ctx.sessionId,
+      'gen_ai.agent.type': 'qoder-work',
+      'gen_ai.tool.name': tc.name,
+      'gen_ai.tool.call.id': tc.id,
+      'gen_ai.tool.call.exec.id': tc.id,
+      'gen_ai.tool.call.arguments': typeof tc.input === 'string' ? tc.input : JSON.stringify(tc.input),
+      'user.id': ctx.userId,
+      time_unix_nano: timestampToUnixNanos(lastRow.timestamp),
+      observed_time_unix_nano: ctx.observedTs,
+      version: ctx.version,
+    }, firstRow, ctx.runtimeConfig, ctx.cwd));
+  }
+
+  // Move pending state forward.
+  let nextPending = clearWave(pending, { nowMs });
+  nextPending = bumpStepSeq(nextPending, { nowMs });
+  if (toolCalls.length > 0) {
+    nextPending = recordPendingToolCalls(nextPending, toolCalls.map((c) => ({
+      id: c.id,
+      name: c.name,
+      stepId,
+      requestedTsNano: timestampToUnixNanos(lastRow.timestamp),
+    })), { nowMs });
+  }
+
+  // Step N consumed any resolvedResults that fed its input — drop them.
+  let nextResolved = stepSeq === 1 ? resolvedResults : [];
+
+  return { pending: nextPending, resolvedResults: nextResolved, records };
+}
+
+function buildStepLlmRequest({ pending, stepId, inputDelta, timeNano, ctx, sourceRow }) {
+  const fields = {
+    'agent.qoderwork.promptId': pending.promptId,
+    'event.name': 'llm.request',
+    'gen_ai.step.id': stepId,
+    'gen_ai.turn.id': pending.turnId,
+    'gen_ai.session.id': ctx.sessionId,
+    'gen_ai.agent.type': 'qoder-work',
+    'gen_ai.provider.name': ctx.providerName,
+    'gen_ai.request.model': 'auto',
+    'user.id': ctx.userId,
+    time_unix_nano: timeNano,
+    observed_time_unix_nano: ctx.observedTs,
+    version: ctx.version,
+  };
+  if (inputDelta) fields['gen_ai.input.messages'] = inputDelta;
+  return buildRecord(fields, sourceRow, ctx.runtimeConfig, ctx.cwd);
+}
+
+function buildStepLlmResponse({ pending, stepId, outputParts, finishReason, responseId, timeNano, ctx, sourceRow }) {
+  return buildRecord({
+    'agent.qoderwork.promptId': pending.promptId,
+    'event.name': 'llm.response',
+    'gen_ai.step.id': stepId,
+    'gen_ai.turn.id': pending.turnId,
+    'gen_ai.session.id': ctx.sessionId,
+    'gen_ai.agent.type': 'qoder-work',
+    'gen_ai.provider.name': ctx.providerName,
+    'gen_ai.request.model': 'auto',
+    'gen_ai.response.model': 'auto',
+    'gen_ai.response.id': responseId,
+    'gen_ai.response.finish_reasons': [finishReason],
+    'user.id': ctx.userId,
+    'gen_ai.output.messages': [{ role: 'assistant', parts: outputParts, finish_reason: finishReason }],
+    time_unix_nano: timeNano,
+    observed_time_unix_nano: ctx.observedTs,
+    version: ctx.version,
+  }, sourceRow, ctx.runtimeConfig, ctx.cwd);
+}
+
+function collectOutputParts(rows) {
   const outputParts = [];
   const toolCalls = [];
-
-  for (const row of group) {
+  for (const row of rows) {
     const msg = row.message || {};
     const content = Array.isArray(msg.content) ? msg.content : [];
-    // Derive content type from message.content[0].type (raw transcript has no content_type field)
     const contentType = row.content_type || (content[0]?.type) || '';
 
     if (contentType === 'thinking') {
@@ -377,128 +523,78 @@ function buildStepEvents(group, toolResultsByUseId, stepId, turnId, sessionId, u
       toolCalls.push({ id: toolBlock.id, name: toolBlock.name, input: toolBlock.input });
     }
   }
+  return { outputParts, toolCalls };
+}
 
-  const finishReason = toolCalls.length > 0 ? 'tool_calls' : (isLastStep ? 'end_turn' : 'stop');
+// ─── tool_result handling ──────────────────────────────────────────────────
 
-  // llm.request for this step.
-  //
-  // Field choice: gen_ai.input.messages (NOT messages_delta).
-  //
-  // The converter (@loongsuite/otel-util-genai) treats messages_delta as a
-  // turn-level accumulator: when an LLM pair only has messages_delta, it
-  // concatenates ALL prior pairs' deltas to build the LLM span's input.
-  // For QoderWork that means tool_call_response would grow across steps
-  // (step 1: 0 results, step 2: 1, step 3: 2, ...) — wrong for an LLM
-  // span which should show what THIS llm call received.
-  //
-  // Writing to messages (treated as "full") makes the converter use the
-  // value directly without accumulation. We still emit per-step incremental
-  // content, matching Codex's pattern. ENTRY/AGENT spans collect input from
-  // the user-hook event (no step.id, still messages_delta) above, so this
-  // change does not affect the turn-level overview spans.
-  const llmRequestFields = {
-    ...turnMetadata,
-    'event.name': 'llm.request',
-    'gen_ai.step.id': stepId,
-    'gen_ai.turn.id': turnId,
-    'gen_ai.session.id': sessionId,
-    'gen_ai.agent.type': 'qoder-work',
-    'gen_ai.provider.name': providerName,
-    'gen_ai.request.model': 'auto',
-    'user.id': userId,
-    time_unix_nano: llmRequestTs || timestampToUnixNanos(firstRow.timestamp),
-    observed_time_unix_nano: observedTs,
-    version,
-  };
-  if (inputDelta) {
-    llmRequestFields['gen_ai.input.messages'] = inputDelta;
-  }
-  records.push(buildRecord(llmRequestFields, firstRow, runtimeConfig, cwd));
+function handleToolResultRow({ row, pending, resolvedResults, ctx, nowMs }) {
+  const records = [];
+  const content = Array.isArray(row.message?.content) ? row.message.content : [];
+  const resolved = new Set();
+  let nextPending = pending;
+  let nextResolvedResults = [...resolvedResults];
 
-  // llm.response (merged multi-parts)
-  if (outputParts.length > 0) {
+  for (const block of content) {
+    if (block?.type !== 'tool_result' || !block.tool_use_id) continue;
+    const tc = (pending.pendingToolCalls ?? []).find((c) => c.id === block.tool_use_id);
+    if (!tc) continue;
+    const resultText = typeof block.content === 'string' ? block.content : JSON.stringify(block.content);
+    const resultTsNano = timestampToUnixNanos(row.timestamp);
+
     records.push(buildRecord({
-      ...turnMetadata,
-      'event.name': 'llm.response',
-      'gen_ai.step.id': stepId,
-      'gen_ai.turn.id': turnId,
-      'gen_ai.session.id': sessionId,
-      'gen_ai.agent.type': 'qoder-work',
-      'gen_ai.provider.name': providerName,
-      'gen_ai.request.model': 'auto',
-      'gen_ai.response.model': 'auto',
-      'gen_ai.response.id': responseId,
-      'gen_ai.response.finish_reasons': [finishReason],
-      'user.id': userId,
-      'gen_ai.output.messages': [{ role: 'assistant', parts: outputParts, finish_reason: finishReason }],
-      time_unix_nano: llmResponseTs,
-      observed_time_unix_nano: observedTs,
-      version,
-    }, firstRow, runtimeConfig, cwd));
-  }
-
-  // tool.call + tool.result events
-  for (const tc of toolCalls) {
-    records.push(buildRecord({
-      ...turnMetadata,
-      'event.name': 'tool.call',
-      'gen_ai.step.id': stepId,
-      'gen_ai.turn.id': turnId,
-      'gen_ai.session.id': sessionId,
+      'agent.qoderwork.promptId': pending.promptId,
+      'event.name': 'tool.result',
+      'gen_ai.step.id': tc.stepId,
+      'gen_ai.turn.id': pending.turnId,
+      'gen_ai.session.id': ctx.sessionId,
       'gen_ai.agent.type': 'qoder-work',
       'gen_ai.tool.name': tc.name,
       'gen_ai.tool.call.id': tc.id,
       'gen_ai.tool.call.exec.id': tc.id,
-      'gen_ai.tool.call.arguments': typeof tc.input === 'string' ? tc.input : JSON.stringify(tc.input),
-      'user.id': userId,
-      time_unix_nano: timestampToUnixNanos(lastRow.timestamp),
-      observed_time_unix_nano: observedTs,
-      version,
-    }, firstRow, runtimeConfig, cwd));
+      'gen_ai.tool.call.result': resultText,
+      'tool.result.status': block?.is_error ? 'failure' : 'success',
+      'user.id': ctx.userId,
+      time_unix_nano: resultTsNano,
+      observed_time_unix_nano: ctx.observedTs,
+      version: ctx.version,
+    }, row, ctx.runtimeConfig, ctx.cwd));
 
-    // Find matching tool_result
-    const matchingResult = toolResultsByUseId.get(tc.id);
-    if (matchingResult) {
-      const { row: resultRow, block: resultBlock } = matchingResult;
-      const resultText = typeof resultBlock?.content === 'string' ? resultBlock.content : JSON.stringify(resultBlock?.content);
-      records.push(buildRecord({
-        ...turnMetadata,
-        'event.name': 'tool.result',
-        'gen_ai.step.id': stepId,
-        'gen_ai.turn.id': turnId,
-        'gen_ai.session.id': sessionId,
-        'gen_ai.agent.type': 'qoder-work',
-        'gen_ai.tool.name': tc.name,
-        'gen_ai.tool.call.id': tc.id,
-        'gen_ai.tool.call.exec.id': tc.id,
-        'gen_ai.tool.call.result': resultText,
-        'tool.result.status': resultBlock?.is_error ? 'failure' : 'success',
-        'user.id': userId,
-        time_unix_nano: timestampToUnixNanos(resultRow.timestamp),
-        observed_time_unix_nano: observedTs,
-        version,
-      }, resultRow, runtimeConfig, cwd));
-    }
+    nextResolvedResults.push({
+      id: tc.id,
+      name: tc.name,
+      resultText,
+      resultTsNano,
+    });
+    resolved.add(tc.id);
   }
 
-  return records;
+  if (resolved.size > 0) {
+    nextPending = dropResolvedToolCalls(nextPending, resolved, { nowMs });
+  }
+  return { pending: nextPending, resolvedResults: nextResolvedResults, records };
 }
 
-function buildRecord(fields, sourceRow, runtimeConfig, cwd) {
-  const record = {
-    'event.id': crypto.randomUUID(),
-    'agent.source': 'qoder-transcript-hook',
-    'agent.qoderwork.variant': 'qoder-work',
-    ...fields,
-  };
-  if (cwd) record['agent.qoderwork.cwd'] = cwd;
-  if (sourceRow) {
-    if (sourceRow.isSidechain !== undefined) record['agent.qoderwork.isSidechain'] = String(sourceRow.isSidechain);
-    if (sourceRow.userType) record['agent.qoderwork.userType'] = sourceRow.userType;
-    if (sourceRow.version) record['agent.qoderwork.version'] = sourceRow.version;
-    if (sourceRow.agentId) record['agent.qoderwork.agentId'] = sourceRow.agentId;
+// ─── Helpers reused from the legacy implementation ─────────────────────────
+
+function isPromptRow(row) {
+  return row.type === 'user' && !isToolResult(row) && !isSystemInjection(row);
+}
+
+function isSystemInjection(row) {
+  const text = extractText(row).trimStart();
+  if (text.startsWith('<command-message>')
+    || text.startsWith('<command-name>')
+    || text.startsWith('[Request interrupted')
+    || text.startsWith('[SYSTEM: This is an automated background review task')) {
+    return true;
   }
-  return sanitizeObject(applyHookContentPolicy(record, runtimeConfig)) || null;
+  return isPureSystemReminder(text);
+}
+
+function isPureSystemReminder(text) {
+  return text.startsWith('<system-reminder>')
+    && text.replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, '').trim().length === 0;
 }
 
 function isToolResult(row) {
@@ -521,13 +617,49 @@ function extractText(row) {
   return '';
 }
 
+function buildRecord(fields, sourceRow, runtimeConfig, cwd) {
+  const record = {
+    'event.id': crypto.randomUUID(),
+    'agent.source': 'qoder-transcript-hook',
+    'agent.qoderwork.variant': 'qoder-work',
+    ...fields,
+  };
+  if (cwd) record['agent.qoderwork.cwd'] = cwd;
+  if (sourceRow) {
+    if (sourceRow.isSidechain !== undefined) record['agent.qoderwork.isSidechain'] = String(sourceRow.isSidechain);
+    if (sourceRow.userType) record['agent.qoderwork.userType'] = sourceRow.userType;
+    if (sourceRow.version) record['agent.qoderwork.version'] = sourceRow.version;
+    if (sourceRow.agentId) record['agent.qoderwork.agentId'] = sourceRow.agentId;
+  }
+  return sanitizeObject(applyHookContentPolicy(record, runtimeConfig)) || null;
+}
+
+function sanitizeStoredRow(row) {
+  if (!row) return null;
+  // Persisting a transcript row as-is is too heavy. Keep only the metadata
+  // we'll need for downstream record building if a wave gets buffered to
+  // disk between Stop hooks.
+  return {
+    type: row.type,
+    uuid: row.uuid,
+    parentUuid: row.parentUuid,
+    timestamp: row.timestamp,
+    promptId: row.promptId,
+    sessionId: row.sessionId,
+    userType: row.userType,
+    isSidechain: row.isSidechain,
+    isMeta: row.isMeta,
+    version: row.version,
+    agentId: row.agentId,
+  };
+}
+
 /**
  * Resolve QoderWork sandbox cwd to the real project directory.
  *
  * QoderWork stores the user's chosen project path in SQLite
  * (chats.additional_directories), but the hook payload only contains
  * the internal sandbox path (~/.qoderwork/workspace/<chatId>).
- * We query the DB to recover the real project path.
  */
 function resolveQoderWorkProjectDir(sandboxCwd, agentId) {
   if (!sandboxCwd) return undefined;
@@ -558,6 +690,39 @@ function resolveQoderWorkProjectDir(sandboxCwd, agentId) {
   return sandboxCwd;
 }
 
-export { extractText, getTurnIdForRows, isSystemInjection, isToolResult, splitIntoTurns };
+// ─── Legacy helper exports (kept for the qoderwork-hook-processor.test.mjs
+//     suite that pre-dates the assembler rewrite). The main path no longer
+//     uses these. `getTurnIdForRows` deliberately returns `null` instead of
+//     `crypto.randomUUID()` — the assembler-driven main path treats a
+//     missing prompt as drop-on-floor; the legacy test only inspects the
+//     happy path with a real promptId.
+function splitIntoTurns(contentRows) {
+  const turns = [];
+  let currentTurn = [];
+  for (const row of contentRows) {
+    if (isPromptRow(row)) {
+      if (currentTurn.length > 0) turns.push(currentTurn);
+      currentTurn = [row];
+    } else {
+      currentTurn.push(row);
+    }
+  }
+  if (currentTurn.length > 0) turns.push(currentTurn);
+  return turns;
+}
+
+function getTurnIdForRows(turnRows) {
+  const promptRow = turnRows.find(isPromptRow);
+  return promptRow?.promptId || promptRow?.uuid || null;
+}
+
+export {
+  extractText,
+  getTurnIdForRows,
+  isPromptRow,
+  isSystemInjection,
+  isToolResult,
+  splitIntoTurns,
+};
 
 main().catch(() => { /* fail-open */ });

--- a/assets/hooks/qoderwork-turn-assembler.mjs
+++ b/assets/hooks/qoderwork-turn-assembler.mjs
@@ -1,0 +1,232 @@
+/**
+ * QoderWork persistent turn assembler.
+ *
+ * Why this module exists:
+ *   QoderWork's Stop hook fires multiple times per user prompt — once per LLM
+ *   wave, plus once after each tool_result. The previous "stateless splitTurn"
+ *   implementation produced two failure modes:
+ *     1. orphan llm.request when Stop fires between user and assistant rows
+ *     2. random-uuid turn ids when an assistant batch lands without its prompt
+ *   Both stem from the hook processor losing track of pending turns across
+ *   invocations.
+ *
+ * What this module owns:
+ *   - A pure state-machine for a single transcript-path's pending turn.
+ *   - Persistence to a JSON file alongside .line_records.* so multiple Stop
+ *     hooks share the same memory.
+ *
+ * What this module does NOT own:
+ *   - Building the AgentActivityEntry records (hook processor's job).
+ *   - Deciding wave boundaries beyond a stop_reason check (hook processor
+ *     remains responsible for tool_result-driven boundaries).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  HOOKS_DIR,
+  logDebug,
+} from './shared/hook-processor-base.mjs';
+
+const ASSEMBLER_VERSION = 1;
+const DEFAULT_TTL_MS = 60 * 60 * 1000;        // 60 min
+const STATE_RETENTION_MS = 24 * 60 * 60 * 1000; // 24h, for evicting cold transcripts
+const WAVE_END_REASONS = new Set(['end_turn', 'tool_use', 'stop_sequence', 'max_tokens']);
+
+// ─── Pure state-machine helpers ────────────────────────────────────────────
+
+export function openPending({ promptId, userText, userTimestampNano, nowMs }) {
+  if (!promptId) throw new Error('openPending requires promptId');
+  return {
+    promptId,
+    turnId: promptId,
+    userText: userText ?? '',
+    userTimestampNano: userTimestampNano ?? null,
+    userTextEmitted: false,
+    nextStepSeq: 1,
+    pendingToolCalls: [],
+    currentWaveRows: [],
+    lastEmittedThroughLine: 0,
+    createdAtMs: nowMs ?? Date.now(),
+    updatedAtMs: nowMs ?? Date.now(),
+  };
+}
+
+export function appendAssistant(turn, row, { nowMs } = {}) {
+  if (!turn) throw new Error('appendAssistant requires turn');
+  const next = {
+    ...turn,
+    currentWaveRows: [...(turn.currentWaveRows ?? []), row],
+    updatedAtMs: nowMs ?? Date.now(),
+  };
+  return next;
+}
+
+export function clearWave(turn, { nowMs } = {}) {
+  if (!turn) return turn;
+  return {
+    ...turn,
+    currentWaveRows: [],
+    updatedAtMs: nowMs ?? Date.now(),
+  };
+}
+
+export function bumpStepSeq(turn, { nowMs } = {}) {
+  if (!turn) return turn;
+  return {
+    ...turn,
+    nextStepSeq: (turn.nextStepSeq ?? 1) + 1,
+    updatedAtMs: nowMs ?? Date.now(),
+  };
+}
+
+export function recordPendingToolCalls(turn, calls, { nowMs } = {}) {
+  if (!turn) return turn;
+  if (!Array.isArray(calls) || calls.length === 0) return turn;
+  return {
+    ...turn,
+    pendingToolCalls: [...(turn.pendingToolCalls ?? []), ...calls],
+    updatedAtMs: nowMs ?? Date.now(),
+  };
+}
+
+export function dropResolvedToolCalls(turn, resolvedIds, { nowMs } = {}) {
+  if (!turn) return turn;
+  if (!resolvedIds || resolvedIds.size === 0) return turn;
+  const remaining = (turn.pendingToolCalls ?? []).filter((c) => !resolvedIds.has(c.id));
+  return {
+    ...turn,
+    pendingToolCalls: remaining,
+    updatedAtMs: nowMs ?? Date.now(),
+  };
+}
+
+export function markUserTextEmitted(turn, { nowMs } = {}) {
+  if (!turn) return turn;
+  return {
+    ...turn,
+    userTextEmitted: true,
+    updatedAtMs: nowMs ?? Date.now(),
+  };
+}
+
+export function closePending(turn, { reason, nowMs } = {}) {
+  if (!turn) return null;
+  return {
+    promptId: turn.promptId,
+    turnId: turn.turnId,
+    reason: reason ?? 'unknown',
+    closedAtMs: nowMs ?? Date.now(),
+    nextStepSeq: turn.nextStepSeq,
+    pendingToolCalls: turn.pendingToolCalls ?? [],
+  };
+}
+
+export function waveEnded(row) {
+  const stop = row?.message?.stop_reason;
+  if (!stop) return false;
+  return WAVE_END_REASONS.has(stop);
+}
+
+export function isPendingExpired(turn, { nowMs, ttlMs } = {}) {
+  if (!turn) return false;
+  const t = ttlMs ?? DEFAULT_TTL_MS;
+  const now = nowMs ?? Date.now();
+  return now - (turn.updatedAtMs ?? turn.createdAtMs ?? now) > t;
+}
+
+// ─── Persistence ───────────────────────────────────────────────────────────
+
+export function assemblerStateFile(agentId) {
+  return path.join(HOOKS_DIR, `.assembler_state.${agentId}.json`);
+}
+
+function freshState() {
+  return {};
+}
+
+export function loadAssemblerState(agentId) {
+  const file = assemblerStateFile(agentId);
+  try {
+    if (!fs.existsSync(file)) return freshState();
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return freshState();
+    // Drop entries whose schema version doesn't match (worst case: one
+    // round of lost enrichment for that transcript).
+    for (const key of Object.keys(parsed)) {
+      const entry = parsed[key];
+      if (!entry || typeof entry !== 'object' || entry._v !== ASSEMBLER_VERSION) {
+        delete parsed[key];
+      }
+    }
+    return parsed;
+  } catch (e) {
+    logDebug(agentId, `assembler state load failed: ${e.message || e}; reset`);
+    return freshState();
+  }
+}
+
+export function saveAssemblerState(agentId, state) {
+  const file = assemblerStateFile(agentId);
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, JSON.stringify(state, null, 2), 'utf-8');
+    return true;
+  } catch (e) {
+    logDebug(agentId, `assembler state save failed: ${e.message || e}`);
+    return false;
+  }
+}
+
+/**
+ * Read state for one transcript path. Returns the per-transcript subtree, or
+ * a fresh empty object if missing. Caller mutates the returned subtree and
+ * persists the full state via writeTranscriptState.
+ */
+export function getTranscriptState(state, transcriptPath) {
+  const existing = state?.[transcriptPath];
+  if (existing && typeof existing === 'object') {
+    return {
+      session_id: existing.session_id ?? null,
+      consumed_line: typeof existing.consumed_line === 'number' ? existing.consumed_line : 0,
+      pending_turn: existing.pending_turn ?? null,
+      updated_at_ms: existing.updated_at_ms ?? Date.now(),
+    };
+  }
+  return { session_id: null, consumed_line: 0, pending_turn: null, updated_at_ms: Date.now() };
+}
+
+export function writeTranscriptState(state, transcriptPath, sub, { nowMs } = {}) {
+  state[transcriptPath] = { ...sub, updated_at_ms: nowMs ?? Date.now(), _v: ASSEMBLER_VERSION };
+  return state;
+}
+
+export function evictColdTranscripts(state, { nowMs } = {}) {
+  if (!state || typeof state !== 'object') return state;
+  const now = nowMs ?? Date.now();
+  for (const key of Object.keys(state)) {
+    const entry = state[key];
+    if (!entry || typeof entry !== 'object') {
+      delete state[key];
+      continue;
+    }
+    if (now - (entry.updated_at_ms ?? 0) > STATE_RETENTION_MS) {
+      delete state[key];
+    }
+  }
+  return state;
+}
+
+// Allow tests to inject a deterministic clock without monkey-patching Date.
+export function resolveNowMs(envValue) {
+  const raw = envValue ?? process.env.LOONGSUITE_PILOT_ASSEMBLER_NOW_MS;
+  if (!raw) return Date.now();
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : Date.now();
+}
+
+export const ASSEMBLER_DEFAULTS = Object.freeze({
+  TTL_MS: DEFAULT_TTL_MS,
+  STATE_RETENTION_MS,
+  VERSION: ASSEMBLER_VERSION,
+});

--- a/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
+++ b/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
@@ -14,6 +14,7 @@ import {
   resolveQoderWorkRoot,
   type SdkEvent,
 } from '../qoder-work-log/qoder-work-log-input.js';
+import { QoderWorkModelNameCache } from './qoderwork-model-name-cache.js';
 
 const NANO_PER_MILLI = 1_000_000n;
 const SEGMENT_TIMING_TOLERANCE_MS = 5 * 60 * 1000;
@@ -62,12 +63,18 @@ export class QoderWorkTraceInput extends BaseInput {
   // The encoded workspace directory is a fast path; session-id lookup handles
   // writer encoding changes and non-POSIX workspace paths.
   private readonly segmentDirBySession: Map<string, CachedSegmentDir> = new Map();
+  // Display name sidecar — resolves modelKey → human-readable label by tail-reading
+  // qodercli.log. Decoupled from segment FIFO so it never affects timing matching.
+  private readonly modelNameCache: QoderWorkModelNameCache;
 
   constructor(opts: QoderWorkTraceInputOptions) {
     super({ ...opts, pollIntervalMs: opts.pollIntervalMs ?? 30_000 });
     this.logDir = opts.logDir ?? resolveHome('~/.loongsuite-pilot/logs/qoder-work/history');
     this.segmentsRoot = opts.segmentsRoot ?? resolveHome('~/.qoderwork/logs/sessions');
     this.sdkLogDir = opts.sdkLogDir ?? resolveQoderWorkSdkLogDir();
+    this.modelNameCache = new QoderWorkModelNameCache({
+      logFile: opts.qoderCliLogFile ?? resolveHome('~/.qoderwork/logs'),
+    });
   }
 
   static async checkAvailability(): Promise<boolean> {
@@ -90,6 +97,11 @@ export class QoderWorkTraceInput extends BaseInput {
       // Read legacy SDK logs only for token compatibility. Segment data remains
       // authoritative for LLM/tool timing and model attribution.
       await this.readSdkTokenState();
+      try {
+        await this.modelNameCache.refresh();
+      } catch (err) {
+        this.logger.warn('failed to refresh model name cache', { error: (err as Error)?.message });
+      }
 
       // 1. Hook JSONL — primary source of structure.
       const { entries: rawEntries, isFirstRun, turnCount } = await this.readHookJsonl();
@@ -458,12 +470,25 @@ export class QoderWorkTraceInput extends BaseInput {
         const response = stepEntries.find(e => e['event.name'] === 'llm.response');
         let hasSegmentUsage = false;
         if (request && response) {
-          const pair = this.takeSegmentPair(sessionId, turnId, request, response);
-          if (pair) {
+          const result = this.takeSegmentPair(sessionId, turnId, request, response);
+          if (result) {
+            const { pair, matchType } = result;
             (request as Record<string, unknown>)['time_unix_nano'] = pair.startNano;
             (response as Record<string, unknown>)['time_unix_nano'] = pair.endNano;
 
+            for (const e of stepEntries) {
+              (e as Record<string, unknown>)['agent.qoderwork.model_source'] = matchType;
+            }
+            if (matchType === 'segment_time_window') {
+              this.logger.warn('model resolved via time-window fallback', {
+                sessionId,
+                turnId,
+                pairTurnId: pair.turnId,
+              });
+            }
+
             if (pair.model) {
+              const displayName = this.modelNameCache.resolve(pair.model).displayName;
               for (const e of stepEntries) {
                 if (!e['gen_ai.request.model'] || e['gen_ai.request.model'] === 'auto') {
                   (e as Record<string, unknown>)['gen_ai.request.model'] = pair.model;
@@ -471,9 +496,16 @@ export class QoderWorkTraceInput extends BaseInput {
                 if (e['event.name'] === 'llm.response') {
                   (e as Record<string, unknown>)['gen_ai.response.model'] = pair.model;
                 }
+                if (displayName) {
+                  (e as Record<string, unknown>)['agent.qoderwork.model_display_name'] = displayName;
+                }
               }
             }
             hasSegmentUsage = this.applyUsage(response, pair.usage);
+          } else {
+            for (const e of stepEntries) {
+              (e as Record<string, unknown>)['agent.qoderwork.model_source'] = 'unresolved';
+            }
           }
           if (!hasSegmentUsage) this.applySdkTokenUsage(sessionId, request, response);
         }
@@ -684,19 +716,21 @@ export class QoderWorkTraceInput extends BaseInput {
     turnId: string | undefined,
     request: AgentActivityEntry,
     response: AgentActivityEntry,
-  ): SegmentLlmPair | undefined {
+  ): { pair: SegmentLlmPair; matchType: 'segment_turn' | 'segment_time_window' } | undefined {
     const buffer = this.segmentPairs.get(sessionId);
     if (!buffer?.length) return undefined;
 
+    let matchType: 'segment_turn' | 'segment_time_window' = 'segment_turn';
     let idx = turnId ? buffer.findIndex(pair => pair.turnId === turnId) : -1;
     if (idx < 0) {
       idx = buffer.findIndex(pair => this.isSegmentPairCompatible(pair, request, response));
+      matchType = 'segment_time_window';
     }
     if (idx < 0) return undefined;
 
     const [pair] = buffer.splice(idx, 1);
     if (buffer.length === 0) this.segmentPairs.delete(sessionId);
-    return pair;
+    return { pair, matchType };
   }
 
   private isSegmentPairCompatible(
@@ -787,6 +821,7 @@ export interface QoderWorkTraceInputOptions extends InputOptions {
   logDir?: string;
   segmentsRoot?: string;
   sdkLogDir?: string;
+  qoderCliLogFile?: string;
 }
 
 interface HookJsonlBatch {

--- a/src/inputs/qoder-work-trace/qoderwork-model-name-cache.ts
+++ b/src/inputs/qoder-work-trace/qoderwork-model-name-cache.ts
@@ -1,0 +1,200 @@
+/**
+ * Cache that maps QoderWork modelKey → displayName by tail-reading
+ * `qodercli.log` files for `StreamResponse <json>` lines.
+ *
+ * Why this exists:
+ *   - Trace-input enrichment uses segments to recover the canonical modelKey
+ *     (e.g. `qwork-ultimate`) but the user-facing display name (e.g. "Premium")
+ *     only appears in the qodercli runtime log.
+ *   - Display name is dynamically assigned by the Qoder service, so a static
+ *     mapping table is not safe. A tail-read sidecar keeps the cache fresh
+ *     without participating in timing-sensitive segment FIFO matching.
+ *
+ * The cache is lossy by design: legacy lines without a displayName are simply
+ * skipped so they cannot poison a previously-known mapping. Truncation /
+ * inode rotation resets the read offset so we never blindly skip ahead.
+ *
+ * Layout supported (2026 QoderWork):
+ *   - Legacy single-file: `qodercli.log` at the configured path.
+ *   - Per-run multi-file: a directory containing `runs/<ts>-<id>/qodercli.log`
+ *     with a `latest` symlink. We scan up to MAX_RUN_FILES most-recent run
+ *     directories by mtime and tail each independently (keyed by absolute
+ *     path). This catches sessions even when the root aggregated file is
+ *     stale.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+interface CacheOptions {
+  /** Primary log path — may be a single file OR a directory containing runs/. */
+  logFile: string;
+  /** Cap on how many recent run directories we tail concurrently. */
+  maxRunFiles?: number;
+}
+
+interface CacheEntry {
+  displayName: string;
+  updatedAtMs: number;
+}
+
+interface CacheStats {
+  linesParsed: number;
+  bytesRead: number;
+  resets: number;
+  watchedFiles: number;
+}
+
+const STREAM_RESPONSE_MARKER = 'StreamResponse ';
+const DEFAULT_MAX_RUN_FILES = 4;
+
+interface WatchState {
+  offset: number;
+  /** Inode (on macOS/Linux) — if changed we treat as rotation. */
+  ino: number;
+}
+
+export class QoderWorkModelNameCache {
+  private readonly primaryPath: string;
+  private readonly maxRunFiles: number;
+  private readonly cache: Map<string, CacheEntry> = new Map();
+  private readonly watchStates: Map<string, WatchState> = new Map();
+  private stats: CacheStats = { linesParsed: 0, bytesRead: 0, resets: 0, watchedFiles: 0 };
+
+  constructor(opts: CacheOptions) {
+    this.primaryPath = opts.logFile;
+    this.maxRunFiles = opts.maxRunFiles ?? DEFAULT_MAX_RUN_FILES;
+  }
+
+  async refresh(): Promise<void> {
+    const targets = await this.discoverTargets();
+    this.stats.watchedFiles = targets.length;
+    for (const target of targets) {
+      await this.tailFile(target);
+    }
+  }
+
+  /**
+   * Return the list of log files to tail this cycle.
+   * If primaryPath is a regular file → [primaryPath].
+   * If primaryPath is a directory → scan runs/<ts>/qodercli.log by mtime, top-N.
+   * If neither → empty.
+   */
+  private async discoverTargets(): Promise<string[]> {
+    let stat;
+    try { stat = await fs.stat(this.primaryPath); } catch { return []; }
+
+    if (stat.isFile()) return [this.primaryPath];
+
+    if (stat.isDirectory()) {
+      const runsDir = path.join(this.primaryPath, 'runs');
+      try {
+        const entries = await fs.readdir(runsDir, { withFileTypes: true });
+        const runDirs = entries
+          .filter(e => e.isDirectory())
+          .map(e => ({
+            name: e.name,
+            dirPath: path.join(runsDir, e.name),
+          }));
+        // Resolve mtime of qodercli.log inside each run dir; skip missing.
+        const withMtime: Array<{ dirPath: string; mtimeMs: number; logPath: string }> = [];
+        await Promise.all(runDirs.map(async r => {
+          const logPath = path.join(r.dirPath, 'qodercli.log');
+          try {
+            const s = await fs.stat(logPath);
+            withMtime.push({ dirPath: r.dirPath, mtimeMs: s.mtimeMs, logPath });
+          } catch { /* no log in this run */ }
+        }));
+        withMtime.sort((a, b) => b.mtimeMs - a.mtimeMs);
+        return withMtime.slice(0, this.maxRunFiles).map(w => w.logPath);
+      } catch {
+        return [];
+      }
+    }
+    return [];
+  }
+
+  private async tailFile(filePath: string): Promise<void> {
+    let stat;
+    try { stat = await fs.stat(filePath); } catch { return; }
+
+    const prev = this.watchStates.get(filePath);
+    const ino = stat.ino ?? 0;
+    let offset = prev?.offset ?? 0;
+
+    if (prev && prev.ino !== ino) {
+      // Inode changed — file was replaced; reset.
+      offset = 0;
+      this.stats.resets += 1;
+    }
+    if (stat.size < offset) {
+      // Truncated or rotated; reset.
+      offset = 0;
+      this.stats.resets += 1;
+    }
+    if (stat.size === offset) {
+      this.watchStates.set(filePath, { offset, ino });
+      return;
+    }
+
+    let handle: fs.FileHandle | undefined;
+    try {
+      handle = await fs.open(filePath, 'r');
+      const length = stat.size - offset;
+      const buffer = Buffer.alloc(length);
+      const { bytesRead } = await handle.read(buffer, 0, length, offset);
+      const slice = buffer.slice(0, bytesRead).toString('utf-8');
+      offset += bytesRead;
+      this.stats.bytesRead += bytesRead;
+
+      // Avoid splitting a half-written final line: only consume up to the
+      // last newline; the leftover stays unread and will be picked up on the
+      // next refresh once it's terminated.
+      const lastNl = slice.lastIndexOf('\n');
+      if (lastNl < 0) {
+        offset -= bytesRead;
+        this.watchStates.set(filePath, { offset, ino });
+        return;
+      }
+      const consumable = slice.slice(0, lastNl);
+      const leftover = slice.slice(lastNl + 1);
+      offset -= Buffer.byteLength(leftover, 'utf-8');
+
+      for (const line of consumable.split('\n')) {
+        if (!line.includes(STREAM_RESPONSE_MARKER)) continue;
+        this.stats.linesParsed += 1;
+        const idx = line.indexOf(STREAM_RESPONSE_MARKER);
+        const jsonPart = line.slice(idx + STREAM_RESPONSE_MARKER.length).trim();
+        if (!jsonPart) continue;
+        let payload: unknown;
+        try { payload = JSON.parse(jsonPart); } catch { continue; }
+        if (!payload || typeof payload !== 'object') continue;
+        const obj = payload as Record<string, unknown>;
+        const modelKey = typeof obj.modelKey === 'string' ? obj.modelKey : undefined;
+        const displayName = typeof obj.displayName === 'string' ? obj.displayName : undefined;
+        if (!modelKey) continue;
+        if (!displayName) continue; // legacy lines: skip silently
+        this.cache.set(modelKey, { displayName, updatedAtMs: Date.now() });
+      }
+    } finally {
+      await handle?.close();
+      this.watchStates.set(filePath, { offset, ino });
+    }
+  }
+
+  resolve(modelKey: string): { displayName?: string } {
+    const entry = this.cache.get(modelKey);
+    return entry ? { displayName: entry.displayName } : {};
+  }
+
+  /** Returns the set of currently-known (modelKey → displayName) pairs. Test/debug only. */
+  snapshot(): Map<string, string> {
+    const out = new Map<string, string>();
+    for (const [k, v] of this.cache) out.set(k, v.displayName);
+    return out;
+  }
+
+  getStats(): CacheStats {
+    return { ...this.stats };
+  }
+}

--- a/tests/unit/hooks/qoderwork/hook-processor.test.mjs
+++ b/tests/unit/hooks/qoderwork/hook-processor.test.mjs
@@ -10,6 +10,7 @@ const PROCESSOR = path.resolve(__dirname, '../../../../assets/hooks/qoderwork-ho
 const AGENT_ID = 'qoder-work-test';
 const LOG_PREFIX = 'qoder-work';
 const LINE_RECORD = path.resolve(__dirname, '../../../../assets/hooks/.line_records.qoder-work-test.json');
+const ASSEMBLER_RECORD = path.resolve(__dirname, '../../../../assets/hooks/.assembler_state.qoder-work-test.json');
 
 let DATA_DIR;
 let TRANSCRIPT;
@@ -18,11 +19,13 @@ beforeEach(() => {
   DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'qoderwork-hook-test-'));
   TRANSCRIPT = path.join(DATA_DIR, 'transcript.jsonl');
   try { fs.rmSync(LINE_RECORD, { force: true }); } catch {}
+  try { fs.rmSync(ASSEMBLER_RECORD, { force: true }); } catch {}
 });
 
 afterEach(() => {
   try { fs.rmSync(DATA_DIR, { recursive: true, force: true }); } catch {}
   try { fs.rmSync(LINE_RECORD, { force: true }); } catch {}
+  try { fs.rmSync(ASSEMBLER_RECORD, { force: true }); } catch {}
 });
 
 function writeTranscript(records) {
@@ -57,11 +60,15 @@ function readJsonlRecords() {
 
 function inputContents(records) {
   return records
-    .filter((r) => r['event.name'] === 'llm.request')
+    .filter((r) => r['event.name'] === 'llm.request' || r['event.name'] === 'other')
     .flatMap((r) => r['gen_ai.input.messages'] ?? r['gen_ai.input.messages_delta'] ?? [])
     .flatMap((m) => m.parts ?? [])
     .filter((p) => p.type === 'text')
     .map((p) => p.content);
+}
+
+function appendTranscript(records) {
+  fs.appendFileSync(TRANSCRIPT, records.map((r) => JSON.stringify(r)).join('\n') + '\n', 'utf-8');
 }
 
 function baseRows(userContent) {
@@ -176,5 +183,271 @@ describe('qoderwork-hook-processor user prompt extraction', () => {
     expect(result.status).toBe(0);
 
     expect(inputContents(readJsonlRecords())).toEqual([]);
+  });
+});
+
+// ─── Persistent assembler scenarios (problem 1 / 2 redesign) ───────────────────
+//
+// These tests pin down the cross-Hook contract required to fix:
+//   • orphan llm.request when Stop fires between user and assistant rows
+//   • random uuid turn ids when an assistant batch lands without its prompt
+//   • event.name='llm.request' on the turn-level user-input event
+//   • orphan request without a paired response when assistant content is empty
+//
+// All scenarios drive the hook processor as the real runtime would: one Stop
+// per state-machine step, with the transcript file growing between calls.
+
+const STEP_PAIR_USER_TEXT = 'How does QoderWork instrument tool calls?';
+
+function userPromptRow({ uuid = 'user-1', promptId = 'prompt-1', text, ts = '2026-06-18T01:35:54.477Z', sessionId = 'sess-assembler' }) {
+  return {
+    type: 'user',
+    uuid,
+    promptId,
+    timestamp: ts,
+    message: { role: 'user', content: [{ type: 'text', text }] },
+    sessionId,
+    userType: 'external',
+    isSidechain: false,
+  };
+}
+
+function assistantTextRow({ uuid, parentUuid, text, ts, sessionId = 'sess-assembler', stopReason = 'end_turn' }) {
+  return {
+    type: 'assistant',
+    uuid,
+    parentUuid,
+    timestamp: ts,
+    message: {
+      role: 'assistant',
+      id: `msg-${uuid}`,
+      content: [{ type: 'text', text }],
+      stop_reason: stopReason,
+    },
+    sessionId,
+    isSidechain: false,
+  };
+}
+
+function assistantThinkingRow({ uuid, parentUuid, thinking, ts, sessionId = 'sess-assembler' }) {
+  return {
+    type: 'assistant',
+    uuid,
+    parentUuid,
+    timestamp: ts,
+    message: {
+      role: 'assistant',
+      id: `msg-${uuid}`,
+      content: [{ type: 'thinking', thinking }],
+    },
+    sessionId,
+    isSidechain: false,
+  };
+}
+
+function assistantToolUseRow({ uuid, parentUuid, toolUseId, toolName = 'Read', input = {}, ts, sessionId = 'sess-assembler' }) {
+  return {
+    type: 'assistant',
+    uuid,
+    parentUuid,
+    timestamp: ts,
+    message: {
+      role: 'assistant',
+      id: `msg-${uuid}`,
+      content: [{ type: 'tool_use', id: toolUseId, name: toolName, input }],
+      stop_reason: 'tool_use',
+    },
+    sessionId,
+    isSidechain: false,
+  };
+}
+
+function toolResultRow({ uuid, parentUuid, toolUseId, content, ts, sessionId = 'sess-assembler' }) {
+  return {
+    type: 'user',
+    uuid,
+    parentUuid,
+    timestamp: ts,
+    message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: toolUseId, content }] },
+    sessionId,
+    userType: 'external',
+    isSidechain: false,
+  };
+}
+
+function assistantEmptyRow({ uuid, parentUuid, ts, sessionId = 'sess-assembler' }) {
+  return {
+    type: 'assistant',
+    uuid,
+    parentUuid,
+    timestamp: ts,
+    message: { role: 'assistant', id: `msg-${uuid}`, content: [] },
+    sessionId,
+    isSidechain: false,
+  };
+}
+
+function assemblerStateFile() {
+  return ASSEMBLER_RECORD;
+}
+
+function readAssemblerState() {
+  if (!fs.existsSync(assemblerStateFile())) return null;
+  try { return JSON.parse(fs.readFileSync(assemblerStateFile(), 'utf-8')); } catch { return null; }
+}
+
+describe('qoderwork-hook-processor persistent assembler', () => {
+  test('cross-Hook user→assistant share the same promptId-derived turn id', () => {
+    // Stop #1: only user row available
+    writeTranscript([
+      userPromptRow({ uuid: 'u1', promptId: 'turn-A', text: STEP_PAIR_USER_TEXT, ts: '2026-06-18T01:35:54.477Z' }),
+    ]);
+    const r1 = runHook('sess-cross-hook');
+    expect(r1.status).toBe(0);
+
+    const recordsAfterFirst = readJsonlRecords();
+    // 第一次 Stop 必须只产生 turn-level 的 user-input 事件，不产生 step request/response
+    expect(recordsAfterFirst.map((r) => r['event.name'])).toEqual(['other']);
+    expect(recordsAfterFirst[0]['gen_ai.turn.id']).toBe('turn-A');
+    expect(recordsAfterFirst[0]['agent.qoderwork.promptId']).toBe('turn-A');
+    expect(recordsAfterFirst[0]['gen_ai.step.id']).toBeUndefined();
+
+    // Stop #2: assistant row arrives in a second hook invocation
+    appendTranscript([
+      assistantTextRow({ uuid: 'a1', parentUuid: 'u1', text: 'Through Stop hooks.', ts: '2026-06-18T01:35:56.500Z' }),
+    ]);
+    const r2 = runHook('sess-cross-hook');
+    expect(r2.status).toBe(0);
+
+    const allRecords = readJsonlRecords();
+    const turnIds = new Set(allRecords.map((r) => r['gen_ai.turn.id']));
+    expect([...turnIds]).toEqual(['turn-A']); // 跨 Hook 不能引入随机 uuid
+
+    const stepRecords = allRecords.filter((r) => r['gen_ai.step.id']);
+    const requests = stepRecords.filter((r) => r['event.name'] === 'llm.request');
+    const responses = stepRecords.filter((r) => r['event.name'] === 'llm.response');
+    expect(requests.length).toBe(1);
+    expect(responses.length).toBe(1);
+    expect(requests[0]['gen_ai.step.id']).toBe('turn-A:s1');
+    expect(responses[0]['gen_ai.step.id']).toBe('turn-A:s1');
+  });
+
+  test('multi-wave turn keeps single turn id and step request/response are paired', () => {
+    writeTranscript([
+      userPromptRow({ uuid: 'u1', promptId: 'turn-MW', text: 'Read foo then summarise.', ts: '2026-06-18T02:00:00.000Z' }),
+      assistantThinkingRow({ uuid: 'a1', parentUuid: 'u1', thinking: 'Need to read foo first', ts: '2026-06-18T02:00:01.000Z' }),
+      assistantToolUseRow({ uuid: 'a2', parentUuid: 'u1', toolUseId: 'tu_1', toolName: 'Read', input: { path: 'foo' }, ts: '2026-06-18T02:00:01.500Z' }),
+      toolResultRow({ uuid: 'tr1', parentUuid: 'a2', toolUseId: 'tu_1', content: 'file body', ts: '2026-06-18T02:00:02.000Z' }),
+      assistantTextRow({ uuid: 'a3', parentUuid: 'tr1', text: 'foo says hello', ts: '2026-06-18T02:00:02.500Z' }),
+    ]);
+
+    const result = runHook('sess-multi-wave');
+    expect(result.status).toBe(0);
+    const records = readJsonlRecords();
+
+    // 单一 turn id
+    const turnIds = new Set(records.map((r) => r['gen_ai.turn.id']));
+    expect([...turnIds]).toEqual(['turn-MW']);
+
+    // step request 和 response 必须配对（数量相等、step.id 一致）
+    const requests = records.filter((r) => r['event.name'] === 'llm.request');
+    const responses = records.filter((r) => r['event.name'] === 'llm.response');
+    expect(requests.length).toBe(responses.length);
+    expect(requests.length).toBe(2);
+    const requestSteps = requests.map((r) => r['gen_ai.step.id']).sort();
+    const responseSteps = responses.map((r) => r['gen_ai.step.id']).sort();
+    expect(requestSteps).toEqual(responseSteps);
+
+    // tool.call 与 tool.result 都要落到第一个 step
+    const toolCalls = records.filter((r) => r['event.name'] === 'tool.call');
+    expect(toolCalls.length).toBe(1);
+    expect(toolCalls[0]['gen_ai.step.id']).toBe('turn-MW:s1');
+    const toolResults = records.filter((r) => r['event.name'] === 'tool.result');
+    expect(toolResults.length).toBe(1);
+    expect(toolResults[0]['gen_ai.step.id']).toBe('turn-MW:s1');
+  });
+
+  test('empty assistant content does not produce orphan request and stays pending', () => {
+    writeTranscript([
+      userPromptRow({ uuid: 'u1', promptId: 'turn-EMPTY', text: 'Tell me something.', ts: '2026-06-18T03:00:00.000Z' }),
+      assistantEmptyRow({ uuid: 'a-empty', parentUuid: 'u1', ts: '2026-06-18T03:00:01.000Z' }),
+    ]);
+
+    const result = runHook('sess-empty-assistant');
+    expect(result.status).toBe(0);
+    const records = readJsonlRecords();
+
+    // 只允许 turn-level user-input 事件，不允许任何 step 级 request/response
+    const stepRecords = records.filter((r) => r['gen_ai.step.id']);
+    expect(stepRecords).toEqual([]);
+
+    // pending state 必须保留这个未完成 turn，等下次 hook 看到真实输出
+    const state = readAssemblerState();
+    expect(state).not.toBeNull();
+    const transcripts = Object.values(state ?? {});
+    expect(transcripts.length).toBe(1);
+    expect(transcripts[0].pending_turn?.promptId).toBe('turn-EMPTY');
+  });
+
+  test('user-input event uses event.name="other" with messages_delta and no step.id/model', () => {
+    writeTranscript([
+      userPromptRow({ uuid: 'u1', promptId: 'turn-OTH', text: 'Hello there', ts: '2026-06-18T04:00:00.000Z' }),
+      assistantTextRow({ uuid: 'a1', parentUuid: 'u1', text: 'hi', ts: '2026-06-18T04:00:01.000Z' }),
+    ]);
+
+    const result = runHook('sess-other-event');
+    expect(result.status).toBe(0);
+    const records = readJsonlRecords();
+
+    const userInput = records.find((r) => !r['gen_ai.step.id']);
+    expect(userInput).toBeDefined();
+    expect(userInput['event.name']).toBe('other');
+    expect(userInput['gen_ai.request.model']).toBeUndefined();
+    expect(userInput['gen_ai.input.messages_delta']).toBeDefined();
+    // 内层 messages_delta 必须包含 user 文本
+    const text = userInput['gen_ai.input.messages_delta']
+      .flatMap((m) => m.parts ?? [])
+      .find((p) => p.type === 'text')?.content;
+    expect(text).toBe('Hello there');
+  });
+
+  test('orphan assistant batch without a known prompt is dropped (no random uuid)', () => {
+    // 没有任何之前的 user prompt，纯异常路径：只能 warn + skip，不能编 turn id
+    writeTranscript([
+      assistantTextRow({ uuid: 'a-orphan', parentUuid: 'missing-user', text: 'orphan response', ts: '2026-06-18T05:00:00.000Z' }),
+    ]);
+
+    const result = runHook('sess-orphan');
+    expect(result.status).toBe(0);
+    const records = readJsonlRecords();
+    expect(records).toEqual([]);
+  });
+
+  test('TTL cleanup discards a long-stale pending turn on the next empty hook', () => {
+    writeTranscript([
+      userPromptRow({ uuid: 'u1', promptId: 'turn-TTL', text: 'never finishes', ts: '2026-06-18T06:00:00.000Z' }),
+    ]);
+    const r1 = runHook('sess-ttl');
+    expect(r1.status).toBe(0);
+    expect(readAssemblerState()?.[TRANSCRIPT]?.pending_turn?.promptId).toBe('turn-TTL');
+
+    // 模拟过去 2 小时（默认 TTL 60min）
+    const future = Date.now() + 2 * 60 * 60 * 1000;
+    const r2 = spawnSync('node', [PROCESSOR, '--agent-id', AGENT_ID, '--log-prefix', LOG_PREFIX], {
+      input: JSON.stringify({ session_id: 'sess-ttl', transcript_path: TRANSCRIPT, cwd: '/tmp/qoderwork-test' }),
+      env: {
+        ...process.env,
+        LOONGSUITE_PILOT_DATA_DIR: DATA_DIR,
+        LOONGSUITE_PILOT_ASSEMBLER_NOW_MS: String(future),
+      },
+      encoding: 'utf-8',
+      timeout: 10_000,
+    });
+    expect(r2.status).toBe(0);
+
+    const stateAfter = readAssemblerState();
+    const entry = stateAfter?.[TRANSCRIPT];
+    expect(entry).toBeDefined();
+    expect(entry.pending_turn).toBeFalsy();
   });
 });

--- a/tests/unit/hooks/qoderwork/turn-assembler.test.mjs
+++ b/tests/unit/hooks/qoderwork/turn-assembler.test.mjs
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ASSEMBLER_PATH = path.resolve(__dirname, '../../../../assets/hooks/qoderwork-turn-assembler.mjs');
+
+// These are red-light tests. The module qoderwork-turn-assembler.mjs is added in
+// commit 2; this file pins down the contract that the persistent assembler must
+// uphold so that hook-processor.mjs can reuse the same primitives.
+
+const importAssembler = () => import(ASSEMBLER_PATH);
+
+describe('qoderwork-turn-assembler pure helpers', () => {
+  test('openPending creates a pending turn keyed by promptId with seqs reset', async () => {
+    const { openPending } = await importAssembler();
+    const turn = openPending({
+      promptId: 'turn-X',
+      userText: 'Hello',
+      userTimestampNano: '1000000000',
+      nowMs: 1718_000_000_000,
+    });
+    expect(turn.promptId).toBe('turn-X');
+    expect(turn.turnId).toBe('turn-X');
+    expect(turn.userText).toBe('Hello');
+    expect(turn.nextStepSeq).toBe(1);
+    expect(turn.userTextEmitted).toBe(false);
+    expect(Array.isArray(turn.pendingToolCalls)).toBe(true);
+    expect(turn.pendingToolCalls.length).toBe(0);
+    expect(turn.createdAtMs).toBe(1718_000_000_000);
+    expect(turn.updatedAtMs).toBe(1718_000_000_000);
+  });
+
+  test('appendAssistant accumulates rows and bumps updatedAtMs only', async () => {
+    const { openPending, appendAssistant } = await importAssembler();
+    const turn = openPending({
+      promptId: 'turn-Y',
+      userText: 'go',
+      userTimestampNano: '1000000000',
+      nowMs: 1000,
+    });
+    const row1 = { type: 'assistant', uuid: 'a1' };
+    const row2 = { type: 'assistant', uuid: 'a2' };
+    const updated = appendAssistant(turn, row1, { nowMs: 1500 });
+    expect(updated.updatedAtMs).toBe(1500);
+    expect(updated.createdAtMs).toBe(1000);
+    expect(updated.currentWaveRows.map((r) => r.uuid)).toEqual(['a1']);
+    const updated2 = appendAssistant(updated, row2, { nowMs: 2000 });
+    expect(updated2.currentWaveRows.map((r) => r.uuid)).toEqual(['a1', 'a2']);
+  });
+
+  test('waveEnded returns true when the current row carries an end stop_reason', async () => {
+    const { waveEnded } = await importAssembler();
+    expect(waveEnded({ message: { stop_reason: 'end_turn' } })).toBe(true);
+    expect(waveEnded({ message: { stop_reason: 'tool_use' } })).toBe(true);
+    expect(waveEnded({ message: { stop_reason: 'stop_sequence' } })).toBe(true);
+    expect(waveEnded({ message: { stop_reason: 'max_tokens' } })).toBe(true);
+    expect(waveEnded({ message: { stop_reason: undefined } })).toBe(false);
+    expect(waveEnded({ message: {} })).toBe(false);
+    expect(waveEnded({})).toBe(false);
+  });
+
+  test('closePending clears the pending turn and returns the closed snapshot', async () => {
+    const { openPending, appendAssistant, closePending } = await importAssembler();
+    const opened = openPending({
+      promptId: 'turn-Z',
+      userText: 'x',
+      userTimestampNano: '1000000000',
+      nowMs: 1000,
+    });
+    const withAssistant = appendAssistant(opened, { type: 'assistant', uuid: 'a1' }, { nowMs: 1500 });
+    const closed = closePending(withAssistant, { reason: 'new_prompt', nowMs: 2000 });
+    expect(closed.promptId).toBe('turn-Z');
+    expect(closed.closedAtMs).toBe(2000);
+    expect(closed.reason).toBe('new_prompt');
+  });
+
+  test('isPendingExpired honours TTL parameter', async () => {
+    const { isPendingExpired } = await importAssembler();
+    const turn = { updatedAtMs: 1000 };
+    expect(isPendingExpired(turn, { nowMs: 1000 + 30 * 60 * 1000, ttlMs: 60 * 60 * 1000 })).toBe(false);
+    expect(isPendingExpired(turn, { nowMs: 1000 + 90 * 60 * 1000, ttlMs: 60 * 60 * 1000 })).toBe(true);
+    // 自定义 TTL（4h）
+    expect(isPendingExpired(turn, { nowMs: 1000 + 90 * 60 * 1000, ttlMs: 4 * 60 * 60 * 1000 })).toBe(false);
+  });
+});

--- a/tests/unit/inputs/qoder-work-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-work-trace-input.test.ts
@@ -844,6 +844,170 @@ describe('QoderWorkTraceInput', () => {
     const tcOut = entries.find(e => e['event.id'] === 'tc')!;
     expect(tcOut.time_unix_nano).toBe('999999999999000000');
   });
+
+  it("tags step entries with agent.qoderwork.model_source='segment_turn' on precise turn match", async () => {
+    const sessionId = 'sess-source-precise';
+    const turnId = 'turn-source-precise';
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const req = buildHookEntry({
+      'event.id': 'src-req',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: nano('2026-06-16T10:00:00.000Z'),
+    });
+    const resp = buildHookEntry({
+      'event.id': 'src-resp',
+      'event.name': 'llm.response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: nano('2026-06-16T10:00:05.000Z'),
+    });
+    await fs.writeFile(hookFile, [req, resp].map(e => JSON.stringify(e)).join('\n') + '\n');
+    await writeSegments(sessionId, 'run1.jsonl', [
+      segTurnStarted(turnId, false),
+      segModelStart(turnId, 'r1', '2026-06-16T10:00:00.000Z'),
+      segModelEnd(turnId, 'r1', '2026-06-16T10:00:05.000Z'),
+    ]);
+
+    const input = makeInput();
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const reqOut = entries.find(e => e['event.id'] === 'src-req')!;
+    const respOut = entries.find(e => e['event.id'] === 'src-resp')!;
+    expect(reqOut['agent.qoderwork.model_source']).toBe('segment_turn');
+    expect(respOut['agent.qoderwork.model_source']).toBe('segment_turn');
+  });
+
+  it("tags step entries with agent.qoderwork.model_source='segment_time_window' on time-window fallback", async () => {
+    const sessionId = 'sess-source-window';
+    const hookTurnId = 'hook-turn-window';
+    const segTurnId = 'segment-turn-mismatch';
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const req = buildHookEntry({
+      'event.id': 'win-req',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': hookTurnId,
+      'gen_ai.step.id': `${hookTurnId}:s1`,
+      time_unix_nano: nano('2026-06-16T10:00:00.000Z'),
+    });
+    const resp = buildHookEntry({
+      'event.id': 'win-resp',
+      'event.name': 'llm.response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': hookTurnId,
+      'gen_ai.step.id': `${hookTurnId}:s1`,
+      time_unix_nano: nano('2026-06-16T10:00:05.000Z'),
+    });
+    await fs.writeFile(hookFile, [req, resp].map(e => JSON.stringify(e)).join('\n') + '\n');
+    // segment turn id mismatches the hook turn id, but timestamps line up with the
+    // request/response window so the time-window fallback should kick in.
+    await writeSegments(sessionId, 'run1.jsonl', [
+      segTurnStarted(segTurnId, false),
+      segModelStart(segTurnId, 'r1', '2026-06-16T10:00:00.000Z', 'qwork-window'),
+      segModelEnd(segTurnId, 'r1', '2026-06-16T10:00:05.000Z', 'qwork-window'),
+    ]);
+
+    const input = makeInput();
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const respOut = entries.find(e => e['event.id'] === 'win-resp')!;
+    expect(respOut['agent.qoderwork.model_source']).toBe('segment_time_window');
+    // model still rewritten by the fallback pair
+    expect(respOut['gen_ai.response.model']).toBe('qwork-window');
+  });
+
+  it("attaches agent.qoderwork.model_display_name resolved from qodercli.log on a precise turn match", async () => {
+    const sessionId = 'sess-display-name';
+    const turnId = 'turn-display-name';
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const cliLog = path.join(tmpRoot, 'qodercli.log');
+    await fs.writeFile(
+      cliLog,
+      `[2026-06-16T09:00:00.000Z] [INFO] [QODERCLI] [QueryHandler] StreamResponse ${JSON.stringify({
+        modelKey: 'qwork-ultimate',
+        displayName: 'Premium',
+        isReasoning: true,
+      })}\n`,
+    );
+
+    const req = buildHookEntry({
+      'event.id': 'dn-req',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: nano('2026-06-16T10:00:00.000Z'),
+    });
+    const resp = buildHookEntry({
+      'event.id': 'dn-resp',
+      'event.name': 'llm.response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: nano('2026-06-16T10:00:05.000Z'),
+    });
+    await fs.writeFile(hookFile, [req, resp].map(e => JSON.stringify(e)).join('\n') + '\n');
+    await writeSegments(sessionId, 'run1.jsonl', [
+      segTurnStarted(turnId, false),
+      segModelStart(turnId, 'r1', '2026-06-16T10:00:00.000Z', 'qwork-ultimate'),
+      segModelEnd(turnId, 'r1', '2026-06-16T10:00:05.000Z', 'qwork-ultimate'),
+    ]);
+
+    const input = new QoderWorkTraceInput({
+      stateStore: stateStore as any,
+      logDir: hookLogDir,
+      segmentsRoot,
+      sdkLogDir,
+      qoderCliLogFile: cliLog,
+    });
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const respOut = entries.find(e => e['event.id'] === 'dn-resp')!;
+    expect(respOut['gen_ai.response.model']).toBe('qwork-ultimate');
+    expect(respOut['agent.qoderwork.model_display_name']).toBe('Premium');
+  });
+
+  it("tags step entries with agent.qoderwork.model_source='unresolved' when no segment pair exists", async () => {
+    const sessionId = 'sess-source-unresolved';
+    const turnId = 'turn-source-unresolved';
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const req = buildHookEntry({
+      'event.id': 'unr-req',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: nano('2026-06-16T10:00:00.000Z'),
+    });
+    const resp = buildHookEntry({
+      'event.id': 'unr-resp',
+      'event.name': 'llm.response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: nano('2026-06-16T10:00:05.000Z'),
+    });
+    await fs.writeFile(hookFile, [req, resp].map(e => JSON.stringify(e)).join('\n') + '\n');
+    // No segments written for this session at all.
+
+    const input = makeInput();
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const reqOut = entries.find(e => e['event.id'] === 'unr-req')!;
+    const respOut = entries.find(e => e['event.id'] === 'unr-resp')!;
+    expect(reqOut['agent.qoderwork.model_source']).toBe('unresolved');
+    expect(respOut['agent.qoderwork.model_source']).toBe('unresolved');
+    // model stays at hook default ('auto'-style) since no pair was matched
+    expect(reqOut['gen_ai.request.model']).not.toBe('qwork-window');
+  });
 });
 
 async function startAndCollect(input: any): Promise<AgentActivityEntry[]> {

--- a/tests/unit/inputs/qoder-work-trace/model-name-cache.test.ts
+++ b/tests/unit/inputs/qoder-work-trace/model-name-cache.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+// Red-light tests for the not-yet-implemented model name cache. The module
+// is added in commit 5; until then this file pins the contract so the
+// hook-processor → trace-input pipeline can use displayName as a sidecar
+// attribute without disturbing model_source enrichment.
+const CACHE_MODULE = '../../../../src/inputs/qoder-work-trace/qoderwork-model-name-cache.js';
+
+async function importCache() {
+  // Imported lazily: the module does not exist yet.
+  return import(CACHE_MODULE);
+}
+
+function streamResponseLine(payload: object, ts = '2026-06-18T01:35:54.477Z') {
+  return `[${ts}] [INFO] [QODERCLI] [QueryHandler] StreamResponse ${JSON.stringify(payload)}`;
+}
+
+describe('QoderWorkModelNameCache', () => {
+  let tmpRoot: string;
+  let logFile: string;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'qoderwork-model-name-cache-'));
+    logFile = path.join(tmpRoot, 'qodercli.log');
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('parses StreamResponse lines and resolves modelKey → displayName', async () => {
+    const { QoderWorkModelNameCache } = await importCache();
+    await fs.writeFile(logFile, [
+      '[2026-06-18T01:35:54.477Z] [INFO] [QODERCLI] startup line, irrelevant',
+      streamResponseLine({ modelKey: 'qwork-ultimate', displayName: 'Premium', isReasoning: true, querySource: 'coder' }),
+      streamResponseLine({ modelKey: 'qwork-auto', displayName: 'Standard', isReasoning: false, querySource: 'coder' }),
+    ].join('\n') + '\n');
+
+    const cache = new QoderWorkModelNameCache({ logFile });
+    await cache.refresh();
+    expect(cache.resolve('qwork-ultimate').displayName).toBe('Premium');
+    expect(cache.resolve('qwork-auto').displayName).toBe('Standard');
+    expect(cache.resolve('not-seen').displayName).toBeUndefined();
+  });
+
+  it('does not pollute cache when displayName is missing on a legacy line', async () => {
+    const { QoderWorkModelNameCache } = await importCache();
+    await fs.writeFile(logFile, [
+      streamResponseLine({ modelKey: 'qwork-legacy', isReasoning: false }),
+      streamResponseLine({ modelKey: 'qwork-ultimate', displayName: 'Premium' }),
+    ].join('\n') + '\n');
+
+    const cache = new QoderWorkModelNameCache({ logFile });
+    await cache.refresh();
+    // 旧版日志缺 displayName 不能写脏 cache
+    expect(cache.resolve('qwork-legacy').displayName).toBeUndefined();
+    expect(cache.resolve('qwork-ultimate').displayName).toBe('Premium');
+  });
+
+  it('reads only newly appended lines on incremental refresh', async () => {
+    const { QoderWorkModelNameCache } = await importCache();
+    await fs.writeFile(logFile, [
+      streamResponseLine({ modelKey: 'qwork-ultimate', displayName: 'Premium' }),
+    ].join('\n') + '\n');
+
+    const cache = new QoderWorkModelNameCache({ logFile });
+    await cache.refresh();
+    const stats1 = cache.getStats?.() ?? { linesParsed: undefined };
+    expect(cache.resolve('qwork-ultimate').displayName).toBe('Premium');
+
+    // append 一条新行
+    await fs.appendFile(logFile, streamResponseLine({ modelKey: 'qwork-auto', displayName: 'Standard' }) + '\n');
+    await cache.refresh();
+    expect(cache.resolve('qwork-auto').displayName).toBe('Standard');
+    if (stats1.linesParsed !== undefined) {
+      const stats2 = cache.getStats!();
+      // 增量解析：第二次只读了新增的 1 条
+      expect(stats2.linesParsed - stats1.linesParsed).toBe(1);
+    }
+  });
+
+  it('resets offset and re-reads on truncate (size shrinks below previous offset)', async () => {
+    const { QoderWorkModelNameCache } = await importCache();
+    await fs.writeFile(logFile, [
+      streamResponseLine({ modelKey: 'qwork-ultimate', displayName: 'Premium' }),
+      streamResponseLine({ modelKey: 'qwork-auto', displayName: 'Standard' }),
+    ].join('\n') + '\n');
+
+    const cache = new QoderWorkModelNameCache({ logFile });
+    await cache.refresh();
+    expect(cache.resolve('qwork-ultimate').displayName).toBe('Premium');
+    expect(cache.resolve('qwork-auto').displayName).toBe('Standard');
+
+    // 文件被截断后重写
+    await fs.writeFile(logFile, [
+      streamResponseLine({ modelKey: 'qwork-flash', displayName: 'Lite' }),
+    ].join('\n') + '\n');
+    await cache.refresh();
+    expect(cache.resolve('qwork-flash').displayName).toBe('Lite');
+  });
+
+  it('scans runs/<id>/qodercli.log when logFile points to a directory', async () => {
+    const { QoderWorkModelNameCache } = await importCache();
+    // 构造 directory 模式：根目录 + runs/ 子目录
+    const runsDir = path.join(tmpRoot, 'runs');
+    await fs.mkdir(runsDir);
+    const older = path.join(runsDir, '2026-06-24T10-00-00-000+08-00-run1');
+    const newer = path.join(runsDir, '2026-06-25T10-00-00-000+08-00-run2');
+    await fs.mkdir(older);
+    await fs.mkdir(newer);
+    await fs.writeFile(
+      path.join(older, 'qodercli.log'),
+      streamResponseLine({ modelKey: 'qwork-ultimate', displayName: 'Premium' }) + '\n',
+    );
+    await fs.writeFile(
+      path.join(newer, 'qodercli.log'),
+      streamResponseLine({ modelKey: 'qwork-auto', displayName: 'Standard' }) + '\n',
+    );
+    // mtime 排序：newer 比 older 更新
+    const later = new Date(Date.now() + 1000);
+    await fs.utimes(path.join(newer, 'qodercli.log'), later, later);
+
+    const cache = new QoderWorkModelNameCache({ logFile: tmpRoot });
+    await cache.refresh();
+    expect(cache.resolve('qwork-ultimate').displayName).toBe('Premium');
+    expect(cache.resolve('qwork-auto').displayName).toBe('Standard');
+    const stats = cache.getStats!();
+    expect(stats.watchedFiles).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two QoderWork trace-pipeline bugs and adds durable turn-assembler state:

- **Orphan `llm.request`**: a response delayed to the next hook used to strand its request forever. The new incremental walker keeps the row **pending** until the matching response arrives, then emits them as an atomic pair.
- **Duplicate `llm.request` with split attributes** (messages in one, model in another): the processor no longer emits half-formed events; every `gen_ai.step.id` is guaranteed 1 request + 1 response.

## Approach

- **`assets/hooks/qoderwork-turn-assembler.mjs`** (new): pure state machine + persistence at `~/.loongsuite-pilot/.assembler_state.<agent>.json`. Wave boundary on `stop_reason ∈ {end_turn, tool_use, stop_sequence, max_tokens}`. TTL eviction (60 min default) with injectable clock (`LOONGSUITE_PILOT_ASSEMBLER_NOW_MS`).
- **`assets/hooks/qoderwork-hook-processor.mjs`** (rewritten): `processBatch()` → `processIncremental()`. User-hook events are now `event.name="other"` (no `step.id`, only `messages_delta`), so downstream can't mistake them for LLM calls. `crypto.randomUUID()` fallback in `getTurnIdForRows` removed — returns `null` now and forces callers to handle missing turn ids explicitly.
- **`src/inputs/qoder-work-trace/qoderwork-model-name-cache.ts`** (new): tail-read sidecar that watches `~/.qoderwork/logs` (directory mode auto-scans `runs/<ts>/qodercli.log`, newest N by mtime) with per-file offset + inode rotation detection. Partial-line rewind prevents JSON splits.
- **`src/inputs/qoder-work-trace/qoder-work-trace-input.ts`**: 3-state `agent.qoderwork.model_source ∈ {segment_turn, segment_time_window, unresolved}`. Time-window fallback emits `WARN` and the attribute makes the choice observable. `agent.qoderwork.model_display_name` injected from cache when hit; absent when cache is cold (no pollution).

## Hard constraints preserved

- No rollback-offset replay — once a state-store offset is recorded, never re-read backwards.
- No static `modelKey → displayName` mapping — only the runtime `StreamResponse` line is authoritative.
- Atomic request/response pairs — both emitted together or neither.
- No `crypto.randomUUID()` fallback for turn ids.

## Tests

+16 new cases across `tests/unit/hooks/qoderwork/`, `tests/unit/hooks/qoderwork-hook-processor.test.mjs`, `tests/unit/inputs/qoder-work-trace-input.test.ts`, and `tests/unit/inputs/qoder-work-trace/model-name-cache.test.ts`. Covers orphan request, delayed response, duplicate request, TTL eviction, user-hook `event.name=other`, 3-state enrichment, and directory-mode cache scan. Full suite: **1292 passed / 2 skipped / 0 failed**.

## Deployment

Verified locally: `npm run build`, hook + dist copied into `~/.loongsuite-pilot/versions/<current>/`, `launchctl stop/start com.loongsuite-pilot`. Live trace (`qoder-work-2026-06-25.jsonl`, 4522 rows / 198 turns) shows every `gen_ai.step.id` has exactly 1 `llm.request` + 1 `llm.response`, user-hook events are `event.name="other"`, and `model_source=segment_turn` dominates.

## Note on `model_display_name`

The cache currently reads `StreamResponse` lines from `qodercli.log`. As of 2026-06-25 the QoderWork runtime no longer writes those lines to any location, so the cache stays cold and `agent.qoderwork.model_display_name` is not injected. Restoring this attribute requires either (a) the runtime re-emitting `StreamResponse`, or (b) wiring a different source (SDK session log / runtime.json / upstream API). The cache plumbing itself is correct and will activate the moment a source becomes available.