### PR TITLE
feat(watchdog): self-heal OpenCode plugin-inject + uninstall cleanup

### DIFF
--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -885,9 +885,12 @@ function Remove-HookConfigs {
     $configs = @(
         (Join-Path $env:USERPROFILE ".cursor\hooks.json"),
         (Join-Path $env:USERPROFILE ".qoder\settings.json"),
+        (Join-Path $env:USERPROFILE ".qoder-cn\settings.json"),
         (Join-Path $env:USERPROFILE ".qoderwork\settings.json"),
+        (Join-Path $env:USERPROFILE ".qoderworkcn\settings.json"),
         (Join-Path $env:USERPROFILE ".claude\settings.json"),
-        (Join-Path $env:USERPROFILE ".codex\hooks.json")
+        (Join-Path $env:USERPROFILE ".codex\hooks.json"),
+        (Join-Path $env:USERPROFILE ".qwen\settings.json")
     )
 
     foreach ($cfg in $configs) {
@@ -924,6 +927,62 @@ try {
             Msg "    ✅ 已清理: $short" "    ✅ Cleaned: $short"
         } catch {
             Msg "    ⚠️  跳过: $short (需手动清理)" "    ⚠️  Skipped: $short (manual cleanup needed)"
+        }
+    }
+}
+
+# ============================================================
+# Remove plugin-inject specs (OpenCode)
+# ============================================================
+# OpenCode uses deployMode "plugin-inject": a spec is written into its own
+# config file's plugin array, not a shared settings.json. Remove-HookConfigs
+# does not cover it, so clean it here to avoid a dangling spec.
+function Remove-OpenCodePlugin {
+    $configs = @(
+        (Join-Path $env:USERPROFILE ".config\opencode\opencode.jsonc"),
+        (Join-Path $env:USERPROFILE ".config\opencode\opencode.json"),
+        (Join-Path $env:USERPROFILE ".config\opencode\config.json")
+    )
+
+    foreach ($cfg in $configs) {
+        if (-not (Test-Path $cfg)) { continue }
+        $short = $cfg -replace [regex]::Escape($env:USERPROFILE), "~"
+
+        if (-not $script:NODE_BIN) {
+            Msg "    ⚠️  跳过: $short (无 node,需手动清理)" "    ⚠️  Skipped: $short (node unavailable, manual cleanup needed)"
+            continue
+        }
+
+        $result = & $script:NODE_BIN -e @'
+const fs = require('fs');
+const f = process.argv[1];
+const isOurs = s => typeof s === 'string' && (s.includes('loongsuite-pilot-opencode') || s.includes('plugins/opencode/plugin.mjs'));
+const entryStr = e => typeof e === 'string' ? e : (Array.isArray(e) ? String(e[0]) : '');
+const stripJsonc = src => src
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/^\s*\/\/.*$/gm, '')
+  .replace(/[ \t]+\/\/.*$/gm, '');
+try {
+  const raw = fs.readFileSync(f, 'utf-8');
+  let data, hadComments = false;
+  try { data = JSON.parse(raw); }
+  catch { data = JSON.parse(stripJsonc(raw)); hadComments = true; }
+  const key = Array.isArray(data.plugins) ? 'plugins' : (Array.isArray(data.plugin) ? 'plugin' : null);
+  if (!key) { process.stdout.write('nochange'); process.exit(0); }
+  const before = data[key].length;
+  data[key] = data[key].filter(e => !isOurs(entryStr(e)));
+  if (data[key].length === before) { process.stdout.write('nochange'); process.exit(0); }
+  if (hadComments) fs.writeFileSync(f + '.bak', raw, 'utf-8');
+  fs.writeFileSync(f, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+  process.stdout.write(hadComments ? 'cleaned-bak' : 'cleaned');
+} catch (e) { process.stderr.write(e.message); process.exit(1); }
+'@ $cfg 2>$null
+
+        switch ($result) {
+            "cleaned"     { Msg "    ✅ 已清理: $short" "    ✅ Cleaned: $short" }
+            "cleaned-bak" { Msg "    ✅ 已清理: $short (含注释,原文件备份为 $short.bak)" "    ✅ Cleaned: $short (had comments, original backed up to $short.bak)" }
+            "nochange"    { }
+            default       { Msg "    ⚠️  跳过: $short (需手动清理)" "    ⚠️  Skipped: $short (manual cleanup needed)" }
         }
     }
 }
@@ -1161,6 +1220,10 @@ function Cmd-Uninstall {
 
     Msg "==> 清理 Claude/Codex 插件..." "==> Cleaning up Claude/Codex plugins..."
     Remove-OtelPlugin
+    Write-Host ""
+
+    Msg "==> 清理 OpenCode 插件配置..." "==> Cleaning up OpenCode plugin config..."
+    Remove-OpenCodePlugin
     Write-Host ""
 
     if ($Purge) {

--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -1582,9 +1582,12 @@ remove_hook_configs() {
     local configs=(
         "$HOME/.cursor/hooks.json"
         "$HOME/.qoder/settings.json"
+        "$HOME/.qoder-cn/settings.json"
         "$HOME/.qoderwork/settings.json"
+        "$HOME/.qoderworkcn/settings.json"
         "$HOME/.claude/settings.json"
         "$HOME/.codex/hooks.json"
+        "$HOME/.qwen/settings.json"
     )
 
     for cfg in "${configs[@]}"; do
@@ -1629,6 +1632,73 @@ try {
         else
             msg "    ⚠️  跳过: $short (需手动清理)" "    ⚠️  Skipped: $short (manual cleanup needed)"
         fi
+    done
+}
+
+# ============================================================
+# Remove plugin-inject specs (OpenCode)
+# ============================================================
+# OpenCode uses deployMode "plugin-inject": a spec is written into its own
+# config file's plugin array, not a shared settings.json. remove_hook_configs
+# does not cover it, so clean it here to avoid a dangling spec that points at
+# the (possibly purged) data dir.
+remove_opencode_plugin() {
+    local configs=(
+        "$HOME/.config/opencode/opencode.jsonc"
+        "$HOME/.config/opencode/opencode.json"
+        "$HOME/.config/opencode/config.json"
+    )
+
+    for cfg in "${configs[@]}"; do
+        [ -f "$cfg" ] || continue
+        local short="${cfg/#$HOME/\~}"
+
+        if ! command -v node &>/dev/null; then
+            msg "    ⚠️  跳过: $short (无 node,需手动清理)" "    ⚠️  Skipped: $short (node unavailable, manual cleanup needed)"
+            continue
+        fi
+
+        local result
+        result=$(node -e "
+const fs = require('fs');
+const f = process.argv[1];
+// Our entries are identified by the pluginId or the plugin file path.
+const isOurs = s => typeof s === 'string' && (s.includes('loongsuite-pilot-opencode') || s.includes('plugins/opencode/plugin.mjs'));
+const entryStr = e => typeof e === 'string' ? e : (Array.isArray(e) ? String(e[0]) : '');
+// JSONC fallback: strip block comments, whole-line // comments, and trailing
+// // comments preceded by whitespace. URL values like file:/// are never
+// touched because their slashes are not preceded by whitespace.
+const stripJsonc = src => src
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/^\s*\/\/.*\$/gm, '')
+  .replace(/[ \t]+\/\/.*\$/gm, '');
+try {
+  const raw = fs.readFileSync(f, 'utf-8');
+  let data, hadComments = false;
+  try { data = JSON.parse(raw); }
+  catch { data = JSON.parse(stripJsonc(raw)); hadComments = true; }
+  const key = Array.isArray(data.plugins) ? 'plugins' : (Array.isArray(data.plugin) ? 'plugin' : null);
+  if (!key) { process.stdout.write('nochange'); process.exit(0); }
+  const before = data[key].length;
+  data[key] = data[key].filter(e => !isOurs(entryStr(e)));
+  if (data[key].length === before) { process.stdout.write('nochange'); process.exit(0); }
+  if (hadComments) fs.writeFileSync(f + '.bak', raw, 'utf-8');
+  fs.writeFileSync(f, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+  process.stdout.write(hadComments ? 'cleaned-bak' : 'cleaned');
+} catch (e) { process.stderr.write(e.message); process.exit(1); }
+" "$cfg" 2>/dev/null) || result="error"
+
+        case "$result" in
+            cleaned)
+                msg "    ✅ 已清理: $short" "    ✅ Cleaned: $short" ;;
+            cleaned-bak)
+                msg "    ✅ 已清理: $short (含注释,原文件备份为 $short.bak)" \
+                    "    ✅ Cleaned: $short (had comments, original backed up to $short.bak)" ;;
+            nochange)
+                : ;;
+            *)
+                msg "    ⚠️  跳过: $short (需手动清理)" "    ⚠️  Skipped: $short (manual cleanup needed)" ;;
+        esac
     done
 }
 
@@ -1734,6 +1804,11 @@ cmd_uninstall() {
     # Remove OTel Claude plugin
     msg "==> 清理 Claude/Codex 插件..." "==> Cleaning up Claude/Codex plugins..."
     remove_otel_plugin
+    echo ""
+
+    # Remove plugin-inject specs (OpenCode)
+    msg "==> 清理 OpenCode 插件配置..." "==> Cleaning up OpenCode plugin config..."
+    remove_opencode_plugin
     echo ""
 
     # Data directory

--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -96,6 +96,8 @@ Important fields:
 | `pluginInject` | Config paths and plugin spec. Required for plugin injection mode. |
 | `input` | Source type and source location for the collector input. |
 
+> When adding a `plugin-inject` agent, also register it in the uninstaller (`deploy/installer-opensource.sh` / `.ps1`) so its injected spec is removed on uninstall. Plugin-inject agents are additionally self-healed at runtime by the hook watchdog, which re-injects the spec if another tool overwrites the config.
+
 ## Emit Normalized Records Early
 
 For hook and plugin integrations, make the hook or plugin write newline-delimited JSON records to:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -135,6 +135,8 @@ http://127.0.0.1:8765/
 
 ## Uninstall
 
+Uninstall stops the service, removes installed files, and cleans the integrations written into agent configs (hook entries for Claude Code, Codex, Cursor, Qoder, Qwen, etc., and the injected plugin spec in OpenCode's config). Add `--purge` (`-Purge` on Windows) to also delete the local data directory.
+
 Keep data on Linux/macOS:
 
 ```bash

--- a/docs/zh-CN/agent-onboarding.md
+++ b/docs/zh-CN/agent-onboarding.md
@@ -96,6 +96,8 @@ Hook 示例：
 | `pluginInject` | 配置路径和插件 spec。插件注入模式必填。 |
 | `input` | collector input 使用的数据源类型和位置。 |
 
+> 新增 `plugin-inject` 类型 agent 时，请同时在卸载脚本（`deploy/installer-opensource.sh` / `.ps1`）中登记，确保卸载时移除其注入的 spec。此外 plugin-inject agent 在运行时会由 hook watchdog 自愈：若配置被其它工具覆盖，会自动重新注入 spec。
+
 ## 尽早输出规范化记录
 
 对于 Hook 和插件集成，建议让 Hook 或插件写 newline-delimited JSON 到：

--- a/docs/zh-CN/installation.md
+++ b/docs/zh-CN/installation.md
@@ -135,6 +135,8 @@ http://127.0.0.1:8765/
 
 ## 卸载
 
+卸载会停止服务、删除已安装文件，并清理写入各 agent 配置中的接入内容（Claude Code、Codex、Cursor、Qoder、Qwen 等的 hook 条目，以及注入到 OpenCode 配置里的插件 spec）。加 `--purge`（Windows 为 `-Purge`）可一并删除本地数据目录。
+
 Linux/macOS 保留数据：
 
 ```bash

--- a/scripts/check-opencode-injection.sh
+++ b/scripts/check-opencode-injection.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# check-opencode-injection.sh
+# ---------------------------------------------------------------------------
+# 独立检测脚本：判断本机 loongsuite-pilot 是否已为 OpenCode 注入采集能力。
+# 零依赖，拷贝到目标机器直接运行即可：
+#
+#     bash check-opencode-injection.sh
+#
+# 退出码：
+#   0  = 已注入且已产出采集数据（链路完全打通）
+#   1  = 已注入但尚未产出数据（配置就绪，等待一次真实会话）
+#   2  = 未注入 / 注入不完整
+# ---------------------------------------------------------------------------
+
+set -u
+
+# ---- 颜色（非 TTY 时自动关闭）----
+if [ -t 1 ]; then
+  RED=$'\033[31m'; GRN=$'\033[32m'; YLW=$'\033[33m'; BLU=$'\033[36m'; BLD=$'\033[1m'; RST=$'\033[0m'
+else
+  RED=''; GRN=''; YLW=''; BLU=''; BLD=''; RST=''
+fi
+
+ok()   { printf "  ${GRN}✔${RST} %s\n" "$1"; }
+warn() { printf "  ${YLW}!${RST} %s\n" "$1"; }
+bad()  { printf "  ${RED}✘${RST} %s\n" "$1"; }
+hdr()  { printf "\n${BLD}${BLU}== %s ==${RST}\n" "$1"; }
+
+# ---- 路径解析 ----
+PILOT_DATA="${LOONGSUITE_PILOT_DATA_DIR:-$HOME/.loongsuite-pilot}"
+PLUGIN_FILE="$PILOT_DATA/plugins/opencode/plugin.mjs"
+LOG_DIR="$PILOT_DATA/logs/opencode"
+MARKERS='loongsuite-pilot-opencode|plugins/opencode/plugin.mjs'
+CFG_CANDIDATES=(
+  "$HOME/.config/opencode/opencode.jsonc"
+  "$HOME/.config/opencode/opencode.json"
+  "$HOME/.config/opencode/config.json"
+)
+
+printf "${BLD}OpenCode 采集注入检测${RST}\n"
+printf "主机: %s   用户: %s   时间: %s\n" "$(hostname 2>/dev/null || echo '?')" "$(whoami 2>/dev/null || echo '?')" "$(date '+%Y-%m-%d %H:%M:%S')"
+printf "PILOT_DATA: %s\n" "$PILOT_DATA"
+
+config_injected=0
+plugin_ready=0
+logs_present=0
+
+# ---- 1) OpenCode 配置是否注入插件 spec ----
+hdr "1) OpenCode 配置注入"
+found_cfg=""
+for f in "${CFG_CANDIDATES[@]}"; do
+  [ -f "$f" ] || continue
+  found_cfg="yes"
+  if grep -Eq "$MARKERS" "$f" 2>/dev/null; then
+    ok "已注入: $f"
+    grep -En "$MARKERS" "$f" 2>/dev/null | sed 's/^/       /'
+    config_injected=1
+  else
+    warn "存在但未注入 pilot 插件: $f"
+  fi
+done
+if [ -z "$found_cfg" ]; then
+  bad "未找到任何 OpenCode 配置文件（检查过: ${CFG_CANDIDATES[*]}）"
+  warn "可能 OpenCode 从未启动过，或配置目录不在默认位置"
+fi
+
+# ---- 2) 注入目标插件文件是否就绪 ----
+hdr "2) 插件文件"
+if [ -f "$PLUGIN_FILE" ]; then
+  size=$(wc -c < "$PLUGIN_FILE" 2>/dev/null | tr -d ' ')
+  mtime=$(date -r "$PLUGIN_FILE" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo '?')
+  ok "存在: $PLUGIN_FILE (${size} bytes, 更新于 ${mtime})"
+  plugin_ready=1
+else
+  bad "缺失: $PLUGIN_FILE"
+  warn "pilot 尚未部署插件文件，注入的 spec 会指向一个不存在的文件"
+fi
+
+# ---- 3) 是否已真正产出采集数据（最可信）----
+hdr "3) 采集数据 (JSONL)"
+if [ -d "$LOG_DIR" ]; then
+  jsonl_count=$(find "$LOG_DIR" -maxdepth 1 -name 'opencode-*.jsonl' -type f 2>/dev/null | grep -vc 'error' )
+  # 上一行在无匹配时 grep 返回 0 计数，稳妥起见重算：
+  jsonl_files=$(find "$LOG_DIR" -maxdepth 1 -name 'opencode-*.jsonl' ! -name '*error*' -type f 2>/dev/null)
+  if [ -n "$jsonl_files" ]; then
+    logs_present=1
+    total_lines=0
+    while IFS= read -r jf; do
+      [ -n "$jf" ] || continue
+      lc=$(wc -l < "$jf" 2>/dev/null | tr -d ' ')
+      total_lines=$((total_lines + lc))
+      ok "$(basename "$jf"): ${lc} 条记录"
+    done <<< "$jsonl_files"
+    latest=$(find "$LOG_DIR" -maxdepth 1 -name 'opencode-*.jsonl' ! -name '*error*' -type f -exec ls -t {} + 2>/dev/null | head -1)
+    if [ -n "$latest" ]; then
+      printf "  ${BLU}最新一条记录预览:${RST}\n"
+      tail -1 "$latest" 2>/dev/null | cut -c1-200 | sed 's/^/       /'
+      printf "       ...\n"
+    fi
+    printf "  合计: ${BLD}%s${RST} 条采集记录\n" "$total_lines"
+  else
+    warn "日志目录存在但为空: $LOG_DIR"
+    warn "说明: 注入已就绪，但注入后还没有真实跑过 OpenCode 会话"
+  fi
+
+  # 错误日志
+  err_files=$(find "$LOG_DIR" -maxdepth 1 -name 'opencode-error-*.log' -type f 2>/dev/null)
+  if [ -n "$err_files" ]; then
+    printf "\n  ${YLW}发现插件错误日志:${RST}\n"
+    while IFS= read -r ef; do
+      [ -n "$ef" ] || continue
+      warn "$(basename "$ef") (最后 3 行):"
+      tail -3 "$ef" 2>/dev/null | sed 's/^/       /'
+    done <<< "$err_files"
+  fi
+else
+  warn "日志目录不存在: $LOG_DIR"
+  warn "说明: 插件从未写过数据（未运行过，或注入未生效）"
+fi
+
+# ---- 环境信息 ----
+hdr "环境信息"
+if command -v opencode >/dev/null 2>&1; then
+  ok "opencode 已安装: $(command -v opencode)"
+  ver=$(opencode --version 2>/dev/null | head -1)
+  [ -n "$ver" ] && printf "       版本: %s\n" "$ver"
+else
+  warn "PATH 中未找到 opencode 命令（不影响已注入的判断）"
+fi
+
+# ---- 结论 ----
+hdr "结论"
+if [ "$config_injected" -eq 1 ] && [ "$plugin_ready" -eq 1 ] && [ "$logs_present" -eq 1 ]; then
+  printf "  ${GRN}${BLD}✔ 已注入且采集链路已打通${RST}（配置✔ 文件✔ 数据✔）\n"
+  exit 0
+elif [ "$config_injected" -eq 1 ] && [ "$plugin_ready" -eq 1 ]; then
+  printf "  ${YLW}${BLD}! 已注入，等待数据${RST}（配置✔ 文件✔ 数据✘）\n"
+  printf "  下一步: 正常用 opencode 发起一轮对话后重新运行本脚本，应能看到 JSONL 记录。\n"
+  exit 1
+else
+  printf "  ${RED}${BLD}✘ 未注入 / 注入不完整${RST}"
+  printf "（配置%s 文件%s 数据%s）\n" \
+    "$( [ "$config_injected" -eq 1 ] && echo '✔' || echo '✘')" \
+    "$( [ "$plugin_ready" -eq 1 ] && echo '✔' || echo '✘')" \
+    "$( [ "$logs_present" -eq 1 ] && echo '✔' || echo '✘')"
+  printf "  下一步: 确认 loongsuite-pilot 已启动并成功执行过部署（deployAll）。\n"
+  exit 2
+fi

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -42,7 +42,7 @@ import { QwenCodeCliLogInput } from '../inputs/qwen-code-cli-log/qwen-code-cli-l
 import { WukongInput } from '../inputs/wukong/wukong-input.js';
 
 import { LogRetentionService } from './log-retention-service.js';
-import { HookWatchdog, type PluginCheckTarget } from './hook-watchdog.js';
+import { HookWatchdog, type PluginCheckTarget, type InterceptCheckTarget } from './hook-watchdog.js';
 import { UpdaterWatchdog } from './updater-watchdog.js';
 import { FileCollectionManager } from '../file-collection/file-collection-manager.js';
 import { MetricsWriter } from '../metrics/metrics-writer.js';
@@ -202,7 +202,10 @@ export class Orchestrator extends EventEmitter {
       ...HookWatchdog.defaultTargets(),
       ...this.buildHookWatchdogTargets(),
     ];
-    const interceptTargets = HookWatchdog.defaultInterceptTargets(this.dataDir);
+    const interceptTargets = [
+      ...HookWatchdog.defaultInterceptTargets(this.dataDir),
+      ...this.buildPluginInjectInterceptTargets(),
+    ];
     this.hookWatchdog = new HookWatchdog(this.config.hookWatchdog, hookWatchdogTargets, interceptTargets);
     this.hookWatchdog.start();
 
@@ -369,6 +372,60 @@ export class Orchestrator extends EventEmitter {
     }
 
     return targets;
+  }
+
+  /**
+   * Self-heal targets for plugin-inject agents (e.g. opencode, qwen-code-cli).
+   *
+   * Unlike hook agents, these write a plugin spec into the agent's own config
+   * file (not a shared settings.json), so they use the intercept mechanism:
+   * an arbitrary check/repair pair rather than the hook-array-shaped
+   * PluginCheckTarget. The intercept runner also gives us cooldown + a daily
+   * repair cap, which bounds config rewrites (relevant because re-injecting
+   * into a JSONC config strips comments).
+   */
+  private buildPluginInjectInterceptTargets(): InterceptCheckTarget[] {
+    const defs = this.deploymentManager.getDefinitions();
+    const targets: InterceptCheckTarget[] = [];
+
+    for (const def of defs) {
+      if (def.deployMode !== 'plugin-inject' || !def.pluginInject) continue;
+
+      const pluginFile = this.resolvePluginSpecPath(def.pluginInject.pluginSpec);
+
+      targets.push({
+        id: `plugin-inject:${def.id}`,
+        precondition: async () => {
+          // Only self-heal when the plugin asset is actually deployed AND the
+          // agent is present. Otherwise repair would inject a spec pointing at
+          // a missing file, or fail repeatedly when no config file exists.
+          if (pluginFile && !(await fileExists(pluginFile))) return false;
+          return detectAgent(def.detection);
+        },
+        check: async () => {
+          // Healthy == spec still present in the agent's config file.
+          return !(await this.deploymentManager.needsRedeploy(def));
+        },
+        repair: async () => {
+          const result = await this.deploymentManager.deploySingle(def);
+          if (!result.success) {
+            throw new Error(result.error ?? `re-inject failed for ${def.id}`);
+          }
+        },
+      });
+    }
+
+    return targets;
+  }
+
+  /**
+   * Resolve a plugin spec to a local file path for existence checks.
+   * Returns null for non-file specs (e.g. npm package names), which skips the
+   * plugin-file precondition gate.
+   */
+  private resolvePluginSpecPath(spec: string): string | null {
+    const resolved = spec.replace(/\$PILOT_DATA/g, this.dataDir);
+    return resolved.startsWith('file://') ? resolved.slice('file://'.length) : null;
   }
 
   private async buildFlusher(): Promise<BaseFlusher> {

--- a/src/deployment/deployment-manager.ts
+++ b/src/deployment/deployment-manager.ts
@@ -103,6 +103,17 @@ export class DeploymentManager {
     return this.definitions;
   }
 
+  /**
+   * Whether the agent's integration is currently missing and needs to be
+   * (re)deployed. Used by the watchdog to detect specs overwritten by other
+   * tools. Returns true when the strategy reports the integration is absent.
+   */
+  async needsRedeploy(def: AgentDefinition): Promise<boolean> {
+    await this.loadState();
+    const strategy = this.getStrategy(def);
+    return strategy.needsDeploy(def, this.state[def.id]);
+  }
+
   async stopWorkers(): Promise<void> {
     for (const def of this.definitions) {
       if (def.deployMode !== 'plugin-probe' || !def.pluginProbe) continue;

--- a/tests/integration/opencode-watchdog-selfheal.test.ts
+++ b/tests/integration/opencode-watchdog-selfheal.test.ts
@@ -1,0 +1,143 @@
+/**
+ * End-to-end self-heal test for plugin-inject agents (opencode).
+ *
+ * Uses REAL components — DeploymentManager, PluginInjectStrategy, HookWatchdog,
+ * and the orchestrator's target builder — against a throwaway sandbox. No logic
+ * is mocked (only the build-time global and logger noise). It proves the full
+ * loop: deploy → spec overwritten by a 3rd party → watchdog re-injects it.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import type { AgentDefinition, HookWatchdogConfig } from '../../src/types/index.js';
+
+vi.mock('../../src/utils/logger.js', () => ({
+  createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+// Orchestrator transitively imports build-constants (build-time global).
+vi.mock('../../src/core/build-constants.js', () => ({ PROPRIETARY_BUILD: false }));
+
+import { DeploymentManager } from '../../src/deployment/deployment-manager.js';
+import { HookWatchdog, type InterceptCheckTarget } from '../../src/core/hook-watchdog.js';
+import { Orchestrator } from '../../src/core/orchestrator.js';
+
+function buildTargets(orch: Orchestrator, mgr: DeploymentManager): InterceptCheckTarget[] {
+  (orch as unknown as { deploymentManager: DeploymentManager }).deploymentManager = mgr;
+  return (orch as unknown as {
+    buildPluginInjectInterceptTargets: () => InterceptCheckTarget[];
+  }).buildPluginInjectInterceptTargets();
+}
+
+const watchdogConfig: HookWatchdogConfig = {
+  enabled: true,
+  intervalMs: 1_000_000, // we drive runCheck() manually
+  repairCooldownMs: 0,   // no cooldown so the test can repair immediately
+};
+
+describe('E2E: opencode plugin-inject watchdog self-heal', () => {
+  let tmpDir: string;
+  let dataDir: string;
+  let configDir: string;
+  let configFile: string;
+  let pluginFile: string;
+  let resolvedSpec: string;
+  let def: AgentDefinition;
+  let mgr: DeploymentManager;
+
+  async function readPlugins(): Promise<unknown[]> {
+    const json = JSON.parse(await fs.readFile(configFile, 'utf-8'));
+    return json.plugin ?? json.plugins ?? [];
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'opencode-selfheal-'));
+    dataDir = path.join(tmpDir, 'pilot-data');
+    configDir = path.join(tmpDir, 'opencode-config'); // exists → detectAgent() passes
+    configFile = path.join(configDir, 'opencode.json');
+    pluginFile = path.join(dataDir, 'plugins', 'opencode', 'plugin.mjs');
+    resolvedSpec = `file://${pluginFile}`;
+
+    await fs.mkdir(configDir, { recursive: true });
+    await fs.mkdir(path.dirname(pluginFile), { recursive: true });
+    await fs.writeFile(pluginFile, '// fake opencode plugin');
+    await fs.writeFile(configFile, JSON.stringify({}, null, 2)); // no plugin yet
+
+    def = {
+      id: 'opencode',
+      displayName: 'OpenCode',
+      deployMode: 'plugin-inject',
+      detection: { paths: [configDir], commands: [] },
+      pluginInject: {
+        configPaths: [configFile],
+        pluginSpec: 'file://$PILOT_DATA/plugins/opencode/plugin.mjs',
+        pluginId: 'loongsuite-pilot-opencode',
+      },
+    };
+
+    mgr = new DeploymentManager({ dataDir, pilotDir: tmpDir, builtinAgentsDir: path.join(tmpDir, 'agents.d') });
+    // Populate definitions without invoking deployAll() (which would run the
+    // real plugin-migration against the real $HOME).
+    (mgr as unknown as { definitions: AgentDefinition[] }).definitions = [def];
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('re-injects the plugin spec after it is overwritten by a third party', async () => {
+    // 1. Initial deploy — real PluginInjectStrategy writes the spec.
+    const deployResult = await mgr.deploySingle(def);
+    expect(deployResult.success).toBe(true);
+    expect(await readPlugins()).toContain(resolvedSpec);
+
+    // 2. Simulate another tool rewriting the config and dropping our spec.
+    await fs.writeFile(configFile, JSON.stringify({ plugin: [] }, null, 2));
+    expect(await readPlugins()).not.toContain(resolvedSpec);
+
+    // 3. Build the REAL watchdog target exactly as the orchestrator does.
+    const targets = buildTargets(new Orchestrator({ dataDir } as never), mgr);
+    expect(targets).toHaveLength(1);
+
+    // 4. Run the watchdog once → it should detect the missing spec and repair.
+    const wd = new HookWatchdog(watchdogConfig, [], targets);
+    const result = await wd.runCheck();
+
+    expect(result.repaired).toBe(1);
+    expect(await readPlugins()).toContain(resolvedSpec);
+  });
+
+  it('does not rewrite the config when the spec is already healthy', async () => {
+    await mgr.deploySingle(def);
+    expect(await readPlugins()).toContain(resolvedSpec);
+
+    const targets = buildTargets(new Orchestrator({ dataDir } as never), mgr);
+
+    const wd = new HookWatchdog(watchdogConfig, [], targets);
+    const before = await fs.readFile(configFile, 'utf-8');
+    const result = await wd.runCheck();
+
+    expect(result.repaired).toBe(0);
+    expect(result.checked).toBe(1);
+    expect(await fs.readFile(configFile, 'utf-8')).toBe(before); // untouched
+  });
+
+  it('skips repair when the plugin asset is missing (precondition gate)', async () => {
+    await mgr.deploySingle(def);
+    // Remove the deployed plugin file AND the spec → unhealthy but not repairable.
+    await fs.rm(pluginFile);
+    await fs.writeFile(configFile, JSON.stringify({ plugin: [] }, null, 2));
+
+    const targets = buildTargets(new Orchestrator({ dataDir } as never), mgr);
+
+    const wd = new HookWatchdog(watchdogConfig, [], targets);
+    const result = await wd.runCheck();
+
+    // precondition fails → skipped, no repair attempt, spec stays absent.
+    expect(result.skipped).toBe(1);
+    expect(result.repaired).toBe(0);
+    expect(await readPlugins()).not.toContain(resolvedSpec);
+  });
+});

--- a/tests/unit/core/orchestrator-plugin-inject-watchdog.test.ts
+++ b/tests/unit/core/orchestrator-plugin-inject-watchdog.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AgentDefinition } from '../../../src/types/index.js';
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(),
+  }),
+}));
+
+// Orchestrator transitively imports build-constants, which reads a build-time
+// global (__PROPRIETARY_BUILD__) that vitest does not define. Stub it out.
+vi.mock('../../../src/core/build-constants.js', () => ({
+  PROPRIETARY_BUILD: false,
+}));
+
+vi.mock('../../../src/deployment/detect-utils.js', () => ({
+  detectAgent: vi.fn(),
+}));
+
+vi.mock('../../../src/utils/fs-utils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/utils/fs-utils.js')>();
+  return { ...actual, fileExists: vi.fn() };
+});
+
+import { Orchestrator } from '../../../src/core/orchestrator.js';
+import { detectAgent } from '../../../src/deployment/detect-utils.js';
+import { fileExists } from '../../../src/utils/fs-utils.js';
+
+const DATA_DIR = '/tmp/orch-plugin-inject-test';
+
+function makeOrchestrator(mockDeploymentManager: unknown): Orchestrator {
+  const orch = new Orchestrator({ dataDir: DATA_DIR } as never);
+  (orch as unknown as { deploymentManager: unknown }).deploymentManager = mockDeploymentManager;
+  return orch;
+}
+
+function callBuild(orch: Orchestrator) {
+  return (orch as unknown as {
+    buildPluginInjectInterceptTargets: () => Array<{
+      id: string;
+      precondition: () => Promise<boolean>;
+      check: () => Promise<boolean>;
+      repair: () => Promise<void>;
+    }>;
+  }).buildPluginInjectInterceptTargets();
+}
+
+function pluginInjectDef(overrides: Partial<AgentDefinition> = {}): AgentDefinition {
+  return {
+    id: 'opencode',
+    displayName: 'OpenCode',
+    deployMode: 'plugin-inject',
+    detection: { paths: ['~/.config/opencode'], commands: ['opencode'] },
+    pluginInject: {
+      configPaths: ['~/.config/opencode/opencode.json'],
+      pluginSpec: 'file://$PILOT_DATA/plugins/opencode/plugin.mjs',
+      pluginId: 'loongsuite-pilot-opencode',
+    },
+    ...overrides,
+  };
+}
+
+function hookDef(): AgentDefinition {
+  return {
+    id: 'claude-code',
+    displayName: 'Claude Code',
+    deployMode: 'hook',
+    detection: { paths: [], commands: [] },
+    hook: {
+      settingsPath: '/tmp/settings.json',
+      events: ['Stop'],
+      hookCommand: '/opt/hook.sh',
+      format: 'flat',
+    },
+  };
+}
+
+describe('Orchestrator.buildPluginInjectInterceptTargets', () => {
+  let getDefinitions: ReturnType<typeof vi.fn>;
+  let needsRedeploy: ReturnType<typeof vi.fn>;
+  let deploySingle: ReturnType<typeof vi.fn>;
+  let orch: Orchestrator;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getDefinitions = vi.fn();
+    needsRedeploy = vi.fn();
+    deploySingle = vi.fn();
+    orch = makeOrchestrator({ getDefinitions, needsRedeploy, deploySingle });
+  });
+
+  it('only builds targets for plugin-inject agents', () => {
+    getDefinitions.mockReturnValue([hookDef(), pluginInjectDef(), pluginInjectDef({ id: 'qwen-code-cli' })]);
+
+    const targets = callBuild(orch);
+
+    expect(targets.map(t => t.id)).toEqual([
+      'plugin-inject:opencode',
+      'plugin-inject:qwen-code-cli',
+    ]);
+  });
+
+  it('skips plugin-inject defs missing pluginInject config', () => {
+    getDefinitions.mockReturnValue([
+      { id: 'broken', displayName: 'Broken', deployMode: 'plugin-inject', detection: { paths: [], commands: [] } },
+    ]);
+
+    expect(callBuild(orch)).toHaveLength(0);
+  });
+
+  describe('precondition (double gate)', () => {
+    it('returns false when the plugin file does not exist', async () => {
+      getDefinitions.mockReturnValue([pluginInjectDef()]);
+      vi.mocked(fileExists).mockResolvedValue(false);
+      vi.mocked(detectAgent).mockResolvedValue(true);
+
+      const [target] = callBuild(orch);
+      expect(await target.precondition()).toBe(false);
+      // agent detection must not even be consulted once the file gate fails
+      expect(detectAgent).not.toHaveBeenCalled();
+    });
+
+    it('returns false when the file exists but the agent is not detected', async () => {
+      getDefinitions.mockReturnValue([pluginInjectDef()]);
+      vi.mocked(fileExists).mockResolvedValue(true);
+      vi.mocked(detectAgent).mockResolvedValue(false);
+
+      const [target] = callBuild(orch);
+      expect(await target.precondition()).toBe(false);
+    });
+
+    it('returns true only when the file exists AND the agent is detected', async () => {
+      getDefinitions.mockReturnValue([pluginInjectDef()]);
+      vi.mocked(fileExists).mockResolvedValue(true);
+      vi.mocked(detectAgent).mockResolvedValue(true);
+
+      const [target] = callBuild(orch);
+      expect(await target.precondition()).toBe(true);
+      // file gate is resolved against $PILOT_DATA → dataDir
+      expect(fileExists).toHaveBeenCalledWith(`${DATA_DIR}/plugins/opencode/plugin.mjs`);
+    });
+
+    it('skips the file gate for non-file specs (e.g. npm package)', async () => {
+      getDefinitions.mockReturnValue([
+        pluginInjectDef({
+          pluginInject: {
+            configPaths: ['~/.config/opencode/opencode.json'],
+            pluginSpec: 'loongsuite-pilot-opencode',
+            pluginId: 'loongsuite-pilot-opencode',
+          },
+        }),
+      ]);
+      vi.mocked(detectAgent).mockResolvedValue(true);
+
+      const [target] = callBuild(orch);
+      expect(await target.precondition()).toBe(true);
+      expect(fileExists).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('check (healthy when spec present)', () => {
+    it('is healthy when needsRedeploy is false', async () => {
+      getDefinitions.mockReturnValue([pluginInjectDef()]);
+      needsRedeploy.mockResolvedValue(false);
+
+      const [target] = callBuild(orch);
+      expect(await target.check()).toBe(true);
+      expect(needsRedeploy).toHaveBeenCalledWith(expect.objectContaining({ id: 'opencode' }));
+    });
+
+    it('is unhealthy when needsRedeploy is true', async () => {
+      getDefinitions.mockReturnValue([pluginInjectDef()]);
+      needsRedeploy.mockResolvedValue(true);
+
+      const [target] = callBuild(orch);
+      expect(await target.check()).toBe(false);
+    });
+  });
+
+  describe('repair (re-inject via deploySingle)', () => {
+    it('calls deploySingle on repair', async () => {
+      getDefinitions.mockReturnValue([pluginInjectDef()]);
+      deploySingle.mockResolvedValue({ success: true, agentId: 'opencode', deployMode: 'plugin-inject' });
+
+      const [target] = callBuild(orch);
+      await target.repair();
+      expect(deploySingle).toHaveBeenCalledWith(expect.objectContaining({ id: 'opencode' }));
+    });
+
+    it('throws when deploySingle fails so the watchdog records the failure', async () => {
+      getDefinitions.mockReturnValue([pluginInjectDef()]);
+      deploySingle.mockResolvedValue({ success: false, agentId: 'opencode', deployMode: 'plugin-inject', error: 'no config file' });
+
+      const [target] = callBuild(orch);
+      await expect(target.repair()).rejects.toThrow('no config file');
+    });
+  });
+});

--- a/tests/unit/deploy/installer-uninstall-cleanup.test.mjs
+++ b/tests/unit/deploy/installer-uninstall-cleanup.test.mjs
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const sh = readFileSync(resolve('deploy', 'installer-opensource.sh'), 'utf-8');
+const ps1 = readFileSync(resolve('deploy', 'installer-opensource.ps1'), 'utf-8');
+
+// Hook-mode agents whose settings files must be cleaned on uninstall. Kept in
+// sync with agents.d/*.json (deployMode: hook). A missing entry means the
+// agent's hook survives uninstall.
+const HOOK_CONFIG_FILES = [
+  '.cursor/hooks.json',
+  '.qoder/settings.json',
+  '.qoder-cn/settings.json',
+  '.qoderwork/settings.json',
+  '.qoderworkcn/settings.json',
+  '.claude/settings.json',
+  '.codex/hooks.json',
+  '.qwen/settings.json',
+];
+
+describe('uninstall cleans hook configs for all hook agents', () => {
+  for (const f of HOOK_CONFIG_FILES) {
+    it(`sh remove_hook_configs includes ${f}`, () => {
+      expect(sh).toContain(`$HOME/${f}`);
+    });
+    it(`ps1 Remove-HookConfigs includes ${f}`, () => {
+      expect(ps1).toContain(f.replace(/\//g, '\\'));
+    });
+  }
+});
+
+describe('uninstall cleans the OpenCode plugin-inject spec', () => {
+  it('sh defines remove_opencode_plugin', () => {
+    expect(sh).toMatch(/remove_opencode_plugin\(\)\s*\{/);
+  });
+
+  it('sh calls remove_opencode_plugin inside cmd_uninstall', () => {
+    const uninstall = sh.slice(sh.indexOf('cmd_uninstall()'));
+    expect(uninstall).toContain('remove_opencode_plugin');
+  });
+
+  it('ps1 defines Remove-OpenCodePlugin', () => {
+    expect(ps1).toMatch(/function Remove-OpenCodePlugin\s*\{/);
+  });
+
+  it('ps1 calls Remove-OpenCodePlugin inside Cmd-Uninstall', () => {
+    const uninstall = ps1.slice(ps1.indexOf('function Cmd-Uninstall'));
+    expect(uninstall).toContain('Remove-OpenCodePlugin');
+  });
+
+  for (const cfg of ['opencode.jsonc', 'opencode.json', 'config.json']) {
+    it(`sh cleans ~/.config/opencode/${cfg}`, () => {
+      expect(sh).toContain(`.config/opencode/${cfg}`);
+    });
+    it(`ps1 cleans .config\\opencode\\${cfg}`, () => {
+      expect(ps1).toContain(`.config\\opencode\\${cfg}`);
+    });
+  }
+
+  it('matches our entries by pluginId or plugin file path', () => {
+    expect(sh).toContain('loongsuite-pilot-opencode');
+    expect(sh).toContain('plugins/opencode/plugin.mjs');
+    expect(ps1).toContain('loongsuite-pilot-opencode');
+    expect(ps1).toContain('plugins/opencode/plugin.mjs');
+  });
+});

--- a/tests/unit/deployment/deployment-manager.test.ts
+++ b/tests/unit/deployment/deployment-manager.test.ts
@@ -192,6 +192,61 @@ describe('DeploymentManager', () => {
     });
   });
 
+  describe('needsRedeploy (plugin-inject self-heal check)', () => {
+    function makePluginInjectDef(configPath: string): AgentDefinition {
+      return {
+        id: 'opencode-test',
+        displayName: 'OpenCode Test',
+        deployMode: 'plugin-inject',
+        detection: { paths: [], commands: [] },
+        pluginInject: {
+          configPaths: [configPath],
+          pluginSpec: 'file://$PILOT_DATA/plugins/opencode/plugin.mjs',
+          pluginId: 'loongsuite-pilot-opencode',
+        },
+      };
+    }
+
+    it('returns false when the plugin spec is present in the config', async () => {
+      const configPath = path.join(tmpDir, 'opencode.json');
+      const resolvedSpec = `file://${path.join(dataDir, 'plugins', 'opencode', 'plugin.mjs')}`;
+      await fs.writeFile(configPath, JSON.stringify({ plugin: [resolvedSpec] }));
+
+      const mgr = makeManager();
+      const def = makePluginInjectDef(configPath);
+
+      expect(await mgr.needsRedeploy(def)).toBe(false);
+    });
+
+    it('returns true when the plugin spec was removed from the config', async () => {
+      const configPath = path.join(tmpDir, 'opencode.json');
+      await fs.writeFile(configPath, JSON.stringify({ plugin: ['some-other-plugin'] }));
+
+      const mgr = makeManager();
+      const def = makePluginInjectDef(configPath);
+
+      expect(await mgr.needsRedeploy(def)).toBe(true);
+    });
+
+    it('returns true when no config file exists', async () => {
+      const mgr = makeManager();
+      const def = makePluginInjectDef(path.join(tmpDir, 'does-not-exist.json'));
+
+      expect(await mgr.needsRedeploy(def)).toBe(true);
+    });
+
+    it('matches by pluginId even when the exact spec string differs', async () => {
+      const configPath = path.join(tmpDir, 'opencode.json');
+      // Entry contains the pluginId but not the exact resolved file path.
+      await fs.writeFile(configPath, JSON.stringify({ plugin: ['loongsuite-pilot-opencode@1.2.3'] }));
+
+      const mgr = makeManager();
+      const def = makePluginInjectDef(configPath);
+
+      expect(await mgr.needsRedeploy(def)).toBe(false);
+    });
+  });
+
   describe('getDefinitions', () => {
     it('returns loaded definitions after deployAll', async () => {
       const def: AgentDefinition = {


### PR DESCRIPTION
## Summary

- **Watchdog self-heal for plugin-inject agents (OpenCode).** Previously plugin-inject agents were deployed once at startup and never re-checked, so if another tool overwrote the config, the spec was only restored on the next pilot restart. This wires plugin-inject agents into the hook watchdog via intercept targets:
  - `check` = spec still present (`DeploymentManager.needsRedeploy`)
  - `repair` = `deploySingle` re-inject
  - `precondition` = plugin file exists **and** agent detected (avoids injecting a spec that points at a missing file, or failing repeatedly when no config file exists)
  - Reuses the intercept runner's cooldown + daily repair cap, which bounds config rewrites (relevant because re-injecting into a JSONC config strips comments).
- **Uninstall cleanup gaps fixed.** The installer never removed the OpenCode plugin-inject spec (leaving a dangling `file://.../plugins/opencode/plugin.mjs` after `--purge`), and `remove_hook_configs` was missing `qwen-code-cli`, `qoder-cn`, and `qoder-work-cn`. Added `remove_opencode_plugin` (sh + ps1, JSONC-aware with `.bak` backup) and the missing hook config paths.
- **Docs + tooling.** Documented what uninstall cleans, added an onboarding note so future plugin-inject agents get registered in the uninstaller/watchdog, and added `scripts/check-opencode-injection.sh` for diagnosing local injection state.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` passes
- [x] Full suite green: **141 files / 1528 tests / 2 skipped**
- [x] New unit tests: `needsRedeploy`, watchdog target builder (precondition double-gate, check, repair)
- [x] New integration test: real DeploymentManager + PluginInjectStrategy + HookWatchdog self-heal loop
- [x] New installer regression tests: `remove_opencode_plugin` wired into uninstall; all hook agents covered
- [x] `bash -n` on installer sh
- [x] **Real-environment E2E**: ran the built daemon, deleted the spec from the real `~/.config/opencode/opencode.json`, confirmed the watchdog re-injected it (logs show `intercept-watchdog.repairing/repaired id=plugin-inject:opencode`), then restored the real launchd daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)