### PR TITLE
fix(codex): 去重分叉 transcript 中复制的历史 turn

### DIFF
--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -126,6 +126,7 @@ export class CodexTranscriptInput extends BaseInput {
       };
     } else if (checkpoint.inode !== stat.ino) {
       await this.baselineFile(filePath, key);
+      this.saveGlobalEmittedTurnIds();
       return [];
     }
 

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -15,8 +15,10 @@ import {
 } from './codex-transcript-extractor.js';
 import {
   MAX_EMITTED_TERMINAL_TURNS,
+  MAX_GLOBAL_EMITTED_TERMINAL_TURNS,
   type CodexActiveTranscriptTurn,
   type CodexTranscriptCheckpoint,
+  type CodexTranscriptGlobalState,
 } from './codex-transcript-types.js';
 import { stringValue, timestampMs } from './codex-transcript-utils.js';
 
@@ -49,6 +51,10 @@ export class CodexTranscriptInput extends BaseInput {
   private readonly sessionDir: string;
   private readonly wakeupDir: string;
   private wakeupWatcher: FSWatcher | null = null;
+  private emittedTurnIdsLoaded = false;
+  private emittedTurnIdsDirty = false;
+  private emittedTurnIds = new Set<string>();
+  private emittedTurnIdOrder: string[] = [];
 
   constructor(opts: CodexTranscriptInputOptions) {
     super({ stateStore: opts.stateStore, pollIntervalMs: opts.pollIntervalMs ?? 30_000 });
@@ -65,10 +71,12 @@ export class CodexTranscriptInput extends BaseInput {
   }
 
   protected override async onStart(): Promise<void> {
+    this.loadGlobalEmittedTurnIds();
     for (const filePath of await this.discoverSessionFiles()) {
       const key = this.stateKey(filePath);
       if (!this.readCheckpoint(key)) await this.baselineFile(filePath, key);
     }
+    this.saveGlobalEmittedTurnIds();
     await fs.mkdir(this.wakeupDir, { recursive: true });
     try {
       this.wakeupWatcher = fsSync.watch(this.wakeupDir, { persistent: false }, () => {
@@ -121,19 +129,24 @@ export class CodexTranscriptInput extends BaseInput {
       return [];
     }
 
+    const hadPendingTerminal = checkpoint.pendingTerminal !== null;
     const recoveredPending = await this.recoverPendingTerminal(filePath, checkpoint);
     if (recoveredPending === null) {
       this.saveCheckpoint(key, checkpoint);
+      this.saveGlobalEmittedTurnIds();
       return [];
     }
+    const checkpointChangedByPending = hadPendingTerminal;
 
     if (stat.size <= checkpoint.scanOffset) {
-      if (recoveredPending.length > 0) this.saveCheckpoint(key, checkpoint);
+      if (checkpointChangedByPending || recoveredPending.length > 0) this.saveCheckpoint(key, checkpoint);
+      this.saveGlobalEmittedTurnIds();
       return recoveredPending;
     }
     const lines = await readJsonLines(filePath, checkpoint.scanOffset, stat.size);
     if (lines.nextOffset === checkpoint.scanOffset) {
-      if (recoveredPending.length > 0) this.saveCheckpoint(key, checkpoint);
+      if (checkpointChangedByPending || recoveredPending.length > 0) this.saveCheckpoint(key, checkpoint);
+      this.saveGlobalEmittedTurnIds();
       return recoveredPending;
     }
 
@@ -162,19 +175,24 @@ export class CodexTranscriptInput extends BaseInput {
       const terminalTurnId = terminalTurnIdFor(line.record, payload);
       if (!terminalTurnId || checkpoint.activeTurn?.turnId !== terminalTurnId) continue;
       if (!checkpoint.emittedTerminalTurnIds.includes(terminalTurnId)) {
-        const recovered = await this.recoverTurn(filePath, checkpoint, line.endOffset);
-        if (recovered.length > 0) {
-          entries.push(...recovered);
-          checkpoint.emittedTerminalTurnIds = [terminalTurnId, ...checkpoint.emittedTerminalTurnIds]
-            .slice(0, MAX_EMITTED_TERMINAL_TURNS);
+        if (this.isGloballyEmittedTurn(terminalTurnId)) {
+          this.rememberCheckpointTurnId(checkpoint, terminalTurnId);
+          checkpoint.activeTurn = null;
         } else {
-          checkpoint.pendingTerminal = { turnId: terminalTurnId, terminalEndOffset: line.endOffset };
-          this.logger.warn('terminal Codex turn could not be reconstructed; retaining it for the next scan', {
-            transcriptPath: filePath,
-            turnId: terminalTurnId,
-          });
-          nextScanOffset = line.endOffset;
-          break;
+          const recovered = await this.recoverTurn(filePath, checkpoint, line.endOffset);
+          if (recovered.length > 0) {
+            entries.push(...recovered);
+            this.rememberCheckpointTurnId(checkpoint, terminalTurnId);
+            this.rememberGlobalEmittedTurnId(terminalTurnId);
+          } else {
+            checkpoint.pendingTerminal = { turnId: terminalTurnId, terminalEndOffset: line.endOffset };
+            this.logger.warn('terminal Codex turn could not be reconstructed; retaining it for the next scan', {
+              transcriptPath: filePath,
+              turnId: terminalTurnId,
+            });
+            nextScanOffset = line.endOffset;
+            break;
+          }
         }
       }
       checkpoint.activeTurn = null;
@@ -182,6 +200,7 @@ export class CodexTranscriptInput extends BaseInput {
 
     checkpoint.scanOffset = nextScanOffset;
     this.saveCheckpoint(key, checkpoint);
+    this.saveGlobalEmittedTurnIds();
     return entries;
   }
 
@@ -199,6 +218,12 @@ export class CodexTranscriptInput extends BaseInput {
       checkpoint.pendingTerminal = null;
       return [];
     }
+    if (this.isGloballyEmittedTurn(pending.turnId)) {
+      this.rememberCheckpointTurnId(checkpoint, pending.turnId);
+      checkpoint.activeTurn = null;
+      checkpoint.pendingTerminal = null;
+      return [];
+    }
     const recovered = await this.recoverTurn(filePath, checkpoint, pending.terminalEndOffset);
     if (recovered.length === 0) {
       this.logger.warn('pending Codex terminal turn still could not be reconstructed; will retry', {
@@ -207,8 +232,8 @@ export class CodexTranscriptInput extends BaseInput {
       });
       return null;
     }
-    checkpoint.emittedTerminalTurnIds = [pending.turnId, ...checkpoint.emittedTerminalTurnIds]
-      .slice(0, MAX_EMITTED_TERMINAL_TURNS);
+    this.rememberCheckpointTurnId(checkpoint, pending.turnId);
+    this.rememberGlobalEmittedTurnId(pending.turnId);
     checkpoint.activeTurn = null;
     checkpoint.pendingTerminal = null;
     return recovered;
@@ -303,6 +328,7 @@ export class CodexTranscriptInput extends BaseInput {
     const lines = await readJsonLines(filePath, 0, stat.size);
     let latestSessionMetaOffset: number | null = null;
     let activeTurn: CodexActiveTranscriptTurn | null = null;
+    const completedTurnIds: string[] = [];
     for (const line of lines.items) {
       const payload = asRecord(line.record.payload);
       if (!payload) continue;
@@ -315,8 +341,13 @@ export class CodexTranscriptInput extends BaseInput {
         activeTurn = { turnId, startOffset: line.startOffset, startedAtMs: timestampMs(line.record, Date.now()) };
         continue;
       }
-      if (terminalTurnIdFor(line.record, payload) === activeTurn?.turnId) activeTurn = null;
+      const terminalTurnId = terminalTurnIdFor(line.record, payload);
+      if (terminalTurnId === activeTurn?.turnId) {
+        completedTurnIds.push(terminalTurnId);
+        activeTurn = null;
+      }
     }
+    for (const turnId of completedTurnIds) this.rememberGlobalEmittedTurnId(turnId);
     this.saveCheckpoint(key, {
       inode: stat.ino,
       scanOffset: lines.nextOffset,
@@ -378,6 +409,80 @@ export class CodexTranscriptInput extends BaseInput {
         codexTranscript: checkpoint,
       },
     });
+  }
+
+  private loadGlobalEmittedTurnIds(): void {
+    if (this.emittedTurnIdsLoaded) return;
+    this.emittedTurnIdsLoaded = true;
+
+    const global = this.readGlobalState();
+    const hasPersistedGlobalState = global.emittedTerminalTurnIds.length > 0;
+    for (const turnId of global.emittedTerminalTurnIds) {
+      if (this.emittedTurnIds.has(turnId)) continue;
+      this.emittedTurnIds.add(turnId);
+      this.emittedTurnIdOrder.push(turnId);
+    }
+
+    if (hasPersistedGlobalState) return;
+    for (const key of this.stateStore.keys()) {
+      if (!key.startsWith(`${this.id}:`)) continue;
+      const raw = this.stateStore.get(key).extra?.codexTranscript;
+      const value = asRecord(raw);
+      const emittedTerminalTurnIds = Array.isArray(value?.emittedTerminalTurnIds)
+        ? value.emittedTerminalTurnIds
+        : [];
+      for (const turnId of emittedTerminalTurnIds) {
+        if (typeof turnId === 'string') this.rememberGlobalEmittedTurnId(turnId);
+      }
+    }
+  }
+
+  private readGlobalState(): CodexTranscriptGlobalState {
+    const raw = this.stateStore.get(this.id).extra?.codexTranscriptGlobal;
+    const value = asRecord(raw);
+    return {
+      emittedTerminalTurnIds: Array.isArray(value?.emittedTerminalTurnIds)
+        ? value.emittedTerminalTurnIds
+          .filter((item): item is string => typeof item === 'string')
+          .slice(0, MAX_GLOBAL_EMITTED_TERMINAL_TURNS)
+        : [],
+    };
+  }
+
+  private saveGlobalEmittedTurnIds(): void {
+    if (!this.emittedTurnIdsDirty) return;
+    const current = this.stateStore.get(this.id);
+    this.stateStore.update(this.id, {
+      lastOffset: this.emittedTurnIdOrder.length,
+      extra: {
+        ...(current.extra ?? {}),
+        codexTranscriptGlobal: {
+          emittedTerminalTurnIds: this.emittedTurnIdOrder,
+        },
+      },
+    });
+    this.emittedTurnIdsDirty = false;
+  }
+
+  private isGloballyEmittedTurn(turnId: string): boolean {
+    this.loadGlobalEmittedTurnIds();
+    return this.emittedTurnIds.has(turnId);
+  }
+
+  private rememberCheckpointTurnId(checkpoint: CodexTranscriptCheckpoint, turnId: string): void {
+    checkpoint.emittedTerminalTurnIds = [turnId, ...checkpoint.emittedTerminalTurnIds.filter(id => id !== turnId)]
+      .slice(0, MAX_EMITTED_TERMINAL_TURNS);
+  }
+
+  private rememberGlobalEmittedTurnId(turnId: string, markDirty = true): void {
+    if (this.emittedTurnIds.has(turnId)) return;
+    this.emittedTurnIds.add(turnId);
+    this.emittedTurnIdOrder.unshift(turnId);
+    while (this.emittedTurnIdOrder.length > MAX_GLOBAL_EMITTED_TERMINAL_TURNS) {
+      const removed = this.emittedTurnIdOrder.pop();
+      if (removed) this.emittedTurnIds.delete(removed);
+    }
+    if (markDirty) this.emittedTurnIdsDirty = true;
   }
 }
 

--- a/src/inputs/codex-transcript/codex-transcript-types.ts
+++ b/src/inputs/codex-transcript/codex-transcript-types.ts
@@ -1,6 +1,7 @@
 import type { JsonValue } from '../../types/index.js';
 
 export const MAX_EMITTED_TERMINAL_TURNS = 100;
+export const MAX_GLOBAL_EMITTED_TERMINAL_TURNS = 10_000;
 
 export type CodexTerminalStatus = 'completed' | 'interrupted';
 
@@ -26,6 +27,10 @@ export interface CodexTranscriptCheckpoint {
   activeTurn: CodexActiveTranscriptTurn | null;
   pendingTerminal: CodexPendingTerminalTurn | null;
   latestSessionMetaOffset: number | null;
+  emittedTerminalTurnIds: string[];
+}
+
+export interface CodexTranscriptGlobalState {
   emittedTerminalTurnIds: string[];
 }
 

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -127,6 +127,7 @@ async function createInput(root: string): Promise<{
   entries: AgentActivityEntry[];
   sessionDir: string;
   wakeupDir: string;
+  stateStore: StateStore;
 }> {
   const stateStore = new StateStore(path.join(root, 'input-state.json'));
   await stateStore.load();
@@ -136,7 +137,7 @@ async function createInput(root: string): Promise<{
   const entries: AgentActivityEntry[] = [];
   input.on('entries', batch => entries.push(...batch));
   await input.start();
-  return { input, entries, sessionDir, wakeupDir };
+  return { input, entries, sessionDir, wakeupDir, stateStore };
 }
 
 async function writeTranscript(sessionDir: string, text: string): Promise<string> {
@@ -496,6 +497,133 @@ describe('CodexTranscriptInput', () => {
     expect(responsesForTurn(entries, 'turn-2')).toHaveLength(1);
     expect(responsesForTurn(entries, 'turn-1')[0]?.['gen_ai.usage.total_tokens']).toBe(110);
     expect(responsesForTurn(entries, 'turn-2')[0]?.['gen_ai.usage.total_tokens']).toBe(132);
+  });
+
+  it('keeps fork dedupe after restarting the Codex transcript input', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-fork-restart-'));
+    tempDirs.push(root);
+    const first = await createInput(root);
+
+    const originalTurn = simpleCompletedTurn(
+      'session-1',
+      'turn-1',
+      'fix it',
+      'fixed once',
+      100,
+      10,
+      '2026-06-24T06:00:00.000Z',
+    );
+    await writeTranscriptNamed(first.sessionDir, 'rollout-original.jsonl', originalTurn.join('\n') + '\n');
+
+    await waitFor(() => responsesForTurn(first.entries, 'turn-1').length === 1);
+    await first.input.stop();
+
+    const restarted = await createInput(root);
+    const forkedHistory = simpleCompletedTurn(
+      'session-1',
+      'turn-1',
+      'fix it',
+      'fixed once',
+      100,
+      10,
+      '2026-06-24T06:10:00.000Z',
+    );
+    const forkedNewTurn = simpleCompletedTurn(
+      'session-1',
+      'turn-2',
+      'continue from the fork',
+      'fixed twice',
+      120,
+      12,
+      '2026-06-24T06:11:00.000Z',
+    ).slice(1);
+    await writeTranscriptNamed(
+      restarted.sessionDir,
+      'rollout-fork.jsonl',
+      [...forkedHistory, ...forkedNewTurn].join('\n') + '\n',
+    );
+
+    await waitFor(() => responsesForTurn(restarted.entries, 'turn-2').length === 1);
+    await new Promise(resolve => setTimeout(resolve, 50));
+    await restarted.input.stop();
+
+    expect(responsesForTurn(restarted.entries, 'turn-1')).toHaveLength(0);
+    expect(responsesForTurn(restarted.entries, 'turn-2')).toHaveLength(1);
+    expect(responsesForTurn(restarted.entries, 'turn-2')[0]?.['gen_ai.usage.total_tokens']).toBe(132);
+  });
+
+  it('persists global fork dedupe after baselining an inode-changed transcript file', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-fork-inode-'));
+    tempDirs.push(root);
+    const first = await createInput(root);
+
+    const originalTurn = simpleCompletedTurn(
+      'session-1',
+      'turn-1',
+      'fix it',
+      'fixed once',
+      100,
+      10,
+      '2026-06-24T06:00:00.000Z',
+    );
+    const transcript = await writeTranscriptNamed(
+      first.sessionDir,
+      'rollout-original.jsonl',
+      originalTurn.join('\n') + '\n',
+    );
+    await waitFor(() => responsesForTurn(first.entries, 'turn-1').length === 1);
+
+    await fs.rm(transcript);
+    const replacementTurn = simpleCompletedTurn(
+      'session-1',
+      'turn-2',
+      'fix it again',
+      'fixed from replacement',
+      200,
+      20,
+      '2026-06-24T06:20:00.000Z',
+    );
+    await fs.writeFile(transcript, replacementTurn.join('\n') + '\n', 'utf8');
+    const replacementStat = await fs.stat(transcript);
+    const checkpointKey = `codex-transcript:${transcript}`;
+    await waitFor(() => {
+      const checkpoint = first.stateStore.get(checkpointKey).extra?.codexTranscript as { inode?: number } | undefined;
+      return checkpoint?.inode === replacementStat.ino;
+    });
+    await first.input.stop();
+
+    const restarted = await createInput(root);
+    const forkedHistory = simpleCompletedTurn(
+      'session-1',
+      'turn-2',
+      'fix it again',
+      'fixed from replacement',
+      200,
+      20,
+      '2026-06-24T06:30:00.000Z',
+    );
+    const forkedNewTurn = simpleCompletedTurn(
+      'session-1',
+      'turn-3',
+      'continue after inode change',
+      'fixed after inode change',
+      300,
+      30,
+      '2026-06-24T06:31:00.000Z',
+    ).slice(1);
+    await writeTranscriptNamed(
+      restarted.sessionDir,
+      'rollout-fork.jsonl',
+      [...forkedHistory, ...forkedNewTurn].join('\n') + '\n',
+    );
+
+    await waitFor(() => responsesForTurn(restarted.entries, 'turn-3').length === 1);
+    await new Promise(resolve => setTimeout(resolve, 50));
+    await restarted.input.stop();
+
+    expect(responsesForTurn(restarted.entries, 'turn-2')).toHaveLength(0);
+    expect(responsesForTurn(restarted.entries, 'turn-3')).toHaveLength(1);
+    expect(responsesForTurn(restarted.entries, 'turn-3')[0]?.['gen_ai.usage.total_tokens']).toBe(330);
   });
 
   it('waits for task_complete before exporting a Stop-triggered transcript', async () => {

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -572,8 +572,8 @@ describe('CodexTranscriptInput', () => {
       originalTurn.join('\n') + '\n',
     );
     await waitFor(() => responsesForTurn(first.entries, 'turn-1').length === 1);
+    const originalStat = await fs.stat(transcript);
 
-    await fs.rm(transcript);
     const replacementTurn = simpleCompletedTurn(
       'session-1',
       'turn-2',
@@ -583,8 +583,11 @@ describe('CodexTranscriptInput', () => {
       20,
       '2026-06-24T06:20:00.000Z',
     );
-    await fs.writeFile(transcript, replacementTurn.join('\n') + '\n', 'utf8');
+    const replacementTranscript = `${transcript}.replacement`;
+    await fs.writeFile(replacementTranscript, replacementTurn.join('\n') + '\n', 'utf8');
+    await fs.rename(replacementTranscript, transcript);
     const replacementStat = await fs.stat(transcript);
+    expect(replacementStat.ino).not.toBe(originalStat.ino);
     const checkpointKey = `codex-transcript:${transcript}`;
     await waitFor(() => {
       const checkpoint = first.stateStore.get(checkpointKey).extra?.codexTranscript as { inode?: number } | undefined;

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -88,6 +88,40 @@ function completedTurn(): string {
   ].join('\n') + '\n';
 }
 
+function simpleCompletedTurn(
+  sessionId: string,
+  turnId: string,
+  prompt: string,
+  response: string,
+  usageInput: number,
+  usageOutput: number,
+  start: string,
+): string[] {
+  const baseMs = Date.parse(start);
+  const at = (offsetMs: number) => new Date(baseMs + offsetMs).toISOString();
+  return [
+    record(at(0), 'session_meta', {
+      id: sessionId, model_provider: 'openai',
+    }),
+    record(at(1_000), 'turn_context', {
+      turn_id: turnId, model: 'gpt-5.5', cwd: '/tmp/project',
+    }),
+    record(at(2_000), 'event_msg', {
+      type: 'task_started', turn_id: turnId,
+    }),
+    record(at(3_000), 'response_item', {
+      type: 'message', role: 'user', content: [{ type: 'input_text', text: prompt }],
+    }),
+    record(at(4_000), 'event_msg', {
+      type: 'agent_message', message: response, phase: 'final',
+    }),
+    record(at(4_000), 'event_msg', tokenUsage(usageInput, usageOutput)),
+    record(at(5_000), 'event_msg', {
+      type: 'task_complete', turn_id: turnId, last_agent_message: response,
+    }),
+  ];
+}
+
 async function createInput(root: string): Promise<{
   input: CodexTranscriptInput;
   entries: AgentActivityEntry[];
@@ -115,6 +149,20 @@ async function writeTranscript(sessionDir: string, text: string): Promise<string
 async function writeWakeupMarker(wakeupDir: string, sessionId: string, payload: Record<string, unknown>): Promise<void> {
   await fs.mkdir(wakeupDir, { recursive: true });
   await fs.writeFile(path.join(wakeupDir, `${sessionId}.json`), JSON.stringify(payload), 'utf8');
+}
+
+async function writeTranscriptNamed(sessionDir: string, name: string, text: string): Promise<string> {
+  const transcript = path.join(sessionDir, '2026', '06', '24', name);
+  await fs.mkdir(path.dirname(transcript), { recursive: true });
+  await fs.writeFile(transcript, text, 'utf8');
+  return transcript;
+}
+
+function responsesForTurn(entries: AgentActivityEntry[], turnId: string): AgentActivityEntry[] {
+  return entries.filter(entry =>
+    entry['event.name'] === 'llm.response'
+    && entry['agent.codex.transcript_turn_id'] === turnId,
+  );
 }
 
 describe('CodexTranscriptInput', () => {
@@ -396,6 +444,58 @@ describe('CodexTranscriptInput', () => {
       'Codex wakeup marker has no resourceAttributes; attribution skipped',
       { marker: path.join(wakeupDir, 'session-1.json') },
     );
+  });
+
+  it('does not re-emit completed turns copied into a forked Codex transcript file', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-fork-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir } = await createInput(root);
+
+    const originalTurn = simpleCompletedTurn(
+      'session-1',
+      'turn-1',
+      'fix it',
+      'fixed once',
+      100,
+      10,
+      '2026-06-24T06:00:00.000Z',
+    );
+    await writeTranscriptNamed(sessionDir, 'rollout-original.jsonl', originalTurn.join('\n') + '\n');
+
+    await waitFor(() => responsesForTurn(entries, 'turn-1').length === 1);
+
+    const forkedHistory = simpleCompletedTurn(
+      'session-1',
+      'turn-1',
+      'fix it',
+      'fixed once',
+      100,
+      10,
+      '2026-06-24T06:10:00.000Z',
+    );
+    const forkedNewTurn = simpleCompletedTurn(
+      'session-1',
+      'turn-2',
+      'continue from the fork',
+      'fixed twice',
+      120,
+      12,
+      '2026-06-24T06:11:00.000Z',
+    ).slice(1);
+    await writeTranscriptNamed(
+      sessionDir,
+      'rollout-fork.jsonl',
+      [...forkedHistory, ...forkedNewTurn].join('\n') + '\n',
+    );
+
+    await waitFor(() => responsesForTurn(entries, 'turn-2').length === 1);
+    await new Promise(resolve => setTimeout(resolve, 50));
+    await input.stop();
+
+    expect(responsesForTurn(entries, 'turn-1')).toHaveLength(1);
+    expect(responsesForTurn(entries, 'turn-2')).toHaveLength(1);
+    expect(responsesForTurn(entries, 'turn-1')[0]?.['gen_ai.usage.total_tokens']).toBe(110);
+    expect(responsesForTurn(entries, 'turn-2')[0]?.['gen_ai.usage.total_tokens']).toBe(132);
   });
 
   it('waits for task_complete before exporting a Stop-triggered transcript', async () => {


### PR DESCRIPTION
## 背景

Codex App 的分叉不是在原来的 turn 上继续写，而是创建一个新的 thread/head 和新的 rollout 文件，然后把分叉点之前的历史记录复制到新 rollout 里。实测到的关键行为是：

1. 分叉会产生新的 rollout 文件。
2. 复制过来的历史 turn 会保留原来的 `turn_id`。
3. 分叉之后用户真正发起的新对话会产生新的 `turn_id`。

原来的 Codex transcript 采集只在单个 transcript 文件内做 terminal turn 去重。这样一来，分叉 rollout 文件里复制出来的旧 `turn_id` 会被当成新文件里的新完成 turn 再 emit 一次，导致 LLM/token spans 重复上报，在 CMS 上表现为历史 token 消耗突增。

## 改动

本 PR 给 Codex transcript input 增加一个有上限、可持久化的全局 terminal `turn_id` 去重状态。

行为变成：

- 如果一个 completed/interrupted terminal `turn_id` 已经在其他 transcript 文件里 emit 过，后续在 fork 文件里再次看到它时，只更新当前文件 checkpoint，不再 emit entries。
- 如果 fork 之后出现真正新的 `turn_id`，仍然正常恢复 turn、emit entries、上报 token。
- 首次启动 baseline 已跳过的历史 completed turns 也会写入全局去重状态，避免后续 fork 复制这些历史时再次上报。
- 全局状态上限是 10,000 个 terminal turn，避免本地 state 无限增长。

## Reviewer 阅读路径

建议按这个顺序看：

1. `tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts`
   - 重点看新增的 fork transcript 用例。它表达了核心契约：原始文件里的 `turn-1` emit 一次；fork 文件里复制的 `turn-1` 不再 emit；fork 后新增的 `turn-2` 正常 emit。
2. `src/inputs/codex-transcript/codex-transcript-input.ts`
   - 先看 terminal turn 处理和 pending terminal recovery 的逻辑。
   - 再看新增的 global emitted turn state 读写、旧 checkpoint 迁移和上限控制。
3. `src/inputs/codex-transcript/codex-transcript-types.ts`
   - 这里只新增了全局状态类型和 10,000 的上限常量。

## 关于 trace / ENTRY 行为

这个 PR 不改变现有 trace 建模。当前 `codex-transcript-builder.ts` 仍然按 `sessionId + transcriptTurnId` 生成 trace，所以分叉后真正新增的 turn 仍然会创建新的 trace/ENTRY 组。

这里的判断是：

- fork 复制来的历史 turn 是已经发生过的执行，不能重复上报，否则 token 会被重复计数。
- fork 后的新 turn 是新的模型调用和工具执行，应该正常上报 token。
- “把整棵分支树展示在一条 trace 里”是另一个产品建模问题，需要 root thread/branch lineage、parent turn、branch id 等字段配合，不在这次 bugfix 范围内。

## 风险和边界

- 这个方案依赖 Codex fork 会保留复制历史的旧 `turn_id`、新对话生成新 `turn_id`。这是我们在 Codex App 本地真实 rollout 文件里验证到的行为。
- 全局去重状态有 10,000 个 terminal turn 上限。极老的历史 turn 被淘汰后，如果又被 fork 复制，有理论上的再次 emit 可能；这里用有界本地状态换取避免 state 无限增长。
- startup baseline 会把已完成历史 turn 写入全局去重状态。这符合现有 first-run guard 的语义：首次启动不回补历史，后续 fork 复制这些历史也不应该重新上报。
- 不改 SLS / JSONL / OTLP flusher，不改 hook/plugin 部署，不改其他 agent input，不改 package metadata。

## 验证

代码检查：

- `npm run test -- tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts` 通过，12 个测试。/
- `npm run typecheck` 通过。
- `npm run build` 通过。
- `git diff --check` 通过。
- qoder review loop 跑过，0 个 parsed findings。n- 已根据 review comment 修复 inode 变更 baseline 后未持久化全局去重状态的问题，并补充重启后去重、inode baseline 后重启去重两个测试。/

真实回放 / CMS 验证：

- 用 Codex App 手动分叉后产生的真实 rollout 文件做了 old/new replay。旧逻辑会从 fork 文件里重复 emit 已有历史 turn；新逻辑只跳过复制历史，保留 fork 后新增 turn。
- 内部 CMS 对比中，旧版本能看到历史 token spans 重复出现；新版本去掉了这部分重复 token spans，同时保留新增 fork turn 的上报。相关内部验证材料不放到公开 PR 里，避免暴露内部链接和上报配置。

全量测试说明：

- 本机当前分支运行 `npm test` 时，曾在和本 PR 无直接关系的 shell worker 启动类测试上失败：`local-worker-activation-service`，串行模式下还出现过 `plugin-probe-strategy` 的临时 capture 文件未及时生成。
- 目标 Codex transcript 测试稳定通过；同一个 local-worker 文件单独运行通过；一个干净 `origin/main` worktree 的 `npm test -- --reporter=dot` 曾完整通过。
- 本 PR 没有修改 worker/deployment 相关模块，因此把这部分作为本机验证环境下的 residual risk 透明记录。