### PR TITLE
fix: log retention, tmp file cleanup, and unified daemon logging

### DIFF
--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -9,7 +9,7 @@ import { HookManager } from '../hooks/hook-manager.js';
 import { DeploymentManager } from '../deployment/deployment-manager.js';
 import { detectAgent } from '../deployment/detect-utils.js';
 import { createLogger } from '../utils/logger.js';
-import { resolveHome, ensureDir, directoryExists, readJsonFile, writeJsonFile, fileExists, readInstalledVersion } from '../utils/fs-utils.js';
+import { resolveHome, ensureDir, directoryExists, readJsonFile, writeJsonFile, fileExists, readInstalledVersion, cleanStaleTmpFiles } from '../utils/fs-utils.js';
 import * as path from 'node:path';
 import * as fsSync from 'node:fs';
 
@@ -132,6 +132,7 @@ export class Orchestrator extends EventEmitter {
     // 1. Ensure data directories
     await ensureDir(this.dataDir);
     await ensureDir(path.join(this.dataDir, 'logs'));
+    await cleanStaleTmpFiles(path.join(this.dataDir, 'logs'));
 
     // 2. Load state & agent-control config
     this.stateStore = new StateStore(path.join(this.dataDir, 'logs', 'input-state.json'));

--- a/src/types/pino-roll.d.ts
+++ b/src/types/pino-roll.d.ts
@@ -9,7 +9,7 @@ declare module 'pino-roll' {
     mkdir?: boolean;
     extension?: string;
     symlink?: boolean;
-    limit?: { count?: number };
+    limit?: { count?: number; removeOtherLogFiles?: boolean };
   }
 
   function build(options: PinoRollOptions): Promise<WriteStream>;

--- a/src/utils/fs-utils.ts
+++ b/src/utils/fs-utils.ts
@@ -55,18 +55,47 @@ export async function writeJsonFile(
     await fsp.writeFile(tmp, text, 'utf8');
     await fsp.rename(tmp, path);
   } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
     // Directory may vanish between ensureDir and write/rename (e.g. concurrent cleanup).
     // Retry once after re-creating the directory.
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+    if (code === 'ENOENT') {
       await fsp.unlink(tmp).catch(() => {});
       await ensureDir(dir);
       const tmp2 = `${path}.${process.pid}.${Date.now()}.tmp`;
-      await fsp.writeFile(tmp2, text, 'utf8');
-      await fsp.rename(tmp2, path);
+      try {
+        await fsp.writeFile(tmp2, text, 'utf8');
+        await fsp.rename(tmp2, path);
+      } catch (retryErr) {
+        await fsp.unlink(tmp2).catch(() => {});
+        throw retryErr;
+      }
+    } else if (code === 'EPERM' || code === 'EBUSY' || code === 'EACCES') {
+      // On Windows, rename can fail when the target is briefly locked by
+      // antivirus/indexer or concurrent I/O. Retry once after a short delay.
+      await new Promise(r => setTimeout(r, 50));
+      try {
+        await fsp.rename(tmp, path);
+      } catch {
+        await fsp.unlink(tmp).catch(() => {});
+        throw err;
+      }
     } else {
+      await fsp.unlink(tmp).catch(() => {});
       throw err;
     }
   }
+}
+
+/**
+ * Removes stale `.tmp` files left behind by interrupted atomic writes (e.g. process
+ * killed mid-rename). Call once at startup for directories that use writeJsonFile.
+ */
+export async function cleanStaleTmpFiles(dir: string): Promise<void> {
+  try {
+    const entries = await fsp.readdir(dir);
+    const tmpFiles = entries.filter(f => /\.\d+\.\d+\.tmp$/.test(f));
+    await Promise.all(tmpFiles.map(f => fsp.unlink(nodePath.join(dir, f)).catch(() => {})));
+  } catch {}
 }
 
 /**

--- a/src/utils/fs-utils.ts
+++ b/src/utils/fs-utils.ts
@@ -72,6 +72,9 @@ export async function writeJsonFile(
     } else if (code === 'EPERM' || code === 'EBUSY' || code === 'EACCES') {
       // On Windows, rename can fail when the target is briefly locked by
       // antivirus/indexer or concurrent I/O. Retry once after a short delay.
+      // If the error came from writeFile (tmp doesn't exist), skip the retry.
+      const tmpExists = await fsp.stat(tmp).then(() => true, () => false);
+      if (!tmpExists) throw err;
       await new Promise(r => setTimeout(r, 50));
       try {
         await fsp.rename(tmp, path);
@@ -91,9 +94,13 @@ export async function writeJsonFile(
  * killed mid-rename). Call once at startup for directories that use writeJsonFile.
  */
 export async function cleanStaleTmpFiles(dir: string): Promise<void> {
+  const currentPid = String(process.pid);
   try {
     const entries = await fsp.readdir(dir);
-    const tmpFiles = entries.filter(f => /\.\d+\.\d+\.tmp$/.test(f));
+    const tmpFiles = entries.filter(f => {
+      const m = f.match(/\.(\d+)\.\d+\.tmp$/);
+      return m != null && m[1] !== currentPid;
+    });
     await Promise.all(tmpFiles.map(f => fsp.unlink(nodePath.join(dir, f)).catch(() => {})));
   } catch {}
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,5 +1,6 @@
 import pino from 'pino';
 import build from 'pino-roll';
+import { writeFile } from 'node:fs/promises';
 
 const LOG_LEVEL = (process.env.LOG_LEVEL?.toLowerCase() ?? 'info') as pino.Level;
 
@@ -42,15 +43,20 @@ export async function initFileLogging(logFilePath: string): Promise<void> {
     mkdir: true,
     size: '50m',
     dateFormat: 'yyyy-MM-dd',
+    limit: { count: 10, removeOtherLogFiles: true },
   });
 
-  rootLogger = pino(
-    pinoOpts,
-    pino.multistream([
-      { stream: process.stdout, level: LOG_LEVEL },
-      { stream: fileStream, level: LOG_LEVEL },
-    ]),
-  );
+  const streams: pino.StreamEntry[] = [{ stream: fileStream, level: LOG_LEVEL }];
+  if (process.stdout.isTTY) {
+    streams.unshift({ stream: process.stdout, level: LOG_LEVEL });
+  } else {
+    // Daemon mode: truncate the base file that launchd/service manager may
+    // have opened via StandardOutPath. pino-roll writes to date-suffixed files
+    // so this base file is no longer needed.
+    await writeFile(logFilePath, '', 'utf8').catch(() => {});
+  }
+
+  rootLogger = pino(pinoOpts, pino.multistream(streams));
 
   loggerVersion++;
   childCache.clear();

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -46,8 +46,9 @@ export async function initFileLogging(logFilePath: string): Promise<void> {
     limit: { count: 10, removeOtherLogFiles: true },
   });
 
+  const useStdout = process.stdout.isTTY || process.env.LOONGSUITE_PILOT_STDOUT === '1';
   const streams: pino.StreamEntry[] = [{ stream: fileStream, level: LOG_LEVEL }];
-  if (process.stdout.isTTY) {
+  if (useStdout) {
     streams.unshift({ stream: process.stdout, level: LOG_LEVEL });
   } else {
     // Daemon mode: truncate the base file that launchd/service manager may


### PR DESCRIPTION
## Summary

- Add pino-roll `limit: { count: 10, removeOtherLogFiles: true }` to auto-delete old rotated log files beyond 10 days
- Fix `writeJsonFile` to clean up `.tmp` files on all error paths (EPERM/EBUSY/EACCES retry with cleanup, and generic error cleanup)
- Add `cleanStaleTmpFiles()` called at startup to remove orphaned `.tmp` files left by killed processes
- Only write to stdout when running in TTY mode (dev); daemon mode skips stdout to avoid double-logging via launchd `StandardOutPath`
- Truncate stale base log file on daemon startup

## Context

On Windows, antivirus/indexer services briefly lock files causing `fs.rename` to fail with EPERM/EBUSY. The atomic write in `writeJsonFile` only handled ENOENT, leaving hundreds of `.tmp` files behind. On macOS, launchd's `StandardOutPath` redirect combined with pino's stdout multistream caused double-logging — a growing unrotated base file plus the rotated date-suffixed files.

## Test plan

- [x] TypeScript type check passes (`tsc --noEmit`)
- [ ] Verify on Windows: no new `.tmp` file accumulation after service runs for 24h+
- [ ] Verify on macOS: base log file stays empty/truncated after service restart
- [ ] Verify old rotated log files are cleaned up after count exceeds 10

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>