### PR TITLE
fix(qoder-work): write step-level input to messages_delta, not messages

### DIFF
--- a/assets/hooks/qoderwork-hook-processor.mjs
+++ b/assets/hooks/qoderwork-hook-processor.mjs
@@ -382,20 +382,14 @@ function buildStepEvents(group, toolResultsByUseId, stepId, turnId, sessionId, u
 
   // llm.request for this step.
   //
-  // Field choice: gen_ai.input.messages (NOT messages_delta).
+  // Field choice: gen_ai.input.messages_delta (incremental, NOT full).
   //
-  // The converter (@loongsuite/otel-util-genai) treats messages_delta as a
-  // turn-level accumulator: when an LLM pair only has messages_delta, it
-  // concatenates ALL prior pairs' deltas to build the LLM span's input.
-  // For QoderWork that means tool_call_response would grow across steps
-  // (step 1: 0 results, step 2: 1, step 3: 2, ...) — wrong for an LLM
-  // span which should show what THIS llm call received.
-  //
-  // Writing to messages (treated as "full") makes the converter use the
-  // value directly without accumulation. We still emit per-step incremental
-  // content, matching Codex's pattern. ENTRY/AGENT spans collect input from
-  // the user-hook event (no step.id, still messages_delta) above, so this
-  // change does not affect the turn-level overview spans.
+  // Each step's delta contains only the NEW content since the previous step:
+  //   - Step 1: user prompt
+  //   - Step N>1: previous step's tool_results
+  // The converter (@loongsuite/otel-util-genai) accumulates deltas across
+  // steps to reconstruct the full context window for each LLM span, which
+  // is the correct behaviour.
   const llmRequestFields = {
     ...turnMetadata,
     'event.name': 'llm.request',
@@ -411,7 +405,7 @@ function buildStepEvents(group, toolResultsByUseId, stepId, turnId, sessionId, u
     version,
   };
   if (inputDelta) {
-    llmRequestFields['gen_ai.input.messages'] = inputDelta;
+    llmRequestFields['gen_ai.input.messages_delta'] = inputDelta;
   }
   records.push(buildRecord(llmRequestFields, firstRow, runtimeConfig, cwd));
 

--- a/tests/unit/hooks/qoderwork/hook-processor.test.mjs
+++ b/tests/unit/hooks/qoderwork/hook-processor.test.mjs
@@ -4,6 +4,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { convertEventLogToReadableSpans } from '@loongsuite/otel-util-genai';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROCESSOR = path.resolve(__dirname, '../../../../assets/hooks/qoderwork-hook-processor.mjs');
@@ -93,6 +94,100 @@ function baseRows(userContent) {
 }
 
 describe('qoderwork-hook-processor user prompt extraction', () => {
+  test('emits per-step input deltas that the converter accumulates', async () => {
+    writeTranscript([
+      {
+        type: 'user',
+        uuid: 'user-1',
+        promptId: 'prompt-turn-1',
+        timestamp: '2026-06-18T01:35:54.477Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'solve it' }] },
+        sessionId: 'sess-1',
+        userType: 'external',
+        isSidechain: false,
+      },
+      {
+        type: 'assistant',
+        uuid: 'assistant-1',
+        parentUuid: 'user-1',
+        timestamp: '2026-06-18T01:35:56.477Z',
+        message: {
+          role: 'assistant',
+          id: 'msg-1',
+          content: [{ type: 'tool_use', id: 'tool-1', name: 'shell', input: { command: 'pwd' } }],
+          stop_reason: 'tool_use',
+        },
+        sessionId: 'sess-1',
+        isSidechain: false,
+      },
+      {
+        type: 'user',
+        uuid: 'tool-result-1',
+        parentUuid: 'assistant-1',
+        timestamp: '2026-06-18T01:35:57.477Z',
+        message: {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: '/tmp/project' }],
+        },
+        sessionId: 'sess-1',
+        isSidechain: false,
+      },
+      {
+        type: 'assistant',
+        uuid: 'assistant-2',
+        parentUuid: 'tool-result-1',
+        timestamp: '2026-06-18T01:35:59.477Z',
+        message: {
+          role: 'assistant',
+          id: 'msg-2',
+          content: [{ type: 'text', text: 'done' }],
+          stop_reason: 'end_turn',
+        },
+        sessionId: 'sess-1',
+        isSidechain: false,
+      },
+    ]);
+
+    const result = runHook('sess-step-deltas');
+    expect(result.status).toBe(0);
+
+    const records = readJsonlRecords();
+    const requests = records.filter((record) => record['event.name'] === 'llm.request');
+    const promptDelta = [{ role: 'user', parts: [{ type: 'text', content: 'solve it' }] }];
+    const toolDelta = [{
+      role: 'tool',
+      parts: [{ type: 'tool_call_response', id: 'tool-1', response: '/tmp/project' }],
+    }];
+
+    expect(requests).toHaveLength(2);
+    expect(requests.map((request) => request['gen_ai.input.messages'])).toEqual([undefined, undefined]);
+    expect(requests.map((request) => request['gen_ai.input.messages_delta'])).toEqual([
+      promptDelta,
+      toolDelta,
+    ]);
+
+    const previousStability = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+    const previousCapture = process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+    process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'gen_ai_latest_experimental';
+    process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = 'SPAN_ONLY';
+    try {
+      const conversion = await convertEventLogToReadableSpans(records);
+      const convertedInputs = conversion.spans
+        .filter((span) => span.attributes['gen_ai.span.kind'] === 'LLM')
+        .map((span) => JSON.parse(span.attributes['gen_ai.input.messages']));
+
+      expect(convertedInputs).toEqual([
+        promptDelta,
+        [...promptDelta, ...toolDelta],
+      ]);
+    } finally {
+      if (previousStability === undefined) delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+      else process.env.OTEL_SEMCONV_STABILITY_OPT_IN = previousStability;
+      if (previousCapture === undefined) delete process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+      else process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = previousCapture;
+    }
+  });
+
   test('uses transcript promptId as the stable turn id', () => {
     writeTranscript(baseRows([
       { type: 'text', text: '你先搜索力扣565题' },


### PR DESCRIPTION
## Summary
- Per-step `llm.request` was writing incremental content to `gen_ai.input.messages` (semantically = full context window), but the content is actually a delta: step 1 gets the user prompt, step N>1 gets the previous step's tool_results
- Changed to `gen_ai.input.messages_delta` so the converter correctly accumulates deltas across steps to reconstruct the full context for each LLM span
- Updated the comment to reflect the correct semantics

## Test plan
- [ ] Verify step-level `llm.request` events in history/ now carry `gen_ai.input.messages_delta` instead of `gen_ai.input.messages`
- [ ] Verify OTLP LLM spans have correct accumulated input (step 1 = user prompt, step 2 = user prompt + tool_result, etc.)
- [ ] Run `npx vitest run tests/unit/hooks/qoderwork/` — all 6 tests pass