### PR TITLE
fix: Windows compatibility for installer-opensource.ps1 and agent detection

### DIFF
--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -50,6 +50,7 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
 # ============================================================
 # Constants

--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -189,7 +189,9 @@ function Check-Deps {
         exit 1
     }
 
+    $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
     $nodeMajor = & $script:NODE_BIN -e "process.stdout.write(String(process.versions.node.split('.')[0]))"
+    $ErrorActionPreference = $prevEAP
     if ([int]$nodeMajor -lt 18) {
         $nodeVer = & $script:NODE_BIN --version
         Msg "❌ 需要 Node.js >= 18，当前版本: $nodeVer" "❌ Requires Node.js >= 18, current: $nodeVer"
@@ -214,8 +216,10 @@ function Check-Deps {
         }
     }
 
+    $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
     $nodeVer = & $script:NODE_BIN --version
     $npmVer = & $script:NPM_BIN --version
+    $ErrorActionPreference = $prevEAP
     Msg "    ✅ node $nodeVer  npm $npmVer" "    ✅ node $nodeVer  npm $npmVer"
     Msg "    node pinned: $($script:NODE_BIN)" "    node pinned: $($script:NODE_BIN)"
     Write-Host ""
@@ -280,16 +284,20 @@ $script:PROBE_RESULT = "[]"
 function Probe-Agents {
     Msg "==> 探测 AI Agent..." "==> Probing AI Agents..."
     $probeScript = Join-Path $script:INSTALL_SRC "dist\cli-probe.cjs"
+    $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
     if (Test-Path $probeScript) {
         try {
-            $script:PROBE_RESULT = & $script:NODE_BIN $probeScript 2>$null
-            if (-not $script:PROBE_RESULT) { $script:PROBE_RESULT = "[]" }
+            $raw = & $script:NODE_BIN $probeScript 2>$null
+            if ($raw) {
+                $script:PROBE_RESULT = if ($raw -is [array]) { $raw -join "" } else { $raw }
+            }
         } catch {
             Msg "    ⚠️  Agent 探测失败，将跳过选择" "    ⚠️  Agent probe failed, skipping selection"
             $script:PROBE_RESULT = "[]"
         }
     }
-    $count = & $script:NODE_BIN -e "const r=JSON.parse(process.argv[1]);process.stdout.write(String(r.length))" $script:PROBE_RESULT 2>$null
+    $count = $script:PROBE_RESULT | & $script:NODE_BIN -e "const r=JSON.parse(require('fs').readFileSync(0,'utf-8'));process.stdout.write(String(r.length))" 2>$null
+    $ErrorActionPreference = $prevEAP
     if (-not $count) { $count = "0" }
     Msg "    ✅ 探测到 ${count} 个 Agent 定义" "    ✅ Found ${count} agent definitions"
     Write-Host ""
@@ -307,17 +315,21 @@ function Select-Agents {
         return
     }
 
-    $agentCount = & $script:NODE_BIN -e "const r=JSON.parse(process.argv[1]);process.stdout.write(String(r.length))" $script:PROBE_RESULT 2>$null
+    $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
+    $agentCount = $script:PROBE_RESULT | & $script:NODE_BIN -e "const r=JSON.parse(require('fs').readFileSync(0,'utf-8'));process.stdout.write(String(r.length))" 2>$null
+    $ErrorActionPreference = $prevEAP
     if (-not $agentCount -or $agentCount -eq "0") { return }
 
     # Non-interactive detection
     $isInteractive = [Environment]::UserInteractive -and $Host.UI.RawUI -ne $null
     if (-not $isInteractive) {
-        $script:SELECTED_AGENTS = & $script:NODE_BIN -e @'
-const r = JSON.parse(process.argv[1]);
+        $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
+        $script:SELECTED_AGENTS = $script:PROBE_RESULT | & $script:NODE_BIN -e @'
+const r = JSON.parse(require('fs').readFileSync(0,'utf-8'));
 const detected = r.filter(a => a.detected).map(a => a.id);
 process.stdout.write(detected.join(','));
-'@ $script:PROBE_RESULT 2>$null
+'@ 2>$null
+        $ErrorActionPreference = $prevEAP
         Msg "    (非交互模式) 自动选择已检测到的 Agent: $($script:SELECTED_AGENTS)" `
             "    (non-interactive) Auto-selected detected agents: $($script:SELECTED_AGENTS)"
         Write-Host ""
@@ -325,9 +337,10 @@ process.stdout.write(detected.join(','));
     }
 
     # Interactive menu
-    & $script:NODE_BIN -e @'
-const r = JSON.parse(process.argv[1]);
-const lang = process.argv[2];
+    $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
+    $script:PROBE_RESULT | & $script:NODE_BIN -e @'
+const r = JSON.parse(require('fs').readFileSync(0,'utf-8'));
+const lang = process.argv[1];
 const defaults = [];
 for (let i = 0; i < r.length; i++) {
   const a = r[i];
@@ -345,13 +358,15 @@ if (lang === 'zh') {
   console.log('    Default selection (detected): ' + defaults.join(','));
   console.log('    Enter numbers to enable (comma-separated), press Enter for default:');
 }
-'@ $script:PROBE_RESULT $LANG_MODE
+'@ $LANG_MODE
+    $ErrorActionPreference = $prevEAP
 
     $selectInput = Read-Host "    >"
 
-    $script:SELECTED_AGENTS = & $script:NODE_BIN -e @'
-const r = JSON.parse(process.argv[1]);
-const input = process.argv[2] || '';
+    $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
+    $script:SELECTED_AGENTS = $script:PROBE_RESULT | & $script:NODE_BIN -e @'
+const r = JSON.parse(require('fs').readFileSync(0,'utf-8'));
+const input = process.argv[1] || '';
 let indices;
 if (!input.trim()) {
   indices = r.map((a, i) => a.detected ? i : -1).filter(i => i >= 0);
@@ -360,7 +375,8 @@ if (!input.trim()) {
 }
 const ids = indices.sort((a,b) => a-b).map(i => r[i].id);
 process.stdout.write(ids.join(','));
-'@ $script:PROBE_RESULT $selectInput 2>$null
+'@ $selectInput 2>$null
+    $ErrorActionPreference = $prevEAP
 
     if ($script:SELECTED_AGENTS) {
         Msg "    已选择: $($script:SELECTED_AGENTS)" "    Selected: $($script:SELECTED_AGENTS)"
@@ -382,9 +398,11 @@ function Prompt-UserId {
     $existingUid = ""
     if (Test-Path $configFile) {
         try {
+            $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
             $existingUid = & $script:NODE_BIN -e @'
 try { const c=JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')); process.stdout.write(c.userId||''); } catch {}
 '@ $configFile 2>$null
+            $ErrorActionPreference = $prevEAP
         } catch {}
     }
 
@@ -423,6 +441,7 @@ function Confirm-ConfigOverwrite {
         maskTypes = $MaskTypes
     } | ConvertTo-Json -Compress
 
+    $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
     $diffs = & $script:NODE_BIN -e @'
 const fs = require('fs');
 let old = {};
@@ -444,6 +463,7 @@ const changed = checks.filter(c => c.newVal && c.oldVal && c.newVal !== c.oldVal
 if (!changed.length) process.exit(0);
 for (const c of changed) { console.log(c.label + ': ' + c.oldVal + ' -> ' + c.newVal); }
 '@ $configFile $jsonArg 2>$null
+    $ErrorActionPreference = $prevEAP
 
     if (-not $diffs) { return }
 
@@ -526,13 +546,22 @@ function Deploy-Package {
     Deploy-BootstrapScripts
 
     Msg "==> 安装依赖..." "==> Installing dependencies..."
+    $nodeDir = Split-Path $script:NODE_BIN
+    $savedPath = $env:PATH
+    if ($env:PATH -notlike "*$nodeDir*") { $env:PATH = "$nodeDir;$env:PATH" }
     Push-Location $script:PERMANENT_DIR
     try {
         $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
-        & $script:NPM_BIN install --omit=dev --no-optional 2>&1 | Select-Object -Last 1
+        & $script:NPM_BIN install --omit=dev --omit=optional 2>&1 | Select-Object -Last 1
+        $npmExit = $LASTEXITCODE
         $ErrorActionPreference = $prevEAP
     } finally {
         Pop-Location
+        $env:PATH = $savedPath
+    }
+    if ($npmExit -ne 0) {
+        Msg "❌ 依赖安装失败 (exit=$npmExit)，请检查 npm 日志" "❌ Dependencies installation failed (exit=$npmExit), check npm logs"
+        exit 1
     }
     Msg "    ✅ 依赖安装完成" "    ✅ Dependencies installed"
     Write-Host ""
@@ -540,7 +569,9 @@ function Deploy-Package {
     Msg "==> 部署 hook 脚本..." "==> Deploying hook scripts..."
     $postinstallScript = Join-Path $script:PERMANENT_DIR "scripts\postinstall.js"
     if (Test-Path $postinstallScript) {
+        $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
         & $script:NODE_BIN $postinstallScript
+        $ErrorActionPreference = $prevEAP
     }
     Msg "    ✅ Hook 脚本已部署" "    ✅ Hook scripts deployed"
     Write-Host ""
@@ -616,6 +647,7 @@ function Write-Config {
     $cfgTmp = Join-Path $env:TEMP "lp-config-args.json"
     [System.IO.File]::WriteAllText($cfgTmp, $cfgJson, [System.Text.UTF8Encoding]::new($false))
 
+    $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
     & $script:NODE_BIN -e @'
 const fs = require('fs');
 const opts = JSON.parse(fs.readFileSync(process.argv[1], 'utf-8'));
@@ -679,6 +711,7 @@ if (opts.selectedAgents) {
 
 fs.writeFileSync(opts.configPath, JSON.stringify(config, null, 2) + '\n');
 '@ $cfgTmp
+    $ErrorActionPreference = $prevEAP
 
     Remove-Item $cfgTmp -Force -ErrorAction SilentlyContinue
 
@@ -895,6 +928,7 @@ function Remove-HookConfigs {
         $short = $cfg -replace [regex]::Escape($env:USERPROFILE), "~"
 
         try {
+            $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
             & $script:NODE_BIN -e @'
 const fs = require('fs');
 const cfg = process.argv[1];
@@ -921,6 +955,7 @@ try {
   }
 } catch(e) { process.stderr.write(e.message); process.exit(1); }
 '@ $cfg $HOOK_MARKER 2>$null
+            $ErrorActionPreference = $prevEAP
             Msg "    ✅ 已清理: $short" "    ✅ Cleaned: $short"
         } catch {
             Msg "    ⚠️  跳过: $short (需手动清理)" "    ⚠️  Skipped: $short (manual cleanup needed)"
@@ -940,6 +975,7 @@ function Remove-OtelPlugin {
     if ((Test-Path $claudeSettings) -and $script:NODE_BIN) {
         $content = Get-Content $claudeSettings -Raw -ErrorAction SilentlyContinue
         if ($content -match "otel-claude-hook|hook-entry") {
+            $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
             & $script:NODE_BIN -e @'
 const fs = require('fs');
 const f = process.argv[1];
@@ -961,6 +997,7 @@ try {
   }
 } catch {}
 '@ $claudeSettings 2>$null
+            $ErrorActionPreference = $prevEAP
             Msg "    ✅ settings.json hooks 已清理" "    ✅ settings.json hooks cleaned"
         }
     }

--- a/src/cli-probe.ts
+++ b/src/cli-probe.ts
@@ -23,8 +23,9 @@ async function findDetectionReason(detection: { paths: string[]; commands: strin
   }
   for (const cmd of detection.commands) {
     try {
+      const bin = process.platform === 'win32' ? 'where.exe' : 'which';
       const found = await new Promise<boolean>(resolve => {
-        execFile('which', [cmd], err => resolve(!err));
+        execFile(bin, [cmd], err => resolve(!err));
       });
       if (found) return `command: ${cmd}`;
     } catch { /* ignore */ }

--- a/src/cli-probe.ts
+++ b/src/cli-probe.ts
@@ -1,7 +1,6 @@
 import * as path from 'node:path';
-import { execFile } from 'node:child_process';
 import { AgentDefLoader } from './deployment/agent-def-loader.js';
-import { detectAgent } from './deployment/detect-utils.js';
+import { detectAgent, commandExists } from './deployment/detect-utils.js';
 import { resolveHome, directoryExists, fileExists } from './utils/fs-utils.js';
 
 // This file is always bundled as CJS (build.mjs), so __dirname is guaranteed.
@@ -23,11 +22,7 @@ async function findDetectionReason(detection: { paths: string[]; commands: strin
   }
   for (const cmd of detection.commands) {
     try {
-      const bin = process.platform === 'win32' ? 'where.exe' : 'which';
-      const found = await new Promise<boolean>(resolve => {
-        execFile(bin, [cmd], err => resolve(!err));
-      });
-      if (found) return `command: ${cmd}`;
+      if (await commandExists(cmd)) return `command: ${cmd}`;
     } catch { /* ignore */ }
   }
   return '';

--- a/src/deployment/detect-utils.ts
+++ b/src/deployment/detect-utils.ts
@@ -29,7 +29,7 @@ export async function detectAgent(detection: AgentDetectionConfig): Promise<bool
   return false;
 }
 
-function commandExists(command: string): Promise<boolean> {
+export function commandExists(command: string): Promise<boolean> {
   const bin = process.platform === 'win32' ? 'where.exe' : 'which';
   return new Promise(resolve => {
     execFile(bin, [command], err => {

--- a/src/deployment/detect-utils.ts
+++ b/src/deployment/detect-utils.ts
@@ -30,8 +30,9 @@ export async function detectAgent(detection: AgentDetectionConfig): Promise<bool
 }
 
 function commandExists(command: string): Promise<boolean> {
+  const bin = process.platform === 'win32' ? 'where.exe' : 'which';
   return new Promise(resolve => {
-    execFile('which', [command], err => {
+    execFile(bin, [command], err => {
       resolve(!err);
     });
   });


### PR DESCRIPTION
## Summary
- Wrap all `& $script:NODE_BIN` calls with `$prevEAP` pattern to prevent PowerShell `NativeCommandError` when `$ErrorActionPreference = "Stop"` and node writes to stderr
- Switch PROBE_RESULT JSON passing from `process.argv[1]` to stdin pipe (`readFileSync(0,'utf-8')`) to avoid Windows command-line length/escaping issues — aligns with `installer.ps1`
- Add node directory to `$env:PATH` before `npm install` for nvm-windows setups where node is installed under a different user profile
- Check npm exit code and fail fast on install errors instead of silently continuing with broken `node_modules`
- Replace deprecated `--no-optional` with `--omit=optional`
- Use `where.exe` instead of `which` on Windows for command detection in `cli-probe.ts` and `detect-utils.ts`

## Test plan
- [x] Verified diff aligns with working `installer.ps1` patterns
- [ ] Run `installer-opensource.ps1` on Windows with nvm-windows under Administrator
- [ ] Verify agent probe detects agents (should match `installer.ps1` count)
- [ ] Verify npm install fails fast if node is not in PATH
- [ ] Verify cli-probe command detection works on Windows (where.exe) and macOS/Linux (which)

🤖 Generated with [Claude Code](https://claude.com/claude-code)