### PR TITLE
fix(qoder-idea): resolve token enrichment and tool.call.duration for IntelliJ sessions

### DIFF
--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -137,6 +137,17 @@ function timestampToUnixNanos(value) {
   return String(BigInt(Date.now()) * 1_000_000n);
 }
 
+function computeDurationMs(startNanos, endNanos) {
+  if (!startNanos || !endNanos || startNanos === endNanos) return 0;
+  try {
+    const diffNs = BigInt(endNanos) - BigInt(startNanos);
+    if (diffNs <= 0n) return 0;
+    return Number(diffNs / 1_000_000n);
+  } catch {
+    return 0;
+  }
+}
+
 // --- Main --------------------------------------------------------------------
 
 async function main() {
@@ -722,6 +733,7 @@ function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, turnId,
         // Find PostToolUse timestamp for this tool
         const postToolTs = findPostToolUseTs(boundaries, i)
           || (BigInt(toolCallTs) + 1_000_000n).toString(); // +1ms fallback → tool span duration ≥ 1ms
+        const toolDurationMs = computeDurationMs(toolCallTs, postToolTs);
         records.push({
           'event.id': crypto.randomUUID(),
           'event.name': 'tool.result',
@@ -734,6 +746,7 @@ function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, turnId,
           'gen_ai.tool.call.exec.id': tc.id,
           'gen_ai.tool.call.result': tr.result,
           'tool.result.status': 'success',
+          ...(toolDurationMs > 0 ? { 'gen_ai.tool.call.duration': toolDurationMs } : {}),
           'user.id': userId,
           'agent.source': 'qoder-transcript-hook',
           time_unix_nano: postToolTs,

--- a/src/inputs/qoder-trace/qoder-trace-input.ts
+++ b/src/inputs/qoder-trace/qoder-trace-input.ts
@@ -8,7 +8,7 @@ import { getTodayDateString } from '../../utils/fs-utils.js';
 import { buildCanonicalHookEntry } from '../base/canonical-hook-record.js';
 import { enrichCanonicalEntryWithGit } from '../../normalization/enrich-git-context.js';
 import { readSegmentTokensForSession } from './segment-token-reader.js';
-import { readSqliteTokensForSession } from './sqlite-token-reader.js';
+import { readSqliteTokensForSession, isIdeaDbPath } from './sqlite-token-reader.js';
 import { readInterceptData, type InterceptData } from './intercept-token-reader.js';
 import { enrichCliTurn, enrichIdeTurn, injectTraceId } from './token-enricher.js';
 
@@ -80,8 +80,19 @@ export class QoderTraceInput extends BaseInput {
     }
 
     for (const [sessionId, sessionEntries] of ideSessionGroups) {
-      const sqliteRows = await readSqliteTokensForSession(sessionId);
+      const { rows: sqliteRows, matchedDbPath } = await readSqliteTokensForSession(sessionId);
       enrichIdeTurn(sessionEntries, sqliteRows);
+
+      // Fix agent type when hook processor couldn't detect qoder-idea (Node < 22 fallback).
+      // If all entries are labeled 'qoder' but tokens came from the IntelliJ-specific DB, relabel.
+      const needsRelabel = sessionEntries.every(
+        e => (e['gen_ai.agent.type'] as string) === ClientType.Qoder,
+      );
+      if (needsRelabel && isIdeaDbPath(matchedDbPath)) {
+        for (const entry of sessionEntries) {
+          entry['gen_ai.agent.type'] = ClientType.QoderIdea;
+        }
+      }
     }
 
     // 4. Inject trace_id per turn

--- a/src/inputs/qoder-trace/sqlite-token-reader.ts
+++ b/src/inputs/qoder-trace/sqlite-token-reader.ts
@@ -18,9 +18,15 @@ export interface SqliteTokenData {
   model?: string;
 }
 
-export async function readSqliteTokensForSession(sessionId: string): Promise<SqliteTokenData[]> {
-  const dbPath = resolveQoderDbPath();
-  if (!dbPath) return [];
+export interface SqliteTokenResult {
+  rows: SqliteTokenData[];
+  /** The DB path that contained the session data, for caller-side variant detection. */
+  matchedDbPath: string | null;
+}
+
+export async function readSqliteTokensForSession(sessionId: string): Promise<SqliteTokenResult> {
+  const dbPaths = resolveAllQoderDbPaths();
+  if (dbPaths.length === 0) return { rows: [], matchedDbPath: null };
 
   const sql = `
     SELECT
@@ -41,43 +47,59 @@ export async function readSqliteTokensForSession(sessionId: string): Promise<Sql
     ORDER BY cm.gmt_create ASC
   `;
 
-  let rows: Array<{
-    message_id?: string;
-    session_id?: string;
-    request_id: string;
-    gmt_create: number;
-    token_info: string;
-    model_info?: string | null;
-    record_extra?: string | null;
-  }>;
-  try {
-    rows = await queryReadonly(dbPath, sql, [sessionId]);
-  } catch (err) {
-    logger.debug('sqlite query failed', { sessionId, error: String(err) });
-    return [];
-  }
+  for (const dbPath of dbPaths) {
+    let rows: Array<{
+      message_id?: string;
+      session_id?: string;
+      request_id: string;
+      gmt_create: number;
+      token_info: string;
+      model_info?: string | null;
+      record_extra?: string | null;
+    }>;
+    try {
+      rows = await queryReadonly(dbPath, sql, [sessionId]);
+    } catch (err) {
+      logger.debug('sqlite query failed', { sessionId, dbPath, error: String(err) });
+      continue;
+    }
 
-  const results: SqliteTokenData[] = [];
-  for (const row of rows) {
-    const info = parseTokenInfo(row.token_info);
-    if (!info) continue;
-    results.push({
-      sessionId: row.session_id ?? '',
-      requestId: row.request_id ?? '',
-      messageId: row.message_id ?? '',
-      gmtCreate: row.gmt_create,
-      inputTokens: info.promptTokens,
-      outputTokens: info.completionTokens,
-      cacheReadTokens: info.cachedTokens,
-      model: parseModelKey(row.model_info) ?? parseRecordModelKey(row.record_extra),
-    });
+    if (rows.length === 0) continue;
+
+    const results: SqliteTokenData[] = [];
+    for (const row of rows) {
+      const info = parseTokenInfo(row.token_info);
+      if (!info) continue;
+      results.push({
+        sessionId: row.session_id ?? '',
+        requestId: row.request_id ?? '',
+        messageId: row.message_id ?? '',
+        gmtCreate: row.gmt_create,
+        inputTokens: info.promptTokens,
+        outputTokens: info.completionTokens,
+        cacheReadTokens: info.cachedTokens,
+        model: parseModelKey(row.model_info) ?? parseRecordModelKey(row.record_extra),
+      });
+    }
+    if (results.length > 0) return { rows: results, matchedDbPath: dbPath };
   }
-  return results;
+  return { rows: [], matchedDbPath: null };
 }
 
-function resolveQoderDbPath(): string | null {
+/**
+ * Determine if a matched DB path belongs to the IntelliJ-specific database.
+ * Normalizes path separators to handle Windows backslashes correctly.
+ */
+export function isIdeaDbPath(dbPath: string | null): boolean {
+  if (!dbPath) return false;
+  const normalized = dbPath.replace(/\\/g, '/');
+  return normalized.includes('.qoder/shared_client');
+}
+
+function resolveAllQoderDbPaths(): string[] {
   // Qoder Desktop (Electron app) keeps SQLite under platform app-support.
   // Qoder for JetBrains shares state through ~/.qoder/shared_client/.
+  // Both may coexist on the same machine with different sessions, so we return ALL accessible paths.
   const appdata = process.env.APPDATA ?? path.join(os.homedir(), 'AppData', 'Roaming');
   const candidates = process.platform === 'darwin'
     ? [
@@ -94,17 +116,16 @@ function resolveQoderDbPath(): string | null {
           resolveHome('~/.qoder/shared_client/cache/db/local.db'),
         ];
 
-  // Sync access check: only runs once per collect cycle for a fixed set of paths.
-  // Acceptable because the path list is small (1-2 candidates) and the result is cached by callers.
+  const available: string[] = [];
   for (const candidate of candidates) {
     try {
       fs.accessSync(candidate);
-      return candidate;
+      available.push(candidate);
     } catch {
       continue;
     }
   }
-  return null;
+  return available;
 }
 
 function parseTokenInfo(raw: string): { promptTokens: number; completionTokens: number; cachedTokens: number } | null {

--- a/src/inputs/qoder-trace/token-enricher.ts
+++ b/src/inputs/qoder-trace/token-enricher.ts
@@ -87,8 +87,16 @@ export function enrichCliTurn(
       );
       const toolCallTs = String(BigInt(seg.responseEndTs) * 1_000_000n);
       const toolResultTs = String(BigInt(seg.toolFinishedTs) * 1_000_000n);
+      const toolDurationMs = seg.responseEndTs > 0
+        ? seg.toolFinishedTs - seg.responseEndTs
+        : 0;
       for (const tc of toolCalls) tc.time_unix_nano = toolCallTs;
-      for (const tr of toolResults) tr.time_unix_nano = toolResultTs;
+      for (const tr of toolResults) {
+        tr.time_unix_nano = toolResultTs;
+        if (toolDurationMs > 0) {
+          (tr as Record<string, unknown>)['gen_ai.tool.call.duration'] = toolDurationMs;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- **sqlite-token-reader**: query ALL available DB paths instead of only the first, fixing the case where IntelliJ sessions live in `~/.qoder/shared_client/` while Desktop sessions live in `~/Library/Application Support/Qoder/`
- **qoder-trace-input**: relabel agent type from `qoder` to `qoder-idea` when session is found exclusively in IntelliJ DB (Node < 22 fallback)
- **qoder-hook-processor**: compute `gen_ai.tool.call.duration` from tool.call and tool.result timestamps
- **token-enricher**: inject `tool.call.duration` from CLI segment `toolFinishedTs`

## Root Cause

On machines where both Qoder Desktop and Qoder for JetBrains coexist, the SQLite token reader only returned the first accessible DB path (`~/Library/Application Support/Qoder/.../local.db`). Since qoder-idea sessions only exist in `~/.qoder/shared_client/cache/db/local.db`, token queries always returned empty — resulting in `input_tokens=0`, `output_tokens=0`, and missing `response.id`.

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Unit tests pass (17/17 qoder-trace-input, 9/9 hook-processor)
- [x] Validated with real IntelliJ session: tokens, response.id, and tool.call.duration all populated correctly in output JSONL


Made with [Cursor](https://cursor.com)