### PR TITLE
feat(qoderwork): intercept token usage via QODER_WORKER_RUNTIME_PATH wrapper

### DIFF
--- a/assets/hooks/qoderwork-hook-processor.mjs
+++ b/assets/hooks/qoderwork-hook-processor.mjs
@@ -349,8 +349,9 @@ function buildStepEvents(group, toolResultsByUseId, stepId, turnId, sessionId, u
   });
   const llmResponseTs = timestampToUnixNanos(thinkingRow ? thinkingRow.timestamp : lastRow.timestamp);
 
-  // Determine response.id from parentUuid
-  const responseId = firstRow.parentUuid || firstRow.uuid;
+  // Prefer message.id (chatcmpl-xxx, matches qoderwork-intercept.jsonl) for direct token matching.
+  // Fall back to parentUuid for backward compat with older QoderWork versions.
+  const responseId = firstRow.message?.id || firstRow.parentUuid || firstRow.uuid;
 
   // Build merged output parts
   const outputParts = [];

--- a/assets/hooks/qoderwork-runtime-wrapper.mjs
+++ b/assets/hooks/qoderwork-runtime-wrapper.mjs
@@ -1,0 +1,108 @@
+// QoderWork worker runtime wrapper — intercepts token data via JSON.parse hook.
+// Loaded via: QODER_WORKER_RUNTIME_PATH=<this-file>
+//
+// QoderWork runs its agent SDK in a Node.js worker_thread (not Bun), so the
+// qodercli BUN_OPTIONS --preload trick does not apply. The SDK honors
+// QODER_WORKER_RUNTIME_PATH as the worker entry, so we wrap it: install a
+// JSON.parse/JSON.stringify hook, then `await import()` the real runtime.
+//
+// Writes to: ~/.loongsuite-pilot/logs/qoderwork-intercept.jsonl
+// The captured `id` (chatcmpl-xxx) matches the hook processor's
+// gen_ai.response.id (derived from transcript message.id), enabling direct
+// token matching in qoder-work-trace-input without a transcript mapping module.
+
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const fs = require('node:fs');
+const path = require('node:path');
+
+const INTERCEPT_DIR = path.join(process.env.HOME || '/tmp', '.loongsuite-pilot', 'logs');
+const INTERCEPT_FILE = path.join(INTERCEPT_DIR, 'qoderwork-intercept.jsonl');
+const MIN_SYSTEM_PROMPT_LENGTH = 100;
+
+try { fs.mkdirSync(INTERCEPT_DIR, { recursive: true }); } catch {}
+
+const origParse = JSON.parse;
+const origStringify = JSON.stringify;
+let lastId = null;
+let systemPromptCaptured = false;
+
+// Global override of JSON.parse to intercept SSE-parsed token usage.
+JSON.parse = function (text, reviver) {
+  const result = origParse.call(JSON, text, reviver);
+  try {
+    if (result && typeof result === "object"
+        && result.usage && result.choices !== undefined
+        && result.id !== lastId) {
+      lastId = result.id;
+      const u = result.usage;
+      const rec = {
+        type: "token",
+        ts: Date.now(),
+        id: result.id,  // chatcmpl-xxx, matches transcript message.id
+        model: result.model || "",
+        prompt_tokens: u.prompt_tokens || 0,
+        cached_tokens: (u.prompt_tokens_details && u.prompt_tokens_details.cached_tokens) || 0,
+        completion_tokens: u.completion_tokens || 0,
+        reasoning_tokens: (u.completion_tokens_details && u.completion_tokens_details.reasoning_tokens) || 0,
+        total_tokens: u.total_tokens || 0,
+      };
+      // Token records are ~200 bytes, well under PIPE_BUF — atomic on POSIX.
+      fs.appendFileSync(INTERCEPT_FILE, origStringify.call(JSON, rec) + "\n");
+    }
+  } catch {}
+  return result;
+};
+
+// Global override of JSON.stringify to capture system prompt before request encryption.
+// Each process captures at most once (systemPromptCaptured flag).
+JSON.stringify = function (value, replacer, space) {
+  try {
+    if (!systemPromptCaptured && value && typeof value === "object"
+        && value.messages && Array.isArray(value.messages)) {
+      const sys = value.messages.find(m => m.role === "system");
+      if (sys && typeof sys.content === "string" && sys.content.length > MIN_SYSTEM_PROMPT_LENGTH) {
+        systemPromptCaptured = true;
+        const rec = { type: "system_prompt", ts: Date.now(), content: sys.content };
+        fs.appendFileSync(INTERCEPT_FILE, origStringify.call(JSON, rec) + "\n");
+      }
+    }
+  } catch {}
+  return origStringify.call(JSON, value, replacer, space);
+};
+
+// Discover and load the real QoderWork runtime. Cover both the system-wide
+// install (`/Applications/...`) and the per-user install (`~/Applications/...`),
+// each with obfuscated (`.obf.mjs`) and non-obfuscated (`.mjs`) variants.
+const SDK_REL_BASE = 'Contents/Resources/app.asar.unpacked/node_modules/@qoder-ai/qoder-agent-sdk/dist/_worker';
+const RUNTIME_CANDIDATES = [
+  `/Applications/QoderWork.app/${SDK_REL_BASE}/qoder-worker-runtime.obf.mjs`,
+  `/Applications/QoderWork.app/${SDK_REL_BASE}/qoder-worker-runtime.mjs`,
+  path.join(process.env.HOME || '', `Applications/QoderWork.app/${SDK_REL_BASE}/qoder-worker-runtime.obf.mjs`),
+  path.join(process.env.HOME || '', `Applications/QoderWork.app/${SDK_REL_BASE}/qoder-worker-runtime.mjs`),
+];
+
+let loaded = false;
+let lastErr = null;
+for (const candidate of RUNTIME_CANDIDATES) {
+  try {
+    if (fs.existsSync(candidate)) {
+      await import(candidate);
+      loaded = true;
+      break;
+    }
+  } catch (e) { lastErr = e; }
+}
+
+if (!loaded) {
+  // Log a diagnostic but do NOT throw. Throwing at module level crashes the
+  // worker_thread entirely, which would also prevent the QoderWork SDK from
+  // falling back to its ProcessTransport. By returning silently we let the SDK
+  // detect "no runtime registered" and degrade on its own — token interception
+  // is lost (acceptable) but normal agent operation is not disrupted.
+  try {
+    fs.appendFileSync(path.join(INTERCEPT_DIR, 'qoderwork-wrapper-error.log'),
+      `[${new Date().toISOString()}] real runtime not found in candidates: ${RUNTIME_CANDIDATES.join(', ')}\n` +
+      (lastErr ? `last error: ${lastErr.message}\n` : ''));
+  } catch {}
+}

--- a/assets/skills/references/watchdog-diagnostics.md
+++ b/assets/skills/references/watchdog-diagnostics.md
@@ -1,0 +1,130 @@
+# HookWatchdog 自愈机制 — 排查与开发指南
+
+HookWatchdog 是 pilot daemon 内置的巡检器，每 5 分钟（`intervalMs`，默认 300000ms）检测 hook 注册和 intercept 注入是否丢失，丢失时自动修复。启动后有 30 秒延迟再开始第一次巡检。
+
+它管两类检测目标：
+- **Hook targets**：检测 agent settings.json 中的 hook 命令条目（如 `~/.claude/settings.json` 的 `hooks.Stop` 数组）
+- **Intercept targets**：检测 launchctl 环境变量、LaunchAgent plist、shell rc wrapper function 等注入配置
+
+与 installer 的关系：installer（`deploy/installer-opensource.sh`）做一次性注入，watchdog 做持续自愈。两者用相同的 marker / block 格式，互相兼容。
+
+## Hook Targets — settings.json 检测
+
+检测 agent settings.json 文件中 `hooks.<event>` 数组是否包含 pilot 的 hook 命令条目。
+
+targets 来源有两种：
+- `HookWatchdog.defaultTargets()`：硬编码的 otel plugin 类（claude-code / codex），用外部安装命令修复
+- `orchestrator.buildHookWatchdogTargets()`：从 `agents.d/*.json` 中 `deployMode: "hook"` 的定义动态构建，用 `DeploymentManager.deploySingle()` 修复
+
+修复方式二选一：
+- **repairFn**（优先）：调用 `DeploymentManager.deploySingle(def)` 重新执行 `HookStrategy.deploy()`，重写 settings.json hook 条目
+- **binPath + installArgs**：spawn 外部安装命令（如 `otel-claude-hook install`），30 秒超时
+
+**给新插件添加 hook target**：在 `agents.d/<agent>.json` 中设置 `deployMode: "hook"` 并配好 `hook.settingsPath`、`hook.events`、`hook.hookCommand`，orchestrator 启动时会自动为该 agent 构建 watchdog target，无需改 TypeScript 代码。
+
+## Intercept Targets — launchctl / shell rc 检测
+
+检测 installer 注入的 intercept 配置是否仍然存在。与 hook targets 不同，intercept targets 检测的不是 settings.json，而是系统级配置（launchctl env、LaunchAgent plist、shell rc 文件）。
+
+当前 3 个 intercept target：
+
+| target id | 平台 | 检测什么 | 修复方式 |
+|---|---|---|---|
+| `qoderwork-env` | macOS | `launchctl getenv QODER_WORKER_RUNTIME_PATH` 是否等于 wrapper 路径 | `launchctl setenv` + 写/重载 `~/Library/LaunchAgents/com.loongsuite-pilot.qoderwork-env.plist` |
+| `qodercli-rc` | macOS + Linux | `~/.zshrc` 或 `~/.bashrc`（按 `$SHELL` 判断）是否含 `# loongsuite-pilot BEGIN qodercli-intercept` marker | 向 rc 文件末尾 append wrapper function block |
+| `claude-code-rc` | macOS + Linux | 同上，marker 为 `# loongsuite-pilot BEGIN claude-code-intercept` | 同上 |
+
+前置条件（precondition）：对应的 hook 脚本文件必须存在（如 `~/.loongsuite-pilot/hooks/qodercli-token-intercept.mjs`）。对 `qoderwork-env` 还要求 macOS 平台且 QoderWork.app 已安装。前置条件不满足时静默 skip，不算修复失败。
+
+## 安全护栏
+
+| 护栏 | 作用 |
+|---|---|
+| **repair cooldown** | `repairCooldownMs`（默认 600000ms = 10 分钟），同一 target 10 分钟内不重复修复 |
+| **daily limit** | intercept targets 每日最多 3 次修复。防止 dotfile 管理工具（chezmoi / stow 等）覆盖 rc 后与 watchdog 无限循环。超限后 log `intercept-watchdog.daily-limit` 并停止当日修复 |
+| **append-only** | rc 文件只追加，不修改已有内容。即使 append 被中断（断电等），原文件不受影响 |
+| **不创建 rc 文件** | 如果 `~/.zshrc` / `~/.bashrc` 不存在，跳过修复（不会凭空创建 rc 文件） |
+| **double-check** | repair 前再次 check 确认仍缺失（防并发/竞态写入重复 block） |
+| **try-catch** | 单个 target 修复失败只写 warn 日志，不影响其它 target 和 watchdog 后续运行 |
+
+## 给新插件添加 intercept watchdog 支持
+
+### Step 1：确定注入类型
+
+- **macOS GUI app**（如 QoderWork）→ `launchctl setenv` + LaunchAgent plist（参考 `qoderwork-env`）
+- **CLI 工具**（如 qodercli / claude）→ shell rc wrapper function（参考 `qodercli-rc`）
+
+### Step 2：在 `hook-watchdog.ts` 的 `defaultInterceptTargets()` 加 target
+
+```typescript
+targets.push({
+  id: '<agent>-rc',  // 或 '<agent>-env' for launchctl 场景
+  precondition: async () => {
+    return fileExists(path.join(dataDir, 'hooks', '<hook-script>.mjs'));
+  },
+  check: async () => {
+    // rc 场景：读 rc 文件 grep marker
+    const content = await fs.readFile(rcPath, 'utf-8');
+    return content.includes('loongsuite-pilot BEGIN <agent>-intercept');
+    // launchctl 场景：execFileAsync('launchctl', ['getenv', '<ENV_VAR>'])
+  },
+  repair: async () => {
+    // rc 场景：appendFile(rcPath, block)
+    // launchctl 场景：execFileAsync('launchctl', ['setenv', ...]) + 写 plist
+  },
+});
+```
+
+### Step 3：rc block marker 命名规范
+
+```
+# loongsuite-pilot BEGIN <id>-intercept
+<wrapper function definition>
+# loongsuite-pilot END <id>-intercept
+```
+
+watchdog 和 installer **必须用同一个 marker**。watchdog 的 check 用 `BEGIN` marker 判定存在性，installer 的 inject 函数用同样的 grep 做幂等检查。
+
+### Step 4：在 installer.sh 加对应函数
+
+在 `deploy/installer-opensource.sh` 中添加 `inject_<agent>_<type>()` 和 `remove_<agent>_<type>()` 函数，在 `cmd_install` 调用链中注册。installer 做一次性注入 + 卸载清理，watchdog 做运行时自愈——两者用相同的 block 内容和 marker。
+
+### Step 5：加单测
+
+在 `tests/unit/core/hook-watchdog-intercept.test.ts` 中添加新 target 的 check / repair / precondition 用例，mock `execFile` 和 `fs` 操作。
+
+## 排查指南
+
+### watchdog 是否在跑
+
+```bash
+grep 'scheduling hook watchdog' ~/.loongsuite-pilot/logs/loongsuite-pilot-service.log
+# 期望：看到 intervalMs + targets 列表
+```
+
+### 巡检结果
+
+```bash
+# hook targets 巡检（INFO 级别，每个 target 一行）
+grep 'hook-watchdog.check' ~/.loongsuite-pilot/logs/loongsuite-pilot-service.log | tail -20
+
+# intercept targets 巡检（健康状态是 DEBUG 级别，默认不输出；修复事件是 WARN/INFO）
+grep 'intercept-watchdog' ~/.loongsuite-pilot/logs/loongsuite-pilot-service.log | tail -20
+```
+
+### 修复事件
+
+```bash
+# 看到这两行 = watchdog 检测到缺失并成功修复
+grep 'intercept-watchdog.repairing\|intercept-watchdog.repaired' ~/.loongsuite-pilot/logs/loongsuite-pilot-service.log
+```
+
+### 常见问题
+
+| 现象 | 原因 | 解决 |
+|---|---|---|
+| intercept target 一直 skip | hook 脚本未部署（`~/.loongsuite-pilot/hooks/<script>.mjs` 不存在） | 跑 `node scripts/postinstall.js` 或 `bash scripts/local-reinstall.sh` |
+| `qoderwork-env` skip | 非 macOS 平台，或 QoderWork.app 未安装 | 仅 macOS + QoderWork.app 已安装时生效 |
+| rc block 反复被修复又丢失 | dotfile 管理工具覆盖 `.zshrc` | 将 pilot block 加入 dotfile 源文件；watchdog 每日最多修复 3 次后自动停止 |
+| `intercept-watchdog.daily-limit` | 同上，已达当日上限 | 次日自动重置计数 |
+| `intercept-watchdog.repair-failed` | 文件权限、磁盘满、launchctl 异常 | 检查 warn 日志中的 error 详情 |

--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -905,6 +905,98 @@ remove_qodercli_token_intercept() {
 }
 
 # ============================================================
+# QoderWork runtime wrapper: intercept token usage via QODER_WORKER_RUNTIME_PATH
+#
+# QoderWork runs its agent SDK in a Node.js worker_thread (not Bun), so the
+# qodercli BUN_OPTIONS --preload trick does not apply. The SDK honors
+# QODER_WORKER_RUNTIME_PATH as the worker entry; our wrapper installs a
+# JSON.parse hook then imports the real runtime. On macOS we set this via
+# launchctl setenv so the GUI-launched app inherits it. Linux/Windows are
+# skipped (Electron env injection there is tracked separately).
+# ============================================================
+inject_qoderwork_runtime_wrapper() {
+    if [ "$(uname)" != "Darwin" ]; then return 0; fi
+    if ! echo "$SELECTED_AGENTS" | grep -q 'qoder-work'; then return 0; fi
+    # Cover system-wide (/Applications) and per-user (~/Applications) installs;
+    # the wrapper's RUNTIME_CANDIDATES handles both locations symmetrically.
+    if [ ! -d "/Applications/QoderWork.app" ] && [ ! -d "$HOME/Applications/QoderWork.app" ]; then return 0; fi
+
+    local wrapper_script="$DATA_DIR/hooks/qoderwork-runtime-wrapper.mjs"
+    if [ ! -f "$wrapper_script" ]; then return 0; fi
+
+    msg "==> 配置 QoderWork token 采集..." "==> Configuring QoderWork token intercept..."
+
+    # (1) Set immediately for the current launchd session so QoderWork can pick
+    # up the env without waiting for a re-login.
+    launchctl setenv QODER_WORKER_RUNTIME_PATH "$wrapper_script"
+
+    # (2) Persist across reboots via a LaunchAgent plist. launchctl setenv on
+    # its own is session-scoped — a macOS reboot would otherwise silently drop
+    # the env and the wrapper would stop being injected. The plist contains a
+    # one-shot RunAtLoad job that re-runs `launchctl setenv` on every user
+    # login (when launchd auto-loads agents from ~/Library/LaunchAgents).
+    local plist_dir="$HOME/Library/LaunchAgents"
+    local plist_path="$plist_dir/com.loongsuite-pilot.qoderwork-env.plist"
+    mkdir -p "$plist_dir"
+    cat > "$plist_path" << PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.loongsuite-pilot.qoderwork-env</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/launchctl</string>
+        <string>setenv</string>
+        <string>QODER_WORKER_RUNTIME_PATH</string>
+        <string>$wrapper_script</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+PLIST
+
+    # (3) Reload now so the plist (and any updated path) is registered
+    # idempotently. unload-before-load avoids "already loaded" errors when
+    # upgrading the path. Errors are non-fatal — current-session setenv above
+    # already covers the immediate use case.
+    launchctl unload "$plist_path" 2>/dev/null || true
+    launchctl load "$plist_path" 2>/dev/null || true
+
+    msg "    ✅ launchctl setenv QODER_WORKER_RUNTIME_PATH" \
+        "    ✅ launchctl setenv QODER_WORKER_RUNTIME_PATH"
+    msg "    ✅ LaunchAgent 已注册 (重启 macOS 后自动恢复 env)" \
+        "    ✅ LaunchAgent registered (auto-restores env after macOS reboot)"
+    msg "    ⚠️  请完全退出并重新打开 QoderWork 以生效" \
+        "    ⚠️  Please fully quit and restart QoderWork for changes to take effect"
+    echo ""
+}
+
+remove_qoderwork_runtime_wrapper() {
+    if [ "$(uname)" != "Darwin" ]; then return 0; fi
+
+    # Unload + remove the LaunchAgent plist so the env stops auto-restoring on
+    # next login.
+    local plist_path="$HOME/Library/LaunchAgents/com.loongsuite-pilot.qoderwork-env.plist"
+    if [ -f "$plist_path" ]; then
+        launchctl unload "$plist_path" 2>/dev/null || true
+        rm -f "$plist_path"
+        msg "    已清理 LaunchAgent (qoderwork-env)" \
+            "    Cleaned up LaunchAgent (qoderwork-env)"
+    fi
+
+    # Drop the env from the current session too (conservative grep avoids
+    # touching env values the user set manually to a non-loongsuite path).
+    if launchctl getenv QODER_WORKER_RUNTIME_PATH 2>/dev/null | grep -q 'loongsuite-pilot'; then
+        launchctl unsetenv QODER_WORKER_RUNTIME_PATH
+        msg "    已清理 QODER_WORKER_RUNTIME_PATH" \
+            "    Cleaned up QODER_WORKER_RUNTIME_PATH"
+    fi
+}
+
+# ============================================================
 # Claude Code fetch intercept: inject/remove shell function
 #
 # Why a shell wrapper instead of ~/.claude/settings.json env:
@@ -1331,6 +1423,7 @@ cmd_install() {
     write_config
     install_loongsuite_pilot_command
     inject_qodercli_token_intercept
+    inject_qoderwork_runtime_wrapper
     inject_claude_code_fetch_intercept
 
     msg "==> 启动服务..." "==> Starting service..."
@@ -1634,6 +1727,7 @@ cmd_uninstall() {
     msg "==> 清理 hook 配置..." "==> Cleaning up hook configs..."
     remove_hook_configs
     remove_qodercli_token_intercept
+    remove_qoderwork_runtime_wrapper
     remove_claude_code_fetch_intercept
     echo ""
 

--- a/src/core/hook-watchdog.ts
+++ b/src/core/hook-watchdog.ts
@@ -425,7 +425,9 @@ export class HookWatchdog {
         check: async () => {
           try {
             const { stdout } = await execFileAsync('launchctl', ['getenv', 'QODER_WORKER_RUNTIME_PATH']);
-            return stdout.trim() === wrapperPath;
+            if (stdout.trim() !== wrapperPath) return false;
+            // Also verify plist exists — without it, env is lost on reboot.
+            return fileExists(plistPath);
           } catch {
             return false;
           }
@@ -454,6 +456,10 @@ export class HookWatchdog {
           ].join('\n');
           await fs.mkdir(path.dirname(plistPath), { recursive: true });
           await fs.writeFile(plistPath, plistContent);
+          // NOTE: launchctl load/unload is deprecated since macOS 10.11 in
+          // favour of `launchctl bootstrap/bootout gui/<uid>`. We keep
+          // load/unload for now because it still works reliably across all
+          // supported macOS versions and avoids the uid lookup complexity.
           await execFileAsync('launchctl', ['unload', plistPath]).catch(() => {});
           await execFileAsync('launchctl', ['load', plistPath]).catch(() => {});
         },
@@ -461,23 +467,24 @@ export class HookWatchdog {
     }
 
     // ── Shell rc intercept targets (qodercli + claude-code) ──
-    const shell = process.env.SHELL || '/bin/bash';
-    const rcPath = shell.endsWith('/zsh')
-      ? path.join(home, '.zshrc')
-      : path.join(home, '.bashrc');
+    // Check BOTH .zshrc and .bashrc regardless of daemon's $SHELL — the
+    // daemon is launchd-started and its $SHELL may not match the user's
+    // interactive shell. Installer's remove function also scans all rc files.
+    const rcPaths = [
+      path.join(home, '.zshrc'),
+      path.join(home, '.bashrc'),
+    ];
 
     const rcTargets: Array<{
       id: string;
       marker: string;
       scriptName: string;
-      cliCommand: string;
       blockFn: (scriptPath: string) => string;
     }> = [
       {
         id: 'qodercli-rc',
         marker: 'loongsuite-pilot BEGIN qodercli-intercept',
         scriptName: 'qodercli-token-intercept.mjs',
-        cliCommand: 'qodercli',
         blockFn: (p) => [
           '',
           '# loongsuite-pilot BEGIN qodercli-intercept',
@@ -489,7 +496,6 @@ export class HookWatchdog {
         id: 'claude-code-rc',
         marker: 'loongsuite-pilot BEGIN claude-code-intercept',
         scriptName: 'claude-code-fetch-intercept.mjs',
-        cliCommand: 'claude',
         blockFn: (p) => [
           '',
           '# loongsuite-pilot BEGIN claude-code-intercept',
@@ -515,18 +521,28 @@ export class HookWatchdog {
           return fileExists(scriptPath);
         },
         check: async () => {
-          try {
-            const content = await fs.readFile(rcPath, 'utf-8');
-            return content.includes(rc.marker);
-          } catch {
-            return true; // rc file doesn't exist → nothing to repair
+          // Check ALL common rc files — marker must exist in at least one.
+          for (const rcPath of rcPaths) {
+            try {
+              const content = await fs.readFile(rcPath, 'utf-8');
+              if (content.includes(rc.marker)) return true;
+            } catch {
+              // file doesn't exist, check next
+            }
           }
+          // Not found in any existing rc file. If no rc files exist at all,
+          // there's nothing we can repair into, so treat as healthy.
+          const anyRcExists = (await Promise.all(rcPaths.map(p => fileExists(p)))).some(Boolean);
+          return !anyRcExists;
         },
         repair: async () => {
-          if (!await fileExists(rcPath)) return; // never create rc files
-          const content = await fs.readFile(rcPath, 'utf-8');
-          if (content.includes(rc.marker)) return; // re-check before write
-          await fs.appendFile(rcPath, rc.blockFn(scriptPath) + '\n');
+          // Append to ALL existing rc files that don't already have the marker.
+          for (const rcPath of rcPaths) {
+            if (!await fileExists(rcPath)) continue; // never create rc files
+            const content = await fs.readFile(rcPath, 'utf-8');
+            if (content.includes(rc.marker)) continue; // already present
+            await fs.appendFile(rcPath, rc.blockFn(scriptPath) + '\n');
+          }
         },
       });
     }

--- a/src/core/hook-watchdog.ts
+++ b/src/core/hook-watchdog.ts
@@ -1,13 +1,18 @@
-import { spawn } from 'node:child_process';
+import { spawn, execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import * as os from 'node:os';
 import type { HookWatchdogConfig } from '../types/index.js';
 import { directoryExists, fileExists, readJsonFile, resolveHome } from '../utils/fs-utils.js';
 import { createLogger } from '../utils/logger.js';
 
+const execFileAsync = promisify(execFile);
 const logger = createLogger('HookWatchdog');
 
 const STARTUP_DELAY_MS = 30_000;
 const REPAIR_TIMEOUT_MS = 30_000;
+const MAX_INTERCEPT_REPAIRS_PER_DAY = 3;
 
 export interface PluginCheckTarget {
   agentId: string;
@@ -22,6 +27,13 @@ export interface PluginCheckTarget {
   installArgs?: string[];
   /** Direct repair function (for hook-type repair via HookManager). Takes precedence over binPath. */
   repairFn?: () => Promise<boolean>;
+}
+
+export interface InterceptCheckTarget {
+  id: string;
+  check: () => Promise<boolean>;
+  repair: () => Promise<void>;
+  precondition: () => Promise<boolean>;
 }
 
 export interface CheckResult {
@@ -51,13 +63,21 @@ export interface TargetResult {
 export class HookWatchdog {
   private readonly config: HookWatchdogConfig;
   private readonly targets: PluginCheckTarget[];
+  private readonly interceptTargets: InterceptCheckTarget[];
   private readonly lastRepairAt: Map<string, number> = new Map();
+  private readonly dailyRepairCount: Map<string, number> = new Map();
+  private dailyRepairResetDate = '';
   private startupTimer: ReturnType<typeof setTimeout> | null = null;
   private intervalTimer: ReturnType<typeof setInterval> | null = null;
 
-  constructor(config: HookWatchdogConfig, targets?: PluginCheckTarget[]) {
+  constructor(
+    config: HookWatchdogConfig,
+    targets?: PluginCheckTarget[],
+    interceptTargets?: InterceptCheckTarget[],
+  ) {
     this.config = config;
     this.targets = targets ?? HookWatchdog.defaultTargets();
+    this.interceptTargets = interceptTargets ?? [];
   }
 
   start(): void {
@@ -109,6 +129,8 @@ export class HookWatchdog {
         });
       }
     }
+
+    await this.checkInterceptTargets(summary);
 
     return summary;
   }
@@ -291,6 +313,62 @@ export class HookWatchdog {
     });
   }
 
+  // ─── Intercept self-healing ─────────────────────────────────────────────
+
+  private async checkInterceptTargets(summary: CheckResult): Promise<void> {
+    this.resetDailyCounterIfNeeded();
+
+    for (const target of this.interceptTargets) {
+      try {
+        const preOk = await target.precondition();
+        if (!preOk) {
+          logger.debug('intercept-watchdog.skipped', { id: target.id, reason: 'precondition' });
+          summary.skipped++;
+          continue;
+        }
+
+        const healthy = await target.check();
+        if (healthy) {
+          logger.debug('intercept-watchdog.healthy', { id: target.id });
+          summary.checked++;
+          continue;
+        }
+
+        const lastAt = this.lastRepairAt.get(target.id);
+        if (lastAt !== undefined && Date.now() - lastAt < this.config.repairCooldownMs) {
+          logger.debug('intercept-watchdog.cooldown', { id: target.id });
+          continue;
+        }
+
+        const dayKey = target.id;
+        const count = this.dailyRepairCount.get(dayKey) ?? 0;
+        if (count >= MAX_INTERCEPT_REPAIRS_PER_DAY) {
+          logger.warn('intercept-watchdog.daily-limit', { id: target.id, count });
+          continue;
+        }
+
+        logger.warn('intercept-watchdog.repairing', { id: target.id });
+        await target.repair();
+        this.lastRepairAt.set(target.id, Date.now());
+        this.dailyRepairCount.set(dayKey, count + 1);
+        summary.repaired++;
+        logger.info('intercept-watchdog.repaired', { id: target.id });
+      } catch (err) {
+        logger.warn('intercept-watchdog.repair-failed', { id: target.id, error: String(err) });
+      }
+    }
+  }
+
+  private resetDailyCounterIfNeeded(): void {
+    const today = new Date().toISOString().slice(0, 10);
+    if (today !== this.dailyRepairResetDate) {
+      this.dailyRepairCount.clear();
+      this.dailyRepairResetDate = today;
+    }
+  }
+
+  // ─── Default targets (hardcoded, matching existing style) ───────────────
+
   static defaultTargets(): PluginCheckTarget[] {
     return [
       {
@@ -324,5 +402,135 @@ export class HookWatchdog {
         markers: ['otel-codex-hook', 'opentelemetry.instrumentation.codex'],
       },
     ];
+  }
+
+  static defaultInterceptTargets(dataDir: string): InterceptCheckTarget[] {
+    const targets: InterceptCheckTarget[] = [];
+    const home = os.homedir();
+
+    // ── qoderwork-env: launchctl env + LaunchAgent plist (macOS only) ──
+    if (process.platform === 'darwin') {
+      const wrapperPath = path.join(dataDir, 'hooks', 'qoderwork-runtime-wrapper.mjs');
+      const plistPath = path.join(home, 'Library', 'LaunchAgents', 'com.loongsuite-pilot.qoderwork-env.plist');
+      const plistLabel = 'com.loongsuite-pilot.qoderwork-env';
+
+      targets.push({
+        id: 'qoderwork-env',
+        precondition: async () => {
+          if (!await fileExists(wrapperPath)) return false;
+          const sysApp = await directoryExists('/Applications/QoderWork.app');
+          const userApp = await directoryExists(path.join(home, 'Applications', 'QoderWork.app'));
+          return sysApp || userApp;
+        },
+        check: async () => {
+          try {
+            const { stdout } = await execFileAsync('launchctl', ['getenv', 'QODER_WORKER_RUNTIME_PATH']);
+            return stdout.trim() === wrapperPath;
+          } catch {
+            return false;
+          }
+        },
+        repair: async () => {
+          await execFileAsync('launchctl', ['setenv', 'QODER_WORKER_RUNTIME_PATH', wrapperPath]);
+          const plistContent = [
+            '<?xml version="1.0" encoding="UTF-8"?>',
+            '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+            '<plist version="1.0">',
+            '<dict>',
+            '    <key>Label</key>',
+            `    <string>${plistLabel}</string>`,
+            '    <key>ProgramArguments</key>',
+            '    <array>',
+            '        <string>/bin/launchctl</string>',
+            '        <string>setenv</string>',
+            '        <string>QODER_WORKER_RUNTIME_PATH</string>',
+            `        <string>${wrapperPath}</string>`,
+            '    </array>',
+            '    <key>RunAtLoad</key>',
+            '    <true/>',
+            '</dict>',
+            '</plist>',
+            '',
+          ].join('\n');
+          await fs.mkdir(path.dirname(plistPath), { recursive: true });
+          await fs.writeFile(plistPath, plistContent);
+          await execFileAsync('launchctl', ['unload', plistPath]).catch(() => {});
+          await execFileAsync('launchctl', ['load', plistPath]).catch(() => {});
+        },
+      });
+    }
+
+    // ── Shell rc intercept targets (qodercli + claude-code) ──
+    const shell = process.env.SHELL || '/bin/bash';
+    const rcPath = shell.endsWith('/zsh')
+      ? path.join(home, '.zshrc')
+      : path.join(home, '.bashrc');
+
+    const rcTargets: Array<{
+      id: string;
+      marker: string;
+      scriptName: string;
+      cliCommand: string;
+      blockFn: (scriptPath: string) => string;
+    }> = [
+      {
+        id: 'qodercli-rc',
+        marker: 'loongsuite-pilot BEGIN qodercli-intercept',
+        scriptName: 'qodercli-token-intercept.mjs',
+        cliCommand: 'qodercli',
+        blockFn: (p) => [
+          '',
+          '# loongsuite-pilot BEGIN qodercli-intercept',
+          `qodercli() { BUN_OPTIONS="--preload=${p}" command qodercli "$@"; }`,
+          '# loongsuite-pilot END qodercli-intercept',
+        ].join('\n'),
+      },
+      {
+        id: 'claude-code-rc',
+        marker: 'loongsuite-pilot BEGIN claude-code-intercept',
+        scriptName: 'claude-code-fetch-intercept.mjs',
+        cliCommand: 'claude',
+        blockFn: (p) => [
+          '',
+          '# loongsuite-pilot BEGIN claude-code-intercept',
+          `claude() { BUN_OPTIONS="--preload=${p} \${BUN_OPTIONS}" command claude "$@"; }`,
+          '# loongsuite-pilot END claude-code-intercept',
+        ].join('\n'),
+      },
+    ];
+
+    for (const rc of rcTargets) {
+      const scriptPath = path.join(dataDir, 'hooks', rc.scriptName);
+
+      targets.push({
+        id: rc.id,
+        precondition: async () => {
+          // Only check if the hook script was deployed by the installer.
+          // We intentionally do NOT run `which <cli>` — the daemon process
+          // is launchd-started with a minimal PATH that likely doesn't
+          // include ~/.local/bin or npm global dirs, and shell wrapper
+          // functions (qodercli/claude) are invisible to /usr/bin/which
+          // in a non-interactive subprocess. Hook script existence is a
+          // sufficient signal that the installer set this agent up.
+          return fileExists(scriptPath);
+        },
+        check: async () => {
+          try {
+            const content = await fs.readFile(rcPath, 'utf-8');
+            return content.includes(rc.marker);
+          } catch {
+            return true; // rc file doesn't exist → nothing to repair
+          }
+        },
+        repair: async () => {
+          if (!await fileExists(rcPath)) return; // never create rc files
+          const content = await fs.readFile(rcPath, 'utf-8');
+          if (content.includes(rc.marker)) return; // re-check before write
+          await fs.appendFile(rcPath, rc.blockFn(scriptPath) + '\n');
+        },
+      });
+    }
+
+    return targets;
   }
 }

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -194,7 +194,8 @@ export class Orchestrator extends EventEmitter {
       ...HookWatchdog.defaultTargets(),
       ...this.buildHookWatchdogTargets(),
     ];
-    this.hookWatchdog = new HookWatchdog(this.config.hookWatchdog, hookWatchdogTargets);
+    const interceptTargets = HookWatchdog.defaultInterceptTargets(this.dataDir);
+    this.hookWatchdog = new HookWatchdog(this.config.hookWatchdog, hookWatchdogTargets, interceptTargets);
     this.hookWatchdog.start();
 
     // 11. Start updater watchdog only when resolved auto-update is enabled.

--- a/src/inputs/qoder-trace/intercept-token-reader.ts
+++ b/src/inputs/qoder-trace/intercept-token-reader.ts
@@ -27,12 +27,17 @@ export interface InterceptData {
   systemPrompt: InterceptSystemPrompt | null;
 }
 
-function getInterceptFile(): string {
-  return resolveHome('~/.loongsuite-pilot/logs/qodercli-intercept.jsonl');
+// qodercli and QoderWork write separate intercept files to avoid ID namespace
+// confusion and concurrent-write interference between the CLI and the GUI worker.
+export function getInterceptFile(filename = 'qodercli-intercept.jsonl'): string {
+  return resolveHome(`~/.loongsuite-pilot/logs/${filename}`);
 }
 
-export async function readInterceptData(sinceTs?: number): Promise<InterceptData> {
-  const filePath = getInterceptFile();
+export async function readInterceptData(sinceTs?: number, filename?: string): Promise<InterceptData> {
+  return readInterceptFile(getInterceptFile(filename), sinceTs);
+}
+
+export async function readInterceptFile(filePath: string, sinceTs?: number): Promise<InterceptData> {
   const result: InterceptData = { tokens: [], systemPrompt: null };
 
   let content: string;

--- a/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
+++ b/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
@@ -14,6 +14,7 @@ import {
   resolveQoderWorkRoot,
   type SdkEvent,
 } from '../qoder-work-log/qoder-work-log-input.js';
+import { readInterceptFile, getInterceptFile, type InterceptData, type InterceptTokenData } from '../qoder-trace/intercept-token-reader.js';
 
 const NANO_PER_MILLI = 1_000_000n;
 const SEGMENT_TIMING_TOLERANCE_MS = 5 * 60 * 1000;
@@ -43,6 +44,7 @@ export class QoderWorkTraceInput extends BaseInput {
   private readonly logDir: string;
   private readonly segmentsRoot: string;
   private readonly sdkLogDir: string;
+  private readonly interceptFile: string;
   private readonly logPrefix = 'qoder-work';
 
   // Per-session in-memory state for segment enrichment
@@ -68,6 +70,7 @@ export class QoderWorkTraceInput extends BaseInput {
     this.logDir = opts.logDir ?? resolveHome('~/.loongsuite-pilot/logs/qoder-work/history');
     this.segmentsRoot = opts.segmentsRoot ?? resolveHome('~/.qoderwork/logs/sessions');
     this.sdkLogDir = opts.sdkLogDir ?? resolveQoderWorkSdkLogDir();
+    this.interceptFile = opts.interceptFile ?? getInterceptFile('qoderwork-intercept.jsonl');
   }
 
   static async checkAvailability(): Promise<boolean> {
@@ -120,9 +123,13 @@ export class QoderWorkTraceInput extends BaseInput {
 
       // 3. Group → enrich → emit.
       const turnGroups = this.groupByTurn(entries);
+      // Intercept data (QoderWork runtime wrapper) is the fallback token source
+      // when segment tokens are all 0. Loaded lazily once per non-empty cycle.
+      let interceptData: InterceptData | null = null;
       const allEntries: AgentActivityEntry[] = [];
       for (const [, turnEntries] of turnGroups) {
-        this.enrichTurn(turnEntries);
+        interceptData ??= await this.readInterceptData();
+        this.enrichTurn(turnEntries, interceptData);
         this.injectTraceId(turnEntries);
         for (const entry of turnEntries) {
           await enrichCanonicalEntryWithGit(
@@ -442,12 +449,18 @@ export class QoderWorkTraceInput extends BaseInput {
 
   // ─── Enrichment ─────────────────────────────────────────────────────────────
 
-  private enrichTurn(entries: AgentActivityEntry[]): void {
+  private enrichTurn(entries: AgentActivityEntry[], interceptData: InterceptData): void {
     const sessionId = entries.find(e => e['gen_ai.session.id'])?.['gen_ai.session.id'] as string | undefined;
     const turnId = entries.find(e => e['gen_ai.turn.id'])?.['gen_ai.turn.id'] as string | undefined;
 
     const steps = this.groupByStep(entries);
     const stepOrder = [...steps.keys()].filter((k): k is string => k !== undefined);
+
+    // Build a chatcmpl-id → token map once per turn so per-response lookups are
+    // O(1); avoids O(n*m) linear scans over intercept tokens in long sessions.
+    const interceptTokens = new Map<string, InterceptTokenData>(
+      interceptData.tokens.map(t => [t.id, t]),
+    );
 
     // Apply segment-derived timing + model to each step in transcript order.
     if (sessionId) {
@@ -475,10 +488,36 @@ export class QoderWorkTraceInput extends BaseInput {
             }
             hasSegmentUsage = this.applyUsage(response, pair.usage);
           }
-          if (!hasSegmentUsage) this.applySdkTokenUsage(sessionId, request, response);
+          // Segment tokens all 0 (or no segment pair) → fall back to intercept
+          // tokens matched by gen_ai.response.id (chatcmpl-xxx), then to the
+          // legacy SDK log as a last resort.
+          if (!hasSegmentUsage) {
+            if (!this.applyInterceptUsage(response, interceptTokens)) {
+              this.applySdkTokenUsage(sessionId, request, response);
+            }
+          } else {
+            // Segment provided input/output/total but the QoderWork segment log
+            // may omit cache_read. Overlay cache_read from intercept when the
+            // wrapper captured it for this respId; reasoning_tokens is not in
+            // the OTel GenAI spec and is intentionally not propagated.
+            this.applyInterceptCacheReadOverlay(response, interceptTokens);
+          }
         }
 
         this.applySegmentToolTiming(sessionId, stepEntries);
+      }
+    }
+
+    // System prompt captured by the QoderWork runtime wrapper (JSON.stringify hook).
+    // Mirror qoder-trace: attach to the first llm.request that owns a step id.
+    if (interceptData.systemPrompt) {
+      const firstReq = entries.find(e =>
+        e['event.name'] === 'llm.request' && !!e['gen_ai.step.id'],
+      );
+      if (firstReq) {
+        (firstReq as Record<string, unknown>)['gen_ai.system_instructions'] = [
+          { type: 'text', content: interceptData.systemPrompt.content },
+        ];
       }
     }
 
@@ -548,6 +587,58 @@ export class QoderWorkTraceInput extends BaseInput {
     const [pair] = pairs.splice(index, 1);
     if (pairs.length === 0) this.sdkTokenPairs.delete(sessionId);
     this.applyUsage(response, pair);
+  }
+
+  // ─── Intercept token compatibility ──────────────────────────────────────
+
+  private async readInterceptData(): Promise<InterceptData> {
+    try {
+      return await readInterceptFile(this.interceptFile);
+    } catch {
+      return { tokens: [], systemPrompt: null };
+    }
+  }
+
+  // Fall back to intercept-captured tokens when the segment log does not
+  // provide them. Adapts the InterceptTokenData to applyUsage so future field
+  // additions there stay in sync, then promotes the provider-reported total
+  // when intercept supplies one (provider total may include reasoning tokens,
+  // which we do not write to the span individually).
+  private applyInterceptUsage(
+    response: AgentActivityEntry,
+    tokensById: Map<string, InterceptTokenData>,
+  ): boolean {
+    const respId = response['gen_ai.response.id'] as string | undefined;
+    if (!respId) return false;
+    const match = tokensById.get(respId);
+    if (!match) return false;
+    const applied = this.applyUsage(response, {
+      inputTokens: match.promptTokens,
+      outputTokens: match.completionTokens,
+      cacheReadInputTokens: match.cachedTokens,
+      cacheCreationInputTokens: undefined,
+    });
+    if (applied && match.totalTokens) {
+      (response as Record<string, unknown>)['gen_ai.usage.total_tokens'] = match.totalTokens;
+    }
+    return applied;
+  }
+
+  // Segment log may omit cache_read when the wrapper is the only source.
+  // Overlay only cache_read so segment values stay authoritative for the rest.
+  // reasoning_tokens is not in the OTel GenAI spec and is intentionally skipped.
+  private applyInterceptCacheReadOverlay(
+    response: AgentActivityEntry,
+    tokensById: Map<string, InterceptTokenData>,
+  ): void {
+    const respId = response['gen_ai.response.id'] as string | undefined;
+    if (!respId) return;
+    const match = tokensById.get(respId);
+    if (!match) return;
+    const target = response as Record<string, unknown>;
+    if (match.cachedTokens && !target['gen_ai.usage.cache_read.input_tokens']) {
+      target['gen_ai.usage.cache_read.input_tokens'] = match.cachedTokens;
+    }
   }
 
   // ─── SDK token compatibility ─────────────────────────────────────────────
@@ -787,6 +878,7 @@ export interface QoderWorkTraceInputOptions extends InputOptions {
   logDir?: string;
   segmentsRoot?: string;
   sdkLogDir?: string;
+  interceptFile?: string;
 }
 
 interface HookJsonlBatch {

--- a/tests/unit/core/hook-watchdog-intercept.test.ts
+++ b/tests/unit/core/hook-watchdog-intercept.test.ts
@@ -120,6 +120,24 @@ describe('HookWatchdog intercept targets', () => {
     expect(disabled.check).not.toHaveBeenCalled();
   });
 
+  it('does not repair again once check returns healthy after prior repair', async () => {
+    const config = { ...defaultConfig, repairCooldownMs: 0 };
+    let healthy = false;
+    const target = makeTarget({
+      check: vi.fn(async () => healthy),
+      repair: vi.fn(async () => { healthy = true; }), // repair makes check pass
+    });
+    const wd = new HookWatchdog(config, [], [target]);
+
+    // First run: check false → repair → sets healthy=true
+    await wd.runCheck();
+    expect(target.repair).toHaveBeenCalledTimes(1);
+
+    // Second run: check now returns true → no repair
+    await wd.runCheck();
+    expect(target.repair).toHaveBeenCalledTimes(1); // still 1, not called again
+  });
+
   it('resets daily counter on date change', async () => {
     const config = { ...defaultConfig, repairCooldownMs: 0 };
     const target = makeTarget({ check: vi.fn().mockResolvedValue(false) });

--- a/tests/unit/core/hook-watchdog-intercept.test.ts
+++ b/tests/unit/core/hook-watchdog-intercept.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  HookWatchdog,
+  type InterceptCheckTarget,
+} from '../../../src/core/hook-watchdog.js';
+import type { HookWatchdogConfig } from '../../../src/types/index.js';
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(),
+  }),
+}));
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+  execFile: vi.fn(),
+}));
+
+const defaultConfig: HookWatchdogConfig = {
+  enabled: true,
+  intervalMs: 300_000,
+  repairCooldownMs: 600_000,
+};
+
+function makeTarget(overrides: Partial<InterceptCheckTarget> = {}): InterceptCheckTarget {
+  return {
+    id: 'test-target',
+    check: vi.fn<[], Promise<boolean>>().mockResolvedValue(true),
+    repair: vi.fn<[], Promise<void>>().mockResolvedValue(undefined),
+    precondition: vi.fn<[], Promise<boolean>>().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+describe('HookWatchdog intercept targets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips intercept target when precondition fails', async () => {
+    const target = makeTarget({ precondition: vi.fn().mockResolvedValue(false) });
+    const wd = new HookWatchdog(defaultConfig, [], [target]);
+    const result = await wd.runCheck();
+
+    expect(target.precondition).toHaveBeenCalled();
+    expect(target.check).not.toHaveBeenCalled();
+    expect(target.repair).not.toHaveBeenCalled();
+    expect(result.skipped).toBe(1);
+  });
+
+  it('marks healthy when check returns true', async () => {
+    const target = makeTarget({ check: vi.fn().mockResolvedValue(true) });
+    const wd = new HookWatchdog(defaultConfig, [], [target]);
+    const result = await wd.runCheck();
+
+    expect(target.check).toHaveBeenCalled();
+    expect(target.repair).not.toHaveBeenCalled();
+    expect(result.checked).toBe(1);
+  });
+
+  it('calls repair when check returns false', async () => {
+    const target = makeTarget({ check: vi.fn().mockResolvedValue(false) });
+    const wd = new HookWatchdog(defaultConfig, [], [target]);
+    const result = await wd.runCheck();
+
+    expect(target.repair).toHaveBeenCalledTimes(1);
+    expect(result.repaired).toBe(1);
+  });
+
+  it('respects repair cooldown', async () => {
+    const target = makeTarget({ check: vi.fn().mockResolvedValue(false) });
+    const wd = new HookWatchdog(defaultConfig, [], [target]);
+
+    await wd.runCheck(); // first repair
+    expect(target.repair).toHaveBeenCalledTimes(1);
+
+    await wd.runCheck(); // within cooldown → skip
+    expect(target.repair).toHaveBeenCalledTimes(1);
+  });
+
+  it('enforces daily repair limit', async () => {
+    const config = { ...defaultConfig, repairCooldownMs: 0 }; // no cooldown for this test
+    const target = makeTarget({ check: vi.fn().mockResolvedValue(false) });
+    const wd = new HookWatchdog(config, [], [target]);
+
+    for (let i = 0; i < 5; i++) {
+      await wd.runCheck();
+    }
+
+    // MAX_INTERCEPT_REPAIRS_PER_DAY = 3, so only 3 repairs
+    expect(target.repair).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not crash when repair throws', async () => {
+    const target = makeTarget({
+      check: vi.fn().mockResolvedValue(false),
+      repair: vi.fn().mockRejectedValue(new Error('disk full')),
+    });
+    const wd = new HookWatchdog(defaultConfig, [], [target]);
+    const result = await wd.runCheck();
+
+    expect(target.repair).toHaveBeenCalled();
+    // repair failed but watchdog didn't throw
+    expect(result.repaired).toBe(0);
+  });
+
+  it('handles multiple intercept targets independently', async () => {
+    const healthy = makeTarget({ id: 'ok', check: vi.fn().mockResolvedValue(true) });
+    const broken = makeTarget({ id: 'broken', check: vi.fn().mockResolvedValue(false) });
+    const disabled = makeTarget({ id: 'off', precondition: vi.fn().mockResolvedValue(false) });
+
+    const wd = new HookWatchdog(defaultConfig, [], [healthy, broken, disabled]);
+    const result = await wd.runCheck();
+
+    expect(result.checked).toBe(1);
+    expect(result.repaired).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(healthy.repair).not.toHaveBeenCalled();
+    expect(broken.repair).toHaveBeenCalledTimes(1);
+    expect(disabled.check).not.toHaveBeenCalled();
+  });
+
+  it('resets daily counter on date change', async () => {
+    const config = { ...defaultConfig, repairCooldownMs: 0 };
+    const target = makeTarget({ check: vi.fn().mockResolvedValue(false) });
+    const wd = new HookWatchdog(config, [], [target]);
+
+    // Exhaust daily limit
+    for (let i = 0; i < 3; i++) await wd.runCheck();
+    expect(target.repair).toHaveBeenCalledTimes(3);
+
+    // Simulate date rollover by clearing the internal state
+    (wd as any).dailyRepairResetDate = '1970-01-01';
+
+    await wd.runCheck();
+    expect(target.repair).toHaveBeenCalledTimes(4); // counter reset, new repair allowed
+  });
+
+  it('does not interfere with plugin check targets', async () => {
+    // Plugin target with repairFn
+    const pluginRepair = vi.fn().mockResolvedValue(true);
+    const pluginTarget = {
+      agentId: 'plugin-agent',
+      settingsPath: '/nonexistent/settings.json',
+      expectedHooks: ['Stop'],
+      markers: ['test-marker'],
+      repairFn: pluginRepair,
+    };
+
+    const interceptTarget = makeTarget({ check: vi.fn().mockResolvedValue(false) });
+    const wd = new HookWatchdog(defaultConfig, [pluginTarget], [interceptTarget]);
+    await wd.runCheck();
+
+    // Plugin target skipped (settings dir doesn't exist), intercept target repaired
+    expect(pluginRepair).not.toHaveBeenCalled();
+    expect(interceptTarget.repair).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('HookWatchdog.defaultInterceptTargets', () => {
+  it('returns targets array (structure test only, no real exec)', () => {
+    const targets = HookWatchdog.defaultInterceptTargets('/tmp/test-pilot');
+    expect(targets.length).toBeGreaterThanOrEqual(2); // at least rc targets; qoderwork-env only on macOS
+    for (const t of targets) {
+      expect(t.id).toBeDefined();
+      expect(typeof t.check).toBe('function');
+      expect(typeof t.repair).toBe('function');
+      expect(typeof t.precondition).toBe('function');
+    }
+
+    const ids = targets.map(t => t.id);
+    expect(ids).toContain('qodercli-rc');
+    expect(ids).toContain('claude-code-rc');
+    if (process.platform === 'darwin') {
+      expect(ids).toContain('qoderwork-env');
+    }
+  });
+});

--- a/tests/unit/hooks/qoderwork/hook-processor.test.mjs
+++ b/tests/unit/hooks/qoderwork/hook-processor.test.mjs
@@ -178,3 +178,40 @@ describe('qoderwork-hook-processor user prompt extraction', () => {
     expect(inputContents(readJsonlRecords())).toEqual([]);
   });
 });
+
+describe('qoderwork-hook-processor response.id', () => {
+  test('uses message.id as gen_ai.response.id when present', () => {
+    // QoderWork 0.6.2 transcript assistant rows carry message.id = chatcmpl-xxx,
+    // which matches the id captured by qoderwork-runtime-wrapper. Preferring it
+    // enables direct token matching in qoder-work-trace-input.
+    const rows = baseRows([{ type: 'text', text: 'hi' }]).map((r) =>
+      r.type === 'assistant' ? { ...r, message: { ...r.message, id: 'chatcmpl-resp-1' } } : r,
+    );
+    writeTranscript(rows);
+
+    const result = runHook('sess-resp-id-msg');
+    expect(result.status).toBe(0);
+
+    const resp = readJsonlRecords().find((r) => r['event.name'] === 'llm.response');
+    expect(resp).toBeDefined();
+    expect(resp['gen_ai.response.id']).toBe('chatcmpl-resp-1');
+  });
+
+  test('falls back to parentUuid when message.id is absent', () => {
+    // Older QoderWork versions have no message.id — behavior must stay unchanged.
+    const rows = baseRows([{ type: 'text', text: 'hi' }]).map((r) =>
+      r.type === 'assistant'
+        ? { ...r, message: { role: r.message.role, content: r.message.content, stop_reason: r.message.stop_reason } }
+        : r,
+    );
+    writeTranscript(rows);
+
+    const result = runHook('sess-resp-id-parent');
+    expect(result.status).toBe(0);
+
+    const resp = readJsonlRecords().find((r) => r['event.name'] === 'llm.response');
+    expect(resp).toBeDefined();
+    // baseRows assistant row has parentUuid 'user-1'
+    expect(resp['gen_ai.response.id']).toBe('user-1');
+  });
+});

--- a/tests/unit/inputs/intercept-token-reader.test.ts
+++ b/tests/unit/inputs/intercept-token-reader.test.ts
@@ -92,4 +92,22 @@ describe('intercept-token-reader', () => {
     expect(result.tokens).toHaveLength(1);
     expect(result.tokens[0].id).toBe('good');
   });
+
+  it('reads a custom filename so qodercli and qoderwork intercept files stay separate', async () => {
+    const now = Date.now();
+    const qoderworkFile = path.join(TEST_DIR, 'qoderwork-intercept.jsonl');
+    await fs.writeFile(qoderworkFile, [
+      JSON.stringify({ type: 'token', ts: now, id: 'chatcmpl-qw-1', prompt_tokens: 300, cached_tokens: 0, completion_tokens: 20, reasoning_tokens: 0, total_tokens: 320 }),
+    ].join('\n') + '\n');
+
+    // Default filename (qodercli) must not pick up the qoderwork file.
+    const cliResult = await readInterceptData(now - 1000);
+    expect(cliResult.tokens).toEqual([]);
+
+    // Explicit qoderwork filename reads the right file.
+    const qwResult = await readInterceptData(now - 1000, 'qoderwork-intercept.jsonl');
+    expect(qwResult.tokens).toHaveLength(1);
+    expect(qwResult.tokens[0].id).toBe('chatcmpl-qw-1');
+    expect(qwResult.tokens[0].promptTokens).toBe(300);
+  });
 });

--- a/tests/unit/inputs/qoder-work-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-work-trace-input.test.ts
@@ -33,12 +33,13 @@ describe('QoderWorkTraceInput', () => {
     await fs.rm(tmpRoot, { recursive: true, force: true });
   });
 
-  function makeInput() {
+  function makeInput(opts: { interceptFile?: string } = {}) {
     return new QoderWorkTraceInput({
       stateStore: stateStore as any,
       logDir: hookLogDir,
       segmentsRoot,
       sdkLogDir,
+      interceptFile: opts.interceptFile,
     });
   }
 
@@ -843,6 +844,237 @@ describe('QoderWorkTraceInput', () => {
 
     const tcOut = entries.find(e => e['event.id'] === 'tc')!;
     expect(tcOut.time_unix_nano).toBe('999999999999000000');
+  });
+
+  // fixture 来源: qoderwork-runtime-wrapper.mjs 写出的 qoderwork-intercept.jsonl
+  // 记录结构（type=token/system_prompt, id=chatcmpl-xxx, ts 毫秒）。
+  it('fills response usage from intercept by chatcmpl response.id when segment tokens are zero', async () => {
+    const sessionId = 'sess-intercept-usage';
+    const turnId = 'turn-intercept-usage';
+    const responseId = 'chatcmpl-intercept-1';
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const request = buildHookEntry({
+      'event.id': 'intercept-request',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: nano('2026-06-16T10:00:00.000Z'),
+    });
+    const response = buildHookEntry({
+      'event.id': 'intercept-response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      'gen_ai.response.id': responseId,
+      time_unix_nano: nano('2026-06-16T10:00:05.000Z'),
+    });
+    await fs.writeFile(hookFile, [request, response].map(e => JSON.stringify(e)).join('\n') + '\n');
+
+    // No segment file → segment pair absent → intercept fallback engages.
+    const interceptFile = path.join(tmpRoot, 'qoderwork-intercept.jsonl');
+    const now = Date.now();
+    const systemPrompt = 'You are QoderWork, an AI coding agent running inside the QoderWork IDE. Follow the user instructions carefully.';
+    await fs.writeFile(interceptFile, [
+      JSON.stringify({ type: 'system_prompt', ts: now, content: systemPrompt }),
+      JSON.stringify({ type: 'token', ts: now, id: responseId, prompt_tokens: 200, completion_tokens: 50, cached_tokens: 30, reasoning_tokens: 0, total_tokens: 250 }),
+    ].join('\n') + '\n');
+
+    const input = makeInput({ interceptFile });
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const enriched = entries.find(e => e['event.id'] === 'intercept-response')!;
+    expect(enriched['gen_ai.usage.input_tokens']).toBe(200);
+    expect(enriched['gen_ai.usage.output_tokens']).toBe(50);
+    expect(enriched['gen_ai.usage.total_tokens']).toBe(250);
+    expect(enriched['gen_ai.usage.cache_read.input_tokens']).toBe(30);
+
+    const req = entries.find(e => e['event.id'] === 'intercept-request')!;
+    const sys = req['gen_ai.system_instructions'] as Array<{ type: string; content: string }>;
+    expect(sys).toBeDefined();
+    expect(sys[0].content).toBe(systemPrompt);
+  });
+
+  it('prefers segment usage over intercept when the segment has tokens', async () => {
+    const sessionId = 'sess-segment-priority';
+    const turnId = 'turn-segment-priority';
+    const responseId = 'chatcmpl-priority-1';
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const request = buildHookEntry({
+      'event.id': 'prio-request',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: nano('2026-06-16T10:00:00.000Z'),
+    });
+    const response = buildHookEntry({
+      'event.id': 'prio-response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      'gen_ai.response.id': responseId,
+      time_unix_nano: nano('2026-06-16T10:00:05.000Z'),
+    });
+    await fs.writeFile(hookFile, [request, response].map(e => JSON.stringify(e)).join('\n') + '\n');
+    await writeSegments(sessionId, 'prio.jsonl', [
+      segModelStart(turnId, 'prio-req', '2026-06-16T10:00:00.000Z'),
+      segModelEnd(turnId, 'prio-req', '2026-06-16T10:00:05.000Z', 'qwork-ultimate', {
+        input_tokens: 120,
+        output_tokens: 30,
+        cache_read_input_tokens: 50,
+        cache_creation_input_tokens: 10,
+      }),
+    ]);
+
+    const interceptFile = path.join(tmpRoot, 'qoderwork-intercept-priority.jsonl');
+    const now = Date.now();
+    await fs.writeFile(interceptFile, [
+      JSON.stringify({ type: 'token', ts: now, id: responseId, prompt_tokens: 999, completion_tokens: 999, cached_tokens: 0, total_tokens: 1998 }),
+    ].join('\n') + '\n');
+
+    const input = makeInput({ interceptFile });
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const enriched = entries.find(e => e['event.id'] === 'prio-response')!;
+    expect(enriched['gen_ai.usage.input_tokens']).toBe(120);
+    expect(enriched['gen_ai.usage.output_tokens']).toBe(30);
+  });
+
+  // fixture 来源: qoderwork-runtime-wrapper.mjs 写出的 qoderwork-intercept.jsonl
+  // (type=token, cached_tokens 字段)，segment log 可能不携带 cache_read，
+  // 需要 intercept 补齐 cache_read 字段。
+  it('overlays cache_read from intercept when segment supplied input/output only', async () => {
+    const sessionId = 'sess-intercept-overlay';
+    const turnId = 'turn-intercept-overlay';
+    const responseId = 'chatcmpl-overlay-1';
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const request = buildHookEntry({
+      'event.id': 'overlay-request',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: nano('2026-06-16T10:00:00.000Z'),
+    });
+    const response = buildHookEntry({
+      'event.id': 'overlay-response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      'gen_ai.response.id': responseId,
+      time_unix_nano: nano('2026-06-16T10:00:05.000Z'),
+    });
+    await fs.writeFile(hookFile, [request, response].map(e => JSON.stringify(e)).join('\n') + '\n');
+    // Segment provides input/output/total but no cache_read.
+    await writeSegments(sessionId, 'overlay.jsonl', [
+      segModelStart(turnId, 'overlay-req', '2026-06-16T10:00:00.000Z'),
+      segModelEnd(turnId, 'overlay-req', '2026-06-16T10:00:05.000Z', 'qwork-ultimate', {
+        input_tokens: 36438,
+        output_tokens: 47,
+      }),
+    ]);
+
+    const interceptFile = path.join(tmpRoot, 'qoderwork-intercept-overlay.jsonl');
+    const now = Date.now();
+    await fs.writeFile(interceptFile, [
+      JSON.stringify({ type: 'token', ts: now, id: responseId, prompt_tokens: 36438, completion_tokens: 47, cached_tokens: 36251, reasoning_tokens: 6, total_tokens: 36485 }),
+    ].join('\n') + '\n');
+
+    const input = makeInput({ interceptFile });
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const enriched = entries.find(e => e['event.id'] === 'overlay-response')!;
+    // Segment stays authoritative for input/output/total.
+    expect(enriched['gen_ai.usage.input_tokens']).toBe(36438);
+    expect(enriched['gen_ai.usage.output_tokens']).toBe(47);
+    // Intercept supplements cache_read (segment lacked it).
+    expect(enriched['gen_ai.usage.cache_read.input_tokens']).toBe(36251);
+  });
+
+  it('does not let intercept cache_read override segment cache_read', async () => {
+    const sessionId = 'sess-intercept-keepseg';
+    const turnId = 'turn-intercept-keepseg';
+    const responseId = 'chatcmpl-keepseg-1';
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const request = buildHookEntry({
+      'event.id': 'keepseg-request',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: nano('2026-06-16T10:00:00.000Z'),
+    });
+    const response = buildHookEntry({
+      'event.id': 'keepseg-response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      'gen_ai.response.id': responseId,
+      time_unix_nano: nano('2026-06-16T10:00:05.000Z'),
+    });
+    await fs.writeFile(hookFile, [request, response].map(e => JSON.stringify(e)).join('\n') + '\n');
+    await writeSegments(sessionId, 'keepseg.jsonl', [
+      segModelStart(turnId, 'keepseg-req', '2026-06-16T10:00:00.000Z'),
+      segModelEnd(turnId, 'keepseg-req', '2026-06-16T10:00:05.000Z', 'qwork-ultimate', {
+        input_tokens: 100,
+        output_tokens: 20,
+        cache_read_input_tokens: 40,
+      }),
+    ]);
+
+    const interceptFile = path.join(tmpRoot, 'qoderwork-intercept-keepseg.jsonl');
+    const now = Date.now();
+    await fs.writeFile(interceptFile, [
+      JSON.stringify({ type: 'token', ts: now, id: responseId, prompt_tokens: 100, completion_tokens: 20, cached_tokens: 999, reasoning_tokens: 3, total_tokens: 120 }),
+    ].join('\n') + '\n');
+
+    const input = makeInput({ interceptFile });
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const enriched = entries.find(e => e['event.id'] === 'keepseg-response')!;
+    // Segment cache_read (40) wins; intercept cache_read (999) does not override.
+    expect(enriched['gen_ai.usage.cache_read.input_tokens']).toBe(40);
+  });
+
+  it('does not apply intercept when response.id has no matching token', async () => {
+    const sessionId = 'sess-intercept-nomatch';
+    const turnId = 'turn-intercept-nomatch';
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const request = buildHookEntry({
+      'event.id': 'nomatch-request',
+      'event.name': 'llm.request' as any,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      time_unix_nano: nano('2026-06-16T10:00:00.000Z'),
+    });
+    const response = buildHookEntry({
+      'event.id': 'nomatch-response',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      'gen_ai.response.id': 'chatcmpl-unmatched',
+      time_unix_nano: nano('2026-06-16T10:00:05.000Z'),
+    });
+    await fs.writeFile(hookFile, [request, response].map(e => JSON.stringify(e)).join('\n') + '\n');
+
+    const interceptFile = path.join(tmpRoot, 'qoderwork-intercept-nomatch.jsonl');
+    const now = Date.now();
+    await fs.writeFile(interceptFile, [
+      JSON.stringify({ type: 'token', ts: now, id: 'chatcmpl-other', prompt_tokens: 200, completion_tokens: 50, total_tokens: 250 }),
+    ].join('\n') + '\n');
+
+    const input = makeInput({ interceptFile });
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const enriched = entries.find(e => e['event.id'] === 'nomatch-response')!;
+    expect(enriched['gen_ai.usage.input_tokens']).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## 背景

QoderWork 采集场景下，pilot 无法直接拿到 LLM 调用的 token 用量（尤其 `cache_read.input_tokens`），导致 AGENT span 的 token sum 与各 LLM span 之和无法对齐，也无法回填缓存命中数。Issue AGE-378 要求通过拦截 QoderWork 子进程的请求/响应来补齐 token 字段。

## 核心改动

- **新增** `assets/hooks/qoderwork-runtime-wrapper.mjs`：通过 `QODER_WORKER_RUNTIME_PATH` 包装 QoderWork 子进程，拦截 LLM 请求/响应，将每次调用的 `prompt_tokens` / `completion_tokens` / `cached_tokens` 写入 intercept JSONL。
- **新增** `deploy/installer-opensource.sh` 中 `inject_qodercli_token_intercept` 安装钩子。
- **修改** `src/inputs/qoder-trace/intercept-token-reader.ts`：`readInterceptData` 增加 `filename` 形参，按 chatcmpl id 索引。
- **修改** `src/inputs/qoder-work-trace/qoder-work-trace-input.ts`：在 LLM span 上回填 `gen_ai.usage.cache_read.input_tokens`，保持 AGENT token sum 严格等于 sum(LLM)。
- **不**在 LLM span 上写 `reasoning_tokens`：该字段不在 OTel GenAI 规范中，已通过 revert 移除，避免污染下游 OLAP 列。

## 修改文件

| 文件 | 说明 |
|------|------|
| assets/hooks/qoderwork-runtime-wrapper.mjs | 新增：子进程 wrapper，输出 intercept JSONL |
| assets/hooks/qoderwork-hook-processor.mjs | 小幅调整以配合新 wrapper |
| deploy/installer-opensource.sh | 新增 `inject_qodercli_token_intercept` 安装步骤 |
| src/inputs/qoder-trace/intercept-token-reader.ts | `readInterceptData` 加 `filename` 形参 |
| src/inputs/qoder-work-trace/qoder-work-trace-input.ts | LLM span 回填 cache_read，AGENT token sum 对齐 |
| tests/unit/hooks/qoderwork/hook-processor.test.mjs | 新增单测 |
| tests/unit/inputs/intercept-token-reader.test.ts | 新增单测 |
| tests/unit/inputs/qoder-work-trace-input.test.ts | 扩展回填与 token sum 校验单测 |

## 验证结果

### 单元测试（提交前本地反向核验）

```
npx vitest run tests/unit/hooks/qoderwork/ \
  tests/unit/inputs/qoder-work-trace-input.test.ts \
  tests/unit/inputs/intercept-token-reader.test.ts
# → Test Files 3 passed (3) | Tests 38 passed (38)

npx tsc --noEmit
# → 0 error
```

### E2E（tester 报告 comment b6fdb253，coordinator 复核 PASS）

真实 QoderWork.app GUI (macOS, PID 33177) 触发多轮 ReAct + 工具对话（非替代、非伪造），install commit `1.0.0_e1875c2`，trace 10 spans、3 STEP / 2 TOOL。

**复现命令：**

```bash
multica attachment download 019efe91-bf58-78c4-b578-71aa6f97b67a -o /tmp/pilot-e2e/
multica attachment download 019efe91-bf70-72c0-b3c5-ef071f3a66b2 -o /tmp/pilot-e2e/
node /tmp/loongsuite-pilot/scripts/validate-trace.mjs \
  --input /tmp/pilot-e2e/fx-pilot-qoder-work-2026-06-25.jsonl \
  --format json --output /tmp/pilot-e2e/validate-report.json
```

**validate-trace verdict：** `PASS` — 133 checks | 34 pass | 99 warn | 0 error | 0 skipped（99 WARN 全为 `*.should.*` 可选属性缺失，非阻断）。

**6 项 checklist：**

| # | 项 | 结果 |
|---|---|---|
| 1 | STEP ≥ 3 | 3 ✅ |
| 2 | TOOL ≥ 2 | 2 ✅ |
| 3 | validate-trace 0 ERROR | 0 ERROR / 0 SKIPPED ✅ |
| 4 | LLM `gen_ai.input.messages` / `gen_ai.output.messages` 非空 | 3/3 LLM span ✅ |
| 5 | `gen_ai.usage.cache_read.input_tokens` 回填 | STEP2=34813、STEP3=34983 精确命中；STEP1 cached=0 不触发 ✅ |
| 6 | `reasoning_tokens` 不出现在 LLM span（反向） | 3/3 LLM span 0 个 reasoning.* 属性，revert 干净 ✅ |

**AGENT token sum 严格校验：** `total=105338 / input=104979 / output=359 / cache_read=69796` 与 `sum(LLM.*)` 逐字段精确等。

