### PR TITLE
fix(qoder-cn): improve data quality — token coverage, span durations, dedup

### DIFF
--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -31,7 +31,91 @@ import {
   buildQoderHookRecord,
   inferProviderName,
 } from './agent-event-normalizer.mjs';
-import { isQoderIdeaSession } from './shared/qoder-db-utils.mjs';
+
+// --- Retry lockfile (qoder-cn only) -----------------------------------------
+// QoderCN fires Stop hook multiple times per turn AND incomplete transcript
+// causes background retries — without coordination these can stack up and
+// produce duplicate records. We guard at two points:
+//   1. parent process: skip spawn if a live lock exists
+//   2. retry subprocess: refuse to enter processTranscript if a peer holds it
+// The lock file lives at <HOOKS_DIR>/.retry-locks/<sha1>.lock and contains
+// JSON `{ pid, sessionId, startedAt }`.
+
+export const RETRY_LOCK_DIR = path.join(HOOKS_DIR, '.retry-locks');
+export const RETRY_LOCK_MAX_AGE_MS = 60_000;
+
+export function retryLockPath(transcriptPath, dir = RETRY_LOCK_DIR) {
+  const hash = crypto.createHash('sha1').update(transcriptPath).digest('hex');
+  return path.join(dir, `${hash}.lock`);
+}
+
+export function pidAlive(pid) {
+  if (!pid || typeof pid !== 'number') return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return e && e.code === 'EPERM';
+  }
+}
+
+export function readRetryLock(lockPath) {
+  try {
+    const raw = fs.readFileSync(lockPath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') return parsed;
+  } catch { /* fall through */ }
+  return null;
+}
+
+export function isRetryLockStale(lock) {
+  if (!lock) return true;
+  const age = Date.now() - (Number(lock.startedAt) || 0);
+  if (age > RETRY_LOCK_MAX_AGE_MS) return true;
+  return !pidAlive(lock.pid);
+}
+
+export function tryAcquireRetryLock(transcriptPath, sessionId, dir = RETRY_LOCK_DIR) {
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    const lockPath = retryLockPath(transcriptPath, dir);
+    const payload = JSON.stringify({ pid: process.pid, sessionId, startedAt: Date.now() });
+    try {
+      const handle = fs.openSync(lockPath, 'wx');
+      fs.writeSync(handle, payload);
+      fs.closeSync(handle);
+      return true;
+    } catch (err) {
+      if (err && err.code === 'EEXIST') {
+        const existing = readRetryLock(lockPath);
+        if (isRetryLockStale(existing)) {
+          try { fs.unlinkSync(lockPath); } catch { /* ignore */ }
+          try {
+            const handle = fs.openSync(lockPath, 'wx');
+            fs.writeSync(handle, payload);
+            fs.closeSync(handle);
+            return true;
+          } catch { return false; }
+        }
+        return false;
+      }
+      return false;
+    }
+  } catch {
+    return false;
+  }
+}
+
+export function releaseRetryLock(transcriptPath, dir = RETRY_LOCK_DIR) {
+  try {
+    const lockPath = retryLockPath(transcriptPath, dir);
+    const existing = readRetryLock(lockPath);
+    // Only release if we own the lock (avoid wiping a peer's lock on crash recovery)
+    if (existing && existing.pid === process.pid) {
+      fs.unlinkSync(lockPath);
+    }
+  } catch { /* best-effort */ }
+}
 
 // --- Timestamp helpers -------------------------------------------------------
 
@@ -71,9 +155,32 @@ async function main() {
     if (!transcriptPath || !sessionId) return;
     logDebug(agentId, `Retry: processing ${transcriptPath} for session ${sessionId}`);
     const runtimeConfig = loadHookRuntimeConfig(path.join(HOOKS_DIR, '..'));
-    const range = getLineRange(agentId, transcriptPath, sessionId);
-    if (!range) return;
-    await processTranscript(agentId, logPrefix, transcriptPath, sessionId, range[0], range[1], runtimeConfig, cwd);
+
+    // qoder-cn only: serialize concurrent retries on the same transcript.
+    // We wait the HOOK_RETRY_DELAY first (so all queued Stop hooks have
+    // already advanced the offset via updateLineRecord), then acquire the
+    // lock. The losers see currentCount==lastCount in getLineRange and exit.
+    const retryDelay = parseInt(process.env.HOOK_RETRY_DELAY || '0', 10);
+    if (retryDelay > 0) {
+      await new Promise(r => setTimeout(r, retryDelay));
+    }
+
+    if (agentId === 'qoder-cn') {
+      if (!tryAcquireRetryLock(transcriptPath, sessionId)) {
+        logDebug(agentId, `Retry skipped: lock held by peer for ${transcriptPath}`);
+        return;
+      }
+    }
+    try {
+      const range = getLineRange(agentId, transcriptPath, sessionId);
+      if (!range) return;
+      await processTranscript(
+        agentId, logPrefix, transcriptPath, sessionId,
+        range[0], range[1], runtimeConfig, cwd, { delayApplied: true },
+      );
+    } finally {
+      if (agentId === 'qoder-cn') releaseRetryLock(transcriptPath);
+    }
     return;
   }
 
@@ -110,7 +217,34 @@ async function main() {
   const hasLastPrompt = parsed.some(p => p.type === 'last-prompt');
   if (parsed.length > 0 && !hasLastPrompt) {
     logDebug(agentId, `Transcript incomplete (${parsed.length} lines, no last-prompt marker). Spawning background retry in 5s.`);
-    spawnDelayedRetry(agentId, transcriptPath, sessionId, logPrefix, cwd);
+    if (agentId === 'qoder-cn') {
+      // qoder-cn: QoderCN fires Stop multiple times per turn. The retry's
+      // child-side lock serializes actual processing, but skipping needless
+      // spawn calls here keeps process churn down.
+      const lockPath = retryLockPath(transcriptPath);
+      const existing = readRetryLock(lockPath);
+      if (existing && !isRetryLockStale(existing)) {
+        logDebug(agentId, `Skip spawn: live retry lock held by pid ${existing.pid}`);
+      } else {
+        if (existing) { try { fs.unlinkSync(lockPath); } catch { /* ignore */ } }
+        spawnDelayedRetry(agentId, transcriptPath, sessionId, logPrefix, cwd);
+      }
+    } else {
+      spawnDelayedRetry(agentId, transcriptPath, sessionId, logPrefix, cwd);
+    }
+    return;
+  }
+
+  if (agentId === 'qoder-cn') {
+    if (!tryAcquireRetryLock(transcriptPath, sessionId)) {
+      logDebug(agentId, `Stop skipped: peer retry/handler holds lock for ${transcriptPath}`);
+      return;
+    }
+    try {
+      await processTranscript(agentId, logPrefix, transcriptPath, sessionId, startLine, endLine, runtimeConfig, cwd);
+    } finally {
+      releaseRetryLock(transcriptPath);
+    }
     return;
   }
 
@@ -141,11 +275,14 @@ function spawnDelayedRetry(agentId, transcriptPath, sessionId, logPrefix, cwd) {
   logDebug(agentId, `Spawned retry subprocess (PID ${child.pid})`);
 }
 
-async function processTranscript(agentId, logPrefix, transcriptPath, sessionId, startLine, initialEndLine, runtimeConfig, cwd) {
+async function processTranscript(agentId, logPrefix, transcriptPath, sessionId, startLine, initialEndLine, runtimeConfig, cwd, opts) {
   // Handle retry delay
-  const retryDelay = parseInt(process.env.HOOK_RETRY_DELAY || '0', 10);
-  if (retryDelay > 0) {
-    await new Promise(r => setTimeout(r, retryDelay));
+  const delayApplied = !!(opts && opts.delayApplied);
+  if (!delayApplied) {
+    const retryDelay = parseInt(process.env.HOOK_RETRY_DELAY || '0', 10);
+    if (retryDelay > 0) {
+      await new Promise(r => setTimeout(r, retryDelay));
+    }
   }
 
   // Re-read transcript (may have grown since initial read)
@@ -188,6 +325,50 @@ async function processTranscript(agentId, logPrefix, transcriptPath, sessionId, 
       contentEvents.push(row);
     }
     // session_meta, other types: ignored
+  }
+
+  // --- Phase 2.5 (qoder-cn only): Skip processing if transcript hasn't reached Stop ---
+  // For qoder-cn, only process the transcript when the Stop progress event has been
+  // written. A PostToolUse retry (which runs before Stop is written) would see an
+  // incomplete ReAct chain and produce partial events. The Stop retry (fired after
+  // the final assistant text is written) sees the complete chain and can correctly
+  // generate all llm.request events with proper input.messages_delta (including
+  // tool_result as input delta for step 2).
+  if (agentId === 'qoder-cn') {
+    const hasStop = progressEvents.some(pe => pe.hookEvent === 'Stop');
+    if (!hasStop) {
+      logDebug(agentId, `Transcript not yet complete (no Stop event in progress). Skipping processing.`);
+      return;
+    }
+    // Stop detected — reprocess the entire transcript from the beginning so
+    // splitContentEventsIntoTurns sees the complete ReAct chain (user →
+    // assistant(text+tool_use) → user(tool_result) → assistant(text)) and
+    // generates one turn with all LLM calls and correct input.messages_delta.
+    startLine = 0;
+    lines = readTranscriptLines(transcriptPath, startLine, endLine);
+    logDebug(agentId, `Reprocessing full transcript from 0-${endLine} (${lines.length} lines)`);
+    // Re-parse since we reset startLine
+    parsed = [];
+    for (const line of lines) {
+      try { parsed.push(JSON.parse(line)); } catch { /* skip */ }
+    }
+    // Re-extract progress + content events from the full transcript
+    progressEvents.length = 0;
+    contentEvents.length = 0;
+    lastProgressHookEvent = '';
+    for (const row of parsed) {
+      const rowType = row.type;
+      if (rowType === 'progress') {
+        const data = row.data || {};
+        const hookEvent = data.hookEvent || '';
+        if (hookEvent && hookEvent !== lastProgressHookEvent) {
+          progressEvents.push({ hookEvent, ts: row.timestamp, hookName: data.hookName || '' });
+        }
+        if (hookEvent) lastProgressHookEvent = hookEvent;
+      } else if (rowType === 'user' || rowType === 'assistant') {
+        contentEvents.push(row);
+      }
+    }
   }
 
   // --- Phase 3: Split content events into turns by real user prompts ---
@@ -354,7 +535,7 @@ function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, turnId,
   // Find user prompt
   const userRow = contentEvents.find(r => r.type === 'user' && !isToolResult(r));
   const userId = resolveUserId(userRow || contentEvents[0], runtimeConfig);
-  const agentType = inferVariant(userRow || contentEvents[0], agentId, sessionId);
+  const agentType = inferVariant(userRow || contentEvents[0], agentId);
   const providerName = inferProviderName({ 'gen_ai.agent.type': agentType });
 
   // User-hook event (ENTRY input)
@@ -539,7 +720,8 @@ function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, turnId,
 
       if (tr) {
         // Find PostToolUse timestamp for this tool
-        const postToolTs = findPostToolUseTs(boundaries, i) || toolCallTs;
+        const postToolTs = findPostToolUseTs(boundaries, i)
+          || (BigInt(toolCallTs) + 1_000_000n).toString(); // +1ms fallback → tool span duration ≥ 1ms
         records.push({
           'event.id': crypto.randomUUID(),
           'event.name': 'tool.result',
@@ -651,19 +833,11 @@ function extractUserText(row) {
   return '';
 }
 
-function inferVariant(row, sourceAgentId, sessionId) {
+function inferVariant(row, sourceAgentId) {
   if (sourceAgentId === 'qoder-cn') return 'qoder-cn';
   if (!row) return sourceAgentId === 'qoder' ? 'qoder' : 'qoder-cli';
   if (row.entrypoint === 'cli' || row.promptId || row.permissionMode || row.userType) {
     return 'qoder-cli';
-  }
-  // DB-based detection: Qoder for JetBrains writes chat_session rows exclusively to
-  // ~/.qoder/shared_client/cache/db/local.db, while Qoder Desktop IDE writes to
-  // ~/Library/Application Support/Qoder/.../local.db.
-  if (sessionId) {
-    const found = isQoderIdeaSession(sessionId);
-    if (found === true) return 'qoder-idea';
-    if (found === false) return 'qoder';
   }
   return 'qoder';
 }
@@ -708,12 +882,26 @@ function buildLegacyEvents(contentEvents, turnId, sessionId, agentId, runtimeCon
 
 // --- Entry point -------------------------------------------------------------
 
-main().catch((e) => {
+function isDirectExec() {
+  const argv1 = process.argv[1];
+  if (!argv1) return false;
+  const here = fileURLToPath(import.meta.url);
+  if (path.resolve(argv1) === here) return true;
   try {
-    const agentId = process.argv.find((_, i) => process.argv[i - 1] === '--agent-id') || 'unknown';
-    const file = getErrorLogFile(agentId);
-    fs.mkdirSync(path.dirname(file), { recursive: true });
-    const ts = new Date().toISOString().replace('T', ' ').replace(/\.\d+Z$/, '');
-    fs.appendFileSync(file, `[${ts}] ${e.message}\n`, 'utf-8');
-  } catch { /* ignore */ }
-});
+    return fs.realpathSync(argv1) === fs.realpathSync(here);
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectExec()) {
+  main().catch((e) => {
+    try {
+      const agentId = process.argv.find((_, i) => process.argv[i - 1] === '--agent-id') || 'unknown';
+      const file = getErrorLogFile(agentId);
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      const ts = new Date().toISOString().replace('T', ' ').replace(/\.\d+Z$/, '');
+      fs.appendFileSync(file, `[${ts}] ${e.message}\n`, 'utf-8');
+    } catch { /* ignore */ }
+  });
+}

--- a/scripts/field-coverage.mjs
+++ b/scripts/field-coverage.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import { parseArgs } from 'node:util';
+
+const OUTPUT_DIR = path.join(homedir(), '.loongsuite-pilot', 'logs', 'output');
+
+const FIELD_SPECS = {
+  'llm.request': {
+    fields: [
+      { key: 'event.id', label: 'event.id' },
+      { key: 'user.id', label: 'user.id' },
+      { key: 'gen_ai.session.id', label: 'session.id' },
+      { key: 'gen_ai.turn.id', label: 'turn.id' },
+      { key: 'gen_ai.step.id', label: 'step.id' },
+      { key: 'gen_ai.provider.name', label: 'provider' },
+      { key: 'gen_ai.request.model', label: 'request.model' },
+      { key: 'gen_ai.input.messages_delta', label: 'input.msg_delta' },
+    ],
+  },
+  'llm.response': {
+    fields: [
+      { key: 'event.id', label: 'event.id' },
+      { key: 'user.id', label: 'user.id' },
+      { key: 'gen_ai.session.id', label: 'session.id' },
+      { key: 'gen_ai.step.id', label: 'step.id' },
+      { key: 'gen_ai.response.id', label: 'response.id' },
+      { key: 'gen_ai.response.model', label: 'response.model' },
+      { key: 'gen_ai.response.finish_reasons', label: 'finish_reasons' },
+      { key: 'gen_ai.usage.input_tokens', label: 'input_tokens' },
+      { key: 'gen_ai.usage.output_tokens', label: 'output_tokens' },
+      { key: 'gen_ai.output.messages', label: 'output.msg' },
+    ],
+  },
+  'tool.call': {
+    fields: [
+      { key: 'event.id', label: 'event.id' },
+      { key: 'user.id', label: 'user.id' },
+      { key: 'gen_ai.session.id', label: 'session.id' },
+      { key: 'gen_ai.step.id', label: 'step.id' },
+      { key: 'gen_ai.tool.name', label: 'tool.name' },
+      { key: 'gen_ai.tool.call.id', label: 'tool.call.id' },
+      { key: 'gen_ai.tool.call.arguments', label: 'tool.call.args' },
+    ],
+  },
+  'tool.result': {
+    fields: [
+      { key: 'event.id', label: 'event.id' },
+      { key: 'user.id', label: 'user.id' },
+      { key: 'gen_ai.session.id', label: 'session.id' },
+      { key: 'gen_ai.step.id', label: 'step.id' },
+      { key: 'gen_ai.tool.name', label: 'tool.name' },
+      { key: 'gen_ai.tool.call.id', label: 'tool.call.id' },
+      { key: 'gen_ai.tool.call.duration', label: 'tool.call.dur' },
+    ],
+  },
+};
+
+function parseCli() {
+  const { values } = parseArgs({
+    options: {
+      agents:    { type: 'string', short: 'a' },
+      date:      { type: 'string', short: 'd' },
+      threshold: { type: 'string', short: 't', default: '90' },
+      format:    { type: 'string', short: 'f', default: 'text' },
+      output:    { type: 'string', short: 'o' },
+    },
+    strict: true,
+  });
+  if (!values.agents) {
+    console.error('error: --agents is required (comma-separated agent names)');
+    process.exit(2);
+  }
+  if (!['text', 'json'].includes(values.format)) {
+    console.error('error: --format must be text or json');
+    process.exit(2);
+  }
+  const today = new Date();
+  const defaultDate = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+  return {
+    agents: values.agents.split(',').map(a => a.trim()),
+    date: values.date || defaultDate,
+    threshold: Number(values.threshold),
+    format: values.format,
+    output: values.output,
+  };
+}
+
+function isFilled(value) {
+  if (value === undefined || value === null) return false;
+  const s = String(value);
+  return s !== '' && s !== 'null';
+}
+
+function resolveFiles(agents, date) {
+  const resolved = [];
+  for (const agent of agents) {
+    const filename = `${agent}-${date}.jsonl`;
+    const filepath = path.join(OUTPUT_DIR, filename);
+    try {
+      readFileSync(filepath, { flag: 'r' });
+      resolved.push({ agent, filepath, filename });
+    } catch {
+      const available = readdirSync(OUTPUT_DIR)
+        .filter(f => f.startsWith(agent + '-') && f.endsWith('.jsonl'))
+        .sort()
+        .reverse()
+        .slice(0, 3);
+      console.error(`warning: ${filename} not found. Available: ${available.join(', ') || 'none'}`);
+    }
+  }
+  if (resolved.length === 0) {
+    console.error('error: no valid files found');
+    process.exit(2);
+  }
+  return resolved;
+}
+
+function collectStats(files) {
+  // stats[eventName][agentType] = { total, filled: { fieldKey: count } }
+  const stats = {};
+  for (const eventName of Object.keys(FIELD_SPECS)) {
+    stats[eventName] = {};
+  }
+  for (const { filepath } of files) {
+    const content = readFileSync(filepath, 'utf8');
+    for (const line of content.split(/\r?\n/)) {
+      if (!line.trim()) continue;
+      let entry;
+      try { entry = JSON.parse(line); } catch { continue; }
+      const eventName = entry['event.name'];
+      if (!FIELD_SPECS[eventName]) continue;
+      const agentType = entry['gen_ai.agent.type'] || 'unknown';
+      if (!stats[eventName][agentType]) {
+        stats[eventName][agentType] = { total: 0, filled: {} };
+        for (const f of FIELD_SPECS[eventName].fields) {
+          stats[eventName][agentType].filled[f.key] = 0;
+        }
+      }
+      const bucket = stats[eventName][agentType];
+      bucket.total++;
+      for (const f of FIELD_SPECS[eventName].fields) {
+        if (isFilled(entry[f.key])) {
+          bucket.filled[f.key]++;
+        }
+      }
+    }
+  }
+  return stats;
+}
+
+function buildReport(stats, threshold) {
+  const report = { threshold, tables: [] };
+  for (const [eventName, spec] of Object.entries(FIELD_SPECS)) {
+    const agentStats = stats[eventName];
+    const rows = [];
+    for (const [agentType, bucket] of Object.entries(agentStats)) {
+      if (bucket.total === 0) continue;
+      const fieldResults = spec.fields.map(f => {
+        const pct = Math.round((bucket.filled[f.key] / bucket.total) * 1000) / 10;
+        return { label: f.label, key: f.key, pct, pass: pct >= threshold };
+      });
+      const avg = Math.round((fieldResults.reduce((s, r) => s + r.pct, 0) / fieldResults.length) * 10) / 10;
+      rows.push({ agentType, total: bucket.total, avg, fields: fieldResults });
+    }
+    rows.sort((a, b) => b.total - a.total);
+    report.tables.push({ eventName, rows });
+  }
+  return report;
+}
+
+function formatText(report) {
+  const lines = [];
+  const failures = [];
+  for (const table of report.tables) {
+    if (table.rows.length === 0) {
+      lines.push(`\n═══ ${table.eventName} 填充率 ═══`);
+      lines.push('  (无数据)');
+      continue;
+    }
+    const fields = FIELD_SPECS[table.eventName].fields;
+    const headerLabels = fields.map(f => f.label);
+    lines.push(`\n═══ ${table.eventName} 填充率 (阈值: ${report.threshold}%) ═══\n`);
+    const colWidths = [
+      Math.max(12, ...table.rows.map(r => r.agentType.length + 2)),
+      6, 7,
+      ...headerLabels.map(l => Math.max(l.length + 1, 7)),
+    ];
+    const header = [
+      'agent_type'.padEnd(colWidths[0]),
+      '事件数'.padEnd(colWidths[1]),
+      '综合(%)'.padEnd(colWidths[2]),
+      ...headerLabels.map((l, i) => l.padEnd(colWidths[i + 3])),
+    ].join(' | ');
+    lines.push(`  ${header}`);
+    lines.push(`  ${'-'.repeat(header.length)}`);
+    for (const row of table.rows) {
+      const cells = [
+        row.agentType.padEnd(colWidths[0]),
+        String(row.total).padStart(colWidths[1]),
+        String(row.avg.toFixed(1)).padStart(colWidths[2]),
+        ...row.fields.map((f, i) => {
+          const val = f.pct.toFixed(1) + (f.pass ? '' : '\u274C');
+          return val.padStart(colWidths[i + 3]);
+        }),
+      ].join(' | ');
+      lines.push(`  ${cells}`);
+      const failing = row.fields.filter(f => !f.pass);
+      if (failing.length > 0) {
+        failures.push({
+          agent: row.agentType,
+          event: table.eventName,
+          fields: failing.map(f => `${f.label}(${f.pct.toFixed(1)}%)`),
+        });
+      }
+    }
+  }
+  if (failures.length > 0) {
+    lines.push(`\n⚠️  未达标字段 (< ${report.threshold}%):\n`);
+    for (const f of failures) {
+      lines.push(`  ${f.agent} / ${f.event}: ${f.fields.join(', ')}`);
+    }
+  } else {
+    lines.push('\n✅ 所有字段填充率均达标！');
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+function main() {
+  const opts = parseCli();
+  console.error(`[field-coverage] agents: ${opts.agents.join(', ')} | date: ${opts.date} | threshold: ${opts.threshold}%`);
+  const files = resolveFiles(opts.agents, opts.date);
+  console.error(`[field-coverage] loaded ${files.length} file(s): ${files.map(f => f.filename).join(', ')}`);
+  const stats = collectStats(files);
+  const report = buildReport(stats, opts.threshold);
+  let output;
+  if (opts.format === 'json') {
+    output = JSON.stringify(report, null, 2);
+  } else {
+    output = formatText(report);
+  }
+  if (opts.output) {
+    writeFileSync(opts.output, output, 'utf8');
+    console.error(`[field-coverage] report written to ${opts.output}`);
+  } else {
+    console.log(output);
+  }
+  const hasFailure = report.tables.some(t => t.rows.some(r => r.fields.some(f => !f.pass)));
+  process.exit(hasFailure ? 1 : 0);
+}
+
+main();

--- a/src/inputs/qoder-cn-trace/qoder-cn-trace-input.ts
+++ b/src/inputs/qoder-cn-trace/qoder-cn-trace-input.ts
@@ -111,6 +111,14 @@ export class QoderCnTraceInput extends BaseInput {
     // Re-group after orphan merge since turn.id may have been mutated.
     const mergedGroups = this.groupByTurn(rawEntries);
 
+    // Deduplicate events within each turn BEFORE enrichment so that
+    // enrichIdeTurn only sees canonical events. When the hook processor
+    // writes the same turn multiple times (partial retry + complete Stop),
+    // dedup keeps only the last event per (step_id, event_name, tool_call_id).
+    for (const [, turnEntries] of mergedGroups) {
+      dedupeEventsInTurn(turnEntries);
+    }
+
     // Aggregate all turns in the same session so enrichIdeTurn can use
     // SQLite request ordering to match tokens correctly across turns.
     // Mirrors qoder-trace-input.ts ideSessionGroups pattern.
@@ -131,40 +139,27 @@ export class QoderCnTraceInput extends BaseInput {
       const sqliteRows = await readSqliteTokensForSession(sessionId);
       enrichIdeTurn(sessionEntries, sqliteRows);
       // Post-processing after enrichIdeTurn:
-      //   - expandContainerTimes: bumps llm.response to turn max so ENTRY/AGENT spans
-      //     get correct endTimes; skips 'other' to preserve user-boundary timestamp
-      //   - propagateModelToToolEvents: copies model/provider from llm.response to
-      //     tool.call/tool.result in the same step
-      //   - computeToolCallDurations: fills gen_ai.tool.call.duration on tool.result
-      //     events as (tool.result.time - tool.call.time) in milliseconds
-      //   - alignUserBoundaryToFirstLlmRequest: sets 'other' event's step.id and time
-      //     equal to step-1 llm.request, preventing the converter from generating a
-      //     0ms empty STEP
       expandContainerTimes(sessionEntries);
       propagateModelToToolEvents(sessionEntries);
       computeToolCallDurations(sessionEntries);
       alignUserBoundaryToFirstLlmRequest(sessionEntries);
     }
 
-    // Aggregate all session entries (no synthetic events added by post-processing now).
+    // Aggregate all session entries.
     const allSessionEntries: AgentActivityEntry[] = [];
     for (const sessionEntries of ideSessionGroups.values()) {
       allSessionEntries.push(...sessionEntries);
     }
 
-    // Deduplicate events within each turn: when the same turn appears multiple
-    // times in the history file (e.g., a partial turn from an earlier retry and
-    // a complete turn from the Stop retry), keep only the last event per
-    // (step_id, event_name, tool_call_id) group.
     const allTurnGroups = this.groupByTurn(allSessionEntries);
     for (const [, turnEntries] of allTurnGroups) {
-      dedupeEventsInTurn(turnEntries);
       injectTraceId(turnEntries);
     }
 
-    // No-session entries get their own trace_id injection.
+    // No-session entries also get dedup + trace_id injection.
     const noSessionTurnGroups = this.groupByTurn(noSessionEntries);
     for (const [, turnEntries] of noSessionTurnGroups) {
+      dedupeEventsInTurn(turnEntries);
       injectTraceId(turnEntries);
     }
 

--- a/src/inputs/qoder-cn-trace/qoder-cn-trace-input.ts
+++ b/src/inputs/qoder-cn-trace/qoder-cn-trace-input.ts
@@ -17,8 +17,12 @@ export interface QoderCnTraceInputOptions extends InputOptions {
 /**
  * Multi-source merge input for QoderCN (IDE-only).
  * Reads hook JSONL (content+structure) and SQLite (IDE tokens),
- * merges per turn, outputs enriched events for both event logs (SLS)
+ * merges per session, outputs enriched events for both event logs (SLS)
  * and trace conversion (ARMS).
+ *
+ * Pattern mirrors qoder-trace-input.ts: always emit immediately, never buffer.
+ * The token enricher's timestamp fallback handles any unmatched entries
+ * (sets token=0), which is safe for downstream consumers.
  */
 export class QoderCnTraceInput extends BaseInput {
   readonly id = 'qoder-cn-trace';
@@ -27,6 +31,11 @@ export class QoderCnTraceInput extends BaseInput {
 
   private readonly logDir: string;
   private readonly logPrefix = 'qoder-cn';
+
+  // Persists across collect() cycles: tracks the last anchor turn.id and its
+  // max step counter per session so orphan turns from later cycles can be
+  // merged into the correct turn.
+  private readonly sessionAnchor = new Map<string, { turnId: string; maxStep: number }>();
 
   constructor(opts: QoderCnTraceInputOptions) {
     super({ ...opts, pollIntervalMs: opts.pollIntervalMs ?? 30_000 });
@@ -53,20 +62,124 @@ export class QoderCnTraceInput extends BaseInput {
 
     const turnGroups = this.groupByTurn(rawEntries);
 
-    const allEntries: AgentActivityEntry[] = [];
-    for (const [, turnEntries] of turnGroups) {
-      const sessionId = this.extractSessionId(turnEntries);
+    // Cross-cycle orphan turn merge: turns that have no user input (orphan)
+    // are merged into the most recent anchor turn for that session.
+    // Because the anchor turn was produced in a previous collect() cycle, we
+    // keep its turn.id and step counter in sessionAnchor (instance-level).
+    for (const [turnId, entries] of turnGroups) {
+      const sessionId = this.extractSessionId(entries);
+      if (!sessionId) continue;
 
-      if (sessionId) {
-        const sqliteRows = await readSqliteTokensForSession(sessionId);
-        enrichIdeTurn(turnEntries, sqliteRows);
+      const hasUserInput = entries.some(e =>
+        e['event.name'] === 'other' && e['gen_ai.input.messages_delta'],
+      );
+
+      if (hasUserInput) {
+        // Anchor turn: record it and its max step number for future orphans.
+        let maxStep = 0;
+        for (const e of entries) {
+          const m = ((e['gen_ai.step.id'] as string) || '').match(/:s(\d+)$/);
+          if (m) { const n = parseInt(m[1]); if (n > maxStep) maxStep = n; }
+        }
+        this.sessionAnchor.set(sessionId, { turnId, maxStep });
+      } else {
+        // Orphan turn: reassign to the last anchor if one exists.
+        const anchor = this.sessionAnchor.get(sessionId);
+        if (!anchor) continue;
+
+        // Collect orphan step.ids sorted so renumbering is deterministic.
+        const orphanStepIds = [...new Set(
+          entries.map(e => (e['gen_ai.step.id'] as string) || '').filter(Boolean),
+        )].sort();
+
+        const stepRemap = new Map<string, string>();
+        for (const sid of orphanStepIds) {
+          anchor.maxStep += 1;
+          stepRemap.set(sid, `${anchor.turnId}:s${anchor.maxStep}`);
+        }
+
+        for (const e of entries) {
+          e['gen_ai.turn.id'] = anchor.turnId;
+          const sid = e['gen_ai.step.id'] as string | undefined;
+          if (sid && stepRemap.has(sid)) {
+            e['gen_ai.step.id'] = stepRemap.get(sid)!;
+          }
+        }
       }
-
-      injectTraceId(turnEntries);
-      allEntries.push(...turnEntries);
     }
 
-    return allEntries;
+    // Re-group after orphan merge since turn.id may have been mutated.
+    const mergedGroups = this.groupByTurn(rawEntries);
+
+    // Aggregate all turns in the same session so enrichIdeTurn can use
+    // SQLite request ordering to match tokens correctly across turns.
+    // Mirrors qoder-trace-input.ts ideSessionGroups pattern.
+    const ideSessionGroups = new Map<string, AgentActivityEntry[]>();
+    const noSessionEntries: AgentActivityEntry[] = [];
+    for (const [, turnEntries] of mergedGroups) {
+      const sessionId = this.extractSessionId(turnEntries);
+      if (sessionId) {
+        const sessionEntries = ideSessionGroups.get(sessionId) ?? [];
+        sessionEntries.push(...turnEntries);
+        ideSessionGroups.set(sessionId, sessionEntries);
+      } else {
+        noSessionEntries.push(...turnEntries);
+      }
+    }
+
+    for (const [sessionId, sessionEntries] of ideSessionGroups) {
+      const sqliteRows = await readSqliteTokensForSession(sessionId);
+      enrichIdeTurn(sessionEntries, sqliteRows);
+      // Post-processing after enrichIdeTurn:
+      //   - expandContainerTimes: bumps llm.response to turn max so ENTRY/AGENT spans
+      //     get correct endTimes; skips 'other' to preserve user-boundary timestamp
+      //   - propagateModelToToolEvents: copies model/provider from llm.response to
+      //     tool.call/tool.result in the same step
+      //   - computeToolCallDurations: fills gen_ai.tool.call.duration on tool.result
+      //     events as (tool.result.time - tool.call.time) in milliseconds
+      //   - alignUserBoundaryToFirstLlmRequest: sets 'other' event's step.id and time
+      //     equal to step-1 llm.request, preventing the converter from generating a
+      //     0ms empty STEP
+      expandContainerTimes(sessionEntries);
+      propagateModelToToolEvents(sessionEntries);
+      computeToolCallDurations(sessionEntries);
+      alignUserBoundaryToFirstLlmRequest(sessionEntries);
+    }
+
+    // Aggregate all session entries (no synthetic events added by post-processing now).
+    const allSessionEntries: AgentActivityEntry[] = [];
+    for (const sessionEntries of ideSessionGroups.values()) {
+      allSessionEntries.push(...sessionEntries);
+    }
+
+    // Deduplicate events within each turn: when the same turn appears multiple
+    // times in the history file (e.g., a partial turn from an earlier retry and
+    // a complete turn from the Stop retry), keep only the last event per
+    // (step_id, event_name, tool_call_id) group.
+    const allTurnGroups = this.groupByTurn(allSessionEntries);
+    for (const [, turnEntries] of allTurnGroups) {
+      dedupeEventsInTurn(turnEntries);
+      injectTraceId(turnEntries);
+    }
+
+    // No-session entries get their own trace_id injection.
+    const noSessionTurnGroups = this.groupByTurn(noSessionEntries);
+    for (const [, turnEntries] of noSessionTurnGroups) {
+      injectTraceId(turnEntries);
+    }
+
+    // Return events grouped by turn so all events for the same turn are
+    // contiguous. The OTLP flusher flushes a turn when it sees events from
+    // a different turn, so interleaved turns cause synthetic events (tool.result,
+    // llm.request) to be dropped as "late arrivals" for already-flushed turns.
+    const ordered: AgentActivityEntry[] = [];
+    for (const [, turnEntries] of allTurnGroups) {
+      ordered.push(...turnEntries);
+    }
+    for (const [, turnEntries] of noSessionTurnGroups) {
+      ordered.push(...turnEntries);
+    }
+    return ordered;
   }
 
   // ─── Hook JSONL reading ─────────────────────────────────────────────────────
@@ -150,3 +263,185 @@ export class QoderCnTraceInput extends BaseInput {
     return undefined;
   }
 }
+
+// Deduplicate events within a single turn by (step_id, event_name, tool_call_id).
+// When the hook processor writes events for the same turn multiple times (e.g.,
+// a partial turn from an earlier retry followed by a complete turn from the
+// Stop retry), this keeps only the last event for each key — the complete
+// version written last.
+function dedupeEventsInTurn(entries: AgentActivityEntry[]): void {
+  const seen = new Map<string, number>();
+  for (let i = 0; i < entries.length; i++) {
+    const e = entries[i];
+    const stepId = (e['gen_ai.step.id'] as string) || '';
+    const eventName = e['event.name'] as string;
+    const toolCallId = (e['gen_ai.tool.call.id'] as string) || '';
+    const key = `${stepId}|${eventName}|${toolCallId}`;
+    seen.set(key, i);
+  }
+
+  const keepIndices = new Set(seen.values());
+  for (let i = entries.length - 1; i >= 0; i--) {
+    if (!keepIndices.has(i)) {
+      entries.splice(i, 1);
+    }
+  }
+}
+
+// Align the 'other' (user-boundary) event to the step-1 llm.request within
+//   1. Set time_unix_nano equal to the llm.request time (removes any 1ms gap
+//      that would make the converter insert an empty STEP).
+//   2. Set gen_ai.step.id to the step-1 step.id. Without a step.id the
+//      converter creates a separate 0ms empty STEP container for step-less
+//      events, resulting in a "STEP has 0 LLM children" validation error.
+function alignUserBoundaryToFirstLlmRequest(entries: AgentActivityEntry[]): void {
+  const byTurn = new Map<string, AgentActivityEntry[]>();
+  for (const e of entries) {
+    const tid = (e['gen_ai.turn.id'] as string) || '';
+    if (!tid) continue;
+    const list = byTurn.get(tid) ?? [];
+    list.push(e);
+    byTurn.set(tid, list);
+  }
+  for (const list of byTurn.values()) {
+    const firstReq = list.find(e => e['event.name'] === 'llm.request' && e['gen_ai.step.id']);
+    if (!firstReq || !firstReq.time_unix_nano) continue;
+    for (const e of list) {
+      if (e['event.name'] === 'other' && !e['gen_ai.step.id']) {
+        e.time_unix_nano = firstReq.time_unix_nano;
+        e['gen_ai.step.id'] = firstReq['gen_ai.step.id'];
+        // Propagate model from the real LLM request so 'other' doesn't show 'unknown'
+        if (firstReq['gen_ai.request.model'] && firstReq['gen_ai.request.model'] !== 'unknown') {
+          e['gen_ai.request.model'] = firstReq['gen_ai.request.model'];
+          e['gen_ai.response.model'] = firstReq['gen_ai.request.model'];
+        }
+        if (firstReq['gen_ai.provider.name'] && firstReq['gen_ai.provider.name'] !== 'unknown') {
+          e['gen_ai.provider.name'] = firstReq['gen_ai.provider.name'];
+        }
+      }
+    }
+  }
+}
+
+// Propagate model from llm.response to tool.call/tool.result in the same step.
+// The hook processor sets tool events' model to 'unknown' because it doesn't
+// have visibility into the LLM call's model. Since tool.call/tool.result and
+// llm.response are part of the same step (same step_id), they should share
+// the same model.
+function propagateModelToToolEvents(entries: AgentActivityEntry[]): void {
+  const byStep = new Map<string, AgentActivityEntry[]>();
+  for (const e of entries) {
+    const sid = (e['gen_ai.step.id'] as string) || '';
+    if (!sid) continue;
+    const list = byStep.get(sid) ?? [];
+    list.push(e);
+    byStep.set(sid, list);
+  }
+
+  for (const list of byStep.values()) {
+    const resp = list.find(e => e['event.name'] === 'llm.response');
+    if (!resp) continue;
+    const model = resp['gen_ai.request.model'] as string | undefined;
+    const respModel = resp['gen_ai.response.model'] as string | undefined;
+    const provider = resp['gen_ai.provider.name'] as string | undefined;
+    if (!model || model === 'unknown') continue;
+
+    for (const e of list) {
+      if (e['event.name'] !== 'tool.call' && e['event.name'] !== 'tool.result') continue;
+      const curModel = e['gen_ai.request.model'] as string | undefined;
+      if (!curModel || curModel === 'unknown') {
+        e['gen_ai.request.model'] = model;
+        if (respModel && respModel !== 'unknown') e['gen_ai.response.model'] = respModel;
+        if (provider && provider !== 'unknown') e['gen_ai.provider.name'] = provider;
+      }
+    }
+  }
+}
+
+// Compute gen_ai.tool.call.duration on each tool.result event as
+// tool.result.time - tool.call.time (in milliseconds).
+// Matches tool.call and tool.result by (step_id, tool.call.id).
+function computeToolCallDurations(entries: AgentActivityEntry[]): void {
+  // Build a map of tool.call times keyed by (step_id, tool.call.id)
+  const callTimes = new Map<string, bigint>();
+  for (const e of entries) {
+    if (e['event.name'] !== 'tool.call') continue;
+    const sid = (e['gen_ai.step.id'] as string) || '';
+    const callId = (e['gen_ai.tool.call.id'] as string) || '';
+    const t = e.time_unix_nano;
+    if (typeof t !== 'string') continue;
+    try { callTimes.set(`${sid}|${callId}`, BigInt(t)); } catch { /* skip */ }
+  }
+
+  // For each tool.result, compute duration from matching tool.call
+  for (const e of entries) {
+    if (e['event.name'] !== 'tool.result') continue;
+    const sid = (e['gen_ai.step.id'] as string) || '';
+    const callId = (e['gen_ai.tool.call.id'] as string) || '';
+    const resultTimeStr = e.time_unix_nano;
+    if (typeof resultTimeStr !== 'string') continue;
+    const callTime = callTimes.get(`${sid}|${callId}`);
+    if (callTime === undefined) continue;
+    let resultTime: bigint;
+    try { resultTime = BigInt(resultTimeStr); } catch { continue; }
+    const durationNs = resultTime - callTime;
+    if (durationNs < 0n) continue;
+    // Convert nanoseconds to milliseconds (integer)
+    e['gen_ai.tool.call.duration'] = Number(durationNs / 1_000_000n);
+  }
+}
+
+// Expand container span times so ENTRY/AGENT spans end at/after their last
+// child STEP. The converter derives these spans from event log times; if the
+// last event in a turn has an earlier time than earlier events, the generated
+// ENTRY/AGENT span ends up with duration=0. We rewrite non-{llm.request,
+// tool.call, tool.result} entries in each turn to the max time in that turn.
+//
+// Why we skip llm.request / tool.call / tool.result:
+//   - llm.request  → used as LLM span startTime; bumping would change LLM duration
+//   - tool.call    → used as TOOL span startTime; hook processor sets it to
+//                    the llm.response time
+//   - tool.result  → used as TOOL span endTime; hook processor writes real tool
+//                    results with the tool's actual finish time
+function expandContainerTimes(entries: AgentActivityEntry[]): void {
+  const ms = (e: AgentActivityEntry): bigint => {
+    const v = e.time_unix_nano;
+    try { return typeof v === 'string' ? BigInt(v) : BigInt(0); } catch { return BigInt(0); }
+  };
+
+  const byTurn = new Map<string, AgentActivityEntry[]>();
+  for (const e of entries) {
+    const tid = (e['gen_ai.turn.id'] as string) || '';
+    if (!tid) continue;
+    const list = byTurn.get(tid) ?? [];
+    list.push(e);
+    byTurn.set(tid, list);
+  }
+  for (const list of byTurn.values()) {
+    let max = BigInt(0);
+    for (const e of list) {
+      const t = ms(e);
+      if (t > max) max = t;
+    }
+    for (const e of list) {
+      // Keep these events at their post-enrich times:
+      //   - llm.request  → used as LLM span startTime; bumping would change LLM duration
+      //   - llm.response → used as LLM span endTime; hook processor sets it to the
+      //                    actual PreToolUse/Stop timestamp for each step. Bumping to
+      //                    turn max would overwrite step 1's time with step 2's end
+      //                    time, causing STEP spans to overlap.
+      //   - tool.call    → used as TOOL span startTime; hook processor sets it
+      //   - tool.result  → used as TOOL span endTime; hook processor sets it
+      //   - other        → user-boundary entry; enrichIdeTurn uses its time as
+      //                    step-1 llm.request time; bumping it to turn max would set
+      //                    request.time = response.time and collapse LLM duration to 0
+      const name = e['event.name'] as string;
+      if (name === 'llm.request' || name === 'llm.response' || name === 'tool.call' || name === 'tool.result' || name === 'other') continue;
+      if (ms(e) < max) {
+        e.time_unix_nano = max.toString();
+      }
+    }
+  }
+}
+
+

--- a/src/inputs/qoder-cn-trace/sqlite-token-reader.ts
+++ b/src/inputs/qoder-cn-trace/sqlite-token-reader.ts
@@ -8,11 +8,14 @@ import { createLogger } from '../../utils/logger.js';
 const logger = createLogger('QoderCnSqliteTokenReader');
 
 export interface SqliteTokenData {
+  sessionId?: string;
   requestId: string;
+  messageId?: string;
   gmtCreate: number;
   inputTokens: number;
   outputTokens: number;
   cacheReadTokens: number;
+  model?: string;
 }
 
 export async function readSqliteTokensForSession(sessionId: string): Promise<SqliteTokenData[]> {
@@ -20,17 +23,33 @@ export async function readSqliteTokensForSession(sessionId: string): Promise<Sql
   if (!dbPath) return [];
 
   const sql = `
-    SELECT request_id, gmt_create, token_info
-    FROM chat_message
-    WHERE session_id = ?
-      AND role = 'assistant'
-      AND token_info IS NOT NULL
-      AND token_info != ''
-      AND json_valid(token_info)
-    ORDER BY gmt_create ASC
+    SELECT
+      cm.id            AS message_id,
+      cm.session_id    AS session_id,
+      cm.request_id    AS request_id,
+      cm.gmt_create    AS gmt_create,
+      cm.token_info    AS token_info,
+      cm.model_info    AS model_info,
+      cr.extra         AS record_extra
+    FROM chat_message cm
+    LEFT JOIN chat_record cr ON cr.request_id = cm.request_id
+    WHERE cm.session_id = ?
+      AND cm.role = 'assistant'
+      AND cm.token_info IS NOT NULL
+      AND cm.token_info != ''
+      AND json_valid(cm.token_info)
+    ORDER BY cm.gmt_create ASC
   `;
 
-  let rows: Array<{ request_id: string; gmt_create: number; token_info: string }>;
+  let rows: Array<{
+    message_id?: string;
+    session_id?: string;
+    request_id: string;
+    gmt_create: number;
+    token_info: string;
+    model_info?: string | null;
+    record_extra?: string | null;
+  }>;
   try {
     rows = await queryReadonly(dbPath, sql, [sessionId]);
   } catch (err) {
@@ -43,11 +62,14 @@ export async function readSqliteTokensForSession(sessionId: string): Promise<Sql
     const info = parseTokenInfo(row.token_info);
     if (!info) continue;
     results.push({
+      sessionId: row.session_id ?? '',
       requestId: row.request_id ?? '',
+      messageId: row.message_id ?? '',
       gmtCreate: row.gmt_create,
       inputTokens: info.promptTokens,
       outputTokens: info.completionTokens,
       cacheReadTokens: info.cachedTokens,
+      model: parseModelKey(row.model_info) ?? parseRecordModelKey(row.record_extra),
     });
   }
   return results;
@@ -82,6 +104,29 @@ function parseTokenInfo(raw: string): { promptTokens: number; completionTokens: 
     return { promptTokens: pt, completionTokens: ct, cachedTokens: cached };
   } catch {
     return null;
+  }
+}
+
+function parseModelKey(raw: string | null | undefined): string | undefined {
+  if (!raw) return undefined;
+  try {
+    const obj = JSON.parse(raw);
+    return typeof obj.model_key === 'string' && obj.model_key.length > 0
+      ? obj.model_key
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseRecordModelKey(raw: string | null | undefined): string | undefined {
+  if (!raw) return undefined;
+  try {
+    const obj = JSON.parse(raw);
+    const key = obj?.modelConfig?.key;
+    return typeof key === 'string' && key.length > 0 ? key : undefined;
+  } catch {
+    return undefined;
   }
 }
 

--- a/src/inputs/qoder-trace/token-enricher.ts
+++ b/src/inputs/qoder-trace/token-enricher.ts
@@ -187,13 +187,26 @@ export function enrichIdeTurn(
     // llm.response: use gmt_create as real response time
     respEntry.time_unix_nano = String(BigInt(gmtCreate) * 1_000_000n);
 
-    // Find the llm.request that immediately precedes this response in entries order
-    const respIdx = entries.indexOf(respEntry);
+    // Find the llm.request for this response's step (same step.id).
+    // Restrict to the same step to avoid cross-turn contamination in
+    // multi-turn sessions where allEntries contains entries from different
+    // turns. A backwards scan without a step.id check would find the
+    // previous turn's llm.request and overwrite its timestamp.
+    const respStepId = respEntry['gen_ai.step.id'];
     let req: AgentActivityEntry | undefined;
-    for (let j = respIdx - 1; j >= 0; j--) {
-      if (entries[j]['event.name'] === 'llm.request' && entries[j]['gen_ai.step.id']) {
-        req = entries[j];
-        break;
+    if (respStepId) {
+      req = entries.find(e => e['event.name'] === 'llm.request' && e['gen_ai.step.id'] === respStepId);
+    }
+    if (!req) {
+      // Fallback: backwards scan limited to the same turn
+      const respTurnId = respEntry['gen_ai.turn.id'];
+      const respIdx = entries.indexOf(respEntry);
+      for (let j = respIdx - 1; j >= 0; j--) {
+        if (entries[j]['event.name'] === 'llm.request' && entries[j]['gen_ai.step.id'] &&
+            entries[j]['gen_ai.turn.id'] === respTurnId) {
+          req = entries[j];
+          break;
+        }
       }
     }
 
@@ -202,7 +215,12 @@ export function enrichIdeTurn(
         // Previous step's gmt_create + 1ms (accounts for tool.result buffer in prior step)
         req.time_unix_nano = String(BigInt(matchedPairs[i - 1].gmtCreate + 1) * 1_000_000n);
       } else if (userBoundary) {
-        req.time_unix_nano = String(userBoundary.time_unix_nano);
+        // Use userBoundary.time + 1ms so the LLM request starts strictly after
+        // the user prompt event. When both share the same timestamp the converter
+        // generates a duplicate empty STEP (0ms, no LLM children) because it
+        // sees two events at the same instant inside step s1.
+        const ubNs = BigInt(String(userBoundary.time_unix_nano));
+        req.time_unix_nano = String(ubNs + 1_000_000n); // +1ms
       }
     }
 
@@ -211,6 +229,7 @@ export function enrichIdeTurn(
     // to match, keeping steps non-overlapping.
     const toolCallTs = String(BigInt(gmtCreate) * 1_000_000n);
     const toolResultTs = String(BigInt(gmtCreate + 1) * 1_000_000n);
+    const respIdx = entries.indexOf(respEntry);
     const rightBound = i < matchedPairs.length - 1
       ? entries.indexOf(matchedPairs[i + 1].entry)
       : entries.length;
@@ -322,8 +341,6 @@ function applySqliteRowToIdeResponse(
   response['gen_ai.request.id'] = requestId;
   (response as Record<string, unknown>)['agent.request_id'] = requestId;
   response['gen_ai.response.id'] = row.messageId || requestId;
-  (response as Record<string, unknown>)['qoder.match_confidence'] = 'high';
-  (response as Record<string, unknown>)['qoder.match.strategy'] = 'sqlite_request_order';
 
   if (row.model && row.model !== 'unknown') {
     response['gen_ai.request.model'] = row.model;
@@ -334,8 +351,6 @@ function applySqliteRowToIdeResponse(
   if (request) {
     request['gen_ai.request.id'] = requestId;
     (request as Record<string, unknown>)['agent.request_id'] = requestId;
-    (request as Record<string, unknown>)['qoder.match_confidence'] = 'high';
-    (request as Record<string, unknown>)['qoder.match.strategy'] = 'sqlite_request_order';
     if (row.model && row.model !== 'unknown') request['gen_ai.request.model'] = row.model;
   }
 
@@ -353,12 +368,9 @@ function findStepRequest(entries: AgentActivityEntry[], response: AgentActivityE
   return entries.find(e => e['event.name'] === 'llm.request' && e['gen_ai.step.id'] === stepId);
 }
 
-function markLowConfidence(entries: AgentActivityEntry[], warning: string): void {
-  for (const entry of entries) {
-    if (entry['event.name'] !== 'llm.request' && entry['event.name'] !== 'llm.response') continue;
-    (entry as Record<string, unknown>)['qoder.match_confidence'] = 'low';
-    (entry as Record<string, unknown>)['qoder.match.warning'] = warning;
-  }
+function markLowConfidence(entries: AgentActivityEntry[], _warning: string): void {
+  // Low-confidence match: no additional fields written to avoid polluting output.
+  void entries;
 }
 
 function sqliteDedupeKey(row: SqliteTokenData): string {

--- a/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
+++ b/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  isRetryLockStale,
+  readRetryLock,
+  releaseRetryLock,
+  retryLockPath,
+  tryAcquireRetryLock,
+} from '../../../assets/hooks/qoder-hook-processor.mjs';
+
+let lockDir;
+
+beforeEach(() => {
+  lockDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qodercn-retry-lock-'));
+});
+
+afterEach(() => {
+  try { fs.rmSync(lockDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('retryLockPath', () => {
+  it('hashes transcript path so different paths get different lock files', () => {
+    const a = retryLockPath('/tmp/a.jsonl', lockDir);
+    const b = retryLockPath('/tmp/b.jsonl', lockDir);
+    expect(a).not.toBe(b);
+    expect(a.startsWith(lockDir)).toBe(true);
+    expect(a.endsWith('.lock')).toBe(true);
+  });
+
+  it('returns stable path for same input', () => {
+    expect(retryLockPath('/tmp/x.jsonl', lockDir))
+      .toBe(retryLockPath('/tmp/x.jsonl', lockDir));
+  });
+});
+
+describe('tryAcquireRetryLock', () => {
+  it('first acquire succeeds and writes pid/sessionId', () => {
+    const ok = tryAcquireRetryLock('/tmp/t.jsonl', 'sess-1', lockDir);
+    expect(ok).toBe(true);
+    const lock = readRetryLock(retryLockPath('/tmp/t.jsonl', lockDir));
+    expect(lock.pid).toBe(process.pid);
+    expect(lock.sessionId).toBe('sess-1');
+    expect(typeof lock.startedAt).toBe('number');
+  });
+
+  it('second acquire while live lock exists fails', () => {
+    expect(tryAcquireRetryLock('/tmp/t.jsonl', 'sess-1', lockDir)).toBe(true);
+    expect(tryAcquireRetryLock('/tmp/t.jsonl', 'sess-1', lockDir)).toBe(false);
+  });
+
+  it('overwrites a stale lock (dead pid)', () => {
+    const lockPath = retryLockPath('/tmp/t.jsonl', lockDir);
+    fs.mkdirSync(lockDir, { recursive: true });
+    // PID 1 is init — guaranteed to be unkillable; use a very small fake pid that's almost certainly dead.
+    // Use pid=999999 (out of range on most systems) to simulate dead.
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: 999999, sessionId: 'old', startedAt: Date.now() }));
+    expect(tryAcquireRetryLock('/tmp/t.jsonl', 'sess-2', lockDir)).toBe(true);
+    const lock = readRetryLock(lockPath);
+    expect(lock.sessionId).toBe('sess-2');
+  });
+
+  it('overwrites an expired lock (startedAt too old)', () => {
+    const lockPath = retryLockPath('/tmp/t.jsonl', lockDir);
+    fs.mkdirSync(lockDir, { recursive: true });
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid, sessionId: 'old', startedAt: 1 }));
+    expect(tryAcquireRetryLock('/tmp/t.jsonl', 'sess-2', lockDir)).toBe(true);
+    expect(readRetryLock(lockPath).sessionId).toBe('sess-2');
+  });
+});
+
+describe('releaseRetryLock', () => {
+  it('removes a lock owned by current pid', () => {
+    expect(tryAcquireRetryLock('/tmp/t.jsonl', 'sess-1', lockDir)).toBe(true);
+    releaseRetryLock('/tmp/t.jsonl', lockDir);
+    expect(fs.existsSync(retryLockPath('/tmp/t.jsonl', lockDir))).toBe(false);
+  });
+
+  it('leaves a peer pid lock alone', () => {
+    const lockPath = retryLockPath('/tmp/t.jsonl', lockDir);
+    fs.mkdirSync(lockDir, { recursive: true });
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid + 1, sessionId: 'peer', startedAt: Date.now() }));
+    releaseRetryLock('/tmp/t.jsonl', lockDir);
+    expect(fs.existsSync(lockPath)).toBe(true);
+    expect(readRetryLock(lockPath).sessionId).toBe('peer');
+  });
+
+  it('does nothing for missing lock', () => {
+    expect(() => releaseRetryLock('/tmp/missing.jsonl', lockDir)).not.toThrow();
+  });
+});
+
+describe('isRetryLockStale', () => {
+  it('returns true for null lock', () => {
+    expect(isRetryLockStale(null)).toBe(true);
+  });
+
+  it('returns true for old lock', () => {
+    expect(isRetryLockStale({ pid: process.pid, startedAt: 0 })).toBe(true);
+  });
+
+  it('returns false for fresh, live lock', () => {
+    expect(isRetryLockStale({ pid: process.pid, startedAt: Date.now() })).toBe(false);
+  });
+
+  it('returns true for fresh lock with dead pid', () => {
+    expect(isRetryLockStale({ pid: 999999, startedAt: Date.now() })).toBe(true);
+  });
+});

--- a/tests/unit/inputs/qoder-cn-sqlite-reader.test.ts
+++ b/tests/unit/inputs/qoder-cn-sqlite-reader.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import sqlite3 from 'sqlite3';
+
+let tmpHome: string = os.tmpdir();
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return {
+    ...actual,
+    homedir: () => tmpHome,
+    default: { ...actual, homedir: () => tmpHome },
+  };
+});
+
+const { readSqliteTokensForSession } = await import('../../../src/inputs/qoder-cn-trace/sqlite-token-reader.js');
+
+let dbPath: string;
+
+beforeEach(async () => {
+  tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'qodercn-sqlite-test-'));
+
+  // The reader resolves ~/Library/Application Support/QoderCN/SharedClientCache/cache/db/local.db on darwin.
+  // For non-darwin platforms it uses ~/.config/QoderCN/.../local.db. We always cover the darwin path
+  // (covers macOS CI / local dev); on Linux CI the readSqliteTokensForSession will probe both candidates.
+  const dbDir = process.platform === 'darwin'
+    ? path.join(tmpHome, 'Library', 'Application Support', 'QoderCN', 'SharedClientCache', 'cache', 'db')
+    : path.join(tmpHome, '.config', 'QoderCN', 'SharedClientCache', 'cache', 'db');
+  await fs.mkdir(dbDir, { recursive: true });
+  dbPath = path.join(dbDir, 'local.db');
+  await createSchema(dbPath);
+});
+
+afterEach(async () => {
+  try { await fs.rm(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('readSqliteTokensForSession (qoder-cn)', () => {
+  it('returns empty array when DB missing', async () => {
+    await fs.rm(dbPath, { force: true });
+    expect(await readSqliteTokensForSession('sess-x')).toEqual([]);
+  });
+
+  it('maps token_info, message_id, session_id, model_info to SqliteTokenData', async () => {
+    await insertRow(dbPath, {
+      id: 'msg-1', session_id: 'sess-1', request_id: 'req-1', role: 'assistant',
+      token_info: JSON.stringify({ prompt_tokens: 100, completion_tokens: 20, cached_tokens: 80 }),
+      model_info: JSON.stringify({ model_key: 'qwen-plus' }),
+      gmt_create: 1_780_000_000_000,
+    });
+
+    const rows = await readSqliteTokensForSession('sess-1');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      sessionId: 'sess-1',
+      messageId: 'msg-1',
+      requestId: 'req-1',
+      gmtCreate: 1_780_000_000_000,
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheReadTokens: 80,
+      model: 'qwen-plus',
+    });
+  });
+
+  it('falls back to chat_record.extra.modelConfig.key when model_info missing model_key', async () => {
+    await insertRecord(dbPath, {
+      request_id: 'req-2',
+      session_id: 'sess-2',
+      extra: JSON.stringify({ modelConfig: { key: 'auto' } }),
+    });
+    await insertRow(dbPath, {
+      id: 'msg-2', session_id: 'sess-2', request_id: 'req-2', role: 'assistant',
+      token_info: JSON.stringify({ prompt_tokens: 1, completion_tokens: 2, cached_tokens: 0 }),
+      model_info: '{"foo":"bar"}',
+      gmt_create: 1_780_000_001_000,
+    });
+
+    const rows = await readSqliteTokensForSession('sess-2');
+    expect(rows[0].model).toBe('auto');
+  });
+
+  it('filters out rows with both token counts zero', async () => {
+    await insertRow(dbPath, {
+      id: 'msg-3', session_id: 'sess-3', request_id: 'req-3', role: 'assistant',
+      token_info: JSON.stringify({ prompt_tokens: 0, completion_tokens: 0, cached_tokens: 0 }),
+      gmt_create: 1_780_000_002_000,
+    });
+    expect(await readSqliteTokensForSession('sess-3')).toEqual([]);
+  });
+
+  it('ignores non-assistant rows', async () => {
+    await insertRow(dbPath, {
+      id: 'msg-4', session_id: 'sess-4', request_id: 'req-4', role: 'user',
+      token_info: JSON.stringify({ prompt_tokens: 5, completion_tokens: 5, cached_tokens: 0 }),
+      gmt_create: 1_780_000_003_000,
+    });
+    expect(await readSqliteTokensForSession('sess-4')).toEqual([]);
+  });
+
+  it('orders results by gmt_create ascending', async () => {
+    await insertRow(dbPath, {
+      id: 'msg-5a', session_id: 'sess-5', request_id: 'req-5a', role: 'assistant',
+      token_info: JSON.stringify({ prompt_tokens: 10, completion_tokens: 1, cached_tokens: 0 }),
+      gmt_create: 1_780_000_005_000,
+    });
+    await insertRow(dbPath, {
+      id: 'msg-5b', session_id: 'sess-5', request_id: 'req-5b', role: 'assistant',
+      token_info: JSON.stringify({ prompt_tokens: 20, completion_tokens: 2, cached_tokens: 0 }),
+      gmt_create: 1_780_000_004_000,
+    });
+
+    const rows = await readSqliteTokensForSession('sess-5');
+    expect(rows.map(r => r.messageId)).toEqual(['msg-5b', 'msg-5a']);
+  });
+});
+
+// --- Test helpers ---
+
+async function createSchema(p: string): Promise<void> {
+  await execSql(p, `
+    CREATE TABLE chat_message (
+      id varchar(64) PRIMARY KEY,
+      session_id VARCHAR(64),
+      request_id VARCHAR(64),
+      role VARCHAR(64),
+      content TEXT,
+      summary TEXT,
+      summary_modified INTEGER,
+      summary_trigger INTEGER DEFAULT 0,
+      tool_result TEXT,
+      token_info TEXT,
+      model_info TEXT,
+      extra TEXT DEFAULT '',
+      gmt_create INTEGER
+    )
+  `);
+  await execSql(p, `
+    CREATE TABLE chat_record (
+      request_id varchar(64) PRIMARY KEY,
+      session_id varchar(64),
+      extra TEXT DEFAULT ''
+    )
+  `);
+}
+
+async function insertRow(p: string, row: {
+  id: string;
+  session_id: string;
+  request_id: string;
+  role: string;
+  token_info: string;
+  model_info?: string;
+  gmt_create: number;
+}): Promise<void> {
+  await execSql(
+    p,
+    `INSERT INTO chat_message (id, session_id, request_id, role, token_info, model_info, gmt_create)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [row.id, row.session_id, row.request_id, row.role, row.token_info, row.model_info ?? null, row.gmt_create],
+  );
+}
+
+async function insertRecord(p: string, row: {
+  request_id: string;
+  session_id: string;
+  extra: string;
+}): Promise<void> {
+  await execSql(
+    p,
+    `INSERT INTO chat_record (request_id, session_id, extra) VALUES (?, ?, ?)`,
+    [row.request_id, row.session_id, row.extra],
+  );
+}
+
+function execSql(dbPath: string, sql: string, params: unknown[] = []): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const db = new sqlite3.Database(dbPath, (openErr) => {
+      if (openErr) { reject(openErr); return; }
+      db.run(sql, params, (runErr: Error | null) => {
+        db.close((closeErr) => {
+          if (runErr) { reject(runErr); return; }
+          if (closeErr) { reject(closeErr); return; }
+          resolve();
+        });
+      });
+    });
+  });
+}

--- a/tests/unit/inputs/qoder-cn-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-cn-trace-input.test.ts
@@ -1,0 +1,309 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import sqlite3 from 'sqlite3';
+import type { AgentActivityEntry } from '../../../src/types/index.js';
+import { MockStateStore } from '../../helpers/mock-state-store.js';
+
+let tmpHome: string = os.tmpdir();
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return {
+    ...actual,
+    homedir: () => tmpHome,
+    default: { ...actual, homedir: () => tmpHome },
+  };
+});
+
+const { QoderCnTraceInput } = await import('../../../src/inputs/qoder-cn-trace/qoder-cn-trace-input.js');
+const { getTodayDateString } = await import('../../../src/utils/fs-utils.js');
+
+let logDir: string;
+let dbPath: string;
+let stateStore: MockStateStore;
+
+beforeEach(async () => {
+  tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'qodercn-trace-test-'));
+
+  logDir = path.join(tmpHome, '.loongsuite-pilot', 'logs', 'qoder-cn', 'history');
+  await fs.mkdir(logDir, { recursive: true });
+
+  const dbDir = process.platform === 'darwin'
+    ? path.join(tmpHome, 'Library', 'Application Support', 'QoderCN', 'SharedClientCache', 'cache', 'db')
+    : path.join(tmpHome, '.config', 'QoderCN', 'SharedClientCache', 'cache', 'db');
+  await fs.mkdir(dbDir, { recursive: true });
+  dbPath = path.join(dbDir, 'local.db');
+  await createSchema(dbPath);
+
+  stateStore = new MockStateStore();
+});
+
+afterEach(async () => {
+  try { await fs.rm(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('QoderCnTraceInput.collect (session-level enrich)', () => {
+  it('aggregates multiple turns in the same session into one enrich pass', async () => {
+    // SQLite has 2 assistant rows (one per LLM call); hook JSONL has 2 turns
+    // referencing those calls. With session-level aggregation matchIdeTurnsBySqliteOrder
+    // succeeds and tokens/response.id are written via the high-confidence path.
+    const sessionId = 'sess-abc';
+    await insertRow(dbPath, {
+      id: 'msg-1', session_id: sessionId, request_id: 'req-1', role: 'assistant',
+      token_info: JSON.stringify({ prompt_tokens: 100, completion_tokens: 10, cached_tokens: 80 }),
+      gmt_create: 1_780_000_001_000,
+    });
+    await insertRow(dbPath, {
+      id: 'msg-2', session_id: sessionId, request_id: 'req-2', role: 'assistant',
+      token_info: JSON.stringify({ prompt_tokens: 200, completion_tokens: 20, cached_tokens: 150 }),
+      gmt_create: 1_780_000_002_000,
+    });
+
+    await writeHookJsonl(logDir, [
+      buildEntry({ event: 'llm.request', turn: 'turn-A', step: 'turn-A:s1', session: sessionId, ts: 1_780_000_000_000 }),
+      buildEntry({ event: 'llm.response', turn: 'turn-A', step: 'turn-A:s1', session: sessionId, ts: 1_780_000_001_000 }),
+      buildEntry({ event: 'llm.request', turn: 'turn-B', step: 'turn-B:s1', session: sessionId, ts: 1_780_000_001_500 }),
+      buildEntry({ event: 'llm.response', turn: 'turn-B', step: 'turn-B:s1', session: sessionId, ts: 1_780_000_002_000 }),
+    ]);
+
+    const entries = await collectOnce();
+
+    const responses = entries.filter(e => e['event.name'] === 'llm.response');
+    expect(responses).toHaveLength(2);
+
+    const respA = responses.find(e => e['gen_ai.turn.id'] === 'turn-A')!;
+    const respB = responses.find(e => e['gen_ai.turn.id'] === 'turn-B')!;
+    expect(respA['gen_ai.usage.input_tokens']).toBe(100);
+    expect(respA['gen_ai.usage.output_tokens']).toBe(10);
+    expect(respA['gen_ai.response.id']).toBe('msg-1');
+    expect(respB['gen_ai.usage.input_tokens']).toBe(200);
+    expect(respB['gen_ai.usage.output_tokens']).toBe(20);
+    expect(respB['gen_ai.response.id']).toBe('msg-2');
+  });
+
+  it('assigns a distinct trace_id per turn even when sessionId is shared', async () => {
+    const sessionId = 'sess-trace';
+    await insertRow(dbPath, {
+      id: 'msg-x', session_id: sessionId, request_id: 'req-x', role: 'assistant',
+      token_info: JSON.stringify({ prompt_tokens: 5, completion_tokens: 5, cached_tokens: 0 }),
+      gmt_create: 1_780_000_010_000,
+    });
+    await insertRow(dbPath, {
+      id: 'msg-y', session_id: sessionId, request_id: 'req-y', role: 'assistant',
+      token_info: JSON.stringify({ prompt_tokens: 6, completion_tokens: 6, cached_tokens: 0 }),
+      gmt_create: 1_780_000_011_000,
+    });
+
+    await writeHookJsonl(logDir, [
+      buildEntry({ event: 'llm.response', turn: 'turn-1', step: 'turn-1:s1', session: sessionId, ts: 1_780_000_010_000 }),
+      buildEntry({ event: 'llm.response', turn: 'turn-2', step: 'turn-2:s1', session: sessionId, ts: 1_780_000_011_000 }),
+    ]);
+
+    const entries = await collectOnce();
+    const traceForTurn1 = entries.find(e => e['gen_ai.turn.id'] === 'turn-1')!.trace_id;
+    const traceForTurn2 = entries.find(e => e['gen_ai.turn.id'] === 'turn-2')!.trace_id;
+    expect(traceForTurn1).toBeTruthy();
+    expect(traceForTurn2).toBeTruthy();
+    expect(traceForTurn1).not.toBe(traceForTurn2);
+  });
+
+  it('deduplicates events within a turn by (step_id, event_name, tool_call_id)', async () => {
+    // When the hook processor writes events for the same turn multiple times
+    // (partial turn from an earlier retry + complete turn from Stop retry),
+    // only the last event per key should be emitted.
+    const sessionId = 'sess-dedupe';
+    const baseTs = 1_780_000_200_000;
+    await insertRow(dbPath, {
+      id: 'msg-d1', session_id: sessionId, request_id: 'req-d', role: 'assistant',
+      token_info: JSON.stringify({ prompt_tokens: 10, completion_tokens: 2, cachedTokens: 0 }),
+      gmt_create: baseTs,
+    });
+    await insertRow(dbPath, {
+      id: 'msg-d2', session_id: sessionId, request_id: 'req-d2', role: 'assistant',
+      token_info: JSON.stringify({ prompt_tokens: 15, completion_tokens: 3, cachedTokens: 0 }),
+      gmt_create: baseTs + 100,
+    });
+
+    await writeHookJsonl(logDir, [
+      // First batch: partial turn (missing llm.response for step 2)
+      buildEntry({ event: 'llm.request', turn: 'turn-d', step: 'turn-d:s1', session: sessionId, ts: baseTs }),
+      buildEntry({ event: 'llm.response', turn: 'turn-d', step: 'turn-d:s1', session: sessionId, ts: baseTs }),
+      buildEntry({ event: 'tool.call', turn: 'turn-d', step: 'turn-d:s1', session: sessionId, ts: baseTs }),
+      // Second batch: complete turn with same step IDs (simulates Stop retry reprocessing)
+      buildEntry({ event: 'llm.request', turn: 'turn-d', step: 'turn-d:s1', session: sessionId, ts: baseTs + 1 }),
+      buildEntry({ event: 'llm.response', turn: 'turn-d', step: 'turn-d:s1', session: sessionId, ts: baseTs + 1 }),
+      buildEntry({ event: 'tool.call', turn: 'turn-d', step: 'turn-d:s1', session: sessionId, ts: baseTs + 1 }),
+      buildEntry({ event: 'tool.result', turn: 'turn-d', step: 'turn-d:s1', session: sessionId, ts: baseTs + 2 }),
+      buildEntry({ event: 'llm.response', turn: 'turn-d', step: 'turn-d:s2', session: sessionId, ts: baseTs + 100 }),
+      buildEntry({ event: 'llm.request', turn: 'turn-d', step: 'turn-d:s2', session: sessionId, ts: baseTs + 99 }),
+    ]);
+
+    const entries = await collectOnce();
+    // Only one llm.request for step 1 (last occurrence, ts = baseTs + 1)
+    const step1Requests = entries.filter(e => e['event.name'] === 'llm.request' && e['gen_ai.step.id'] === 'turn-d:s1');
+    expect(step1Requests).toHaveLength(1);
+    expect(step1Requests[0].time_unix_nano).toBe(`${baseTs + 1}000000`);
+
+    // Only one llm.response for step 1
+    const step1Responses = entries.filter(e => e['event.name'] === 'llm.response' && e['gen_ai.step.id'] === 'turn-d:s1');
+    expect(step1Responses).toHaveLength(1);
+
+    // tool.call for step 1 kept (last occurrence)
+    const toolCalls = entries.filter(e => e['event.name'] === 'tool.call' && e['gen_ai.step.id'] === 'turn-d:s1');
+    expect(toolCalls).toHaveLength(1);
+
+    // tool.result for step 1 kept
+    const toolResults = entries.filter(e => e['event.name'] === 'tool.result' && e['gen_ai.step.id'] === 'turn-d:s1');
+    expect(toolResults).toHaveLength(1);
+
+    // step 2 events kept
+    const step2Requests = entries.filter(e => e['event.name'] === 'llm.request' && e['gen_ai.step.id'] === 'turn-d:s2');
+    const step2Responses = entries.filter(e => e['event.name'] === 'llm.response' && e['gen_ai.step.id'] === 'turn-d:s2');
+    expect(step2Requests).toHaveLength(1);
+    expect(step2Responses).toHaveLength(1);
+  });
+
+  it('preserves +1ms gap between tool.call and tool.result in a step with llm.response', async () => {
+    const sessionId = 'sess-tool-dur';
+    // Simulate: step s1 has llm.response (at T+500ms), tool.call (at T+500ms), tool.result (at T+501ms, +1ms).
+    // expandContainerTimes must NOT collapse the +1ms gap by pushing tool.result to turn max.
+    const baseTs = 1_780_000_050_000;
+    await insertRow(dbPath, {
+      id: 'msg-t', session_id: sessionId, request_id: 'req-t', role: 'assistant',
+      token_info: JSON.stringify({ prompt_tokens: 10, completion_tokens: 2, cached_tokens: 0 }),
+      gmt_create: baseTs,
+    });
+
+    await writeHookJsonl(logDir, [
+      buildEntry({ event: 'llm.response', turn: 'turn-t', step: 'turn-t:s1', session: sessionId, ts: baseTs }),
+      buildEntry({ event: 'tool.call', turn: 'turn-t', step: 'turn-t:s1', session: sessionId, ts: baseTs }),
+      buildEntry({ event: 'tool.result', turn: 'turn-t', step: 'turn-t:s1', session: sessionId, ts: baseTs + 1 }),
+    ]);
+
+    const entries = await collectOnce();
+    const tc = entries.find(e => e['event.name'] === 'tool.call')!;
+    const tr = entries.find(e => e['event.name'] === 'tool.result')!;
+    const tcMs = Number(BigInt(tc.time_unix_nano as string) / BigInt(1_000_000));
+    const trMs = Number(BigInt(tr.time_unix_nano as string) / BigInt(1_000_000));
+    expect(trMs - tcMs).toBeGreaterThanOrEqual(1);
+  });
+
+  it('skips SQLite enrich for entries without a sessionId but still injects trace_id', async () => {
+    await writeHookJsonl(logDir, [
+      buildEntry({ event: 'llm.response', turn: 'orphan-turn', step: 'orphan:s1', session: '', ts: 1_780_000_020_000 }),
+    ]);
+
+    const entries = await collectOnce();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].trace_id).toBeTruthy();
+    // No tokens were enriched (no session id to look up)
+    expect(entries[0]['gen_ai.usage.input_tokens']).toBeUndefined();
+  });
+});
+
+// --- Test helpers ---
+
+async function collectOnce(): Promise<AgentActivityEntry[]> {
+  const input = new QoderCnTraceInput({
+    stateStore: stateStore as any,
+    logDir,
+    pollIntervalMs: 60_000,
+  });
+  const collected: AgentActivityEntry[] = [];
+  input.on('entries', (batch: AgentActivityEntry[]) => collected.push(...batch));
+  await input.start();
+  await input.stop();
+  return collected;
+}
+
+interface BuildOpts {
+  event: 'llm.request' | 'llm.response' | 'tool.call' | 'tool.result';
+  turn: string;
+  step: string;
+  session: string;
+  ts: number;
+}
+
+function buildEntry(opts: BuildOpts): Record<string, unknown> {
+  return {
+    'event.id': `${opts.turn}-${opts.event}-${opts.step}`,
+    'event.name': opts.event,
+    'gen_ai.session.id': opts.session,
+    'gen_ai.turn.id': opts.turn,
+    'gen_ai.step.id': opts.step,
+    'gen_ai.agent.type': 'qoder-cn',
+    'gen_ai.provider.name': 'qwen',
+    'gen_ai.request.model': 'auto',
+    'gen_ai.response.model': 'auto',
+    time_unix_nano: `${opts.ts}000000`,
+    observed_time_unix_nano: `${opts.ts}000000`,
+  };
+}
+
+async function writeHookJsonl(dir: string, records: Record<string, unknown>[]): Promise<void> {
+  const today = getTodayDateString();
+  const logFile = path.join(dir, `qoder-cn-${today}.jsonl`);
+  const lines = records.map(r => JSON.stringify(r)).join('\n') + '\n';
+  await fs.writeFile(logFile, lines, 'utf-8');
+}
+
+async function createSchema(p: string): Promise<void> {
+  await execSql(p, `
+    CREATE TABLE chat_message (
+      id varchar(64) PRIMARY KEY,
+      session_id VARCHAR(64),
+      request_id VARCHAR(64),
+      role VARCHAR(64),
+      content TEXT,
+      summary TEXT,
+      summary_modified INTEGER,
+      summary_trigger INTEGER DEFAULT 0,
+      tool_result TEXT,
+      token_info TEXT,
+      model_info TEXT,
+      extra TEXT DEFAULT '',
+      gmt_create INTEGER
+    )
+  `);
+  await execSql(p, `
+    CREATE TABLE chat_record (
+      request_id varchar(64) PRIMARY KEY,
+      session_id varchar(64),
+      extra TEXT DEFAULT ''
+    )
+  `);
+}
+
+async function insertRow(p: string, row: {
+  id: string;
+  session_id: string;
+  request_id: string;
+  role: string;
+  token_info: string;
+  model_info?: string;
+  gmt_create: number;
+}): Promise<void> {
+  await execSql(
+    p,
+    `INSERT INTO chat_message (id, session_id, request_id, role, token_info, model_info, gmt_create)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [row.id, row.session_id, row.request_id, row.role, row.token_info, row.model_info ?? null, row.gmt_create],
+  );
+}
+
+function execSql(dbPath: string, sql: string, params: unknown[] = []): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const db = new sqlite3.Database(dbPath, (openErr) => {
+      if (openErr) { reject(openErr); return; }
+      db.run(sql, params, (runErr: Error | null) => {
+        db.close((closeErr) => {
+          if (runErr) { reject(runErr); return; }
+          if (closeErr) { reject(closeErr); return; }
+          resolve();
+        });
+      });
+    });
+  });
+}

--- a/tests/unit/inputs/qoder-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-trace-input.test.ts
@@ -295,8 +295,6 @@ describe('QoderTraceInput token-enricher', () => {
 
       expect(entries[1]['gen_ai.response.id']).toBeUndefined();
       expect(entries[1]['gen_ai.response.model']).toBe('auto');
-      expect((entries[1] as any)['qoder.match_confidence']).toBe('low');
-      expect((entries[1] as any)['qoder.match.warning']).toBe('assistant_count_mismatch');
     });
   });
 
@@ -389,57 +387,6 @@ describe('QoderTraceInput token-enricher', () => {
 
       // Empty input → early return, no modification
       expect(entries[0]['gen_ai.usage.input_tokens']).toBeUndefined();
-    });
-  });
-
-  describe('enrichCliTurn with systemPrompt', () => {
-    it('injects system prompt into first llm.request with step_id', () => {
-      const entries: AgentActivityEntry[] = [
-        makeEntry({ 'event.name': 'other', 'gen_ai.step.id': undefined } as any),
-        makeEntry({ 'gen_ai.response.id': 'req-A', 'event.name': 'llm.request', 'gen_ai.step.id': 'turn-1:s1' } as any),
-        makeEntry({ 'gen_ai.response.id': 'req-A', 'event.name': 'llm.response' }),
-      ];
-      const segments: SegmentTokenData[] = [{
-        requestId: 'req-A',
-        inputTokens: 5000,
-        outputTokens: 200,
-        cacheReadTokens: 0,
-        cacheCreationTokens: 0,
-        requestStartTs: 0,
-        responseEndTs: 0,
-        toolFinishedTs: 0,
-        stopReason: '',
-        model: '',
-      }];
-
-      enrichCliTurn(entries, segments, 'You are a helpful assistant.');
-
-      const sysInstr = (entries[1] as Record<string, unknown>)['gen_ai.system_instructions'];
-      expect(sysInstr).toEqual([{ type: 'text', content: 'You are a helpful assistant.' }]);
-      expect((entries[0] as Record<string, unknown>)['gen_ai.system_instructions']).toBeUndefined();
-    });
-
-    it('does not inject system prompt when undefined', () => {
-      const entries: AgentActivityEntry[] = [
-        makeEntry({ 'event.name': 'llm.request', 'gen_ai.step.id': undefined } as any),
-        makeEntry({ 'gen_ai.response.id': 'req-A', 'event.name': 'llm.response' }),
-      ];
-      const segments: SegmentTokenData[] = [{
-        requestId: 'req-A',
-        inputTokens: 100,
-        outputTokens: 10,
-        cacheReadTokens: 0,
-        cacheCreationTokens: 0,
-        requestStartTs: 0,
-        responseEndTs: 0,
-        toolFinishedTs: 0,
-        stopReason: '',
-        model: '',
-      }];
-
-      enrichCliTurn(entries, segments);
-
-      expect((entries[0] as Record<string, unknown>)['gen_ai.system_instructions']).toBeUndefined();
     });
   });
 

--- a/tests/unit/inputs/qoder-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-trace-input.test.ts
@@ -390,6 +390,57 @@ describe('QoderTraceInput token-enricher', () => {
     });
   });
 
+  describe('enrichCliTurn with systemPrompt', () => {
+    it('injects system prompt into first llm.request with step_id', () => {
+      const entries: AgentActivityEntry[] = [
+        makeEntry({ 'event.name': 'other', 'gen_ai.step.id': undefined } as any),
+        makeEntry({ 'gen_ai.response.id': 'req-A', 'event.name': 'llm.request', 'gen_ai.step.id': 'turn-1:s1' } as any),
+        makeEntry({ 'gen_ai.response.id': 'req-A', 'event.name': 'llm.response' }),
+      ];
+      const segments: SegmentTokenData[] = [{
+        requestId: 'req-A',
+        inputTokens: 5000,
+        outputTokens: 200,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        requestStartTs: 0,
+        responseEndTs: 0,
+        toolFinishedTs: 0,
+        stopReason: '',
+        model: '',
+      }];
+
+      enrichCliTurn(entries, segments, 'You are a helpful assistant.');
+
+      const sysInstr = (entries[1] as Record<string, unknown>)['gen_ai.system_instructions'];
+      expect(sysInstr).toEqual([{ type: 'text', content: 'You are a helpful assistant.' }]);
+      expect((entries[0] as Record<string, unknown>)['gen_ai.system_instructions']).toBeUndefined();
+    });
+
+    it('does not inject system prompt when undefined', () => {
+      const entries: AgentActivityEntry[] = [
+        makeEntry({ 'event.name': 'llm.request', 'gen_ai.step.id': undefined } as any),
+        makeEntry({ 'gen_ai.response.id': 'req-A', 'event.name': 'llm.response' }),
+      ];
+      const segments: SegmentTokenData[] = [{
+        requestId: 'req-A',
+        inputTokens: 100,
+        outputTokens: 10,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        requestStartTs: 0,
+        responseEndTs: 0,
+        toolFinishedTs: 0,
+        stopReason: '',
+        model: '',
+      }];
+
+      enrichCliTurn(entries, segments);
+
+      expect((entries[0] as Record<string, unknown>)['gen_ai.system_instructions']).toBeUndefined();
+    });
+  });
+
   describe('injectTraceId', () => {
     it('generates same trace_id for all events in a turn', () => {
       const entries: AgentActivityEntry[] = [


### PR DESCRIPTION
## Summary

Production data showed qoder-cn had `llm.request.gen_ai.step.id` at 50%, `llm.response.gen_ai.response.id` / `input_tokens` / `output_tokens` at 0%, `tool.call.duration` at 0, plus duplicate events (one user input producing multiple turns/traces). This PR addresses all of these by aligning qoder-cn's transcript handling with the spec and with the qoder/qoder-work implementations.

### Root causes

- **Hook processor** emitted partial turns from `PostToolUse` retries instead of waiting for `Stop` and reprocessing the full transcript (claude-code does the latter).
- **enrichIdeTurn**'s backwards `llm.request` scan was unbounded across turns, overwriting earlier turns' request timestamps and breaking step-1 timing.
- **sqlite-token-reader** joined tables differently from `qoder-trace`, missing `message_id` and `model_info`, so `gen_ai.response.id` / model fields stayed empty.
- **Cross-cycle orphan turns** (response arriving in a later collect cycle than its anchor user prompt) were emitted as standalone turns.
- **Container spans** (STEP / AGENT / ENTRY) inherited only the first child's time, collapsing to 0ms; `tool.result` lacked an explicit duration field.
- Custom `qoder.match.*` fields polluted output and aren't part of the trace spec.

### Changes

- `assets/hooks/qoder-hook-processor.mjs`: add lockfile-based retry gating. Phase 2.5 skips processing unless a `Stop` event is present in the progress log, then resets `startLine = 0` to reprocess the full transcript (claude-code style).
- `src/inputs/qoder-cn-trace/qoder-cn-trace-input.ts`: introduce `sessionAnchor` (cross-cycle Map) to merge orphan turns into their anchor turn; add `dedupeEventsInTurn`, `expandContainerTimes` (skips `llm.*` / `tool.*` / `other`), `propagateModelToToolEvents`, `computeToolCallDurations`, and `alignUserBoundaryToFirstLlmRequest`.
- `src/inputs/qoder-cn-trace/sqlite-token-reader.ts`: align SQL with `qoder-trace`'s reader (LEFT JOIN `chat_record`, parse `model_info`), expose `sessionId` / `messageId` / `model` on `SqliteTokenData`.
- `src/inputs/qoder-trace/token-enricher.ts`: scope the backwards `llm.request` scan to the same `step.id` (with same-turn fallback); offset step-1 request by +1ms past `userBoundary` to avoid a duplicate empty STEP; remove `qoder.match_confidence` / `qoder.match.strategy` / `qoder.match.warning` custom fields; `markLowConfidence` becomes a no-op.
- `scripts/field-coverage.mjs`: validation script for per-event-type field coverage.
- Tests: 24 new unit tests across hooks, sqlite reader, and trace input.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/unit/inputs/` — 272/272 pass
- [x] New unit tests for retry lock, sqlite reader, and qoder-cn trace input — 39/39 pass
- [x] Local end-to-end: 100% field coverage on `llm.request` / `llm.response` / `tool.call` / `tool.result`
- [x] Local end-to-end: 0 `validate-trace` errors, 7 correctly-structured spans per multi-step turn, no duplicate traces