### PR TITLE
Fix hook log collection across timezone rollover

### DIFF
--- a/src/inputs/base/base-hook-input.ts
+++ b/src/inputs/base/base-hook-input.ts
@@ -1,9 +1,14 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { CollectionMethod } from '../../types/index.js';
-import type { AgentActivityEntry } from '../../types/index.js';
+import type { AgentActivityEntry, InputState } from '../../types/index.js';
 import { BaseInput, type InputOptions } from './base-input.js';
 import { getTodayDateString, ensureDir } from '../../utils/fs-utils.js';
+
+const OFFSET_MAP_EXTRA_KEY = 'hookLogOffsets';
+const RECENT_LOG_FILE_LIMIT = 3;
+
+type OffsetMap = Record<string, number>;
 
 export interface HookInputOptions extends InputOptions {
   /** Directory containing the JSONL hook log files. */
@@ -15,7 +20,15 @@ export interface HookInputOptions extends InputOptions {
 /**
  * Base input for Hook JSONL log files.
  * Hook scripts write JSONL lines into daily-rotated files; this input
- * incrementally reads new bytes using a persisted byte offset.
+ * incrementally reads new bytes using a persisted per-file byte offset.
+ *
+ * Hook writers may inherit a different timezone than the collector process
+ * (e.g. Claude Code running under `America/Los_Angeles` while the collector
+ * uses the machine-local date). Around local date rollover, new records can
+ * still be appended to the previous-day file from the collector's point of
+ * view. Reading only `${prefix}-${today}.jsonl` would miss them, so this input
+ * keeps a small rolling window of recent daily files active and tracks a
+ * per-file offset map in `state.extra.hookLogOffsets`.
  *
  * Subclass must implement:
  *   - transformRecord(): convert a parsed JSON record into an AgentActivityEntry
@@ -52,20 +65,84 @@ export abstract class BaseHookInput extends BaseInput {
 
   protected async collect(): Promise<AgentActivityEntry[]> {
     const today = getTodayDateString();
-    const logFileName = `${this.logPrefix}-${today}.jsonl`;
-    const logFile = path.join(this.logDir, logFileName);
     const entries: AgentActivityEntry[] = [];
+    const state = this.getState();
+    const isColdStart = !state.lastFile;
+    const fileNames = await this.listHookLogFiles();
+    if (fileNames.length === 0) return entries;
 
+    const persistedOffsets = this.getPersistedOffsetMap(state);
+    const shouldPersistOffsets = !persistedOffsets;
+    const offsets: OffsetMap = persistedOffsets ? { ...persistedOffsets } : await this.seedOffsetMap(fileNames, state, today);
+    const candidateFileNames = this.getCandidateFileNames(fileNames, state.lastFile, today);
+
+    for (const logFileName of candidateFileNames) {
+      const logFile = path.join(this.logDir, logFileName);
+      const fileEntries = await this.collectFile(logFile, offsets[logFileName] ?? 0);
+      offsets[logFileName] = fileEntries.offset;
+      entries.push(...fileEntries.entries);
+    }
+
+    // Prune offsets for files that no longer exist on disk so the persisted
+    // map does not grow unbounded as daily files rotate away.
+    const liveFileNames = new Set(fileNames);
+    const prunedOffsets: OffsetMap = {};
+    for (const [fileName, offset] of Object.entries(offsets)) {
+      if (liveFileNames.has(fileName)) prunedOffsets[fileName] = offset;
+    }
+
+    const newestFileName = candidateFileNames[candidateFileNames.length - 1];
+    if (newestFileName && (
+      shouldPersistOffsets ||
+      state.lastFile !== newestFileName ||
+      state.lastOffset !== (prunedOffsets[newestFileName] ?? 0) ||
+      this.isOffsetMapChanged(persistedOffsets, prunedOffsets)
+    )) {
+      this.setState({
+        lastFile: newestFileName,
+        lastOffset: prunedOffsets[newestFileName] ?? 0,
+        extra: {
+          ...(state.extra ?? {}),
+          [OFFSET_MAP_EXTRA_KEY]: prunedOffsets,
+        },
+      });
+    }
+
+    // Cold-start replay protection: when state was wiped (e.g. redeployment or
+    // input-state.json lost during a crash), the daily file already contains
+    // records dispatched earlier today. Re-emitting them creates duplicate
+    // spans on SLS. On cold start keep only the last turn — offsets are already
+    // advanced to each file's end above, so subsequent reads resume from there.
+    // Opt-in via coldStartKeepLastTurnOnly (see field docs for the safety caveat).
+    if (this.coldStartKeepLastTurnOnly && isColdStart && entries.length > 0) {
+      const turnIds = new Set(entries.map(e => (e['gen_ai.turn.id'] as string) || 'unknown'));
+      if (turnIds.size > 1) {
+        const lastTurnId = (entries[entries.length - 1]['gen_ai.turn.id'] as string) || 'unknown';
+        this.logger.info('cold start detected, skipping historical turns', {
+          skipped: turnIds.size - 1,
+          totalTurns: turnIds.size,
+          keepTurnId: lastTurnId,
+        });
+        return entries.filter(e => ((e['gen_ai.turn.id'] as string) || 'unknown') === lastTurnId);
+      }
+    }
+
+    return entries;
+  }
+
+  private async collectFile(
+    logFile: string,
+    startOffset: number,
+  ): Promise<{ entries: AgentActivityEntry[]; offset: number }> {
+    const entries: AgentActivityEntry[] = [];
     let stat;
     try {
       stat = await fs.stat(logFile);
     } catch {
-      return [];
+      return { entries, offset: startOffset };
     }
 
-    const state = this.getState();
-    const isColdStart = !state.lastFile;
-    let offset = state.lastFile === logFileName ? (state.lastOffset ?? 0) : 0;
+    let offset = startOffset;
     // File truncation recovery: if file shrank below recorded offset (e.g.
     // daemon reinstall/rotation), reset to 0 to re-read the new file.
     if (offset > 0 && stat.size < offset) {
@@ -76,14 +153,13 @@ export abstract class BaseHookInput extends BaseInput {
       });
       offset = 0;
     }
-    if (stat.size <= offset) return [];
+    if (stat.size <= offset) return { entries, offset: stat.size };
 
     const handle = await fs.open(logFile, 'r');
     try {
       const buf = Buffer.alloc(stat.size - offset);
       await handle.read(buf, 0, buf.length, offset);
       const text = buf.toString('utf-8');
-      this.setState({ lastFile: logFileName, lastOffset: stat.size });
 
       const lines = text.split('\n').filter(l => l.trim().length > 0);
 
@@ -100,26 +176,107 @@ export abstract class BaseHookInput extends BaseInput {
       await handle.close();
     }
 
-    // Cold-start replay protection: when state was wiped (e.g. redeployment or
-    // input-state.json lost during a crash), the daily file already contains
-    // records dispatched earlier today. Re-emitting them creates duplicate spans
-    // on SLS. On cold start, keep only the last turn — offset is already advanced
-    // to stat.size above, so subsequent reads resume from the end.
-    // Opt-in via coldStartKeepLastTurnOnly (see field docs for the safety caveat).
-    if (this.coldStartKeepLastTurnOnly && isColdStart && entries.length > 0) {
-      const turnIds = new Set(entries.map(e => (e['gen_ai.turn.id'] as string) || 'unknown'));
-      if (turnIds.size > 1) {
-        const lastTurnId = (entries[entries.length - 1]['gen_ai.turn.id'] as string) || 'unknown';
-        this.logger.info('cold start detected, skipping historical turns', {
-          skipped: turnIds.size - 1,
-          totalTurns: turnIds.size,
-          keepTurnId: lastTurnId,
-        });
-        return entries.filter(e => ((e['gen_ai.turn.id'] as string) || 'unknown') === lastTurnId);
+    return { entries, offset: stat.size };
+  }
+
+  private async listHookLogFiles(): Promise<string[]> {
+    let fileNames: string[];
+    try {
+      fileNames = await fs.readdir(this.logDir);
+    } catch {
+      return [];
+    }
+
+    return fileNames
+      .filter(fileName => this.isHookLogFile(fileName))
+      .sort();
+  }
+
+  private isHookLogFile(fileName: string): boolean {
+    const prefix = `${this.logPrefix}-`;
+    if (!fileName.startsWith(prefix)) return false;
+    const suffix = fileName.slice(prefix.length);
+    return /^\d{4}-\d{2}-\d{2}\.jsonl$/.test(suffix);
+  }
+
+  private getCandidateFileNames(
+    fileNames: string[],
+    lastFile: string | undefined,
+    today: string,
+  ): string[] {
+    const todayFileName = `${this.logPrefix}-${today}.jsonl`;
+    const candidates = new Set<string>();
+    // Hook writers may inherit a different TZ than the collector, so keep a
+    // small rolling window active instead of trusting only today's filename.
+    for (const fileName of fileNames.slice(-RECENT_LOG_FILE_LIMIT)) {
+      candidates.add(fileName);
+    }
+    if (lastFile && fileNames.includes(lastFile)) {
+      candidates.add(lastFile);
+    }
+    if (fileNames.includes(todayFileName)) {
+      candidates.add(todayFileName);
+    }
+    return Array.from(candidates).sort();
+  }
+
+  private getPersistedOffsetMap(state: InputState): OffsetMap | null {
+    const raw = state.extra?.[OFFSET_MAP_EXTRA_KEY];
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+
+    const offsets: OffsetMap = {};
+    for (const [fileName, offset] of Object.entries(raw)) {
+      if (typeof offset === 'number' && Number.isFinite(offset) && offset >= 0) {
+        offsets[fileName] = offset;
+      }
+    }
+    return Object.keys(offsets).length > 0 ? offsets : null;
+  }
+
+  private isOffsetMapChanged(previous: OffsetMap | null, next: OffsetMap): boolean {
+    if (!previous) return true;
+    const previousKeys = Object.keys(previous);
+    const nextKeys = Object.keys(next);
+    if (previousKeys.length !== nextKeys.length) return true;
+    return nextKeys.some(fileName => previous[fileName] !== next[fileName]);
+  }
+
+  private async seedOffsetMap(
+    fileNames: string[],
+    state: InputState,
+    today: string,
+  ): Promise<OffsetMap> {
+    const offsets: OffsetMap = {};
+    // Mark every existing file as already-consumed (offset = its current size)
+    // so historical records are never re-ingested on first run / state loss.
+    for (const fileName of fileNames) {
+      const logFile = path.join(this.logDir, fileName);
+      try {
+        offsets[fileName] = (await fs.stat(logFile)).size;
+      } catch {
+        offsets[fileName] = 0;
       }
     }
 
-    return entries;
+    const todayFileName = `${this.logPrefix}-${today}.jsonl`;
+    if (state.lastFile && fileNames.includes(state.lastFile)) {
+      // Migration from legacy lastFile/lastOffset state: resume draining the
+      // previously tracked file from where we left off, and start reading
+      // today's file from the beginning if it is a newer file.
+      offsets[state.lastFile] = state.lastOffset ?? 0;
+      if (state.lastFile !== todayFileName && fileNames.includes(todayFileName)) {
+        offsets[todayFileName] = 0;
+      }
+    } else if (fileNames.includes(todayFileName)) {
+      // True cold start (no prior state): skip all existing history and only
+      // begin reading today's file from the start. Do NOT seed a non-today
+      // file to 0 — that would re-ingest an entire day of history a previous
+      // daemon run already dispatched (the collector's local date may still
+      // lag behind the newest hook file when it first comes up).
+      offsets[todayFileName] = 0;
+    }
+
+    return offsets;
   }
 
   /**

--- a/tests/unit/inputs/base-hook-input.test.ts
+++ b/tests/unit/inputs/base-hook-input.test.ts
@@ -152,6 +152,127 @@ describe('BaseHookInput', () => {
       expect(entries).toHaveLength(1);
       expect(entries[0]!.filePath).toBe('/short.ts');
     });
+
+    it('should drain the stored previous-day file before reading today', async () => {
+      const today = getTodayDateString();
+      const previousDay = addDays(today, -1);
+      const previousFileName = `test-hook-${previousDay}.jsonl`;
+      const todayFileName = `test-hook-${today}.jsonl`;
+      const previousFile = path.join(tmpDir, previousFileName);
+      const todayFile = path.join(tmpDir, todayFileName);
+      const consumedLine = JSON.stringify({ file_path: '/already-read.ts' }) + '\n';
+      await fs.writeFile(previousFile, consumedLine + JSON.stringify({ file_path: '/late-previous.ts' }) + '\n');
+      await fs.writeFile(todayFile, JSON.stringify({ file_path: '/today.ts' }) + '\n');
+      stateStore.set('test-hook', {
+        lastFile: previousFileName,
+        lastOffset: Buffer.byteLength(consumedLine),
+      });
+
+      const entries: AgentActivityEntry[] = [];
+      input.on('entries', (e: AgentActivityEntry[]) => entries.push(...e));
+
+      await input.start();
+      await input.stop();
+
+      expect(entries.map(e => e.filePath)).toEqual(['/late-previous.ts', '/today.ts']);
+      const state = stateStore.get('test-hook');
+      expect(state.lastFile).toBe(todayFileName);
+      expect(state.extra?.hookLogOffsets).toEqual({
+        [previousFileName]: (await fs.stat(previousFile)).size,
+        [todayFileName]: (await fs.stat(todayFile)).size,
+      });
+    });
+
+    it('should not re-ingest history on cold start when only a previous-day file exists', async () => {
+      // Collector freshly installed (no prior state), the agent last ran
+      // "yesterday", and today's file does not exist yet because the
+      // collector's local date still lags the hook writer. Seeding the newest
+      // non-today file to 0 here would re-ingest a whole day of already-sent
+      // history — the cold-start seed must skip it instead.
+      const today = getTodayDateString();
+      const previousDay = addDays(today, -1);
+      const previousFileName = `test-hook-${previousDay}.jsonl`;
+      const previousFile = path.join(tmpDir, previousFileName);
+      await fs.writeFile(
+        previousFile,
+        JSON.stringify({ file_path: '/old-a.ts' }) + '\n' +
+        JSON.stringify({ file_path: '/old-b.ts' }) + '\n',
+      );
+
+      const entries: AgentActivityEntry[] = [];
+      input.on('entries', (e: AgentActivityEntry[]) => entries.push(...e));
+
+      await input.start();
+      await input.stop();
+
+      expect(entries).toHaveLength(0);
+      expect(stateStore.get('test-hook').extra?.hookLogOffsets).toEqual({
+        [previousFileName]: (await fs.stat(previousFile)).size,
+      });
+    });
+
+    it('should prune offsets for daily files that no longer exist on disk', async () => {
+      // A stale entry for a rotated-away file must not accumulate in state.
+      const today = getTodayDateString();
+      const stalePrevious = addDays(today, -30);
+      const staleFileName = `test-hook-${stalePrevious}.jsonl`;
+      const todayFileName = `test-hook-${today}.jsonl`;
+      const todayFile = path.join(tmpDir, todayFileName);
+      await fs.writeFile(todayFile, JSON.stringify({ file_path: '/today.ts' }) + '\n');
+      stateStore.set('test-hook', {
+        lastFile: todayFileName,
+        lastOffset: 0,
+        extra: {
+          hookLogOffsets: {
+            [staleFileName]: 999,
+            [todayFileName]: 0,
+          },
+        },
+      });
+
+      input.on('entries', () => {});
+      await input.start();
+      await input.stop();
+
+      const offsets = stateStore.get('test-hook').extra?.hookLogOffsets as Record<string, number>;
+      expect(offsets[staleFileName]).toBeUndefined();
+      expect(offsets[todayFileName]).toBe((await fs.stat(todayFile)).size);
+    });
+
+    it('should keep reading a recent timezone-lagged file after lastFile advances to today', async () => {
+      const today = getTodayDateString();
+      const previousDay = addDays(today, -1);
+      const previousFileName = `test-hook-${previousDay}.jsonl`;
+      const todayFileName = `test-hook-${today}.jsonl`;
+      const previousFile = path.join(tmpDir, previousFileName);
+      const todayFile = path.join(tmpDir, todayFileName);
+      const previousConsumed = JSON.stringify({ file_path: '/previous-consumed.ts' }) + '\n';
+      const todayConsumed = JSON.stringify({ file_path: '/today-consumed.ts' }) + '\n';
+      await fs.writeFile(previousFile, previousConsumed + JSON.stringify({ file_path: '/late-previous.ts' }) + '\n');
+      await fs.writeFile(todayFile, todayConsumed);
+      stateStore.set('test-hook', {
+        lastFile: todayFileName,
+        lastOffset: Buffer.byteLength(todayConsumed),
+        extra: {
+          hookLogOffsets: {
+            [previousFileName]: Buffer.byteLength(previousConsumed),
+            [todayFileName]: Buffer.byteLength(todayConsumed),
+          },
+        },
+      });
+
+      const entries: AgentActivityEntry[] = [];
+      input.on('entries', (e: AgentActivityEntry[]) => entries.push(...e));
+
+      await input.start();
+      await input.stop();
+
+      expect(entries.map(e => e.filePath)).toEqual(['/late-previous.ts']);
+      expect(stateStore.get('test-hook').extra?.hookLogOffsets).toEqual({
+        [previousFileName]: (await fs.stat(previousFile)).size,
+        [todayFileName]: (await fs.stat(todayFile)).size,
+      });
+    });
   });
 
   describe('transformRecord delegation', () => {
@@ -226,4 +347,10 @@ function getTodayDateString(): string {
   const m = String(d.getMonth() + 1).padStart(2, '0');
   const day = String(d.getDate()).padStart(2, '0');
   return `${y}-${m}-${day}`;
+}
+
+function addDays(dateString: string, days: number): string {
+  const d = new Date(`${dateString}T12:00:00.000Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
 }


### PR DESCRIPTION
## Summary
- Read hook JSONL data from a small rolling set of recent daily files instead of only the collector-local today file.
- Persist per-file byte offsets in input state while keeping the existing `lastFile` / `lastOffset` fields for compatibility.
- Migrate existing state by draining the previous `lastFile` tail without re-uploading old hook history.

## Why
Claude Code hook writers can inherit a different timezone from the collector process. A common setup is running Claude Code under a US timezone such as `America/Los_Angeles`, while the collector process uses the machine-local date. Around local date rollover, new Claude Code hook records may still be appended to the previous-day JSONL file from the collector's point of view.

The previous collector only read `${prefix}-${today}.jsonl`, so once the collector date moved forward it could stop reading the still-active previous-day file and miss those records.

## Validation
- `mise exec node@20.20.2 -- npm test -- tests/unit/inputs/base-hook-input.test.ts`
- `mise exec node@20.20.2 -- npm run typecheck`
- `mise exec node@20.20.2 -- npm test`
- Local live check with a timezone-lagged Claude Code hook file drained the previously unread tail after applying the collector patch.

Recreated from #110 with a GitHub-linked commit author for CLA detection.