### PR TITLE
fix(qoder-work): change user-hook event.name from llm.request to other

### DIFF
--- a/assets/hooks/qoderwork-hook-processor.mjs
+++ b/assets/hooks/qoderwork-hook-processor.mjs
@@ -178,7 +178,7 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
     if (userText) {
       records.push(buildRecord({
         ...turnMetadata,
-        'event.name': 'llm.request',
+        'event.name': 'other',
         'gen_ai.turn.id': turnId,
         'gen_ai.session.id': sessionId,
         'gen_ai.agent.type': 'qoder-work',

--- a/src/inputs/qoder-work-log/qoder-work-trace-input.ts
+++ b/src/inputs/qoder-work-log/qoder-work-trace-input.ts
@@ -592,7 +592,7 @@ export class QoderWorkTraceInput extends BaseSessionInput {
       'gen_ai.request.model': undefined,
       time_unix_nano: msToNanos(entryTime),
       'event.id': crypto.randomUUID(),
-      'event.name': 'llm.request',
+      'event.name': 'other',
       'gen_ai.input.messages_delta': dbData?.userPrompt
         ? [{ role: 'user', parts: [{ type: 'text', content: dbData.userPrompt }] }]
         : undefined,

--- a/tests/unit/hooks/qoderwork/hook-processor.test.mjs
+++ b/tests/unit/hooks/qoderwork/hook-processor.test.mjs
@@ -119,8 +119,9 @@ describe('qoderwork-hook-processor user prompt extraction', () => {
     const result = runHook('sess-system-first');
     expect(result.status).toBe(0);
 
+    // User-hook event is now 'other' (not 'llm.request'), so user text
+    // only appears in step 1's llm.request — no duplicate.
     expect(inputContents(readJsonlRecords())).toEqual([
-      '<system-reminder>\nUser environment\n</system-reminder>\n你先搜索力扣560题，然后在本地创建一个py文件解决这道题，只需解决这一题',
       '<system-reminder>\nUser environment\n</system-reminder>\n你先搜索力扣560题，然后在本地创建一个py文件解决这道题，只需解决这一题',
     ]);
   });
@@ -135,7 +136,6 @@ describe('qoderwork-hook-processor user prompt extraction', () => {
 
     expect(inputContents(readJsonlRecords())).toEqual([
       '<user-selected-text> Trace-Metrics 关联字段 </user-selected-text> 讲讲这个',
-      '<user-selected-text> Trace-Metrics 关联字段 </user-selected-text> 讲讲这个',
     ]);
   });
 
@@ -149,7 +149,6 @@ describe('qoderwork-hook-processor user prompt extraction', () => {
 
     expect(inputContents(readJsonlRecords())).toEqual([
       '帮我安装qodercli <system-reminder>User environment</system-reminder>',
-      '帮我安装qodercli <system-reminder>User environment</system-reminder>',
     ]);
   });
 
@@ -162,7 +161,6 @@ describe('qoderwork-hook-processor user prompt extraction', () => {
     expect(result.status).toBe(0);
 
     expect(inputContents(readJsonlRecords())).toEqual([
-      '<user-selected-text> sudo cp old new </user-selected-text> 这一步不是已经做了吗 <system-reminder>User environment</system-reminder>',
       '<user-selected-text> sudo cp old new </user-selected-text> 这一步不是已经做了吗 <system-reminder>User environment</system-reminder>',
     ]);
   });

--- a/tests/unit/inputs/qoder-work-cn-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-work-cn-trace-input.test.ts
@@ -80,7 +80,7 @@ describe('QoderWorkTraceInput (CN variant)', () => {
     // so the round-tripped ms value may differ from the original due to
     // timezone handling. Verify the nanos are 6 zeros + ms digits (BigInt format).
     const entryRequest = entries.find(
-      e => e['event.name'] === 'llm.request' && !e['gen_ai.step.id'],
+      e => e['event.name'] === 'other' && !e['gen_ai.step.id'],
     );
     expect(entryRequest).toBeDefined();
     const startNano = entryRequest!.time_unix_nano;


### PR DESCRIPTION
## Summary
- User input was incorrectly emitted as `event.name='llm.request'` (without step.id) in the QoderWork hook-processor, creating orphan LLM spans in the trace pipeline
- Production data confirms 558 orphan `llm.request` events (no matching `llm.response`), all containing only user text with no step.id
- Fix: change the user-hook event from `llm.request` to `other` — step 1's `llm.request` already carries user text via `input.messages_delta`, so the user-hook emission was both redundant and harmful

## Test plan
- [ ] Deploy updated hook to `~/.loongsuite-pilot/hooks/` and restart daemon
- [ ] Verify new history records no longer contain orphan `llm.request` events without step.id
- [ ] Verify `llm.request` count equals `llm.response` count (previously 3975 vs 3417, delta = 558)
- [ ] Verify step 1 still correctly includes user input in `gen_ai.input.messages_delta`