### PR TITLE
feat: Drop agent-scoped fields from SLS and JSONL outputs

### DIFF
--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -123,6 +123,7 @@ Use canonical dotted fields whenever possible:
 ```
 
 Keep source-specific fields under `agent.<agent-id>.*` so public output fields stay stable.
+These fields may be used by normalization and enrichment, but SLS and local JSONL outputs drop them by default.
 
 ## Implement The Input
 

--- a/docs/zh-CN/agent-onboarding.md
+++ b/docs/zh-CN/agent-onboarding.md
@@ -123,6 +123,7 @@ Hook 示例：
 ```
 
 Source-specific 字段建议放在 `agent.<agent-id>.*` 下，避免污染公共稳定字段。
+这些字段可供归一化和上下文增强内部使用，但默认不会输出到 SLS 和本地 JSONL。
 
 ## 实现 Input
 

--- a/src/flushers/jsonl-flusher.ts
+++ b/src/flushers/jsonl-flusher.ts
@@ -23,7 +23,7 @@ export class JsonlFlusher extends BaseFlusher {
   async send(entry: AgentActivityEntry): Promise<void> {
     const agentType = entry['gen_ai.agent.type'] ?? entry['agent.type'] ?? 'unknown';
     const filePath = this.resolveFilePath(agentType);
-    const serialized = serialiseLogEntry(entry);
+    const serialized = serialiseLogEntry(entry, { dropAgentScopedFields: true });
     const line = JSON.stringify(serialized);
     await appendLine(filePath, line);
   }

--- a/src/flushers/sls-flusher.ts
+++ b/src/flushers/sls-flusher.ts
@@ -111,7 +111,7 @@ export class SlsFlusher extends BaseFlusher {
   }
 
   async send(entry: AgentActivityEntry): Promise<void> {
-    const serialized = serialiseLogEntry(entry);
+    const serialized = serialiseLogEntry(entry, { dropAgentScopedFields: true });
     const agentType = normalizeAgentType(String(entry['gen_ai.agent.type'] ?? 'unknown'));
 
     for (const endpoint of this.config.endpoints) {

--- a/src/normalization/entry-builder.ts
+++ b/src/normalization/entry-builder.ts
@@ -241,12 +241,22 @@ const LEGACY_ALIAS_FIELDS = new Set([
   'extra',
 ]);
 
-export function serialiseLogEntry(entry: AgentActivityEntry): SerializedLogEntry {
+export interface SerialiseLogEntryOptions {
+  dropAgentScopedFields?: boolean;
+}
+
+const AGENT_SCOPED_FIELD_RE = /^agent\.[^.]+\..+$/;
+
+export function serialiseLogEntry(
+  entry: AgentActivityEntry,
+  options: SerialiseLogEntryOptions = {},
+): SerializedLogEntry {
   const out: SerializedLogEntry = {};
 
   for (const [key, value] of Object.entries(entry)) {
     if (value === undefined || value === null) continue;
     if (LEGACY_ALIAS_FIELDS.has(key)) continue;
+    if (options.dropAgentScopedFields && AGENT_SCOPED_FIELD_RE.test(key)) continue;
     out[key] = serializeValue(value);
   }
 

--- a/tests/unit/flushers/jsonl-flusher.test.ts
+++ b/tests/unit/flushers/jsonl-flusher.test.ts
@@ -51,6 +51,22 @@ describe('JsonlFlusher', () => {
       expect(parsed.data).toBeUndefined();
       expect(parsed['gen_ai.session.id']).toBeDefined();
     });
+
+    it('omits agent-scoped extension fields from output', async () => {
+      const entry = buildTestEntry({
+        agentType: ClientType.Qoder,
+        'agent.qoder.cwd': '/workspace/project',
+        'agent.cursor.hook_event_name': 'preToolUse',
+      });
+      await flusher.send(entry);
+
+      const line = mockAppendLine.mock.calls[0][1];
+      const parsed = JSON.parse(line);
+      expect(parsed).not.toHaveProperty('agent.qoder.cwd');
+      expect(parsed).not.toHaveProperty('agent.cursor.hook_event_name');
+      expect(parsed['agent.file_path']).toBe('/tmp/test/file.ts');
+      expect(parsed['gen_ai.agent.type']).toBe('qoder');
+    });
   });
 
   describe('resolveFilePath with rotateDaily (T009)', () => {

--- a/tests/unit/flushers/sls-flusher.test.ts
+++ b/tests/unit/flushers/sls-flusher.test.ts
@@ -98,6 +98,22 @@ describe('SlsFlusher', () => {
 
       expect(mockPostLogStoreLogs).toHaveBeenCalledTimes(2);
     });
+
+    it('omits agent-scoped extension fields from SLS content', async () => {
+      const entry = buildTestEntry({
+        'agent.qoder.cwd': '/workspace/project',
+        'agent.cursor.hook_event_name': 'preToolUse',
+      });
+      await flusher.send(entry);
+      await flusher.flush();
+
+      const logGroup = mockPostLogStoreLogs.mock.calls[0][2];
+      const content = logGroup.logs[0].content;
+      expect(content).not.toHaveProperty('agent.qoder.cwd');
+      expect(content).not.toHaveProperty('agent.cursor.hook_event_name');
+      expect(content['agent.file_path']).toBe('/tmp/test/file.ts');
+      expect(content['gen_ai.agent.type']).toBe('qoder');
+    });
   });
 
   describe('redact logic (T013)', () => {

--- a/tests/unit/normalization/serialise.test.ts
+++ b/tests/unit/normalization/serialise.test.ts
@@ -34,6 +34,22 @@ describe('serialiseLogEntry', () => {
     expect(out['agent.custom_key']).toBe('customVal');
   });
 
+  it('drops agent-scoped extension fields when requested', () => {
+    const out = serialiseLogEntry(makeEntry({
+      'agent.qoder.cwd': '/workspace/project',
+      'agent.cursor.hook_event_name': 'preToolUse',
+      'agent.qoderwork.promptId': 'prompt-1',
+      'agent.custom_key': 'customVal',
+    }), { dropAgentScopedFields: true });
+
+    expect(out).not.toHaveProperty('agent.qoder.cwd');
+    expect(out).not.toHaveProperty('agent.cursor.hook_event_name');
+    expect(out).not.toHaveProperty('agent.qoderwork.promptId');
+    expect(out['agent.custom_key']).toBe('customVal');
+    expect(out['agent.file_path']).toBe('/src/app.ts');
+    expect(out['gen_ai.agent.type']).toBe('qoder');
+  });
+
   it('converts scalar values to strings', () => {
     const out = serialiseLogEntry(makeEntry({
       'gen_ai.usage.input_tokens': 42,


### PR DESCRIPTION
## Summary
- add an opt-in serialization filter for agent-scoped extension fields like `agent.qoder.cwd`
- enable the filter for SLS and local JSONL outputs while preserving shared fields such as `agent.file_path` and `gen_ai.agent.type`
- document that `agent.<agent-id>.*` fields are internal/enrichment-only for these outputs

## Tests
- `npm test -- --run tests/unit/normalization/serialise.test.ts tests/unit/flushers/jsonl-flusher.test.ts tests/unit/flushers/sls-flusher.test.ts`
- `npm run typecheck`
- `git diff --check`