### PR TITLE
fix(codex): always emit cache_creation.input_tokens in llm.response

### DIFF
--- a/assets/hooks/codex/transcript-parser.mjs
+++ b/assets/hooks/codex/transcript-parser.mjs
@@ -24,6 +24,7 @@ import fs from 'node:fs';
  * @property {number} inputTokens
  * @property {number} outputTokens
  * @property {number} cachedInputTokens
+ * @property {number} cacheCreationTokens
  * @property {number} reasoningOutputTokens
  * @property {number} totalTokens
  */
@@ -106,6 +107,7 @@ function parseTokenUsage(raw) {
     inputTokens: Number(raw['input_tokens'] || 0),
     outputTokens: Number(raw['output_tokens'] || 0),
     cachedInputTokens: Number(raw['cached_input_tokens'] || 0),
+    cacheCreationTokens: Number(raw['cache_creation_input_tokens'] || 0),
     reasoningOutputTokens: Number(raw['reasoning_output_tokens'] || 0),
     totalTokens: Number(raw['total_tokens'] || 0),
   };
@@ -120,6 +122,7 @@ function tokenUsageEqual(a, b) {
     a.inputTokens === b.inputTokens &&
     a.outputTokens === b.outputTokens &&
     a.cachedInputTokens === b.cachedInputTokens &&
+    a.cacheCreationTokens === b.cacheCreationTokens &&
     a.reasoningOutputTokens === b.reasoningOutputTokens &&
     a.totalTokens === b.totalTokens
   );

--- a/src/inputs/codex-aborted-turn/codex-aborted-turn-builder.ts
+++ b/src/inputs/codex-aborted-turn/codex-aborted-turn-builder.ts
@@ -202,6 +202,7 @@ function usageFields(usage: CodexTokenUsage | undefined): Record<string, JsonVal
     'gen_ai.usage.input_tokens': usage.inputTokens,
     'gen_ai.usage.output_tokens': usage.outputTokens,
     'gen_ai.usage.cache_read.input_tokens': usage.cachedInputTokens,
+    'gen_ai.usage.cache_creation.input_tokens': usage.cacheCreationTokens,
     'gen_ai.usage.total_tokens': usage.totalTokens,
     ...(usage.reasoningOutputTokens !== undefined
       ? { 'gen_ai.usage.reasoning_output_tokens': usage.reasoningOutputTokens }

--- a/src/inputs/codex-aborted-turn/codex-aborted-turn-extractor.ts
+++ b/src/inputs/codex-aborted-turn/codex-aborted-turn-extractor.ts
@@ -280,6 +280,7 @@ function extractLastTokenUsage(value: unknown): CodexTokenUsage | undefined {
   const inputTokens = numberValue(raw.input_tokens);
   const outputTokens = numberValue(raw.output_tokens);
   const cachedInputTokens = numberValue(raw.cached_input_tokens);
+  const cacheCreationTokens = numberValue(raw.cache_creation_input_tokens) ?? 0;
   const totalTokens = numberValue(raw.total_tokens);
   if (inputTokens === undefined || outputTokens === undefined) return undefined;
   const reasoningOutputTokens = numberValue(raw.reasoning_output_tokens);
@@ -287,6 +288,7 @@ function extractLastTokenUsage(value: unknown): CodexTokenUsage | undefined {
     inputTokens,
     outputTokens,
     cachedInputTokens: cachedInputTokens ?? 0,
+    cacheCreationTokens,
     totalTokens: totalTokens && totalTokens > 0 ? totalTokens : inputTokens + outputTokens,
     ...(reasoningOutputTokens !== undefined ? { reasoningOutputTokens } : {}),
   };
@@ -301,6 +303,7 @@ function sameUsage(left: CodexTokenUsage | undefined, right: CodexTokenUsage): b
     && left.inputTokens === right.inputTokens
     && left.outputTokens === right.outputTokens
     && left.cachedInputTokens === right.cachedInputTokens
+    && left.cacheCreationTokens === right.cacheCreationTokens
     && left.reasoningOutputTokens === right.reasoningOutputTokens
     && left.totalTokens === right.totalTokens;
 }

--- a/src/inputs/codex-aborted-turn/codex-aborted-turn-types.ts
+++ b/src/inputs/codex-aborted-turn/codex-aborted-turn-types.ts
@@ -66,6 +66,7 @@ export interface CodexTokenUsage {
   inputTokens: number;
   outputTokens: number;
   cachedInputTokens: number;
+  cacheCreationTokens: number;
   reasoningOutputTokens?: number;
   totalTokens: number;
 }

--- a/src/inputs/codex-transcript/codex-transcript-builder.ts
+++ b/src/inputs/codex-transcript/codex-transcript-builder.ts
@@ -237,12 +237,14 @@ function usageFields(usage: CodexTranscriptUsage | undefined): Record<string, Js
     inputTokens: 0,
     outputTokens: 0,
     cachedInputTokens: 0,
+    cacheCreationTokens: 0,
     totalTokens: 0,
   };
   return {
     'gen_ai.usage.input_tokens': resolved.inputTokens,
     'gen_ai.usage.output_tokens': resolved.outputTokens,
     'gen_ai.usage.cache_read.input_tokens': resolved.cachedInputTokens,
+    'gen_ai.usage.cache_creation.input_tokens': resolved.cacheCreationTokens,
     'gen_ai.usage.total_tokens': resolved.totalTokens,
     ...(resolved.reasoningOutputTokens !== undefined
       ? { 'gen_ai.usage.reasoning_output_tokens': resolved.reasoningOutputTokens }

--- a/src/inputs/codex-transcript/codex-transcript-extractor.ts
+++ b/src/inputs/codex-transcript/codex-transcript-extractor.ts
@@ -444,12 +444,14 @@ function extractLastTokenUsage(value: unknown): CodexTranscriptUsage | undefined
   const outputTokens = numberValue(raw.output_tokens);
   if (inputTokens === undefined || outputTokens === undefined) return undefined;
   const cachedInputTokens = numberValue(raw.cached_input_tokens) ?? 0;
+  const cacheCreationTokens = numberValue(raw.cache_creation_input_tokens) ?? 0;
   const totalTokens = numberValue(raw.total_tokens);
   const reasoningOutputTokens = numberValue(raw.reasoning_output_tokens);
   return {
     inputTokens,
     outputTokens,
     cachedInputTokens,
+    cacheCreationTokens,
     totalTokens: totalTokens && totalTokens > 0 ? totalTokens : inputTokens + outputTokens,
     ...(reasoningOutputTokens !== undefined ? { reasoningOutputTokens } : {}),
   };
@@ -464,6 +466,7 @@ function sameUsage(left: CodexTranscriptUsage | undefined, right: CodexTranscrip
     && left.inputTokens === right.inputTokens
     && left.outputTokens === right.outputTokens
     && left.cachedInputTokens === right.cachedInputTokens
+    && left.cacheCreationTokens === right.cacheCreationTokens
     && left.reasoningOutputTokens === right.reasoningOutputTokens
     && left.totalTokens === right.totalTokens;
 }

--- a/src/inputs/codex-transcript/codex-transcript-types.ts
+++ b/src/inputs/codex-transcript/codex-transcript-types.ts
@@ -40,6 +40,7 @@ export interface CodexTranscriptUsage {
   inputTokens: number;
   outputTokens: number;
   cachedInputTokens: number;
+  cacheCreationTokens: number;
   reasoningOutputTokens?: number;
   totalTokens: number;
 }

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -136,6 +136,7 @@ describe('CodexTranscriptInput', () => {
       'gen_ai.usage.input_tokens': 0,
       'gen_ai.usage.output_tokens': 0,
       'gen_ai.usage.cache_read.input_tokens': 0,
+      'gen_ai.usage.cache_creation.input_tokens': 0,
       'gen_ai.usage.total_tokens': 0,
     });
   });


### PR DESCRIPTION
## Summary

- Codex `llm.response` records were missing the `gen_ai.usage.cache_creation.input_tokens` field entirely, while other agents (Claude Code, Cursor) always populate it
- Even when OpenAI API does not provide `cache_creation_input_tokens`, we now explicitly record 0 for schema consistency and downstream aggregation correctness
- Changes span the full Codex token pipeline: type definitions, extractors (with fallback 0), builders (output field), legacy hook parser, and dedup logic

## Test plan

- [x] `npx tsc --noEmit` passes (no type errors)
- [x] `vitest run tests/unit/inputs/codex-transcript` — 15 tests pass
- [x] `vitest run tests/unit/inputs/codex-aborted-turn` — 11 tests pass
- [ ] Verify on SLS that new Codex llm.response records contain `gen_ai.usage.cache_creation.input_tokens: 0`