### PR TITLE
fix(opencode): report input_tokens as total prompt tokens (include cache)

### DIFF
--- a/assets/plugins/opencode/plugin.mjs
+++ b/assets/plugins/opencode/plugin.mjs
@@ -649,6 +649,17 @@ function handleMessageUpdated(props, userId) {
     finishReasons[0]
   );
 
+  // opencode's tokens.input has cache already subtracted out (a cost-bucketing
+  // convention: input/cache.read/cache.write are non-overlapping). Add cache
+  // back so gen_ai.usage.input_tokens is the TOTAL prompt tokens, matching the
+  // claude-code / qwen collectors where cache_read is a subset of input. This
+  // keeps cache_read <= input_tokens. cost_usd is left untouched (opencode
+  // already computed it correctly from the non-overlapping buckets).
+  const cacheRead = tokens.cache?.read || 0;
+  const cacheWrite = tokens.cache?.write || 0;
+  const outputTokens = tokens.output || 0;
+  const inputTotal = (tokens.input || 0) + cacheRead + cacheWrite;
+
   const record = {
     ...buildCommonFields(sessionID, session, userId),
     "event.name": "llm.response",
@@ -660,10 +671,11 @@ function handleMessageUpdated(props, userId) {
     "gen_ai.response.model": info.modelID || model?.modelID,
     "gen_ai.response.id": info.id,
     "gen_ai.response.finish_reasons": finishReasons,
-    "gen_ai.usage.input_tokens": tokens.input || 0,
-    "gen_ai.usage.output_tokens": tokens.output || 0,
-    "gen_ai.usage.cache_read.input_tokens": tokens.cache?.read || 0,
-    "gen_ai.usage.cache_creation.input_tokens": tokens.cache?.write || 0,
+    "gen_ai.usage.input_tokens": inputTotal,
+    "gen_ai.usage.output_tokens": outputTokens,
+    "gen_ai.usage.cache_read.input_tokens": cacheRead,
+    "gen_ai.usage.cache_creation.input_tokens": cacheWrite,
+    "gen_ai.usage.total_tokens": inputTotal + outputTokens,
   };
   if (tokens.reasoning) {
     record["gen_ai.usage.reasoning_tokens"] = tokens.reasoning;

--- a/tests/unit/hooks/opencode-plugin-tokens.test.mjs
+++ b/tests/unit/hooks/opencode-plugin-tokens.test.mjs
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const PLUGIN_PATH = path.resolve(
+  fileURLToPath(import.meta.url),
+  '../../../../assets/plugins/opencode/plugin.mjs',
+);
+
+/**
+ * Drives the REAL plugin: sets a temp data dir, imports the default export,
+ * calls server() to get the live hooks, fires the event sequence that produces
+ * an llm.response record, then reads the emitted JSONL back.
+ */
+let tmpDir;
+let prevDataDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-tokens-'));
+  prevDataDir = process.env.LOONGSUITE_PILOT_DATA_DIR;
+  process.env.LOONGSUITE_PILOT_DATA_DIR = tmpDir;
+});
+
+afterEach(() => {
+  if (prevDataDir === undefined) delete process.env.LOONGSUITE_PILOT_DATA_DIR;
+  else process.env.LOONGSUITE_PILOT_DATA_DIR = prevDataDir;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function loadHooks() {
+  // Cache-bust so module-level state (sessions map, logDir cache) is fresh and
+  // logDir() re-reads the temp LOONGSUITE_PILOT_DATA_DIR set in beforeEach.
+  const mod = await import(`${pathToFileURL(PLUGIN_PATH).href}?t=${Date.now()}_${Math.random()}`);
+  return mod.default.server({}, {});
+}
+
+async function emitLlmResponse({ input, output, cacheRead, cacheWrite }) {
+  const hooks = await loadHooks();
+  const sessionID = 'ses_test';
+
+  await hooks['chat.message'](
+    { sessionID },
+    { message: { model: { providerID: 'anthropic', modelID: 'claude' } }, parts: [{ type: 'text', text: 'hi' }] },
+  );
+  await hooks.event({
+    event: { type: 'message.part.updated', properties: { sessionID, part: { type: 'step-start' }, time: Date.now() } },
+  });
+  await hooks.event({
+    event: {
+      type: 'message.updated',
+      properties: {
+        info: {
+          role: 'assistant',
+          sessionID,
+          id: 'msg_1',
+          modelID: 'claude',
+          providerID: 'anthropic',
+          time: { completed: Date.now() },
+          tokens: { input, output, reasoning: 0, cache: { read: cacheRead, write: cacheWrite } },
+        },
+      },
+    },
+  });
+
+  const dir = path.join(tmpDir, 'logs', 'opencode');
+  const records = fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.jsonl'))
+    .flatMap((f) => fs.readFileSync(path.join(dir, f), 'utf8').trim().split('\n'))
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+  return records.filter((r) => r['event.name'] === 'llm.response');
+}
+
+describe('opencode plugin token mapping', () => {
+  it('reports input_tokens as the total (non-cached + cache read + cache write)', async () => {
+    // opencode passes non-cached input; plugin must add cache back.
+    const [rec] = await emitLlmResponse({ input: 100, output: 50, cacheRead: 1000, cacheWrite: 200 });
+
+    expect(rec).toBeDefined();
+    expect(rec['gen_ai.usage.input_tokens']).toBe(1300); // 100 + 1000 + 200
+    expect(rec['gen_ai.usage.cache_read.input_tokens']).toBe(1000);
+    expect(rec['gen_ai.usage.cache_creation.input_tokens']).toBe(200);
+    expect(rec['gen_ai.usage.output_tokens']).toBe(50);
+    expect(rec['gen_ai.usage.total_tokens']).toBe(1350); // input_total + output (plan A: no reasoning)
+  });
+
+  it('keeps cache_read <= input_tokens (the invariant that was violated before)', async () => {
+    const [rec] = await emitLlmResponse({ input: 5, output: 10, cacheRead: 9000, cacheWrite: 0 });
+
+    expect(rec['gen_ai.usage.cache_read.input_tokens']).toBeLessThanOrEqual(rec['gen_ai.usage.input_tokens']);
+    expect(rec['gen_ai.usage.input_tokens']).toBe(9005);
+  });
+
+  it('is unchanged when there is no caching', async () => {
+    const [rec] = await emitLlmResponse({ input: 300, output: 40, cacheRead: 0, cacheWrite: 0 });
+
+    expect(rec['gen_ai.usage.input_tokens']).toBe(300);
+    expect(rec['gen_ai.usage.cache_read.input_tokens']).toBe(0);
+    expect(rec['gen_ai.usage.total_tokens']).toBe(340);
+  });
+});


### PR DESCRIPTION
## Summary

In opencode traces, `gen_ai.usage.cache_read.input_tokens` could exceed `gen_ai.usage.input_tokens` — which looks wrong and is inconsistent with the rest of the fleet.

**Root cause.** opencode's `Session.getUsage` deliberately subtracts cache from input (`adjustedInputTokens = inputTokens - cacheRead - cacheWrite`) so that `input` / `cache.read` / `cache.write` are **non-overlapping buckets** for accurate per-bucket cost. So opencode's `tokens.input` is the *non-cached* count, and in cached multi-turn sessions `cache_read` is naturally much larger than it. Our plugin passed `tokens.input` through verbatim.

Meanwhile the **claude-code** and **qwen** collectors report `gen_ai.usage.input_tokens` as the **total** prompt tokens (with `cache_read` as a subset), so `cache_read <= input_tokens` holds there. opencode was the outlier.

**Fix.** Add cache back in the plugin so the field matches the fleet convention:
```
input_tokens = non_cached_input + cache_read + cache_creation
total_tokens = input_tokens + output   # reasoning excluded, matching claude-code
```
`cost_usd` is left untouched — opencode already computed it correctly from the non-overlapping buckets.

## Test plan

- [x] New unit test drives the **real plugin** (`server()` hooks → JSONL) and asserts `input = input+read+write`, `cache_read <= input_tokens`, no-cache is unchanged, `total = input+output`
- [x] `npm run typecheck` clean; full suite green (142 files / 1531 tests)
- [x] **Real opencode E2E** (`opencode run --format json`): reproduced the anomaly in raw data (e.g. `input=185, cache.read=12544`) and confirmed the emitted record equals `raw.input + raw.cache.read + raw.cache.write` on every step, with `cache_read <= input_tokens` restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)