### PR TITLE
fix(qoder): robustify IDE token enrichment matching

### DIFF
--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -632,6 +632,7 @@ function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, turnId,
     toolResultsForNextStep = [];
     let responseId = undefined;
     let lastAssistantTs = null;
+    let firstAssistantTs = null;
 
     for (const row of content) {
       if (row.type === 'assistant') {
@@ -639,6 +640,7 @@ function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, turnId,
         const blocks = Array.isArray(msg.content) ? msg.content : [];
         if (msg.id && !responseId) responseId = msg.id;
         if (row.timestamp) lastAssistantTs = row.timestamp;
+        if (row.timestamp && !firstAssistantTs) firstAssistantTs = row.timestamp;
         for (const block of blocks) {
           if (block.type === 'thinking') {
             outputParts.push({ type: 'reasoning', content: block.thinking || '' });
@@ -701,6 +703,10 @@ function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, turnId,
         'user.id': userId,
         'gen_ai.output.messages': [{ role: 'assistant', parts: outputParts, finish_reason: finishReason }],
         'agent.source': 'qoder-transcript-hook',
+        // Accurate per-response timestamp from the transcript's first assistant record
+        // (≈ SQLite gmt_create). Used only for token-enricher matching; dropped from
+        // SLS/JSONL output as an agent-scoped field. Absent for CLI (no firstAssistantTs).
+        'agent.qoder.match_ts': firstAssistantTs ? Date.parse(firstAssistantTs) : undefined,
         time_unix_nano: responseEndNanos,
         observed_time_unix_nano: observedTs,
       });

--- a/src/inputs/qoder-trace/token-enricher.ts
+++ b/src/inputs/qoder-trace/token-enricher.ts
@@ -3,7 +3,18 @@ import type { AgentActivityEntry } from '../../types/index.js';
 import type { SegmentTokenData } from './segment-token-reader.js';
 import type { SqliteTokenData } from './sqlite-token-reader.js';
 
-const TIMESTAMP_THRESHOLD_MS = 1000;
+// Outer bound for the nearest-timestamp fallback (Pass B). Nearest match wins;
+// this is only the acceptance ceiling. Widened from 1000ms because the JSONL
+// llm.response time (hook progress clock) drifts from SQLite gmt_create by up to
+// ~1.4s; the accurate agent.qoder.match_ts (when present) matches within a few ms.
+const TIMESTAMP_THRESHOLD_MS = 5000;
+
+// Time-sanity guard for the order-based pass: reject a positional pair whose
+// response↔row time gap is implausibly large (guards against mis-alignment when a
+// row is missing in the middle). STRICT applies when the response carries the
+// accurate match_ts; LOOSE applies when only the drifted time_unix_nano is available.
+const ORDER_MATCH_STRICT_MS = 1000;
+const ORDER_MATCH_LOOSE_MS = 3000;
 
 export function enrichCliTurn(
   entries: AgentActivityEntry[],
@@ -122,12 +133,17 @@ export function enrichIdeTurn(
   // match by close timestamp only, preserving the previous behavior.
   for (const [requestId, group] of sortedGroups) {
     for (const row of group) {
+      // Skip rows already consumed by the order-based pass so Pass B only handles
+      // genuinely-leftover rows; otherwise an already-matched row could re-stamp a
+      // leftover response with the wrong id/model.
+      if (tokenWritten.has(sqliteDedupeKey(row))) continue;
+
       let bestEntry: AgentActivityEntry | null = null;
       let bestDiff = Infinity;
 
       for (const entry of responseEntries) {
         if (used.has(entry)) continue;
-        const diff = Math.abs(extractMs(entry) - row.gmtCreate);
+        const diff = Math.abs(matchMs(entry) - row.gmtCreate);
         if (diff < bestDiff) {
           bestDiff = diff;
           bestEntry = entry;
@@ -312,13 +328,31 @@ function matchIdeTurnsBySqliteOrder(
     const [requestId, sqliteRows] = candidateGroups[i];
     const responses = turnEntries.filter(e => e['event.name'] === 'llm.response');
 
-    if (responses.length !== sqliteRows.length) {
-      markLowConfidence(turnEntries, 'assistant_count_mismatch');
-      continue;
-    }
-
-    for (let j = 0; j < responses.length; j++) {
-      applySqliteRowToIdeResponse(entries, turnEntries, responses[j], sqliteRows[j], requestId, used, tokenWritten);
+    // Best-effort ordered matching. Counts often differ (sub-agent turns miss the
+    // final answer in the transcript; the latest row may not be persisted yet).
+    // Match the aligned prefix by order instead of abandoning the whole turn to the
+    // timestamp fallback. A time-sanity guard rejects positionally-aligned pairs
+    // whose times are implausibly far apart (mid-turn gap → order shifts by one →
+    // the shifted pair lands on a neighbouring call seconds away) so they fall
+    // through to the nearest-timestamp fallback (Pass B) instead of mis-attributing.
+    const n = Math.min(responses.length, sqliteRows.length);
+    // When counts match exactly, trust order fully (clock-independent) — this is the
+    // original, well-tested contract. The time-sanity guard applies only in the
+    // best-effort (unequal count) path, where a mid-turn gap would shift the pairing.
+    const countsMatch = responses.length === sqliteRows.length;
+    for (let j = 0; j < n; j++) {
+      const response = responses[j];
+      const row = sqliteRows[j];
+      if (!countsMatch) {
+        const threshold = accurateMatchMs(response) !== undefined
+          ? ORDER_MATCH_STRICT_MS
+          : ORDER_MATCH_LOOSE_MS;
+        if (Math.abs(matchMs(response) - row.gmtCreate) > threshold) {
+          markLowConfidence([response], 'order_time_gap');
+          continue;
+        }
+      }
+      applySqliteRowToIdeResponse(entries, turnEntries, response, row, requestId, used, tokenWritten);
     }
   }
 }
@@ -404,4 +438,23 @@ function extractMs(entry: AgentActivityEntry): number {
   const ts = (entry as Record<string, unknown>).timestamp;
   if (typeof ts === 'number') return ts;
   return 0;
+}
+
+// Accurate per-response match timestamp injected by the hook from the transcript's
+// assistant record (≈ SQLite gmt_create, within a few ms). Returns undefined when
+// absent (old JSONL / hook not yet updated).
+function accurateMatchMs(entry: AgentActivityEntry): number | undefined {
+  const raw = (entry as Record<string, unknown>)['agent.qoder.match_ts'];
+  if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+  if (typeof raw === 'string') {
+    const n = Number(raw);
+    if (Number.isFinite(n)) return n;
+  }
+  return undefined;
+}
+
+// Timestamp used for matching against SQLite gmt_create: the accurate match_ts when
+// available, otherwise the drifted time_unix_nano.
+function matchMs(entry: AgentActivityEntry): number {
+  return accurateMatchMs(entry) ?? extractMs(entry);
 }

--- a/tests/unit/inputs/qoder-ide-lag-repro.test.ts
+++ b/tests/unit/inputs/qoder-ide-lag-repro.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest';
+import { enrichIdeTurn } from '../../../src/inputs/qoder-trace/token-enricher.js';
+import type { AgentActivityEntry } from '../../../src/types/index.js';
+import type { SqliteTokenData } from '../../../src/inputs/qoder-trace/sqlite-token-reader.js';
+
+// Reproduces the production symptom for the qoder IDE variant:
+//   response.id empty + model 'auto' + tokens empty
+// when the SQLite chat_message rows are not yet persisted (lag) at read time.
+//
+// The IDE hook JSONL carries NO gen_ai.response.id (transcript assistant records
+// have only {content, role}) and model 'auto' (no message.model in the transcript).
+// Everything (id/model/token) must come from SQLite enrichment.
+function makeIdeTurn(): AgentActivityEntry[] {
+  return [
+    {
+      'event.id': 'req-1',
+      'event.name': 'llm.request',
+      'gen_ai.session.id': 'sess-1',
+      'gen_ai.turn.id': 'turn-1',
+      'gen_ai.step.id': 'turn-1:s1',
+      'gen_ai.agent.type': 'qoder',
+      'gen_ai.request.model': 'auto',
+      time_unix_nano: '1783308010437000000',
+    } as unknown as AgentActivityEntry,
+    {
+      'event.id': 'resp-1',
+      'event.name': 'llm.response',
+      'gen_ai.session.id': 'sess-1',
+      'gen_ai.turn.id': 'turn-1',
+      'gen_ai.step.id': 'turn-1:s1',
+      'gen_ai.agent.type': 'qoder',
+      'gen_ai.request.model': 'auto',
+      'gen_ai.response.model': 'auto',
+      // NOTE: no 'gen_ai.response.id' — IDE hook cannot produce one.
+      time_unix_nano: '1783308010437000000',
+    } as unknown as AgentActivityEntry,
+  ];
+}
+
+describe('qoder IDE enrichment — production lag symptom', () => {
+  it('SQLite not yet persisted (empty rows) → response.id empty + model auto + token empty', () => {
+    const entries = makeIdeTurn();
+    const resp = entries[1];
+
+    enrichIdeTurn(entries, []); // SQLite lag: no rows at read time
+
+    expect(resp['gen_ai.response.id']).toBeUndefined();      // symptom 1
+    expect(resp['gen_ai.response.model']).toBe('auto');      // symptom 2
+    expect(resp['gen_ai.usage.total_tokens']).toBeUndefined(); // symptom 3 (truly empty)
+  });
+
+  it('latest response row not yet persisted (partial lag) → symptom on the unmatched response', () => {
+    // Two responses in the turn; SQLite only has the row for the FIRST one.
+    // The second response's chat_message row hasn't been flushed yet at read time.
+    const entries: AgentActivityEntry[] = [
+      {
+        'event.id': 'resp-1', 'event.name': 'llm.response',
+        'gen_ai.session.id': 'sess-1', 'gen_ai.turn.id': 'turn-1', 'gen_ai.step.id': 'turn-1:s1',
+        'gen_ai.agent.type': 'qoder', 'gen_ai.request.model': 'auto', 'gen_ai.response.model': 'auto',
+        time_unix_nano: '1783308010400000000',
+      } as unknown as AgentActivityEntry,
+      {
+        'event.id': 'resp-2', 'event.name': 'llm.response',
+        'gen_ai.session.id': 'sess-1', 'gen_ai.turn.id': 'turn-1', 'gen_ai.step.id': 'turn-1:s2',
+        'gen_ai.agent.type': 'qoder', 'gen_ai.request.model': 'auto', 'gen_ai.response.model': 'auto',
+        time_unix_nano: '1783308055000000000', // ~44s later; far from the only persisted row
+      } as unknown as AgentActivityEntry,
+    ];
+    const resp2 = entries[1];
+
+    // count (2 responses) != rows (1) → structural Pass A skipped; Pass B matches resp1 only.
+    const rows: SqliteTokenData[] = [
+      {
+        sessionId: 'sess-1', requestId: 'req-1', messageId: 'msg-1',
+        gmtCreate: 1783308010200, inputTokens: 100, outputTokens: 20, cacheReadTokens: 0, model: 'ultimate',
+      },
+    ];
+
+    enrichIdeTurn(entries, rows);
+
+    expect(resp2['gen_ai.response.id']).toBeUndefined();      // symptom 1
+    expect(resp2['gen_ai.response.model']).toBe('auto');      // symptom 2
+    expect(resp2['gen_ai.usage.total_tokens']).toBe(0);       // symptom 3 (zero-filled)
+  });
+
+  it('control: SQLite present and aligned → enrichment succeeds (no symptom)', () => {
+    const entries = makeIdeTurn();
+    const resp = entries[1];
+
+    const rows: SqliteTokenData[] = [
+      {
+        sessionId: 'sess-1',
+        requestId: 'req-good',
+        messageId: 'msg-good',
+        gmtCreate: 1783308010189, // ~248ms from resp; single row + single response → structural match
+        inputTokens: 34824,
+        outputTokens: 1272,
+        cacheReadTokens: 30000,
+        model: 'ultimate',
+      },
+    ];
+
+    enrichIdeTurn(entries, rows);
+
+    expect(resp['gen_ai.response.id']).toBe('msg-good');
+    expect(resp['gen_ai.response.model']).toBe('ultimate');
+    expect(resp['gen_ai.usage.total_tokens']).toBe(34824 + 1272);
+  });
+});
+
+// Fix behaviour (Option 1): order-first best-effort matching + time-sanity guard +
+// nearest-timestamp fallback. All in the qoder IDE variant (no response.id / model 'auto'
+// in the hook JSONL; everything comes from SQLite).
+const B = 1783308010000; // base ms
+
+function makeTurn(
+  timesMs: number[],
+  opts: { matchTs?: (number | undefined)[] } = {},
+): AgentActivityEntry[] {
+  return timesMs.map((t, i) => {
+    const e: Record<string, unknown> = {
+      'event.id': `resp-${i}`,
+      'event.name': 'llm.response',
+      'gen_ai.session.id': 'sess-1',
+      'gen_ai.turn.id': 'turn-1',
+      'gen_ai.step.id': `turn-1:s${i + 1}`,
+      'gen_ai.agent.type': 'qoder',
+      'gen_ai.request.model': 'auto',
+      'gen_ai.response.model': 'auto',
+      time_unix_nano: String(BigInt(t) * 1_000_000n),
+    };
+    const mt = opts.matchTs?.[i];
+    if (mt !== undefined) e['agent.qoder.match_ts'] = mt;
+    return e as unknown as AgentActivityEntry;
+  });
+}
+
+function makeRows(specs: { gmt: number; id: string; in?: number; out?: number }[]): SqliteTokenData[] {
+  return specs.map(s => ({
+    sessionId: 'sess-1',
+    requestId: 'req-1',
+    messageId: s.id,
+    gmtCreate: s.gmt,
+    inputTokens: s.in ?? 100,
+    outputTokens: s.out ?? 10,
+    cacheReadTokens: 0,
+    model: 'ultimate',
+  }));
+}
+
+describe('qoder IDE enrichment — Option 1 robustness', () => {
+  it('tail gap JSONL=3 < SQLite=4 → first 3 matched by order (no collapse to fallback)', () => {
+    const entries = makeTurn([B + 200, B + 10200, B + 20200]);
+    const rows = makeRows([
+      { gmt: B, id: 'm1' },
+      { gmt: B + 10000, id: 'm2' },
+      { gmt: B + 20000, id: 'm3' },
+      { gmt: B + 30000, id: 'm4' }, // final answer with no JSONL response
+    ]);
+
+    enrichIdeTurn(entries, rows);
+
+    expect(entries[0]['gen_ai.response.id']).toBe('m1');
+    expect(entries[1]['gen_ai.response.id']).toBe('m2');
+    expect(entries[2]['gen_ai.response.id']).toBe('m3');
+    expect(entries[2]['gen_ai.usage.total_tokens']).toBe(110);
+    expect(entries.every(e => e['gen_ai.response.model'] === 'ultimate')).toBe(true);
+  });
+
+  it('JSONL=4 > SQLite=3 (latest row not persisted) → first 3 matched, 4th stays empty', () => {
+    const entries = makeTurn([B + 200, B + 10200, B + 20200, B + 30200]);
+    const rows = makeRows([
+      { gmt: B, id: 'm1' },
+      { gmt: B + 10000, id: 'm2' },
+      { gmt: B + 20000, id: 'm3' },
+    ]);
+
+    enrichIdeTurn(entries, rows);
+
+    expect(entries[0]['gen_ai.response.id']).toBe('m1');
+    expect(entries[2]['gen_ai.response.id']).toBe('m3');
+    // 4th: no SQLite row exists for it → symptom (zero-filled), not mis-attributed
+    expect(entries[3]['gen_ai.response.id']).toBeUndefined();
+    expect(entries[3]['gen_ai.response.model']).toBe('auto');
+    expect(entries[3]['gen_ai.usage.total_tokens']).toBe(0);
+  });
+
+  it('middle gap → guard rejects the shifted pair; nearest fallback attaches the correct row (no mis-attribution)', () => {
+    const entries = makeTurn([B + 200, B + 10200, B + 20200]);
+    // SQLite missing the MIDDLE call: only rows for t1 and t3.
+    const rows = makeRows([
+      { gmt: B, id: 'm1' },
+      { gmt: B + 20000, id: 'm3' },
+    ]);
+
+    enrichIdeTurn(entries, rows);
+
+    expect(entries[0]['gen_ai.response.id']).toBe('m1');
+    // Without the guard, order would pair resp#2 (t2) with row m3 (t3) — wrong.
+    // With guard + nearest fallback, m3 attaches to resp#3 (t3), resp#2 stays empty.
+    expect(entries[2]['gen_ai.response.id']).toBe('m3');
+    expect(entries[1]['gen_ai.response.id']).toBeUndefined();
+  });
+
+  it('accurate match_ts rescues a drifted response in the best-effort (unequal count) path', () => {
+    // Unequal counts (2 responses, 1 row) → the time-sanity guard runs. Response #1's
+    // time_unix_nano is drifted +6s (beyond the 3s loose guard and 5s fallback), but its
+    // match_ts is exact. Response #2 is far later and has no row.
+    const withMatchTs = makeTurn([B + 6000, B + 60000], { matchTs: [B, undefined] });
+    enrichIdeTurn(withMatchTs, makeRows([{ gmt: B, id: 'm1' }]));
+    expect(withMatchTs[0]['gen_ai.response.id']).toBe('m1'); // strict guard uses accurate ts
+    expect(withMatchTs[0]['gen_ai.usage.total_tokens']).toBe(110);
+
+    // Same shape WITHOUT match_ts → loose guard on drifted clock rejects, fallback out of
+    // window → response #1 unmatched (demonstrates the value of the accurate timestamp).
+    const noMatchTs = makeTurn([B + 6000, B + 60000]);
+    enrichIdeTurn(noMatchTs, makeRows([{ gmt: B, id: 'm1' }]));
+    expect(noMatchTs[0]['gen_ai.response.id']).toBeUndefined();
+  });
+});

--- a/tests/unit/inputs/qoder-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-trace-input.test.ts
@@ -356,7 +356,7 @@ describe('QoderTraceInput token-enricher', () => {
       expect(entries[1]['gen_ai.response.model']).toBe('gm51model');
     });
 
-    it('does not match if timestamp difference exceeds 1000ms', () => {
+    it('does not match if timestamp difference exceeds the fallback window (5000ms)', () => {
       const entries: AgentActivityEntry[] = [
         makeEntry({
           'event.name': 'llm.response',
@@ -366,7 +366,7 @@ describe('QoderTraceInput token-enricher', () => {
       ];
       const sqliteRows: SqliteTokenData[] = [{
         requestId: 'sqlite-req-far',
-        gmtCreate: 1780000002000,
+        gmtCreate: 1780000006000, // 6000ms away → beyond the widened 5000ms window
         inputTokens: 9999,
         outputTokens: 99,
         cacheReadTokens: 0,
@@ -376,6 +376,27 @@ describe('QoderTraceInput token-enricher', () => {
 
       // Unmatched entries get 0 (not undefined) for consistent AGENT aggregation
       expect(entries[0]['gen_ai.usage.input_tokens']).toBe(0);
+    });
+
+    it('matches within the widened window (2000ms, previously rejected)', () => {
+      const entries: AgentActivityEntry[] = [
+        makeEntry({
+          'event.name': 'llm.response',
+          'gen_ai.agent.type': 'qoder',
+          time_unix_nano: '1780000000000000000',
+        }),
+      ];
+      const sqliteRows: SqliteTokenData[] = [{
+        requestId: 'sqlite-req-near',
+        gmtCreate: 1780000002000, // 2000ms away → now within the 5000ms fallback
+        inputTokens: 777,
+        outputTokens: 9,
+        cacheReadTokens: 0,
+      }];
+
+      enrichIdeTurn(entries, sqliteRows);
+
+      expect(entries[0]['gen_ai.usage.input_tokens']).toBe(777);
     });
 
     it('handles empty SQLite data gracefully', () => {


### PR DESCRIPTION
## 背景

客户反馈:qoder IDE 采集的部分 `llm.response` 匹配不上 SQLite,导致 `gen_ai.response.id` 为空、`model` 兜底成 `auto`、token 为空。

根因(经实测调研收敛):JSONL 与 SQLite 之间**没有可靠关联键**,IDE 富化依赖两个脆弱兜底:
1. 顺序匹配要求 **response 条数 == SQLite 行数**,一旦不等(sub-agent turn 的最终答复不在 transcript 里、或最新一条尚未落库,实测常见)整段放弃;
2. 塌到 **±1s 且用错时钟**的时间戳兜底——比较 hook progress 时间 vs SQLite `gmt_create`,实测漂移达 248~1439ms,靠后的 response 必然超窗匹配失败。

## 改动

**`src/inputs/qoder-trace/token-enricher.ts`**
- 去掉"计数必须相等"硬门槛 → `min(n,m)` **按序尽力匹配**;计数相等时保持原纯顺序(时钟无关)契约不变。
- 计数不等时对每对加**时间合理性闸**(带 `match_ts` 用 1000ms、否则 3000ms):中间缺行导致的错位对会被拒绝,落到就近兜底自愈,避免错归属。
- 兜底窗口 1000ms → **5000ms**;比较改用准时间戳;跳过已被顺序匹配的行。

**`assets/hooks/qoder-hook-processor.mjs`**
- 透传 `agent.qoder.match_ts`(transcript 首个 assistant 时间,≈ `gmt_create`,实测误差 ≤12ms),让富化器用**准时钟**匹配;缺失时回退 `time_unix_nano`。该字段为 agent-scoped,输出时自动剥离,零污染。

## 设计取向

**顺序优先(时钟无关)+ 准时间戳锐化闸 + 就近兜底**。准时间戳仅作安全网,缺失/旧 JSONL 时优雅降级——富化器改动可**独立生效**,不依赖 hook 先行推送,无灰度悬崖。

## 覆盖范围

- ✅ 甲类:**数据在、却没匹配上**(计数不等 / 时钟漂移)——本 PR 解决。
- ⛔ 乙类:**读取时 SQLite 尚未落库**(行不存在)——需采集层重试,另开。

## Test plan

- [x] 新增 `tests/unit/inputs/qoder-ide-lag-repro.test.ts`:尾部缺失(3<4)前缀正确匹配、4>3 第4条留空、中间缺行由闸+就近自愈无错归属、`match_ts` strict 救回漂移 response、放宽窗口 2000ms 命中 / 6000ms 拒绝。
- [x] 更新 `qoder-trace-input.test.ts` 中编码旧 1000ms 窗口的用例。
- [x] 全量:`npm test` → 1492 passed / 2 skipped / 0 failed。
- [x] `tsc --noEmit` 通过;hook `node --check` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)