### PR TITLE
fix bug: not updating version for codex hook.json

### DIFF
--- a/src/deployment/hook-strategy.ts
+++ b/src/deployment/hook-strategy.ts
@@ -70,6 +70,10 @@ export class HookStrategy implements DeployStrategy {
   }
 
   async needsDeploy(def: AgentDefinition, _record?: DeployedAgentRecord): Promise<boolean> {
+    if (await this.needsSettingsRepairForCodex(def)) {
+      return true;
+    }
+
     const hookDefs = this.buildHookDefinitions(def);
     for (const hookDef of hookDefs) {
       if (!(await this.hookManager.isHookInstalled(hookDef))) {
@@ -77,6 +81,17 @@ export class HookStrategy implements DeployStrategy {
       }
     }
     return false;
+  }
+
+  private async needsSettingsRepairForCodex(def: AgentDefinition): Promise<boolean> {
+    const settingsPath = def.hook?.settingsPath;
+    if (!settingsPath) return false;
+
+    const isCodexHooksJson = settingsPath.endsWith('hooks.json') && settingsPath.includes('.codex');
+    if (!isCodexHooksJson) return false;
+
+    const existing = await readJsonFile<Record<string, unknown>>(settingsPath);
+    return existing?.version !== undefined;
   }
 
   async deploy(def: AgentDefinition): Promise<DeployResult> {

--- a/tests/unit/deployment/hook-strategy.test.ts
+++ b/tests/unit/deployment/hook-strategy.test.ts
@@ -91,6 +91,23 @@ describe('HookStrategy', () => {
       expect(mockHookManager.isHookInstalled).toHaveBeenCalledTimes(2);
     });
 
+    it('returns true when Codex hooks.json has a stale version field', async () => {
+      vi.mocked(readJsonFile).mockResolvedValue({ version: 1, hooks: {} });
+      mockHookManager.isHookInstalled.mockResolvedValue(true);
+
+      const result = await strategy.needsDeploy(makeDef({
+        hook: {
+          settingsPath: '/home/.codex/hooks.json',
+          events: ['Stop'],
+          hookCommand: '/opt/pilot/hooks/test.sh',
+          format: 'nested',
+        },
+      }));
+
+      expect(result).toBe(true);
+      expect(mockHookManager.isHookInstalled).not.toHaveBeenCalled();
+    });
+
     it('builds correct hook definitions from agent config', async () => {
       mockHookManager.isHookInstalled.mockResolvedValue(true);
       const def = makeDef();


### PR DESCRIPTION
followup of  https://github.com/alibaba/loongsuite-pilot/pull/74/changes

升级的时候有个needsDeploy函数，它检查发现hook都设置好了就会跳过修改hook settings。本意是避免覆盖写。但这个设计导致上述PR的修复失败。
这个PR修复了这个问题