### PR TITLE
feat: propagate AgentTeams context in qoder and codex traces

### DIFF
--- a/assets/hooks/codex-hook-processor.mjs
+++ b/assets/hooks/codex-hook-processor.mjs
@@ -14,6 +14,15 @@ import os from 'node:os';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import { logHookError } from './shared/error-logger.mjs';
+import {
+  collectResourceAttributesFromEnv,
+} from './shared/resource-context.mjs';
+
+const AGENT_ID = 'codex';
+const RESOURCE_ATTRIBUTES = collectResourceAttributesFromEnv(process.env, { agentId: AGENT_ID });
+const RESOURCE_ATTRIBUTE_FIELDS = Object.keys(RESOURCE_ATTRIBUTES).length > 0
+  ? { resourceAttributes: RESOURCE_ATTRIBUTES }
+  : {};
 
 function pilotDataDir() {
   return process.env.LOONGSUITE_PILOT_DATA_DIR || path.join(os.homedir(), '.loongsuite-pilot');
@@ -27,7 +36,7 @@ function tryReadStdin() {
     return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
   } catch (error) {
     logHookError({
-      agentId: 'codex',
+      agentId: AGENT_ID,
       stage: 'stdin_parse',
       errorType: 'STDIN_PARSE_ERROR',
       errorMessage: error instanceof Error ? error.message : String(error),
@@ -52,6 +61,7 @@ function writeWakeupMarker(input) {
     ...(typeof input.transcript_path === 'string' && input.transcript_path
       ? { transcript_path: input.transcript_path }
       : {}),
+    ...RESOURCE_ATTRIBUTE_FIELDS,
     received_at: new Date().toISOString(),
   };
   try {
@@ -60,14 +70,14 @@ function writeWakeupMarker(input) {
     fs.renameSync(temporary, marker);
   } catch (error) {
     logHookError({
-      agentId: 'codex',
+      agentId: AGENT_ID,
       stage: 'wakeup_write',
       errorType: 'WAKEUP_WRITE_ERROR',
       errorMessage: error instanceof Error ? error.message : String(error),
     });
     try { fs.unlinkSync(temporary); } catch (cleanupError) {
       logHookError({
-        agentId: 'codex',
+        agentId: AGENT_ID,
         stage: 'wakeup_cleanup',
         errorType: 'WAKEUP_CLEANUP_ERROR',
         errorMessage: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),

--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -31,6 +31,16 @@ import {
   buildQoderHookRecord,
   inferProviderName,
 } from './agent-event-normalizer.mjs';
+import {
+  agentBaseFieldPatch,
+  collectResourceAttributesFromEnv,
+} from './shared/resource-context.mjs';
+
+const RESOURCE_ATTRIBUTES = collectResourceAttributesFromEnv(process.env, { agentId: 'qoder' });
+const RESOURCE_BASE_FIELD_PATCH = agentBaseFieldPatch(RESOURCE_ATTRIBUTES);
+const RESOURCE_ATTRIBUTE_FIELDS = Object.keys(RESOURCE_ATTRIBUTES).length > 0
+  ? { resourceAttributes: RESOURCE_ATTRIBUTES }
+  : {};
 
 // --- Retry lockfile (qoder-cn only) -----------------------------------------
 // QoderCN fires Stop hook multiple times per turn AND incomplete transcript
@@ -576,8 +586,7 @@ function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, turnId,
   // If no progress boundaries detected, fall back to legacy behavior
   if (boundaries.length === 0) {
     const legacyRecords = buildLegacyEvents(contentEvents, turnId, sessionId, agentId, runtimeConfig, records, observedTs);
-    if (cwd) for (const r of legacyRecords) r['agent.qoder.cwd'] = cwd;
-    return legacyRecords;
+    return finalizeRecords(legacyRecords, cwd);
   }
 
   // Assign content events to boundaries.
@@ -756,7 +765,14 @@ function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, turnId,
     }
   }
 
-  if (cwd) for (const r of records) r['agent.qoder.cwd'] = cwd;
+  return finalizeRecords(records, cwd);
+}
+
+function finalizeRecords(records, cwd) {
+  for (const record of records) {
+    if (cwd) record['agent.qoder.cwd'] = cwd;
+    Object.assign(record, RESOURCE_BASE_FIELD_PATCH, RESOURCE_ATTRIBUTE_FIELDS);
+  }
   return records;
 }
 

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -4,7 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import type { Dirent, FSWatcher } from 'node:fs';
 import { ClientType, CollectionMethod } from '../../types/index.js';
-import type { AgentActivityEntry } from '../../types/index.js';
+import type { AgentActivityEntry, JsonValue } from '../../types/index.js';
 import { directoryExists, resolveHome } from '../../utils/fs-utils.js';
 import { BaseInput, type InputOptions } from '../base/base-input.js';
 import { buildCodexTranscriptEntries } from './codex-transcript-builder.js';
@@ -22,6 +22,10 @@ import { stringValue, timestampMs } from './codex-transcript-utils.js';
 
 const DEFAULT_SESSION_DIR = '~/.codex/sessions';
 const READ_CHUNK_SIZE = 1024 * 1024;
+const WAKEUP_RESOURCE_ATTRIBUTE_KEYS = [
+  'agentteams.worker.name',
+  'agentteams.instance.id',
+];
 
 interface JsonLine {
   startOffset: number;
@@ -233,7 +237,41 @@ export class CodexTranscriptInput extends BaseInput {
         lastUsage: turn.unmatchedTokenUsages.at(-1),
       });
     }
-    return turn ? buildCodexTranscriptEntries(turn) : [];
+    if (!turn) return [];
+    const entries = buildCodexTranscriptEntries(turn);
+    const resourceAttributes = await this.readWakeupResourceAttributes(turn.sessionId);
+    return resourceAttributes ? attachWakeupResourceAttributes(entries, resourceAttributes) : entries;
+  }
+
+  private async readWakeupResourceAttributes(sessionId: string): Promise<Record<string, JsonValue> | undefined> {
+    const marker = path.join(this.wakeupDir, `${safeWakeupSessionPart(sessionId)}.json`);
+    let raw: string;
+    try {
+      raw = await fs.readFile(marker, 'utf8');
+    } catch {
+      return undefined;
+    }
+
+    let markerRecord: Record<string, unknown> | null = null;
+    try {
+      const parsed = JSON.parse(raw);
+      markerRecord = asRecord(parsed);
+    } catch {
+      return undefined;
+    }
+
+    const markerAttributes = asRecord(markerRecord?.resourceAttributes);
+    if (!markerAttributes) return undefined;
+
+    const resourceAttributes: Record<string, JsonValue> = {};
+    for (const key of WAKEUP_RESOURCE_ATTRIBUTE_KEYS) {
+      const value = markerAttributes[key];
+      if (typeof value !== 'string') continue;
+      const trimmed = value.trim();
+      if (trimmed) resourceAttributes[key] = trimmed;
+    }
+
+    return Object.keys(resourceAttributes).length > 0 ? resourceAttributes : undefined;
   }
 
   private async baselineFile(filePath: string, key: string): Promise<void> {
@@ -439,6 +477,24 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
     ? value as Record<string, unknown>
     : null;
+}
+
+function attachWakeupResourceAttributes(
+  entries: AgentActivityEntry[],
+  resourceAttributes: Record<string, JsonValue>,
+): AgentActivityEntry[] {
+  const workerName = resourceAttributes['agentteams.worker.name'];
+  for (const entry of entries) {
+    entry.resourceAttributes = resourceAttributes;
+    if (typeof workerName === 'string' && workerName.trim()) {
+      entry['gen_ai.agent.name'] = workerName.trim();
+    }
+  }
+  return entries;
+}
+
+function safeWakeupSessionPart(value: string): string {
+  return path.basename(String(value)).replace(/[^a-zA-Z0-9_-]/g, '_') || 'unknown';
 }
 
 function defaultWakeupDir(): string {

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -22,10 +22,13 @@ import { stringValue, timestampMs } from './codex-transcript-utils.js';
 
 const DEFAULT_SESSION_DIR = '~/.codex/sessions';
 const READ_CHUNK_SIZE = 1024 * 1024;
+// Values emitted by DEFAULT_RESOURCE_ENV_FIELD_MAP in assets/hooks/shared/resource-context.mjs.
+// Add new AgentTeams resource fields to both lists together.
 const WAKEUP_RESOURCE_ATTRIBUTE_KEYS = [
   'agentteams.worker.name',
   'agentteams.instance.id',
 ];
+const MAX_WAKEUP_RESOURCE_ATTRIBUTE_VALUE_LENGTH = 512;
 
 interface JsonLine {
   startOffset: number;
@@ -257,21 +260,37 @@ export class CodexTranscriptInput extends BaseInput {
       const parsed = JSON.parse(raw);
       markerRecord = asRecord(parsed);
     } catch {
+      this.logger.debug('Codex wakeup marker could not be parsed; resource attributes skipped', { marker });
       return undefined;
     }
 
     const markerAttributes = asRecord(markerRecord?.resourceAttributes);
-    if (!markerAttributes) return undefined;
+    if (!markerAttributes) {
+      this.logger.debug('Codex wakeup marker has no resourceAttributes; attribution skipped', { marker });
+      return undefined;
+    }
 
     const resourceAttributes: Record<string, JsonValue> = {};
     for (const key of WAKEUP_RESOURCE_ATTRIBUTE_KEYS) {
       const value = markerAttributes[key];
       if (typeof value !== 'string') continue;
       const trimmed = value.trim();
+      if (trimmed.length > MAX_WAKEUP_RESOURCE_ATTRIBUTE_VALUE_LENGTH) {
+        this.logger.debug('Codex wakeup resource attribute skipped because value is too long', {
+          marker,
+          key,
+          maxLength: MAX_WAKEUP_RESOURCE_ATTRIBUTE_VALUE_LENGTH,
+        });
+        continue;
+      }
       if (trimmed) resourceAttributes[key] = trimmed;
     }
 
-    return Object.keys(resourceAttributes).length > 0 ? resourceAttributes : undefined;
+    if (Object.keys(resourceAttributes).length === 0) {
+      this.logger.debug('Codex wakeup marker has no whitelisted resourceAttributes; attribution skipped', { marker });
+      return undefined;
+    }
+    return resourceAttributes;
   }
 
   private async baselineFile(filePath: string, key: string): Promise<void> {

--- a/tests/integration/hook-jsonl-flow.test.ts
+++ b/tests/integration/hook-jsonl-flow.test.ts
@@ -221,6 +221,10 @@ describe('Hook JSONL integration flow', () => {
       path.resolve(process.cwd(), 'assets/hooks/shared/qoder-db-utils.mjs'),
       path.join(sharedDir, 'qoder-db-utils.mjs'),
     );
+    await fs.copyFile(
+      path.resolve(process.cwd(), 'assets/hooks/shared/resource-context.mjs'),
+      path.join(sharedDir, 'resource-context.mjs'),
+    );
     await fs.chmod(hookScript, 0o755);
 
     const transcriptPath = path.join(tmpDir, 'transcript.jsonl');
@@ -262,6 +266,9 @@ describe('Hook JSONL integration flow', () => {
       session_id: 'sess-hook',
     }), {
       LOONGSUITE_PILOT_DATA_DIR: dataDir,
+      AGENTTEAMS_WORKER_NAME: 'qoder-worker',
+      AGENTTEAMS_INSTANCE_ID: 'lw-qoder',
+      AGENTTEAMS_TOKEN: 'should-not-leak',
     });
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBe('{}');
@@ -275,6 +282,14 @@ describe('Hook JSONL integration flow', () => {
     expect(historyRecord.uuid).toBeUndefined();
     expect(historyRecord.sessionId).toBeUndefined();
     expect(historyRecord['event.name']).toBe('other');
+    expect(historyRecord['gen_ai.agent.name']).toBe('qoder-worker');
+    expect(historyRecord.resourceAttributes).toEqual({
+      'agentteams.worker.name': 'qoder-worker',
+      'agentteams.instance.id': 'lw-qoder',
+    });
+    expect(historyRecord['agentteams.worker.name']).toBeUndefined();
+    expect(historyRecord['agentteams.instance.id']).toBeUndefined();
+    expect(historyRecord['agentteams.token']).toBeUndefined();
 
     const input = new QoderCliInput({
       stateStore: stateStore as any,
@@ -296,6 +311,11 @@ describe('Hook JSONL integration flow', () => {
       'event.name': 'other',
       'gen_ai.agent.type': ClientType.QoderCli,
       'gen_ai.session.id': 'sess-hook',
+      'gen_ai.agent.name': 'qoder-worker',
+      resourceAttributes: {
+        'agentteams.worker.name': 'qoder-worker',
+        'agentteams.instance.id': 'lw-qoder',
+      },
     });
   });
 
@@ -322,6 +342,10 @@ describe('Hook JSONL integration flow', () => {
     await fs.copyFile(
       path.resolve(process.cwd(), 'assets/hooks/shared/qoder-db-utils.mjs'),
       path.join(sharedDir, 'qoder-db-utils.mjs'),
+    );
+    await fs.copyFile(
+      path.resolve(process.cwd(), 'assets/hooks/shared/resource-context.mjs'),
+      path.join(sharedDir, 'resource-context.mjs'),
     );
     await fs.chmod(hookScript, 0o755);
 
@@ -573,6 +597,10 @@ describe('Hook JSONL integration flow', () => {
     await fs.copyFile(
       path.resolve(process.cwd(), 'assets/hooks/shared/qoder-db-utils.mjs'),
       path.join(sharedDir, 'qoder-db-utils.mjs'),
+    );
+    await fs.copyFile(
+      path.resolve(process.cwd(), 'assets/hooks/shared/resource-context.mjs'),
+      path.join(sharedDir, 'resource-context.mjs'),
     );
     await fs.chmod(hookScript, 0o755);
 

--- a/tests/unit/hooks/codex/hook-processor.test.mjs
+++ b/tests/unit/hooks/codex/hook-processor.test.mjs
@@ -18,10 +18,10 @@ afterEach(() => {
   fs.rmSync(dataDir, { recursive: true, force: true });
 });
 
-function runHook(subcommand, payload) {
+function runHook(subcommand, payload, extraEnv = {}) {
   return spawnSync('node', [PROCESSOR, subcommand], {
     input: JSON.stringify(payload),
-    env: { ...process.env, LOONGSUITE_PILOT_DATA_DIR: dataDir },
+    env: { ...process.env, LOONGSUITE_PILOT_DATA_DIR: dataDir, ...extraEnv },
     encoding: 'utf-8',
     timeout: 10_000,
   });
@@ -47,6 +47,26 @@ describe('codex Stop wakeup hook', () => {
       transcript_path: '/tmp/rollout-cdx-wakeup.jsonl',
     });
     expect(fs.existsSync(path.join(dataDir, 'logs', 'codex'))).toBe(false);
+  });
+
+  test('writes AgentTeams resource attributes into the wakeup marker', () => {
+    const result = runHook('stop', {
+      session_id: 'cdx-agentteams',
+      turn_id: 'turn-agentteams',
+      transcript_path: '/tmp/rollout-cdx-agentteams.jsonl',
+    }, {
+      AGENTTEAMS_WORKER_NAME: 'codex-worker',
+      AGENTTEAMS_INSTANCE_ID: 'lw-codex',
+      AGENTTEAMS_TOKEN: 'should-not-leak',
+    });
+
+    expect(result.status).toBe(0);
+    const marker = JSON.parse(fs.readFileSync(markerPath('cdx-agentteams'), 'utf8'));
+    expect(marker.resourceAttributes).toEqual({
+      'agentteams.worker.name': 'codex-worker',
+      'agentteams.instance.id': 'lw-codex',
+    });
+    expect(JSON.stringify(marker)).not.toContain('should-not-leak');
   });
 
   test('keeps only the latest wakeup for one session', () => {

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -91,15 +91,17 @@ async function createInput(root: string): Promise<{
   input: CodexTranscriptInput;
   entries: AgentActivityEntry[];
   sessionDir: string;
+  wakeupDir: string;
 }> {
   const stateStore = new StateStore(path.join(root, 'input-state.json'));
   await stateStore.load();
   const sessionDir = path.join(root, 'sessions');
-  const input = new CodexTranscriptInput({ stateStore, sessionDir, pollIntervalMs: 10 });
+  const wakeupDir = path.join(root, 'wakeups');
+  const input = new CodexTranscriptInput({ stateStore, sessionDir, wakeupDir, pollIntervalMs: 10 });
   const entries: AgentActivityEntry[] = [];
   input.on('entries', batch => entries.push(...batch));
   await input.start();
-  return { input, entries, sessionDir };
+  return { input, entries, sessionDir, wakeupDir };
 }
 
 async function writeTranscript(sessionDir: string, text: string): Promise<string> {
@@ -107,6 +109,11 @@ async function writeTranscript(sessionDir: string, text: string): Promise<string
   await fs.mkdir(path.dirname(transcript), { recursive: true });
   await fs.writeFile(transcript, text, 'utf8');
   return transcript;
+}
+
+async function writeWakeupMarker(wakeupDir: string, sessionId: string, payload: Record<string, unknown>): Promise<void> {
+  await fs.mkdir(wakeupDir, { recursive: true });
+  await fs.writeFile(path.join(wakeupDir, `${sessionId}.json`), JSON.stringify(payload), 'utf8');
 }
 
 describe('CodexTranscriptInput', () => {
@@ -289,6 +296,39 @@ describe('CodexTranscriptInput', () => {
     expect(tools.map(entry => entry['gen_ai.step.id'])).toEqual([
       'session-1:turn-1:s1', 'session-1:turn-1:s2',
     ]);
+  });
+
+  it('projects AgentTeams resource context from the Stop wakeup marker', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-agentteams-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, wakeupDir } = await createInput(root);
+    await writeWakeupMarker(wakeupDir, 'session-1', {
+      session_id: 'session-1',
+      resourceAttributes: {
+        'agentteams.worker.name': ' codex-worker ',
+        'agentteams.instance.id': ' lw-codex ',
+        'agentteams.token': 'should-not-leak',
+        'custom.key': 'ignored',
+      },
+    });
+    await writeTranscript(sessionDir, completedTurn());
+
+    await waitFor(() => entries.filter(entry => entry['event.name'] === 'llm.response').length === 3);
+    await input.stop();
+
+    for (const entry of entries) {
+      expect(entry['gen_ai.agent.name']).toBe('codex-worker');
+      expect(entry.resourceAttributes).toEqual({
+        'agentteams.worker.name': 'codex-worker',
+        'agentteams.instance.id': 'lw-codex',
+      });
+      expect(entry['agentteams.worker.name']).toBeUndefined();
+      expect(entry['agentteams.instance.id']).toBeUndefined();
+      expect(entry['agentteams.token']).toBeUndefined();
+      expect(entry['custom.key']).toBeUndefined();
+    }
+    expect(JSON.stringify(entries)).not.toContain('should-not-leak');
+    expect(JSON.stringify(entries)).not.toContain('ignored');
   });
 
   it('waits for task_complete before exporting a Stop-triggered transcript', async () => {

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -329,6 +329,51 @@ describe('CodexTranscriptInput', () => {
     }
     expect(JSON.stringify(entries)).not.toContain('should-not-leak');
     expect(JSON.stringify(entries)).not.toContain('ignored');
+  });
+
+  it('skips overlong AgentTeams resource values from the wakeup marker', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-agentteams-long-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, wakeupDir } = await createInput(root);
+    const longWorkerName = 'x'.repeat(513);
+    await writeWakeupMarker(wakeupDir, 'session-1', {
+      session_id: 'session-1',
+      resourceAttributes: {
+        'agentteams.worker.name': longWorkerName,
+        'agentteams.instance.id': 'lw-codex',
+      },
+    });
+    await writeTranscript(sessionDir, completedTurn());
+
+    await waitFor(() => entries.filter(entry => entry['event.name'] === 'llm.response').length === 3);
+    await input.stop();
+
+    for (const entry of entries) {
+      expect(entry['gen_ai.agent.name']).toBeUndefined();
+      expect(entry.resourceAttributes).toEqual({
+        'agentteams.instance.id': 'lw-codex',
+      });
+    }
+    expect(JSON.stringify(entries)).not.toContain(longWorkerName);
+  });
+
+  it('debug logs when an existing wakeup marker lacks resourceAttributes', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-agentteams-empty-marker-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, wakeupDir } = await createInput(root);
+    const debug = vi.fn();
+    (input as unknown as { logger: { debug: typeof debug } }).logger.debug = debug;
+    await writeWakeupMarker(wakeupDir, 'session-1', { session_id: 'session-1' });
+    await writeTranscript(sessionDir, completedTurn());
+
+    await waitFor(() => entries.filter(entry => entry['event.name'] === 'llm.response').length === 3);
+    await input.stop();
+
+    expect(entries.some(entry => entry.resourceAttributes)).toBe(false);
+    expect(debug).toHaveBeenCalledWith(
+      'Codex wakeup marker has no resourceAttributes; attribution skipped',
+      { marker: path.join(wakeupDir, 'session-1.json') },
+    );
   });
 
   it('waits for task_complete before exporting a Stop-triggered transcript', async () => {

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { DEFAULT_RESOURCE_ENV_FIELD_MAP } from '../../../../assets/hooks/shared/resource-context.mjs';
 import { StateStore } from '../../../../src/checkpoints/state-store.js';
 import { CodexTranscriptInput } from '../../../../src/inputs/codex-transcript/codex-transcript-input.js';
 import type { AgentActivityEntry } from '../../../../src/types/index.js';
@@ -329,6 +330,27 @@ describe('CodexTranscriptInput', () => {
     }
     expect(JSON.stringify(entries)).not.toContain('should-not-leak');
     expect(JSON.stringify(entries)).not.toContain('ignored');
+  });
+
+  it('keeps Codex wakeup resource fields aligned with the shared hook env map', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-agentteams-map-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, wakeupDir } = await createInput(root);
+    const resourceAttributes = Object.fromEntries(
+      Object.values(DEFAULT_RESOURCE_ENV_FIELD_MAP).map((key, index) => [key, `value-${index}`]),
+    );
+    await writeWakeupMarker(wakeupDir, 'session-1', {
+      session_id: 'session-1',
+      resourceAttributes,
+    });
+    await writeTranscript(sessionDir, completedTurn());
+
+    await waitFor(() => entries.filter(entry => entry['event.name'] === 'llm.response').length === 3);
+    await input.stop();
+
+    for (const entry of entries) {
+      expect(entry.resourceAttributes).toEqual(resourceAttributes);
+    }
   });
 
   it('skips overlong AgentTeams resource values from the wakeup marker', async () => {


### PR DESCRIPTION
## Summary

- Propagate `AGENTTEAMS_WORKER_NAME` and `AGENTTEAMS_INSTANCE_ID` into Qoder trace records as OTLP `resourceAttributes`
- Persist the same AgentTeams resource context through Codex Stop wakeup markers and project it onto transcript-derived trace records
- Align Qoder/Codex behavior with Claude Code by also setting `gen_ai.agent.name` from `agentteams.worker.name`

## Test

- `npm test -- tests/integration/hook-jsonl-flow.test.ts tests/unit/hooks/codex/hook-processor.test.mjs tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts`
- `npm run typecheck`