### PR TITLE
feat(qoderwork): intercept token usage via QODER_WORKER_RUNTIME_PATH wrapper

### DIFF
--- a/assets/hooks/qoderwork-hook-processor.mjs
+++ b/assets/hooks/qoderwork-hook-processor.mjs
@@ -349,8 +349,9 @@ function buildStepEvents(group, toolResultsByUseId, stepId, turnId, sessionId, u
   });
   const llmResponseTs = timestampToUnixNanos(thinkingRow ? thinkingRow.timestamp : lastRow.timestamp);
 
-  // Determine response.id from parentUuid
-  const responseId = firstRow.parentUuid || firstRow.uuid;
+  // Prefer message.id (chatcmpl-xxx, matches qoderwork-intercept.jsonl) for direct token matching.
+  // Fall back to parentUuid for backward compat with older QoderWork versions.
+  const responseId = firstRow.message?.id || firstRow.parentUuid || firstRow.uuid;
 
   // Build merged output parts
   const outputParts = [];

--- a/assets/hooks/qoderwork-runtime-wrapper.mjs
+++ b/assets/hooks/qoderwork-runtime-wrapper.mjs
@@ -1,0 +1,101 @@
+// QoderWork worker runtime wrapper — intercepts token data via JSON.parse hook.
+// Loaded via: QODER_WORKER_RUNTIME_PATH=<this-file>
+//
+// QoderWork runs its agent SDK in a Node.js worker_thread (not Bun), so the
+// qodercli BUN_OPTIONS --preload trick does not apply. The SDK honors
+// QODER_WORKER_RUNTIME_PATH as the worker entry, so we wrap it: install a
+// JSON.parse/JSON.stringify hook, then `await import()` the real runtime.
+//
+// Writes to: ~/.loongsuite-pilot/logs/qoderwork-intercept.jsonl
+// The captured `id` (chatcmpl-xxx) matches the hook processor's
+// gen_ai.response.id (derived from transcript message.id), enabling direct
+// token matching in qoder-work-trace-input without a transcript mapping module.
+
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const fs = require('node:fs');
+const path = require('node:path');
+
+const INTERCEPT_DIR = path.join(process.env.HOME || '/tmp', '.loongsuite-pilot', 'logs');
+const INTERCEPT_FILE = path.join(INTERCEPT_DIR, 'qoderwork-intercept.jsonl');
+const MIN_SYSTEM_PROMPT_LENGTH = 100;
+
+try { fs.mkdirSync(INTERCEPT_DIR, { recursive: true }); } catch {}
+
+const origParse = JSON.parse;
+const origStringify = JSON.stringify;
+let lastId = null;
+let systemPromptCaptured = false;
+
+// Global override of JSON.parse to intercept SSE-parsed token usage.
+JSON.parse = function (text, reviver) {
+  const result = origParse.call(JSON, text, reviver);
+  try {
+    if (result && typeof result === "object"
+        && result.usage && result.choices !== undefined
+        && result.id !== lastId) {
+      lastId = result.id;
+      const u = result.usage;
+      const rec = {
+        type: "token",
+        ts: Date.now(),
+        id: result.id,  // chatcmpl-xxx, matches transcript message.id
+        model: result.model || "",
+        prompt_tokens: u.prompt_tokens || 0,
+        cached_tokens: (u.prompt_tokens_details && u.prompt_tokens_details.cached_tokens) || 0,
+        completion_tokens: u.completion_tokens || 0,
+        reasoning_tokens: (u.completion_tokens_details && u.completion_tokens_details.reasoning_tokens) || 0,
+        total_tokens: u.total_tokens || 0,
+      };
+      // Token records are ~200 bytes, well under PIPE_BUF — atomic on POSIX.
+      fs.appendFileSync(INTERCEPT_FILE, origStringify.call(JSON, rec) + "\n");
+    }
+  } catch {}
+  return result;
+};
+
+// Global override of JSON.stringify to capture system prompt before request encryption.
+// Each process captures at most once (systemPromptCaptured flag).
+JSON.stringify = function (value, replacer, space) {
+  try {
+    if (!systemPromptCaptured && value && typeof value === "object"
+        && value.messages && Array.isArray(value.messages)) {
+      const sys = value.messages.find(m => m.role === "system");
+      if (sys && typeof sys.content === "string" && sys.content.length > MIN_SYSTEM_PROMPT_LENGTH) {
+        systemPromptCaptured = true;
+        const rec = { type: "system_prompt", ts: Date.now(), content: sys.content };
+        fs.appendFileSync(INTERCEPT_FILE, origStringify.call(JSON, rec) + "\n");
+      }
+    }
+  } catch {}
+  return origStringify.call(JSON, value, replacer, space);
+};
+
+// Discover and load the real QoderWork runtime.
+const RUNTIME_CANDIDATES = [
+  '/Applications/QoderWork.app/Contents/Resources/app.asar.unpacked/node_modules/@qoder-ai/qoder-agent-sdk/dist/_worker/qoder-worker-runtime.obf.mjs',
+  '/Applications/QoderWork.app/Contents/Resources/app.asar.unpacked/node_modules/@qoder-ai/qoder-agent-sdk/dist/_worker/qoder-worker-runtime.mjs',
+  path.join(process.env.HOME || '', 'Applications/QoderWork.app/Contents/Resources/app.asar.unpacked/node_modules/@qoder-ai/qoder-agent-sdk/dist/_worker/qoder-worker-runtime.obf.mjs'),
+];
+
+let loaded = false;
+let lastErr = null;
+for (const candidate of RUNTIME_CANDIDATES) {
+  try {
+    if (fs.existsSync(candidate)) {
+      await import(candidate);
+      loaded = true;
+      break;
+    }
+  } catch (e) { lastErr = e; }
+}
+
+if (!loaded) {
+  // Diagnostic log for troubleshooting; SDK will fall back to ProcessTransport.
+  try {
+    fs.appendFileSync(path.join(INTERCEPT_DIR, 'qoderwork-wrapper-error.log'),
+      `[${new Date().toISOString()}] real runtime not found in candidates: ${RUNTIME_CANDIDATES.join(', ')}\n` +
+      (lastErr ? `last error: ${lastErr.message}\n` : ''));
+  } catch {}
+  throw new Error('qoderwork-runtime-wrapper: real runtime not found');
+}

--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -905,6 +905,42 @@ remove_qodercli_token_intercept() {
 }
 
 # ============================================================
+# QoderWork runtime wrapper: intercept token usage via QODER_WORKER_RUNTIME_PATH
+#
+# QoderWork runs its agent SDK in a Node.js worker_thread (not Bun), so the
+# qodercli BUN_OPTIONS --preload trick does not apply. The SDK honors
+# QODER_WORKER_RUNTIME_PATH as the worker entry; our wrapper installs a
+# JSON.parse hook then imports the real runtime. On macOS we set this via
+# launchctl setenv so the GUI-launched app inherits it. Linux/Windows are
+# skipped (Electron env injection there is tracked separately).
+# ============================================================
+inject_qoderwork_runtime_wrapper() {
+    if [ "$(uname)" != "Darwin" ]; then return 0; fi
+    if ! echo "$SELECTED_AGENTS" | grep -q 'qoder-work'; then return 0; fi
+    if [ ! -d "/Applications/QoderWork.app" ]; then return 0; fi
+
+    local wrapper_script="$DATA_DIR/hooks/qoderwork-runtime-wrapper.mjs"
+    if [ ! -f "$wrapper_script" ]; then return 0; fi
+
+    msg "==> 配置 QoderWork token 采集..." "==> Configuring QoderWork token intercept..."
+    launchctl setenv QODER_WORKER_RUNTIME_PATH "$wrapper_script"
+    msg "    ✅ launchctl setenv QODER_WORKER_RUNTIME_PATH" \
+        "    ✅ launchctl setenv QODER_WORKER_RUNTIME_PATH"
+    msg "    ⚠️  请完全退出并重新打开 QoderWork 以生效" \
+        "    ⚠️  Please fully quit and restart QoderWork for changes to take effect"
+    echo ""
+}
+
+remove_qoderwork_runtime_wrapper() {
+    if [ "$(uname)" != "Darwin" ]; then return 0; fi
+    if launchctl getenv QODER_WORKER_RUNTIME_PATH 2>/dev/null | grep -q 'loongsuite-pilot'; then
+        launchctl unsetenv QODER_WORKER_RUNTIME_PATH
+        msg "    已清理 QODER_WORKER_RUNTIME_PATH" \
+            "    Cleaned up QODER_WORKER_RUNTIME_PATH"
+    fi
+}
+
+# ============================================================
 # Claude Code fetch intercept: inject/remove shell function
 #
 # Why a shell wrapper instead of ~/.claude/settings.json env:
@@ -1331,6 +1367,7 @@ cmd_install() {
     write_config
     install_loongsuite_pilot_command
     inject_qodercli_token_intercept
+    inject_qoderwork_runtime_wrapper
     inject_claude_code_fetch_intercept
 
     msg "==> 启动服务..." "==> Starting service..."
@@ -1634,6 +1671,7 @@ cmd_uninstall() {
     msg "==> 清理 hook 配置..." "==> Cleaning up hook configs..."
     remove_hook_configs
     remove_qodercli_token_intercept
+    remove_qoderwork_runtime_wrapper
     remove_claude_code_fetch_intercept
     echo ""
 

--- a/src/inputs/qoder-trace/intercept-token-reader.ts
+++ b/src/inputs/qoder-trace/intercept-token-reader.ts
@@ -27,12 +27,17 @@ export interface InterceptData {
   systemPrompt: InterceptSystemPrompt | null;
 }
 
-function getInterceptFile(): string {
-  return resolveHome('~/.loongsuite-pilot/logs/qodercli-intercept.jsonl');
+// qodercli and QoderWork write separate intercept files to avoid ID namespace
+// confusion and concurrent-write interference between the CLI and the GUI worker.
+export function getInterceptFile(filename = 'qodercli-intercept.jsonl'): string {
+  return resolveHome(`~/.loongsuite-pilot/logs/${filename}`);
 }
 
-export async function readInterceptData(sinceTs?: number): Promise<InterceptData> {
-  const filePath = getInterceptFile();
+export async function readInterceptData(sinceTs?: number, filename?: string): Promise<InterceptData> {
+  return readInterceptFile(getInterceptFile(filename), sinceTs);
+}
+
+export async function readInterceptFile(filePath: string, sinceTs?: number): Promise<InterceptData> {
   const result: InterceptData = { tokens: [], systemPrompt: null };
 
   let content: string;

--- a/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
+++ b/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
@@ -489,6 +489,11 @@ export class QoderWorkTraceInput extends BaseInput {
             if (!this.applyInterceptUsage(response, interceptData)) {
               this.applySdkTokenUsage(sessionId, request, response);
             }
+          } else {
+            // Segment provided input/output/total but QoderWork segment log
+            // may omit cache_read and never carries reasoning. Overlay both
+            // from intercept when the wrapper captured them for this respId.
+            this.applyInterceptCacheReasoning(response, interceptData);
           }
         }
 
@@ -600,7 +605,29 @@ export class QoderWorkTraceInput extends BaseInput {
     target['gen_ai.usage.output_tokens'] = match.completionTokens;
     target['gen_ai.usage.total_tokens'] = match.totalTokens || (match.promptTokens + match.completionTokens);
     if (match.cachedTokens) target['gen_ai.usage.cache_read.input_tokens'] = match.cachedTokens;
+    if (match.reasoningTokens) target['gen_ai.usage.reasoning_tokens'] = match.reasoningTokens;
     return match.promptTokens > 0 || match.completionTokens > 0 || match.totalTokens > 0;
+  }
+
+  // Segment log covers input/output/total but QoderWork segments do not carry
+  // reasoning_tokens and may omit cache_read when the wrapper is the only
+  // source. Overlay only these two fields so segment values stay authoritative
+  // for the rest.
+  private applyInterceptCacheReasoning(
+    response: AgentActivityEntry,
+    interceptData: InterceptData,
+  ): void {
+    const respId = response['gen_ai.response.id'] as string | undefined;
+    if (!respId) return;
+    const match = interceptData.tokens.find(t => t.id === respId);
+    if (!match) return;
+    const target = response as Record<string, unknown>;
+    if (match.cachedTokens && !target['gen_ai.usage.cache_read.input_tokens']) {
+      target['gen_ai.usage.cache_read.input_tokens'] = match.cachedTokens;
+    }
+    if (match.reasoningTokens) {
+      target['gen_ai.usage.reasoning_tokens'] = match.reasoningTokens;
+    }
   }
 
   // ─── SDK token compatibility ─────────────────────────────────────────────

--- a/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
+++ b/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
@@ -14,6 +14,7 @@ import {
   resolveQoderWorkRoot,
   type SdkEvent,
 } from '../qoder-work-log/qoder-work-log-input.js';
+import { readInterceptFile, getInterceptFile, type InterceptData } from '../qoder-trace/intercept-token-reader.js';
 
 const NANO_PER_MILLI = 1_000_000n;
 const SEGMENT_TIMING_TOLERANCE_MS = 5 * 60 * 1000;
@@ -43,6 +44,7 @@ export class QoderWorkTraceInput extends BaseInput {
   private readonly logDir: string;
   private readonly segmentsRoot: string;
   private readonly sdkLogDir: string;
+  private readonly interceptFile: string;
   private readonly logPrefix = 'qoder-work';
 
   // Per-session in-memory state for segment enrichment
@@ -68,6 +70,7 @@ export class QoderWorkTraceInput extends BaseInput {
     this.logDir = opts.logDir ?? resolveHome('~/.loongsuite-pilot/logs/qoder-work/history');
     this.segmentsRoot = opts.segmentsRoot ?? resolveHome('~/.qoderwork/logs/sessions');
     this.sdkLogDir = opts.sdkLogDir ?? resolveQoderWorkSdkLogDir();
+    this.interceptFile = opts.interceptFile ?? getInterceptFile('qoderwork-intercept.jsonl');
   }
 
   static async checkAvailability(): Promise<boolean> {
@@ -120,9 +123,13 @@ export class QoderWorkTraceInput extends BaseInput {
 
       // 3. Group → enrich → emit.
       const turnGroups = this.groupByTurn(entries);
+      // Intercept data (QoderWork runtime wrapper) is the fallback token source
+      // when segment tokens are all 0. Loaded lazily once per non-empty cycle.
+      let interceptData: InterceptData | null = null;
       const allEntries: AgentActivityEntry[] = [];
       for (const [, turnEntries] of turnGroups) {
-        this.enrichTurn(turnEntries);
+        interceptData ??= await this.readInterceptData();
+        this.enrichTurn(turnEntries, interceptData);
         this.injectTraceId(turnEntries);
         for (const entry of turnEntries) {
           await enrichCanonicalEntryWithGit(
@@ -442,7 +449,7 @@ export class QoderWorkTraceInput extends BaseInput {
 
   // ─── Enrichment ─────────────────────────────────────────────────────────────
 
-  private enrichTurn(entries: AgentActivityEntry[]): void {
+  private enrichTurn(entries: AgentActivityEntry[], interceptData: InterceptData): void {
     const sessionId = entries.find(e => e['gen_ai.session.id'])?.['gen_ai.session.id'] as string | undefined;
     const turnId = entries.find(e => e['gen_ai.turn.id'])?.['gen_ai.turn.id'] as string | undefined;
 
@@ -475,10 +482,30 @@ export class QoderWorkTraceInput extends BaseInput {
             }
             hasSegmentUsage = this.applyUsage(response, pair.usage);
           }
-          if (!hasSegmentUsage) this.applySdkTokenUsage(sessionId, request, response);
+          // Segment tokens all 0 (or no segment pair) → fall back to intercept
+          // tokens matched by gen_ai.response.id (chatcmpl-xxx), then to the
+          // legacy SDK log as a last resort.
+          if (!hasSegmentUsage) {
+            if (!this.applyInterceptUsage(response, interceptData)) {
+              this.applySdkTokenUsage(sessionId, request, response);
+            }
+          }
         }
 
         this.applySegmentToolTiming(sessionId, stepEntries);
+      }
+    }
+
+    // System prompt captured by the QoderWork runtime wrapper (JSON.stringify hook).
+    // Mirror qoder-trace: attach to the first llm.request that owns a step id.
+    if (interceptData.systemPrompt) {
+      const firstReq = entries.find(e =>
+        e['event.name'] === 'llm.request' && !!e['gen_ai.step.id'],
+      );
+      if (firstReq) {
+        (firstReq as Record<string, unknown>)['gen_ai.system_instructions'] = [
+          { type: 'text', content: interceptData.systemPrompt.content },
+        ];
       }
     }
 
@@ -548,6 +575,32 @@ export class QoderWorkTraceInput extends BaseInput {
     const [pair] = pairs.splice(index, 1);
     if (pairs.length === 0) this.sdkTokenPairs.delete(sessionId);
     this.applyUsage(response, pair);
+  }
+
+  // ─── Intercept token compatibility ──────────────────────────────────────
+
+  private async readInterceptData(): Promise<InterceptData> {
+    try {
+      return await readInterceptFile(this.interceptFile);
+    } catch {
+      return { tokens: [], systemPrompt: null };
+    }
+  }
+
+  private applyInterceptUsage(
+    response: AgentActivityEntry,
+    interceptData: InterceptData,
+  ): boolean {
+    const respId = response['gen_ai.response.id'] as string | undefined;
+    if (!respId) return false;
+    const match = interceptData.tokens.find(t => t.id === respId);
+    if (!match) return false;
+    const target = response as Record<string, unknown>;
+    target['gen_ai.usage.input_tokens'] = match.promptTokens;
+    target['gen_ai.usage.output_tokens'] = match.completionTokens;
+    target['gen_ai.usage.total_tokens'] = match.totalTokens || (match.promptTokens + match.completionTokens);
+    if (match.cachedTokens) target['gen_ai.usage.cache_read.input_tokens'] = match.cachedTokens;
+    return match.promptTokens > 0 || match.completionTokens > 0 || match.totalTokens > 0;
   }
 
   // ─── SDK token compatibility ─────────────────────────────────────────────
@@ -787,6 +840,7 @@ export interface QoderWorkTraceInputOptions extends InputOptions {
   logDir?: string;
   segmentsRoot?: string;
   sdkLogDir?: string;
+  interceptFile?: string;
 }
 
 interface HookJsonlBatch {

--- a/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
+++ b/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
@@ -605,14 +605,11 @@ export class QoderWorkTraceInput extends BaseInput {
     target['gen_ai.usage.output_tokens'] = match.completionTokens;
     target['gen_ai.usage.total_tokens'] = match.totalTokens || (match.promptTokens + match.completionTokens);
     if (match.cachedTokens) target['gen_ai.usage.cache_read.input_tokens'] = match.cachedTokens;
-    if (match.reasoningTokens) target['gen_ai.usage.reasoning_tokens'] = match.reasoningTokens;
     return match.promptTokens > 0 || match.completionTokens > 0 || match.totalTokens > 0;
   }
 
-  // Segment log covers input/output/total but QoderWork segments do not carry
-  // reasoning_tokens and may omit cache_read when the wrapper is the only
-  // source. Overlay only these two fields so segment values stay authoritative
-  // for the rest.
+  // Segment log may omit cache_read when the wrapper is the only source.
+  // Overlay only cache_read so segment values stay authoritative for the rest.
   private applyInterceptCacheReasoning(
     response: AgentActivityEntry,
     interceptData: InterceptData,
@@ -624,9 +621,6 @@ export class QoderWorkTraceInput extends BaseInput {
     const target = response as Record<string, unknown>;
     if (match.cachedTokens && !target['gen_ai.usage.cache_read.input_tokens']) {
       target['gen_ai.usage.cache_read.input_tokens'] = match.cachedTokens;
-    }
-    if (match.reasoningTokens) {
-      target['gen_ai.usage.reasoning_tokens'] = match.reasoningTokens;
     }
   }
 

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -64,6 +64,7 @@ export interface AgentActivityEntry {
   'gen_ai.usage.output_tokens'?: number;
   'gen_ai.usage.cache_read.input_tokens'?: number;
   'gen_ai.usage.cache_creation.input_tokens'?: number;
+  'gen_ai.usage.reasoning_tokens'?: number;
   'gen_ai.usage.total_tokens'?: number;
   'gen_ai.usage.input_cost'?: number;
   'gen_ai.usage.output_cost'?: number;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -64,7 +64,6 @@ export interface AgentActivityEntry {
   'gen_ai.usage.output_tokens'?: number;
   'gen_ai.usage.cache_read.input_tokens'?: number;
   'gen_ai.usage.cache_creation.input_tokens'?: number;
-  'gen_ai.usage.reasoning_tokens'?: number;
   'gen_ai.usage.total_tokens'?: number;
   'gen_ai.usage.input_cost'?: number;
   'gen_ai.usage.output_cost'?: number;

--- a/tests/unit/hooks/qoderwork/hook-processor.test.mjs
+++ b/tests/unit/hooks/qoderwork/hook-processor.test.mjs
@@ -176,3 +176,40 @@ describe('qoderwork-hook-processor user prompt extraction', () => {
     expect(inputContents(readJsonlRecords())).toEqual([]);
   });
 });
+
+describe('qoderwork-hook-processor response.id', () => {
+  test('uses message.id as gen_ai.response.id when present', () => {
+    // QoderWork 0.6.2 transcript assistant rows carry message.id = chatcmpl-xxx,
+    // which matches the id captured by qoderwork-runtime-wrapper. Preferring it
+    // enables direct token matching in qoder-work-trace-input.
+    const rows = baseRows([{ type: 'text', text: 'hi' }]).map((r) =>
+      r.type === 'assistant' ? { ...r, message: { ...r.message, id: 'chatcmpl-resp-1' } } : r,
+    );
+    writeTranscript(rows);
+
+    const result = runHook('sess-resp-id-msg');
+    expect(result.status).toBe(0);
+
+    const resp = readJsonlRecords().find((r) => r['event.name'] === 'llm.response');
+    expect(resp).toBeDefined();
+    expect(resp['gen_ai.response.id']).toBe('chatcmpl-resp-1');
+  });
+
+  test('falls back to parentUuid when message.id is absent', () => {
+    // Older QoderWork versions have no message.id — behavior must stay unchanged.
+    const rows = baseRows([{ type: 'text', text: 'hi' }]).map((r) =>
+      r.type === 'assistant'
+        ? { ...r, message: { role: r.message.role, content: r.message.content, stop_reason: r.message.stop_reason } }
+        : r,
+    );
+    writeTranscript(rows);
+
+    const result = runHook('sess-resp-id-parent');
+    expect(result.status).toBe(0);
+
+    const resp = readJsonlRecords().find((r) => r['event.name'] === 'llm.response');
+    expect(resp).toBeDefined();
+    // baseRows assistant row has parentUuid 'user-1'
+    expect(resp['gen_ai.response.id']).toBe('user-1');
+  });
+});

--- a/tests/unit/inputs/intercept-token-reader.test.ts
+++ b/tests/unit/inputs/intercept-token-reader.test.ts
@@ -92,4 +92,22 @@ describe('intercept-token-reader', () => {
     expect(result.tokens).toHaveLength(1);
     expect(result.tokens[0].id).toBe('good');
   });
+
+  it('reads a custom filename so qodercli and qoderwork intercept files stay separate', async () => {
+    const now = Date.now();
+    const qoderworkFile = path.join(TEST_DIR, 'qoderwork-intercept.jsonl');
+    await fs.writeFile(qoderworkFile, [
+      JSON.stringify({ type: 'token', ts: now, id: 'chatcmpl-qw-1', prompt_tokens: 300, cached_tokens: 0, completion_tokens: 20, reasoning_tokens: 0, total_tokens: 320 }),
+    ].join('\n') + '\n');
+
+    // Default filename (qodercli) must not pick up the qoderwork file.
+    const cliResult = await readInterceptData(now - 1000);
+    expect(cliResult.tokens).toEqual([]);
+
+    // Explicit qoderwork filename reads the right file.
+    const qwResult = await readInterceptData(now - 1000, 'qoderwork-intercept.jsonl');
+    expect(qwResult.tokens).toHaveLength(1);
+    expect(qwResult.tokens[0].id).toBe('chatcmpl-qw-1');
+    expect(qwResult.tokens[0].promptTokens).toBe(300);
+  });
 });

--- a/tests/unit/inputs/qoder-work-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-work-trace-input.test.ts
@@ -944,9 +944,9 @@ describe('QoderWorkTraceInput', () => {
   });
 
   // fixture 来源: qoderwork-runtime-wrapper.mjs 写出的 qoderwork-intercept.jsonl
-  // (type=token, cached_tokens/reasoning_tokens 字段)，segment log 不携带 reasoning
-  // 且可能不携带 cache_read，需要 intercept 补齐这两个字段。
-  it('overlays cache_read and reasoning_tokens from intercept when segment supplied input/output only', async () => {
+  // (type=token, cached_tokens 字段)，segment log 可能不携带 cache_read，
+  // 需要 intercept 补齐 cache_read 字段。
+  it('overlays cache_read from intercept when segment supplied input/output only', async () => {
     const sessionId = 'sess-intercept-overlay';
     const turnId = 'turn-intercept-overlay';
     const responseId = 'chatcmpl-overlay-1';
@@ -968,7 +968,7 @@ describe('QoderWorkTraceInput', () => {
       time_unix_nano: nano('2026-06-16T10:00:05.000Z'),
     });
     await fs.writeFile(hookFile, [request, response].map(e => JSON.stringify(e)).join('\n') + '\n');
-    // Segment provides input/output/total but no cache_read and no reasoning.
+    // Segment provides input/output/total but no cache_read.
     await writeSegments(sessionId, 'overlay.jsonl', [
       segModelStart(turnId, 'overlay-req', '2026-06-16T10:00:00.000Z'),
       segModelEnd(turnId, 'overlay-req', '2026-06-16T10:00:05.000Z', 'qwork-ultimate', {
@@ -991,9 +991,8 @@ describe('QoderWorkTraceInput', () => {
     // Segment stays authoritative for input/output/total.
     expect(enriched['gen_ai.usage.input_tokens']).toBe(36438);
     expect(enriched['gen_ai.usage.output_tokens']).toBe(47);
-    // Intercept supplements cache_read and reasoning_tokens (segment lacked both).
+    // Intercept supplements cache_read (segment lacked it).
     expect(enriched['gen_ai.usage.cache_read.input_tokens']).toBe(36251);
-    expect(enriched['gen_ai.usage.reasoning_tokens']).toBe(6);
   });
 
   it('does not let intercept cache_read override segment cache_read', async () => {
@@ -1040,49 +1039,6 @@ describe('QoderWorkTraceInput', () => {
     const enriched = entries.find(e => e['event.id'] === 'keepseg-response')!;
     // Segment cache_read (40) wins; intercept cache_read (999) does not override.
     expect(enriched['gen_ai.usage.cache_read.input_tokens']).toBe(40);
-    // Reasoning only exists on intercept — still overlaid.
-    expect(enriched['gen_ai.usage.reasoning_tokens']).toBe(3);
-  });
-
-  it('fills reasoning_tokens from intercept on the zero-segment fallback path', async () => {
-    const sessionId = 'sess-intercept-reasoning';
-    const turnId = 'turn-intercept-reasoning';
-    const responseId = 'chatcmpl-reasoning-1';
-    const hookFile = path.join(hookLogDir, todayFileName());
-    const request = buildHookEntry({
-      'event.id': 'reasoning-request',
-      'event.name': 'llm.request' as any,
-      'gen_ai.session.id': sessionId,
-      'gen_ai.turn.id': turnId,
-      'gen_ai.step.id': `${turnId}:s1`,
-      time_unix_nano: nano('2026-06-16T10:00:00.000Z'),
-    });
-    const response = buildHookEntry({
-      'event.id': 'reasoning-response',
-      'gen_ai.session.id': sessionId,
-      'gen_ai.turn.id': turnId,
-      'gen_ai.step.id': `${turnId}:s1`,
-      'gen_ai.response.id': responseId,
-      time_unix_nano: nano('2026-06-16T10:00:05.000Z'),
-    });
-    await fs.writeFile(hookFile, [request, response].map(e => JSON.stringify(e)).join('\n') + '\n');
-
-    // No segment file → full intercept overlay path.
-    const interceptFile = path.join(tmpRoot, 'qoderwork-intercept-reasoning.jsonl');
-    const now = Date.now();
-    await fs.writeFile(interceptFile, [
-      JSON.stringify({ type: 'token', ts: now, id: responseId, prompt_tokens: 200, completion_tokens: 50, cached_tokens: 30, reasoning_tokens: 8, total_tokens: 250 }),
-    ].join('\n') + '\n');
-
-    const input = makeInput({ interceptFile });
-    const entries = await startAndCollect(input);
-    await input.stop();
-
-    const enriched = entries.find(e => e['event.id'] === 'reasoning-response')!;
-    expect(enriched['gen_ai.usage.input_tokens']).toBe(200);
-    expect(enriched['gen_ai.usage.output_tokens']).toBe(50);
-    expect(enriched['gen_ai.usage.cache_read.input_tokens']).toBe(30);
-    expect(enriched['gen_ai.usage.reasoning_tokens']).toBe(8);
   });
 
   it('does not apply intercept when response.id has no matching token', async () => {

--- a/tests/unit/inputs/qoder-work-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-work-trace-input.test.ts
@@ -33,12 +33,13 @@ describe('QoderWorkTraceInput', () => {
     await fs.rm(tmpRoot, { recursive: true, force: true });
   });
 
-  function makeInput() {
+  function makeInput(opts: { interceptFile?: string } = {}) {
     return new QoderWorkTraceInput({
       stateStore: stateStore as any,
       logDir: hookLogDir,
       segmentsRoot,
       sdkLogDir,
+      interceptFile: opts.interceptFile,
     });
   }
 
@@ -843,6 +844,139 @@ describe('QoderWorkTraceInput', () => {
 
     const tcOut = entries.find(e => e['event.id'] === 'tc')!;
     expect(tcOut.time_unix_nano).toBe('999999999999000000');
+  });
+
+  // fixture 来源: qoderwork-runtime-wrapper.mjs 写出的 qoderwork-intercept.jsonl
+  // 记录结构（type=token/system_prompt, id=chatcmpl-xxx, ts 毫秒）。
+  it('fills response usage from intercept by chatcmpl response.id when segment tokens are zero', async () => {
+    const sessionId = 'sess-intercept-usage';
+    const turnId = 'turn-intercept-usage';
+    const responseId = 'chatcmpl-intercept-1';
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const request = buildHookEntry({
+      'event.id': 'intercept-request',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: nano('2026-06-16T10:00:00.000Z'),
+    });
+    const response = buildHookEntry({
+      'event.id': 'intercept-response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      'gen_ai.response.id': responseId,
+      time_unix_nano: nano('2026-06-16T10:00:05.000Z'),
+    });
+    await fs.writeFile(hookFile, [request, response].map(e => JSON.stringify(e)).join('\n') + '\n');
+
+    // No segment file → segment pair absent → intercept fallback engages.
+    const interceptFile = path.join(tmpRoot, 'qoderwork-intercept.jsonl');
+    const now = Date.now();
+    const systemPrompt = 'You are QoderWork, an AI coding agent running inside the QoderWork IDE. Follow the user instructions carefully.';
+    await fs.writeFile(interceptFile, [
+      JSON.stringify({ type: 'system_prompt', ts: now, content: systemPrompt }),
+      JSON.stringify({ type: 'token', ts: now, id: responseId, prompt_tokens: 200, completion_tokens: 50, cached_tokens: 30, reasoning_tokens: 0, total_tokens: 250 }),
+    ].join('\n') + '\n');
+
+    const input = makeInput({ interceptFile });
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const enriched = entries.find(e => e['event.id'] === 'intercept-response')!;
+    expect(enriched['gen_ai.usage.input_tokens']).toBe(200);
+    expect(enriched['gen_ai.usage.output_tokens']).toBe(50);
+    expect(enriched['gen_ai.usage.total_tokens']).toBe(250);
+    expect(enriched['gen_ai.usage.cache_read.input_tokens']).toBe(30);
+
+    const req = entries.find(e => e['event.id'] === 'intercept-request')!;
+    const sys = req['gen_ai.system_instructions'] as Array<{ type: string; content: string }>;
+    expect(sys).toBeDefined();
+    expect(sys[0].content).toBe(systemPrompt);
+  });
+
+  it('prefers segment usage over intercept when the segment has tokens', async () => {
+    const sessionId = 'sess-segment-priority';
+    const turnId = 'turn-segment-priority';
+    const responseId = 'chatcmpl-priority-1';
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const request = buildHookEntry({
+      'event.id': 'prio-request',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: nano('2026-06-16T10:00:00.000Z'),
+    });
+    const response = buildHookEntry({
+      'event.id': 'prio-response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      'gen_ai.response.id': responseId,
+      time_unix_nano: nano('2026-06-16T10:00:05.000Z'),
+    });
+    await fs.writeFile(hookFile, [request, response].map(e => JSON.stringify(e)).join('\n') + '\n');
+    await writeSegments(sessionId, 'prio.jsonl', [
+      segModelStart(turnId, 'prio-req', '2026-06-16T10:00:00.000Z'),
+      segModelEnd(turnId, 'prio-req', '2026-06-16T10:00:05.000Z', 'qwork-ultimate', {
+        input_tokens: 120,
+        output_tokens: 30,
+        cache_read_input_tokens: 50,
+        cache_creation_input_tokens: 10,
+      }),
+    ]);
+
+    const interceptFile = path.join(tmpRoot, 'qoderwork-intercept-priority.jsonl');
+    const now = Date.now();
+    await fs.writeFile(interceptFile, [
+      JSON.stringify({ type: 'token', ts: now, id: responseId, prompt_tokens: 999, completion_tokens: 999, cached_tokens: 0, total_tokens: 1998 }),
+    ].join('\n') + '\n');
+
+    const input = makeInput({ interceptFile });
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const enriched = entries.find(e => e['event.id'] === 'prio-response')!;
+    expect(enriched['gen_ai.usage.input_tokens']).toBe(120);
+    expect(enriched['gen_ai.usage.output_tokens']).toBe(30);
+  });
+
+  it('does not apply intercept when response.id has no matching token', async () => {
+    const sessionId = 'sess-intercept-nomatch';
+    const turnId = 'turn-intercept-nomatch';
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const request = buildHookEntry({
+      'event.id': 'nomatch-request',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: nano('2026-06-16T10:00:00.000Z'),
+    });
+    const response = buildHookEntry({
+      'event.id': 'nomatch-response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      'gen_ai.response.id': 'chatcmpl-unmatched',
+      time_unix_nano: nano('2026-06-16T10:00:05.000Z'),
+    });
+    await fs.writeFile(hookFile, [request, response].map(e => JSON.stringify(e)).join('\n') + '\n');
+
+    const interceptFile = path.join(tmpRoot, 'qoderwork-intercept-nomatch.jsonl');
+    const now = Date.now();
+    await fs.writeFile(interceptFile, [
+      JSON.stringify({ type: 'token', ts: now, id: 'chatcmpl-other', prompt_tokens: 200, completion_tokens: 50, total_tokens: 250 }),
+    ].join('\n') + '\n');
+
+    const input = makeInput({ interceptFile });
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const enriched = entries.find(e => e['event.id'] === 'nomatch-response')!;
+    expect(enriched['gen_ai.usage.input_tokens']).toBeUndefined();
   });
 });
 

--- a/tests/unit/inputs/qoder-work-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-work-trace-input.test.ts
@@ -943,6 +943,148 @@ describe('QoderWorkTraceInput', () => {
     expect(enriched['gen_ai.usage.output_tokens']).toBe(30);
   });
 
+  // fixture 来源: qoderwork-runtime-wrapper.mjs 写出的 qoderwork-intercept.jsonl
+  // (type=token, cached_tokens/reasoning_tokens 字段)，segment log 不携带 reasoning
+  // 且可能不携带 cache_read，需要 intercept 补齐这两个字段。
+  it('overlays cache_read and reasoning_tokens from intercept when segment supplied input/output only', async () => {
+    const sessionId = 'sess-intercept-overlay';
+    const turnId = 'turn-intercept-overlay';
+    const responseId = 'chatcmpl-overlay-1';
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const request = buildHookEntry({
+      'event.id': 'overlay-request',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: nano('2026-06-16T10:00:00.000Z'),
+    });
+    const response = buildHookEntry({
+      'event.id': 'overlay-response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      'gen_ai.response.id': responseId,
+      time_unix_nano: nano('2026-06-16T10:00:05.000Z'),
+    });
+    await fs.writeFile(hookFile, [request, response].map(e => JSON.stringify(e)).join('\n') + '\n');
+    // Segment provides input/output/total but no cache_read and no reasoning.
+    await writeSegments(sessionId, 'overlay.jsonl', [
+      segModelStart(turnId, 'overlay-req', '2026-06-16T10:00:00.000Z'),
+      segModelEnd(turnId, 'overlay-req', '2026-06-16T10:00:05.000Z', 'qwork-ultimate', {
+        input_tokens: 36438,
+        output_tokens: 47,
+      }),
+    ]);
+
+    const interceptFile = path.join(tmpRoot, 'qoderwork-intercept-overlay.jsonl');
+    const now = Date.now();
+    await fs.writeFile(interceptFile, [
+      JSON.stringify({ type: 'token', ts: now, id: responseId, prompt_tokens: 36438, completion_tokens: 47, cached_tokens: 36251, reasoning_tokens: 6, total_tokens: 36485 }),
+    ].join('\n') + '\n');
+
+    const input = makeInput({ interceptFile });
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const enriched = entries.find(e => e['event.id'] === 'overlay-response')!;
+    // Segment stays authoritative for input/output/total.
+    expect(enriched['gen_ai.usage.input_tokens']).toBe(36438);
+    expect(enriched['gen_ai.usage.output_tokens']).toBe(47);
+    // Intercept supplements cache_read and reasoning_tokens (segment lacked both).
+    expect(enriched['gen_ai.usage.cache_read.input_tokens']).toBe(36251);
+    expect(enriched['gen_ai.usage.reasoning_tokens']).toBe(6);
+  });
+
+  it('does not let intercept cache_read override segment cache_read', async () => {
+    const sessionId = 'sess-intercept-keepseg';
+    const turnId = 'turn-intercept-keepseg';
+    const responseId = 'chatcmpl-keepseg-1';
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const request = buildHookEntry({
+      'event.id': 'keepseg-request',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: nano('2026-06-16T10:00:00.000Z'),
+    });
+    const response = buildHookEntry({
+      'event.id': 'keepseg-response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      'gen_ai.response.id': responseId,
+      time_unix_nano: nano('2026-06-16T10:00:05.000Z'),
+    });
+    await fs.writeFile(hookFile, [request, response].map(e => JSON.stringify(e)).join('\n') + '\n');
+    await writeSegments(sessionId, 'keepseg.jsonl', [
+      segModelStart(turnId, 'keepseg-req', '2026-06-16T10:00:00.000Z'),
+      segModelEnd(turnId, 'keepseg-req', '2026-06-16T10:00:05.000Z', 'qwork-ultimate', {
+        input_tokens: 100,
+        output_tokens: 20,
+        cache_read_input_tokens: 40,
+      }),
+    ]);
+
+    const interceptFile = path.join(tmpRoot, 'qoderwork-intercept-keepseg.jsonl');
+    const now = Date.now();
+    await fs.writeFile(interceptFile, [
+      JSON.stringify({ type: 'token', ts: now, id: responseId, prompt_tokens: 100, completion_tokens: 20, cached_tokens: 999, reasoning_tokens: 3, total_tokens: 120 }),
+    ].join('\n') + '\n');
+
+    const input = makeInput({ interceptFile });
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const enriched = entries.find(e => e['event.id'] === 'keepseg-response')!;
+    // Segment cache_read (40) wins; intercept cache_read (999) does not override.
+    expect(enriched['gen_ai.usage.cache_read.input_tokens']).toBe(40);
+    // Reasoning only exists on intercept — still overlaid.
+    expect(enriched['gen_ai.usage.reasoning_tokens']).toBe(3);
+  });
+
+  it('fills reasoning_tokens from intercept on the zero-segment fallback path', async () => {
+    const sessionId = 'sess-intercept-reasoning';
+    const turnId = 'turn-intercept-reasoning';
+    const responseId = 'chatcmpl-reasoning-1';
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const request = buildHookEntry({
+      'event.id': 'reasoning-request',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: nano('2026-06-16T10:00:00.000Z'),
+    });
+    const response = buildHookEntry({
+      'event.id': 'reasoning-response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      'gen_ai.response.id': responseId,
+      time_unix_nano: nano('2026-06-16T10:00:05.000Z'),
+    });
+    await fs.writeFile(hookFile, [request, response].map(e => JSON.stringify(e)).join('\n') + '\n');
+
+    // No segment file → full intercept overlay path.
+    const interceptFile = path.join(tmpRoot, 'qoderwork-intercept-reasoning.jsonl');
+    const now = Date.now();
+    await fs.writeFile(interceptFile, [
+      JSON.stringify({ type: 'token', ts: now, id: responseId, prompt_tokens: 200, completion_tokens: 50, cached_tokens: 30, reasoning_tokens: 8, total_tokens: 250 }),
+    ].join('\n') + '\n');
+
+    const input = makeInput({ interceptFile });
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const enriched = entries.find(e => e['event.id'] === 'reasoning-response')!;
+    expect(enriched['gen_ai.usage.input_tokens']).toBe(200);
+    expect(enriched['gen_ai.usage.output_tokens']).toBe(50);
+    expect(enriched['gen_ai.usage.cache_read.input_tokens']).toBe(30);
+    expect(enriched['gen_ai.usage.reasoning_tokens']).toBe(8);
+  });
+
   it('does not apply intercept when response.id has no matching token', async () => {
     const sessionId = 'sess-intercept-nomatch';
     const turnId = 'turn-intercept-nomatch';


### PR DESCRIPTION
## 背景

QoderWork 采集场景下，pilot 无法直接拿到 LLM 调用的 token 用量（尤其 `cache_read.input_tokens`），导致 AGENT span 的 token sum 与各 LLM span 之和无法对齐，也无法回填缓存命中数。Issue AGE-378 要求通过拦截 QoderWork 子进程的请求/响应来补齐 token 字段。

## 核心改动

- **新增** `assets/hooks/qoderwork-runtime-wrapper.mjs`：通过 `QODER_WORKER_RUNTIME_PATH` 包装 QoderWork 子进程，拦截 LLM 请求/响应，将每次调用的 `prompt_tokens` / `completion_tokens` / `cached_tokens` 写入 intercept JSONL。
- **新增** `deploy/installer-opensource.sh` 中 `inject_qodercli_token_intercept` 安装钩子。
- **修改** `src/inputs/qoder-trace/intercept-token-reader.ts`：`readInterceptData` 增加 `filename` 形参，按 chatcmpl id 索引。
- **修改** `src/inputs/qoder-work-trace/qoder-work-trace-input.ts`：在 LLM span 上回填 `gen_ai.usage.cache_read.input_tokens`，保持 AGENT token sum 严格等于 sum(LLM)。
- **不**在 LLM span 上写 `reasoning_tokens`：该字段不在 OTel GenAI 规范中，已通过 revert 移除，避免污染下游 OLAP 列。

## 修改文件

| 文件 | 说明 |
|------|------|
| assets/hooks/qoderwork-runtime-wrapper.mjs | 新增：子进程 wrapper，输出 intercept JSONL |
| assets/hooks/qoderwork-hook-processor.mjs | 小幅调整以配合新 wrapper |
| deploy/installer-opensource.sh | 新增 `inject_qodercli_token_intercept` 安装步骤 |
| src/inputs/qoder-trace/intercept-token-reader.ts | `readInterceptData` 加 `filename` 形参 |
| src/inputs/qoder-work-trace/qoder-work-trace-input.ts | LLM span 回填 cache_read，AGENT token sum 对齐 |
| tests/unit/hooks/qoderwork/hook-processor.test.mjs | 新增单测 |
| tests/unit/inputs/intercept-token-reader.test.ts | 新增单测 |
| tests/unit/inputs/qoder-work-trace-input.test.ts | 扩展回填与 token sum 校验单测 |

## 验证结果

### 单元测试（提交前本地反向核验）

```
npx vitest run tests/unit/hooks/qoderwork/ \
  tests/unit/inputs/qoder-work-trace-input.test.ts \
  tests/unit/inputs/intercept-token-reader.test.ts
# → Test Files 3 passed (3) | Tests 38 passed (38)

npx tsc --noEmit
# → 0 error
```

### E2E（tester 报告 comment b6fdb253，coordinator 复核 PASS）

真实 QoderWork.app GUI (macOS, PID 33177) 触发多轮 ReAct + 工具对话（非替代、非伪造），install commit `1.0.0_e1875c2`，trace 10 spans、3 STEP / 2 TOOL。

**复现命令：**

```bash
multica attachment download 019efe91-bf58-78c4-b578-71aa6f97b67a -o /tmp/pilot-e2e/
multica attachment download 019efe91-bf70-72c0-b3c5-ef071f3a66b2 -o /tmp/pilot-e2e/
node /tmp/loongsuite-pilot/scripts/validate-trace.mjs \
  --input /tmp/pilot-e2e/fx-pilot-qoder-work-2026-06-25.jsonl \
  --format json --output /tmp/pilot-e2e/validate-report.json
```

**validate-trace verdict：** `PASS` — 133 checks | 34 pass | 99 warn | 0 error | 0 skipped（99 WARN 全为 `*.should.*` 可选属性缺失，非阻断）。

**6 项 checklist：**

| # | 项 | 结果 |
|---|---|---|
| 1 | STEP ≥ 3 | 3 ✅ |
| 2 | TOOL ≥ 2 | 2 ✅ |
| 3 | validate-trace 0 ERROR | 0 ERROR / 0 SKIPPED ✅ |
| 4 | LLM `gen_ai.input.messages` / `gen_ai.output.messages` 非空 | 3/3 LLM span ✅ |
| 5 | `gen_ai.usage.cache_read.input_tokens` 回填 | STEP2=34813、STEP3=34983 精确命中；STEP1 cached=0 不触发 ✅ |
| 6 | `reasoning_tokens` 不出现在 LLM span（反向） | 3/3 LLM span 0 个 reasoning.* 属性，revert 干净 ✅ |

**AGENT token sum 严格校验：** `total=105338 / input=104979 / output=359 / cache_read=69796` 与 `sum(LLM.*)` 逐字段精确等。
