### PR TITLE
fix(codex): always emit cache_creation.input_tokens in llm.response

### DIFF
--- a/assets/hooks/codex/transcript-parser.mjs
+++ b/assets/hooks/codex/transcript-parser.mjs
@@ -24,6 +24,7 @@ import fs from 'node:fs';
  * @property {number} inputTokens
  * @property {number} outputTokens
  * @property {number} cachedInputTokens
+ * @property {number} cacheCreationTokens
  * @property {number} reasoningOutputTokens
  * @property {number} totalTokens
  */
@@ -106,6 +107,7 @@ function parseTokenUsage(raw) {
     inputTokens: Number(raw['input_tokens'] || 0),
     outputTokens: Number(raw['output_tokens'] || 0),
     cachedInputTokens: Number(raw['cached_input_tokens'] || 0),
+    cacheCreationTokens: Number(raw['cache_creation_input_tokens'] || 0),
     reasoningOutputTokens: Number(raw['reasoning_output_tokens'] || 0),
     totalTokens: Number(raw['total_tokens'] || 0),
   };
@@ -120,6 +122,7 @@ function tokenUsageEqual(a, b) {
     a.inputTokens === b.inputTokens &&
     a.outputTokens === b.outputTokens &&
     a.cachedInputTokens === b.cachedInputTokens &&
+    a.cacheCreationTokens === b.cacheCreationTokens &&
     a.reasoningOutputTokens === b.reasoningOutputTokens &&
     a.totalTokens === b.totalTokens
   );

--- a/src/inputs/codex-aborted-turn/codex-aborted-turn-builder.ts
+++ b/src/inputs/codex-aborted-turn/codex-aborted-turn-builder.ts
@@ -202,6 +202,7 @@ function usageFields(usage: CodexTokenUsage | undefined): Record<string, JsonVal
     'gen_ai.usage.input_tokens': usage.inputTokens,
     'gen_ai.usage.output_tokens': usage.outputTokens,
     'gen_ai.usage.cache_read.input_tokens': usage.cachedInputTokens,
+    'gen_ai.usage.cache_creation.input_tokens': usage.cacheCreationTokens,
     'gen_ai.usage.total_tokens': usage.totalTokens,
     ...(usage.reasoningOutputTokens !== undefined
       ? { 'gen_ai.usage.reasoning_output_tokens': usage.reasoningOutputTokens }

--- a/src/inputs/codex-aborted-turn/codex-aborted-turn-extractor.ts
+++ b/src/inputs/codex-aborted-turn/codex-aborted-turn-extractor.ts
@@ -280,6 +280,7 @@ function extractLastTokenUsage(value: unknown): CodexTokenUsage | undefined {
   const inputTokens = numberValue(raw.input_tokens);
   const outputTokens = numberValue(raw.output_tokens);
   const cachedInputTokens = numberValue(raw.cached_input_tokens);
+  const cacheCreationTokens = numberValue(raw.cache_creation_input_tokens) ?? 0;
   const totalTokens = numberValue(raw.total_tokens);
   if (inputTokens === undefined || outputTokens === undefined) return undefined;
   const reasoningOutputTokens = numberValue(raw.reasoning_output_tokens);
@@ -287,6 +288,7 @@ function extractLastTokenUsage(value: unknown): CodexTokenUsage | undefined {
     inputTokens,
     outputTokens,
     cachedInputTokens: cachedInputTokens ?? 0,
+    cacheCreationTokens,
     totalTokens: totalTokens && totalTokens > 0 ? totalTokens : inputTokens + outputTokens,
     ...(reasoningOutputTokens !== undefined ? { reasoningOutputTokens } : {}),
   };
@@ -301,6 +303,7 @@ function sameUsage(left: CodexTokenUsage | undefined, right: CodexTokenUsage): b
     && left.inputTokens === right.inputTokens
     && left.outputTokens === right.outputTokens
     && left.cachedInputTokens === right.cachedInputTokens
+    && left.cacheCreationTokens === right.cacheCreationTokens
     && left.reasoningOutputTokens === right.reasoningOutputTokens
     && left.totalTokens === right.totalTokens;
 }

--- a/src/inputs/codex-aborted-turn/codex-aborted-turn-types.ts
+++ b/src/inputs/codex-aborted-turn/codex-aborted-turn-types.ts
@@ -66,6 +66,7 @@ export interface CodexTokenUsage {
   inputTokens: number;
   outputTokens: number;
   cachedInputTokens: number;
+  cacheCreationTokens: number;
   reasoningOutputTokens?: number;
   totalTokens: number;
 }

--- a/src/inputs/codex-transcript/codex-transcript-builder.ts
+++ b/src/inputs/codex-transcript/codex-transcript-builder.ts
@@ -237,12 +237,14 @@ function usageFields(usage: CodexTranscriptUsage | undefined): Record<string, Js
     inputTokens: 0,
     outputTokens: 0,
     cachedInputTokens: 0,
+    cacheCreationTokens: 0,
     totalTokens: 0,
   };
   return {
     'gen_ai.usage.input_tokens': resolved.inputTokens,
     'gen_ai.usage.output_tokens': resolved.outputTokens,
     'gen_ai.usage.cache_read.input_tokens': resolved.cachedInputTokens,
+    'gen_ai.usage.cache_creation.input_tokens': resolved.cacheCreationTokens,
     'gen_ai.usage.total_tokens': resolved.totalTokens,
     ...(resolved.reasoningOutputTokens !== undefined
       ? { 'gen_ai.usage.reasoning_output_tokens': resolved.reasoningOutputTokens }

--- a/src/inputs/codex-transcript/codex-transcript-extractor.ts
+++ b/src/inputs/codex-transcript/codex-transcript-extractor.ts
@@ -444,12 +444,14 @@ function extractLastTokenUsage(value: unknown): CodexTranscriptUsage | undefined
   const outputTokens = numberValue(raw.output_tokens);
   if (inputTokens === undefined || outputTokens === undefined) return undefined;
   const cachedInputTokens = numberValue(raw.cached_input_tokens) ?? 0;
+  const cacheCreationTokens = numberValue(raw.cache_creation_input_tokens) ?? 0;
   const totalTokens = numberValue(raw.total_tokens);
   const reasoningOutputTokens = numberValue(raw.reasoning_output_tokens);
   return {
     inputTokens,
     outputTokens,
     cachedInputTokens,
+    cacheCreationTokens,
     totalTokens: totalTokens && totalTokens > 0 ? totalTokens : inputTokens + outputTokens,
     ...(reasoningOutputTokens !== undefined ? { reasoningOutputTokens } : {}),
   };
@@ -464,6 +466,7 @@ function sameUsage(left: CodexTranscriptUsage | undefined, right: CodexTranscrip
     && left.inputTokens === right.inputTokens
     && left.outputTokens === right.outputTokens
     && left.cachedInputTokens === right.cachedInputTokens
+    && left.cacheCreationTokens === right.cacheCreationTokens
     && left.reasoningOutputTokens === right.reasoningOutputTokens
     && left.totalTokens === right.totalTokens;
 }

--- a/src/inputs/codex-transcript/codex-transcript-types.ts
+++ b/src/inputs/codex-transcript/codex-transcript-types.ts
@@ -40,6 +40,7 @@ export interface CodexTranscriptUsage {
   inputTokens: number;
   outputTokens: number;
   cachedInputTokens: number;
+  cacheCreationTokens: number;
   reasoningOutputTokens?: number;
   totalTokens: number;
 }

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -136,6 +136,7 @@ describe('CodexTranscriptInput', () => {
       'gen_ai.usage.input_tokens': 0,
       'gen_ai.usage.output_tokens': 0,
       'gen_ai.usage.cache_read.input_tokens': 0,
+      'gen_ai.usage.cache_creation.input_tokens': 0,
       'gen_ai.usage.total_tokens': 0,
     });
   });


### PR DESCRIPTION
## 背景

Codex agent 采集 `llm.response` 时，`gen_ai.usage.cache_creation.input_tokens` 字段始终缺失。其他 agent（Claude Code、Cursor）都会输出该字段，即使值为 0 也应显式记为 0 而非留空，保持 schema 一致性。

根因：整条 Codex token 采集链路从未定义过这个字段——类型定义里没有、解析器不提取、构建器不输出。OpenAI API 的 `token_count` 事件 `last_token_usage` 只包含 `input_tokens`/`output_tokens`/`cached_input_tokens`/`reasoning_output_tokens`/`total_tokens`，不提供 `cache_creation_input_tokens`，所以当前所有值都是 0，但应显式输出 0 而非缺失。

## 改动

在 3 层 × 2 条路径（transcript + aborted-turn）+ legacy hook parser 共 7 个源文件 + 1 个测试补全 `cacheCreationTokens`：

- **类型层**：`codex-transcript-types.ts`、`codex-aborted-turn-types.ts` 的 Usage 接口加 `cacheCreationTokens: number`。
- **解析层**：两个 extractor 的 `extractLastTokenUsage` 读取 `raw.cache_creation_input_tokens ?? 0`（缺失置 0）；`sameUsage` 去重函数补上比较。
- **输出层**：两个 builder 的 `usageFields` 输出 `gen_ai.usage.cache_creation.input_tokens`。
- **Legacy hook**：`assets/hooks/codex/transcript-parser.mjs` 的 typedef、`parseTokenUsage`、`tokenUsageEqual` 三处同步补全。
- **测试**：断言增加 `cache_creation.input_tokens: 0`。

源数据缺失时置 0，真实 0 不被掩盖（`numberValue` 对有限数字返回原值，`?? 0` 只在 undefined/null/NaN 时兜底）。将来 OpenAI 若提供该字段，无需改代码即可采集到真实值。

## 此 PR 的由来

原 PR #97 因 base 分支误选为 feature 分支（`yunshen/codex-aborted-turn-recovery`）而非 `main`，合到了已合入 main 的 feature 分支上，导致改动搁浅未进 main。本 PR 从最新 `origin/main` 拉干净分支后 `git cherry-pick e9ae5c0` 重提，diff 与 #97 完全一致（8 文件 +15 行）。

## 验证

- `npx tsc --noEmit` 通过。
- `tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts` + `codex-aborted-turn-input.test.ts` + `tests/unit/hooks/codex` 共 46 个测试通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)