### PR TITLE
fix(wukong): handle null session_id and empty CLI stdout after Wukong CLI upgrade

### DIFF
--- a/src/inputs/wukong/wukong-input.ts
+++ b/src/inputs/wukong/wukong-input.ts
@@ -25,7 +25,7 @@ const CLI_MAX_BUFFER = 10 * 1024 * 1024;
 
 interface WukongTask {
   id: string;
-  session_id: string;
+  session_id: string | null;
   name: string;
   status: string;
   agent_type: string;
@@ -1294,6 +1294,12 @@ export class WukongInput extends BaseInput {
         ['agent', 'data', 'list_tasks', '--json', JSON.stringify(params)],
         { timeout: CLI_TIMEOUT_MS, maxBuffer: CLI_MAX_BUFFER, signal: this._abortController.signal },
       );
+      if (!stdout || !stdout.trim()) {
+        this.logger.debug('wukong-cli list_tasks returned empty stdout', {
+          stderr: (stderr ?? '').slice(0, 256),
+        });
+        break;
+      }
       let parsed: unknown;
       try {
         parsed = JSON.parse(stdout);
@@ -1304,7 +1310,9 @@ export class WukongInput extends BaseInput {
         throw new Error('unexpected listTasks response structure');
       }
       const resp = parsed as ListTasksResponse;
-      allTasks.push(...resp.items);
+      for (const item of resp.items) {
+        if (item.session_id) allTasks.push(item);
+      }
       cursor = resp.hasMore ? resp.nextCursor : undefined;
       hasMore = !!resp.hasMore;
     } while (cursor && allTasks.length < MAX_TASKS);
@@ -1323,6 +1331,13 @@ export class WukongInput extends BaseInput {
       ['agent', 'data', 'get_spark_agui_messages', '--json', JSON.stringify({ conversationId })],
       { timeout: CLI_TIMEOUT_MS, maxBuffer: CLI_MAX_BUFFER, signal: this._abortController.signal },
     );
+    if (!stdout || !stdout.trim()) {
+      this.logger.debug('wukong-cli get_spark_agui_messages returned empty stdout, treating as no messages', {
+        conversationId,
+        stderr: (stderr ?? '').slice(0, 256),
+      });
+      return { messages: [] };
+    }
     let parsed: unknown;
     try {
       parsed = JSON.parse(stdout);

--- a/src/inputs/wukong/wukong-input.ts
+++ b/src/inputs/wukong/wukong-input.ts
@@ -41,6 +41,8 @@ interface WukongTask {
   };
 }
 
+type ValidWukongTask = WukongTask & { session_id: string };
+
 interface ListTasksResponse {
   hasMore: boolean;
   items: WukongTask[];
@@ -217,7 +219,7 @@ export class WukongInput extends BaseInput {
         ? { ...(state.extra.seenCounts as Record<string, number>) }
         : {};
 
-    let tasks: WukongTask[];
+    let tasks: ValidWukongTask[];
     try {
       tasks = await this.listAllTasks();
     } catch (err) {
@@ -304,7 +306,7 @@ export class WukongInput extends BaseInput {
   }
 
   private async processOneTask(
-    task: WukongTask,
+    task: ValidWukongTask,
     prevCount: number,
   ): Promise<{ entries: AgentActivityEntry[]; newSeenCount: number } | null> {
     const messagesResp = await this.getMessages(task.session_id);
@@ -324,7 +326,7 @@ export class WukongInput extends BaseInput {
     return { entries, newSeenCount: prevCount + processable.length };
   }
 
-  private transformMessages(task: WukongTask, messages: WukongMessage[]): AgentActivityEntry[] {
+  private transformMessages(task: ValidWukongTask, messages: WukongMessage[]): AgentActivityEntry[] {
     const entries: AgentActivityEntry[] = [];
     const sessionId = task.session_id;
     const meta = (task.metadata && typeof task.metadata === 'object')
@@ -403,7 +405,7 @@ export class WukongInput extends BaseInput {
   }
 
   private transformAssistantMessage(
-    task: WukongTask,
+    task: ValidWukongTask,
     msg: WukongMessage,
     events: AguiEvent[],
     model: string,
@@ -1099,7 +1101,7 @@ export class WukongInput extends BaseInput {
   }
 
   private buildToolCallEntry(
-    task: WukongTask,
+    task: ValidWukongTask,
     msg: WukongMessage,
     evt: AguiEvent,
     model: string,
@@ -1142,7 +1144,7 @@ export class WukongInput extends BaseInput {
   }
 
   private buildToolResultEntry(
-    task: WukongTask,
+    task: ValidWukongTask,
     msg: WukongMessage,
     evt: AguiEvent,
     model: string,
@@ -1186,7 +1188,7 @@ export class WukongInput extends BaseInput {
   }
 
   private transformActivitySnapshot(
-    task: WukongTask,
+    task: ValidWukongTask,
     msg: WukongMessage,
     evt: AguiEvent,
     model: string,
@@ -1282,8 +1284,8 @@ export class WukongInput extends BaseInput {
     return [toolCallEntry, toolResultEntry];
   }
 
-  private async listAllTasks(): Promise<WukongTask[]> {
-    const allTasks: WukongTask[] = [];
+  private async listAllTasks(): Promise<Array<WukongTask & { session_id: string }>> {
+    const allTasks: Array<WukongTask & { session_id: string }> = [];
     let cursor: string | undefined;
     let hasMore = false;
     do {
@@ -1294,7 +1296,7 @@ export class WukongInput extends BaseInput {
         ['agent', 'data', 'list_tasks', '--json', JSON.stringify(params)],
         { timeout: CLI_TIMEOUT_MS, maxBuffer: CLI_MAX_BUFFER, signal: this._abortController.signal },
       );
-      if (!stdout || !stdout.trim()) {
+      if (!stdout || !/\S/.test(stdout)) {
         this.logger.debug('wukong-cli list_tasks returned empty stdout', {
           stderr: (stderr ?? '').slice(0, 256),
         });
@@ -1311,7 +1313,7 @@ export class WukongInput extends BaseInput {
       }
       const resp = parsed as ListTasksResponse;
       for (const item of resp.items) {
-        if (item.session_id) allTasks.push(item);
+        if (item.session_id != null) allTasks.push(item as WukongTask & { session_id: string });
       }
       cursor = resp.hasMore ? resp.nextCursor : undefined;
       hasMore = !!resp.hasMore;
@@ -1331,10 +1333,12 @@ export class WukongInput extends BaseInput {
       ['agent', 'data', 'get_spark_agui_messages', '--json', JSON.stringify({ conversationId })],
       { timeout: CLI_TIMEOUT_MS, maxBuffer: CLI_MAX_BUFFER, signal: this._abortController.signal },
     );
-    if (!stdout || !stdout.trim()) {
-      this.logger.debug('wukong-cli get_spark_agui_messages returned empty stdout, treating as no messages', {
+    if (!stdout || !/\S/.test(stdout)) {
+      const stderrSnippet = (stderr ?? '').slice(0, 256);
+      const logLevel = stderrSnippet ? 'warn' : 'debug';
+      this.logger[logLevel]('wukong-cli get_spark_agui_messages returned empty stdout, treating as no messages', {
         conversationId,
-        stderr: (stderr ?? '').slice(0, 256),
+        stderr: stderrSnippet,
       });
       return { messages: [] };
     }

--- a/tests/unit/inputs/wukong-input.test.ts
+++ b/tests/unit/inputs/wukong-input.test.ts
@@ -1278,12 +1278,31 @@ describe('WukongInput', () => {
 
   it('filters out tasks with null session_id from list_tasks', async () => {
     const taskWithNullSession = { ...SAMPLE_TASK, id: 'task-null', session_id: null as any, status: 'failed' };
-    mockExecFile.mockImplementation(makeExecFileImplByConversation(
-      JSON.stringify({ hasMore: false, items: [SAMPLE_TASK, taskWithNullSession] }),
-      {
-        'sess-1': JSON.stringify({ messages: SAMPLE_MESSAGES }),
-      },
-    ));
+    const getMessagesCalls: string[] = [];
+    mockExecFile.mockImplementation((...allArgs: unknown[]) => {
+      const cb = allArgs[allArgs.length - 1] as Function;
+      const args = allArgs[1] as string[];
+      const subcommand = args.join(' ');
+
+      if (subcommand.includes('list_tasks')) {
+        cb(null, {
+          stdout: JSON.stringify({ hasMore: false, items: [SAMPLE_TASK, taskWithNullSession] }),
+          stderr: '',
+        });
+        return;
+      }
+      if (subcommand.includes('get_spark_agui_messages')) {
+        const jsonArg = args[args.length - 1]!;
+        const parsed = JSON.parse(jsonArg);
+        getMessagesCalls.push(parsed.conversationId);
+        cb(null, {
+          stdout: JSON.stringify({ messages: SAMPLE_MESSAGES }),
+          stderr: '',
+        });
+        return;
+      }
+      cb(new Error(`unexpected: ${subcommand}`), { stdout: '', stderr: '' });
+    });
 
     createInput();
     seedSeenCounts();
@@ -1295,8 +1314,8 @@ describe('WukongInput', () => {
     // Should only process the task with valid session_id
     const sessionIds = new Set(entries.map(e => e['gen_ai.session.id']));
     expect(sessionIds.has('sess-1')).toBe(true);
-    // The null-session task should never trigger a getMessages call
-    // (if it did, makeExecFileImplByConversation would error on the missing key)
+    // getMessages should only be called for sess-1, never for null
+    expect(getMessagesCalls).toEqual(['sess-1']);
   });
 
   it('handles empty stdout from get_spark_agui_messages gracefully', async () => {

--- a/tests/unit/inputs/wukong-input.test.ts
+++ b/tests/unit/inputs/wukong-input.test.ts
@@ -1276,6 +1276,109 @@ describe('WukongInput', () => {
     expect(respS2['gen_ai.response.finish_reasons']).toEqual(['end_turn']);
   });
 
+  it('filters out tasks with null session_id from list_tasks', async () => {
+    const taskWithNullSession = { ...SAMPLE_TASK, id: 'task-null', session_id: null as any, status: 'failed' };
+    mockExecFile.mockImplementation(makeExecFileImplByConversation(
+      JSON.stringify({ hasMore: false, items: [SAMPLE_TASK, taskWithNullSession] }),
+      {
+        'sess-1': JSON.stringify({ messages: SAMPLE_MESSAGES }),
+      },
+    ));
+
+    createInput();
+    seedSeenCounts();
+    const entries: AgentActivityEntry[] = [];
+    input.on('entries', (e: AgentActivityEntry[]) => entries.push(...e));
+    await input.start();
+    await input.stop();
+
+    // Should only process the task with valid session_id
+    const sessionIds = new Set(entries.map(e => e['gen_ai.session.id']));
+    expect(sessionIds.has('sess-1')).toBe(true);
+    // The null-session task should never trigger a getMessages call
+    // (if it did, makeExecFileImplByConversation would error on the missing key)
+  });
+
+  it('handles empty stdout from get_spark_agui_messages gracefully', async () => {
+    mockExecFile.mockImplementation((...allArgs: unknown[]) => {
+      const cb = allArgs[allArgs.length - 1] as Function;
+      const args = allArgs[1] as string[];
+      const subcommand = args.join(' ');
+
+      if (subcommand.includes('list_tasks')) {
+        cb(null, {
+          stdout: JSON.stringify({ hasMore: false, items: [SAMPLE_TASK] }),
+          stderr: '',
+        });
+        return;
+      }
+      if (subcommand.includes('get_spark_agui_messages')) {
+        // Simulate the daemon gateway returning empty stdout
+        cb(null, { stdout: '', stderr: '' });
+        return;
+      }
+      cb(new Error(`unexpected: ${subcommand}`), { stdout: '', stderr: '' });
+    });
+
+    createInput();
+    seedSeenCounts();
+    const entries: AgentActivityEntry[] = [];
+    input.on('entries', (e: AgentActivityEntry[]) => entries.push(...e));
+    await input.start();
+    await input.stop();
+
+    // Should not crash; should emit no entries (treated as empty messages)
+    expect(entries).toHaveLength(0);
+  });
+
+  it('handles whitespace-only stdout from get_spark_agui_messages gracefully', async () => {
+    mockExecFile.mockImplementation((...allArgs: unknown[]) => {
+      const cb = allArgs[allArgs.length - 1] as Function;
+      const args = allArgs[1] as string[];
+      const subcommand = args.join(' ');
+
+      if (subcommand.includes('list_tasks')) {
+        cb(null, {
+          stdout: JSON.stringify({ hasMore: false, items: [SAMPLE_TASK] }),
+          stderr: '',
+        });
+        return;
+      }
+      if (subcommand.includes('get_spark_agui_messages')) {
+        cb(null, { stdout: '  \n  ', stderr: '' });
+        return;
+      }
+      cb(new Error(`unexpected: ${subcommand}`), { stdout: '', stderr: '' });
+    });
+
+    createInput();
+    seedSeenCounts();
+    const entries: AgentActivityEntry[] = [];
+    input.on('entries', (e: AgentActivityEntry[]) => entries.push(...e));
+    await input.start();
+    await input.stop();
+
+    expect(entries).toHaveLength(0);
+  });
+
+  it('handles empty stdout from list_tasks gracefully', async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+        // Simulate daemon gateway returning empty stdout for list_tasks
+        cb(null, { stdout: '', stderr: '' });
+      },
+    );
+
+    createInput();
+    seedSeenCounts();
+    const entries: AgentActivityEntry[] = [];
+    input.on('entries', (e: AgentActivityEntry[]) => entries.push(...e));
+    await input.start();
+    await input.stop();
+
+    expect(entries).toHaveLength(0);
+  });
+
   it('prunes seenCounts after STALE_PRUNE_THRESHOLD consecutive misses', async () => {
     mockExecFile.mockImplementation(makeExecFileImpl({
       list_tasks: JSON.stringify({ hasMore: false, items: [SAMPLE_TASK] }),


### PR DESCRIPTION
## Summary

After the Wukong CLI architecture change (where `agent data` commands are now routed through the daemon gateway instead of being built-in subcommands), two issues surfaced in production:

- **`list_tasks` now returns tasks with `session_id: null`** (e.g., failed tasks). Our code passed this null into `getMessages()`, causing `execFile` to error on `{"conversationId":null}`. Fixed by filtering out tasks with falsy `session_id` during listing.

- **`get_spark_agui_messages` occasionally returns empty stdout** (exit code 0, no JSON) when the daemon gateway fails to respond. `JSON.parse('')` threw `Unexpected end of JSON input`. Fixed by checking for empty/whitespace-only stdout before parsing, returning `{ messages: [] }` with debug logging instead of crashing.

Both `listAllTasks` and `getMessages` now have defensive empty-stdout handling consistent with the new CLI gateway architecture.

## Test plan

- [x] Added test: `filters out tasks with null session_id from list_tasks`
- [x] Added test: `handles empty stdout from get_spark_agui_messages gracefully`
- [x] Added test: `handles whitespace-only stdout from get_spark_agui_messages gracefully`
- [x] Added test: `handles empty stdout from list_tasks gracefully`
- [x] All 36 existing + new tests pass

Made with [Cursor](https://cursor.com)