### PR TITLE
fix: skip agents with empty detection config in cli-probe

### DIFF
--- a/src/cli-probe.ts
+++ b/src/cli-probe.ts
@@ -48,6 +48,9 @@ async function main(): Promise<void> {
   const results: ProbeResult[] = [];
 
   for (const def of defs) {
+    if (def.detection.paths.length === 0 && def.detection.commands.length === 0) {
+      continue;
+    }
     const detected = await detectAgent(def.detection);
     const reason = detected ? await findDetectionReason(def.detection) : '';
     results.push({

--- a/src/deployment/detect-utils.ts
+++ b/src/deployment/detect-utils.ts
@@ -5,6 +5,10 @@ import type { AgentDetectionConfig } from '../types/index.js';
 import { directoryExists, fileExists, resolveHome } from '../utils/fs-utils.js';
 
 export async function detectAgent(detection: AgentDetectionConfig): Promise<boolean> {
+  if (detection.paths.length === 0 && detection.commands.length === 0) {
+    return false;
+  }
+
   for (const p of detection.paths) {
     const resolved = resolveHome(p);
     if (hasGlob(resolved)) {


### PR DESCRIPTION
## Summary
- Skip agents with empty `detection.paths` and `detection.commands` in `cli-probe` output and add early return in `detectAgent()`
- Prevents agent identifiers (e.g. `openclaw`) from appearing in `PROBE_RESULT` command-line arguments, which can trigger EDR keyword-based SIGKILL on enterprise machines

## Test plan
- [ ] Verify `cli-probe` output excludes agents with empty detection config
- [ ] Verify `detectAgent()` returns `false` immediately for empty detection
- [ ] Confirm no impact on `local-workers` activation flow (uses `PluginProbeStrategy` independently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)