### PR TITLE
feat(opencode/trace): workspace attribution + git & custom attributes in trace spans

### DIFF
--- a/assets/plugins/opencode/plugin.mjs
+++ b/assets/plugins/opencode/plugin.mjs
@@ -151,6 +151,12 @@ function resolveUserId(cfg) {
 
 let _logDirReady = false;
 
+// Working directory of the OpenCode instance, captured once at server init.
+// One OpenCode server instance maps to one project directory, so this is stable
+// for the process lifetime. Emitted as agent.opencode.cwd so the pilot pipeline
+// can enrich git.repo / workspace.current_root downstream.
+let agentCwd;
+
 function writeRecord(record) {
   try {
     if (!_logDirReady) {
@@ -240,6 +246,7 @@ function buildCommonFields(sessionID, session, userId) {
     "gen_ai.agent.type": AGENT_TYPE,
     "gen_ai.agent.name": AGENT_TYPE,
     "gen_ai.agent.id": session.agentMeta?.name || undefined,
+    ...(agentCwd ? { [`agent.${AGENT_TYPE}.cwd`]: agentCwd } : {}),
   };
 }
 
@@ -828,6 +835,14 @@ export default {
 
   server: async (input, _options) => {
     ensureDir(logDir());
+
+    // OpenCode passes the instance context here; `directory` is the working
+    // directory. Fall back to process.cwd() (the plugin runs inside the
+    // OpenCode process, whose cwd is the same directory).
+    agentCwd =
+      (typeof input?.directory === "string" && input.directory) ||
+      process.cwd() ||
+      undefined;
 
     const cfg = loadPilotConfig();
     const userId = resolveUserId(cfg);

--- a/docs/trace-output.md
+++ b/docs/trace-output.md
@@ -190,6 +190,37 @@ Trace spans can carry sensitive content if message capture is enabled. For sensi
 
 Also enable [Data Masking](masking.md) when trace data may include secrets.
 
+## Custom Span Attributes
+
+Two kinds of extra attributes can be attached to **trace spans** (they are NOT written to the event log / SLS / JSONL output):
+
+**1. Git/workspace attributes (automatic).** When an agent reports its working directory, spans automatically carry `git.repo`, `git.branch`, `git.domain`, and `workspace.current_root`, inferred from the local git repository.
+
+**2. User-defined attributes.** Attach arbitrary key/value pairs to every span from three sources, merged with precedence **config < env < file**:
+
+- `config.json` → `globalSpanAttributes` (read once at startup):
+
+  ```json
+  { "globalSpanAttributes": { "team": "infra", "deployment.env": "prod" } }
+  ```
+
+- Environment variable `OTEL_SPAN_ATTRIBUTES` in OTel format (read once at startup):
+
+  ```bash
+  export OTEL_SPAN_ATTRIBUTES="team=infra,deployment.env=prod"
+  ```
+
+- A mutable file `~/.loongsuite-pilot/span-attributes.json` (`{"key":"value"}`), re-read on change so edits take effect without a restart:
+
+  ```json
+  { "release": "2026.07", "oncall": "alice" }
+  ```
+
+Notes:
+- Values are strings. File edits are picked up on the next processing cycle (bounded by the input poll interval, ~30s), not instantly.
+- Keys are written verbatim as span attribute names. **Avoid keys starting with `agent.`** and other reserved prefixes (`gen_ai.`, `git.`, `workspace.`, `event.`, `trace_`, `user.`, `cost_`) — such keys are skipped.
+- Attributes never overwrite existing span attributes (fill-only).
+
 ## Verify Trace Output
 
 ```bash

--- a/docs/trace-output.md
+++ b/docs/trace-output.md
@@ -210,10 +210,14 @@ Two kinds of extra attributes can be attached to **trace spans** (they are NOT w
   export OTEL_SPAN_ATTRIBUTES="team=infra,deployment.env=prod"
   ```
 
-- A mutable file `~/.loongsuite-pilot/span-attributes.json` (`{"key":"value"}`), re-read on change so edits take effect without a restart:
+- A mutable file `~/.loongsuite-pilot/span-attributes.json` (`{"key":"value"}`), re-read on change so edits take effect without a restart. Manage it with the CLI (recommended) instead of editing by hand:
 
-  ```json
-  { "release": "2026.07", "oncall": "alice" }
+  ```bash
+  loongsuite-pilot span-attr set release 2026.07
+  loongsuite-pilot span-attr set oncall alice
+  loongsuite-pilot span-attr list
+  loongsuite-pilot span-attr unset oncall
+  loongsuite-pilot span-attr clear
   ```
 
 Notes:

--- a/docs/trace-output.md
+++ b/docs/trace-output.md
@@ -192,11 +192,11 @@ Also enable [Data Masking](masking.md) when trace data may include secrets.
 
 ## Custom Span Attributes
 
-Two kinds of extra attributes can be attached to **trace spans** (they are NOT written to the event log / SLS / JSONL output):
+Two kinds of extra attributes can be attached to trace spans:
 
-**1. Git/workspace attributes (automatic).** When an agent reports its working directory, spans automatically carry `git.repo`, `git.branch`, `git.domain`, and `workspace.current_root`, inferred from the local git repository.
+**1. Git/workspace attributes (automatic).** When an agent reports its working directory, spans automatically carry `git.repo`, `git.branch`, `git.domain`, and `workspace.current_root`, inferred from the local git repository. These are also present in the event log (SLS / JSONL) output.
 
-**2. User-defined attributes.** Attach arbitrary key/value pairs to every span from three sources, merged with precedence **config < env < file**:
+**2. User-defined attributes.** Attach arbitrary key/value pairs from three sources, merged with precedence **config < env < file**. Unlike the git fields above, these are written to **trace spans only** (never the event log / SLS / JSONL):
 
 - `config.json` → `globalSpanAttributes` (read once at startup):
 

--- a/docs/zh-CN/trace-output.md
+++ b/docs/zh-CN/trace-output.md
@@ -192,11 +192,11 @@ Pilot 会将 Trace 发送到 `http://localhost:3000/api/public/otel/v1/traces`�
 
 ## 自定义 Span 属性
 
-有两类额外属性可以附加到 **trace span** 上（**不会**写入 event log / SLS / JSONL）：
+有两类额外属性可以附加到 trace span 上：
 
-**1. Git/工作区属性（自动）**：当 agent 上报了工作目录时，span 会自动带上 `git.repo`、`git.branch`、`git.domain`、`workspace.current_root`（由本地 git 仓库推断）。
+**1. Git/工作区属性（自动）**：当 agent 上报了工作目录时，span 会自动带上 `git.repo`、`git.branch`、`git.domain`、`workspace.current_root`（由本地 git 仓库推断）。这几个字段**同时也会**出现在 event log（SLS / JSONL）中。
 
-**2. 用户自定义属性**：从三个来源给每个 span 附加任意键值对，优先级 **config < env < 文件**：
+**2. 用户自定义属性**：从三个来源给 span 附加任意键值对，优先级 **config < env < 文件**。与上面的 git 字段不同，这些**只写入 trace span**（不进 event log / SLS / JSONL）：
 
 - `config.json` → `globalSpanAttributes`（启动时读一次）：
 

--- a/docs/zh-CN/trace-output.md
+++ b/docs/zh-CN/trace-output.md
@@ -210,10 +210,14 @@ Pilot 会将 Trace 发送到 `http://localhost:3000/api/public/otel/v1/traces`�
   export OTEL_SPAN_ATTRIBUTES="team=infra,deployment.env=prod"
   ```
 
-- 可变文件 `~/.loongsuite-pilot/span-attributes.json`（`{"key":"value"}`），改动后会被重新读取，无需重启：
+- 可变文件 `~/.loongsuite-pilot/span-attributes.json`（`{"key":"value"}`），改动后会被重新读取，无需重启。推荐用 CLI 管理（而非手动编辑）：
 
-  ```json
-  { "release": "2026.07", "oncall": "alice" }
+  ```bash
+  loongsuite-pilot span-attr set release 2026.07
+  loongsuite-pilot span-attr set oncall alice
+  loongsuite-pilot span-attr list
+  loongsuite-pilot span-attr unset oncall
+  loongsuite-pilot span-attr clear
   ```
 
 说明：

--- a/docs/zh-CN/trace-output.md
+++ b/docs/zh-CN/trace-output.md
@@ -190,6 +190,37 @@ Pilot 会将 Trace 发送到 `http://localhost:3000/api/public/otel/v1/traces`�
 
 如果 Trace 数据可能包含密钥，也建议开启 [数据脱敏](masking.md)。
 
+## 自定义 Span 属性
+
+有两类额外属性可以附加到 **trace span** 上（**不会**写入 event log / SLS / JSONL）：
+
+**1. Git/工作区属性（自动）**：当 agent 上报了工作目录时，span 会自动带上 `git.repo`、`git.branch`、`git.domain`、`workspace.current_root`（由本地 git 仓库推断）。
+
+**2. 用户自定义属性**：从三个来源给每个 span 附加任意键值对，优先级 **config < env < 文件**：
+
+- `config.json` → `globalSpanAttributes`（启动时读一次）：
+
+  ```json
+  { "globalSpanAttributes": { "team": "infra", "deployment.env": "prod" } }
+  ```
+
+- 环境变量 `OTEL_SPAN_ATTRIBUTES`（OTel 格式，启动时读一次）：
+
+  ```bash
+  export OTEL_SPAN_ATTRIBUTES="team=infra,deployment.env=prod"
+  ```
+
+- 可变文件 `~/.loongsuite-pilot/span-attributes.json`（`{"key":"value"}`），改动后会被重新读取，无需重启：
+
+  ```json
+  { "release": "2026.07", "oncall": "alice" }
+  ```
+
+说明：
+- 值均为字符串。文件改动会在下一个处理周期生效（受采集轮询间隔约束，约 30s），并非即时。
+- key 会原样作为 span 属性名。**请避免以 `agent.` 开头**及其它保留前缀（`gen_ai.`、`git.`、`workspace.`、`event.`、`trace_`、`user.`、`cost_`）——这类 key 会被跳过。
+- 属性为 fill-only，绝不覆盖 span 已有属性。
+
 ## 验证 Trace 输出
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@alicloud/log": "^1.2.6",
-        "@loongsuite/otel-util-genai": "^0.1.0-beta.8",
+        "@loongsuite/otel-util-genai": "^0.1.0-beta.9",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.57.0",
         "@opentelemetry/otlp-transformer": "^0.57.0",
@@ -657,9 +657,9 @@
       }
     },
     "node_modules/@loongsuite/otel-util-genai": {
-      "version": "0.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@loongsuite/otel-util-genai/-/otel-util-genai-0.1.0-beta.8.tgz",
-      "integrity": "sha512-YQdBxoVBGyU6MMbnp14i3D5H3R0+uPFe/3z18DQo26EL1TtMgILTcLtq27Vf751duKZRa9Uw7gu0rss6W0+PVA==",
+      "version": "0.1.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@loongsuite/otel-util-genai/-/otel-util-genai-0.1.0-beta.9.tgz",
+      "integrity": "sha512-XbepHcGnhMKJh1gqee0zxkliE5fI+kSy3TCWjpSzgnwKEECy2hz+KoyxbP6H+CI6TxdUdD8XqY/kR/ZcCBAK6g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.40.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@alicloud/log": "^1.2.6",
-    "@loongsuite/otel-util-genai": "^0.1.0-beta.8",
+    "@loongsuite/otel-util-genai": "^0.1.0-beta.9",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.57.0",
     "@opentelemetry/otlp-transformer": "^0.57.0",

--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -37,6 +37,7 @@ $LOG_DIR = Join-Path $DATA_DIR "logs"
 $LOG_FILE = Join-Path $LOG_DIR "loongsuite-pilot-service.log"
 $UPDATER_LOG_FILE = Join-Path $LOG_DIR "loongsuite-pilot-updater.log"
 $CONFIG_FILE = Join-Path $DATA_DIR "config.json"
+$SPAN_ATTR_FILE = Join-Path $DATA_DIR "span-attributes.json"
 $NODE_PIN_FILE = Join-Path $CACHE_DIR "node-bin"
 $INIT_TYPE_FILE = Join-Path $DATA_DIR "init-type"
 
@@ -922,6 +923,58 @@ function Cmd-Log {
 # ============================================================
 # CMD: help
 # ============================================================
+# Manage span-attributes.json — user-defined attributes injected into trace
+# spans (not the event log). The collector re-reads the file per turn, so
+# changes take effect without a restart.
+function Cmd-SpanAttr {
+    $sub = if ($SubArgs.Count -ge 1) { $SubArgs[0] } else { "" }
+
+    if ($sub -ieq "clear") {
+        if (Test-Path $SPAN_ATTR_FILE) { Remove-Item $SPAN_ATTR_FILE -Force }
+        Write-Host "cleared custom span attributes ($SPAN_ATTR_FILE)"
+        return
+    }
+
+    if ($sub.ToLower() -in @("set", "unset", "list")) {
+        $nodeBin = Resolve-Node
+        if (-not $nodeBin) { Write-Error "[span-attr] node runtime not found"; exit 1 }
+        $js = @'
+const fs = require("fs");
+const file = process.argv[1], op = process.argv[2], key = process.argv[3], value = process.argv[4];
+const RESERVED = ["gen_ai.","git.","workspace.","event.","trace_","user.","cost_","agent.","time_unix_nano","observed_time_unix_nano"];
+const isReserved = k => RESERVED.some(p => k === p || k.indexOf(p) === 0);
+function read() { try { const o = JSON.parse(fs.readFileSync(file, "utf-8")); return (o && typeof o === "object" && !Array.isArray(o)) ? o : {}; } catch { return {}; } }
+function write(o) { fs.writeFileSync(file, JSON.stringify(o, null, 2) + "\n"); }
+if (op === "set") {
+  if (!key || value === undefined) { console.error("usage: span-attr set <key> <value>"); process.exit(1); }
+  if (isReserved(key)) { console.error("refused: \"" + key + "\" uses a reserved prefix (gen_ai./git./workspace./event./trace_/user./cost_/agent./...)"); process.exit(1); }
+  const o = read(); o[key] = String(value); write(o); console.log("set " + key + "=" + o[key]);
+} else if (op === "unset") {
+  if (!key) { console.error("usage: span-attr unset <key>"); process.exit(1); }
+  const o = read(); if (Object.prototype.hasOwnProperty.call(o, key)) { delete o[key]; write(o); console.log("unset " + key); } else { console.log("(no such key: " + key + ")"); }
+} else if (op === "list") {
+  const o = read(); const ks = Object.keys(o);
+  if (ks.length === 0) { console.log("(no custom span attributes)"); } else { for (const k of ks) console.log(k + "=" + o[k]); }
+}
+'@
+        $rest = if ($SubArgs.Count -ge 2) { $SubArgs[1..($SubArgs.Count - 1)] } else { @() }
+        & $nodeBin -e $js $SPAN_ATTR_FILE $sub @rest
+        exit $LASTEXITCODE
+    }
+
+    Write-Host "Usage: loongsuite-pilot span-attr <set|unset|list|clear>"
+    Write-Host ""
+    Write-Host "  set <key> <value>   Set a custom trace span attribute"
+    Write-Host "  unset <key>         Remove a custom attribute"
+    Write-Host "  list                Show current custom attributes"
+    Write-Host "  clear               Remove all custom attributes"
+    Write-Host ""
+    Write-Host "Attributes are injected into trace spans only (not the event log)."
+    Write-Host "Reserved-prefix keys (gen_ai./git./workspace./event./trace_/user./cost_/agent./...) are rejected."
+    Write-Host "Changes take effect on the next turn - no restart needed."
+    if ($sub -ne "" -and $sub.ToLower() -notin @("help", "-h", "--help")) { exit 1 }
+}
+
 function Cmd-Help {
     Write-Host "Usage: loongsuite-pilot <command>"
     Write-Host ""
@@ -932,6 +985,7 @@ function Cmd-Help {
     Write-Host "  status          Show service status (default)"
     Write-Host "  info            Show version and config info"
     Write-Host "  log             Tail the service log"
+    Write-Host "  span-attr ...   Manage custom trace span attributes (set/unset/list/clear)"
     Write-Host "  rollback        Roll back to the previous version"
     Write-Host "  help            Show this help message"
 }
@@ -951,6 +1005,7 @@ switch ($Command.ToLower()) {
     "restart-updater"    { Cmd-RestartUpdater }
     "run"                { Cmd-Run }
     "run-updater"        { Cmd-RunUpdater }
+    "span-attr"          { Cmd-SpanAttr }
     { $_ -in "help","--help","-h" } { Cmd-Help }
     default {
         Write-Host "Unknown command: $Command"

--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -944,7 +944,7 @@ const file = process.argv[1], op = process.argv[2], key = process.argv[3], value
 const RESERVED = ["gen_ai.","git.","workspace.","event.","trace_","user.","cost_","agent.","time_unix_nano","observed_time_unix_nano"];
 const isReserved = k => RESERVED.some(p => k === p || k.indexOf(p) === 0);
 function read() { try { const o = JSON.parse(fs.readFileSync(file, "utf-8")); return (o && typeof o === "object" && !Array.isArray(o)) ? o : {}; } catch { return {}; } }
-function write(o) { fs.writeFileSync(file, JSON.stringify(o, null, 2) + "\n"); }
+function write(o) { const tmp = file + ".tmp"; fs.writeFileSync(tmp, JSON.stringify(o, null, 2) + "\n"); fs.renameSync(tmp, file); }
 if (op === "set") {
   if (!key || value === undefined) { console.error("usage: span-attr set <key> <value>"); process.exit(1); }
   if (isReserved(key)) { console.error("refused: \"" + key + "\" uses a reserved prefix (gen_ai./git./workspace./event./trace_/user./cost_/agent./...)"); process.exit(1); }

--- a/scripts/loongsuite-pilot.sh
+++ b/scripts/loongsuite-pilot.sh
@@ -17,6 +17,7 @@ UPDATER_LOG_FILE="$LOG_DIR/loongsuite-pilot-updater.log"
 MONITOR_LOG_FILE="$LOG_DIR/loongsuite-pilot-monitor-process.log"
 DASHBOARD_LOG_FILE="$LOG_DIR/loongsuite-pilot-dashboard.log"
 CONFIG_FILE="$DATA_DIR/config.json"
+SPAN_ATTR_FILE="$DATA_DIR/span-attributes.json"
 MONITOR_PID_FILE="$DATA_DIR/loongsuite-pilot-monitor.pid"
 DASHBOARD_PID_FILE="$DATA_DIR/loongsuite-pilot-dashboard.pid"
 MONITOR_DATA_DIR="$LOG_DIR/process-monitor"
@@ -1617,6 +1618,61 @@ autostart_status() {
     esac
 }
 
+# Manage ~/.loongsuite-pilot/span-attributes.json — user-defined attributes
+# injected into trace spans (not the event log). The collector re-reads the
+# file per turn, so changes take effect without a restart.
+_span_attr_run() {
+    local node_bin
+    node_bin=$(resolve_node) || { echo "[span-attr] node runtime not found" >&2; exit 1; }
+    "$node_bin" -e '
+const fs = require("fs");
+const file = process.argv[1], op = process.argv[2], key = process.argv[3], value = process.argv[4];
+const RESERVED = ["gen_ai.","git.","workspace.","event.","trace_","user.","cost_","agent.","time_unix_nano","observed_time_unix_nano"];
+const isReserved = k => RESERVED.some(p => k === p || k.indexOf(p) === 0);
+function read() { try { const o = JSON.parse(fs.readFileSync(file, "utf-8")); return (o && typeof o === "object" && !Array.isArray(o)) ? o : {}; } catch { return {}; } }
+function write(o) { fs.writeFileSync(file, JSON.stringify(o, null, 2) + "\n"); }
+if (op === "set") {
+  if (!key || value === undefined) { console.error("usage: span-attr set <key> <value>"); process.exit(1); }
+  if (isReserved(key)) { console.error("refused: \"" + key + "\" uses a reserved prefix (gen_ai./git./workspace./event./trace_/user./cost_/agent./...)"); process.exit(1); }
+  const o = read(); o[key] = String(value); write(o); console.log("set " + key + "=" + o[key]);
+} else if (op === "unset") {
+  if (!key) { console.error("usage: span-attr unset <key>"); process.exit(1); }
+  const o = read(); if (Object.prototype.hasOwnProperty.call(o, key)) { delete o[key]; write(o); console.log("unset " + key); } else { console.log("(no such key: " + key + ")"); }
+} else if (op === "list") {
+  const o = read(); const ks = Object.keys(o);
+  if (ks.length === 0) { console.log("(no custom span attributes)"); } else { for (const k of ks) console.log(k + "=" + o[k]); }
+}
+' "$SPAN_ATTR_FILE" "$@"
+}
+
+cmd_span_attr() {
+    local sub="${1:-}"
+    case "$sub" in
+        set)   shift; _span_attr_run set "$@" ;;
+        unset) shift; _span_attr_run unset "$@" ;;
+        list)  _span_attr_run list ;;
+        clear)
+            rm -f "$SPAN_ATTR_FILE"
+            echo "cleared custom span attributes ($SPAN_ATTR_FILE)"
+            ;;
+        ""|help|-h|--help)
+            echo "Usage: loongsuite-pilot span-attr <set|unset|list|clear>"
+            echo ""
+            echo "  set <key> <value>   Set a custom trace span attribute"
+            echo "  unset <key>         Remove a custom attribute"
+            echo "  list                Show current custom attributes"
+            echo "  clear               Remove all custom attributes"
+            echo ""
+            echo "Attributes are injected into trace spans only (not the event log)."
+            echo "Reserved-prefix keys (gen_ai./git./workspace./event./trace_/user./cost_/agent./...) are rejected."
+            echo "Changes take effect on the next turn — no restart needed." ;;
+        *)
+            echo "Unknown span-attr command: $sub" >&2
+            echo "Usage: loongsuite-pilot span-attr <set|unset|list|clear>" >&2
+            exit 1 ;;
+    esac
+}
+
 cmd_help() {
     echo "Usage: loongsuite-pilot <command> [options]"
     echo ""
@@ -1627,6 +1683,7 @@ cmd_help() {
     echo "  status          Show service status (default)"
     echo "  info            Show version and config info"
     echo "  token-usage     Show token usage TUI"
+    echo "  span-attr ...   Manage custom trace span attributes (set/unset/list/clear)"
     echo "  monitor start   Start process resource monitor"
     echo "  monitor stop    Stop process resource monitor"
     echo "  worker ...      Manage local remote-controlled workers"
@@ -1658,6 +1715,7 @@ case "${1:-status}" in
     info)        cmd_info ;;
     token-usage) shift; cmd_token_usage "$@" ;;
     tokens)      shift; cmd_token_usage "$@" ;;
+    span-attr)   shift; cmd_span_attr "$@" ;;
     monitor)             cmd_monitor "${2:-}" ;;
     worker)              shift; cmd_worker "$@" ;;
     rollback)            cmd_rollback ;;

--- a/scripts/loongsuite-pilot.sh
+++ b/scripts/loongsuite-pilot.sh
@@ -1630,7 +1630,7 @@ const file = process.argv[1], op = process.argv[2], key = process.argv[3], value
 const RESERVED = ["gen_ai.","git.","workspace.","event.","trace_","user.","cost_","agent.","time_unix_nano","observed_time_unix_nano"];
 const isReserved = k => RESERVED.some(p => k === p || k.indexOf(p) === 0);
 function read() { try { const o = JSON.parse(fs.readFileSync(file, "utf-8")); return (o && typeof o === "object" && !Array.isArray(o)) ? o : {}; } catch { return {}; } }
-function write(o) { fs.writeFileSync(file, JSON.stringify(o, null, 2) + "\n"); }
+function write(o) { const tmp = file + ".tmp"; fs.writeFileSync(tmp, JSON.stringify(o, null, 2) + "\n"); fs.renameSync(tmp, file); }
 if (op === "set") {
   if (!key || value === undefined) { console.error("usage: span-attr set <key> <value>"); process.exit(1); }
   if (isReserved(key)) { console.error("refused: \"" + key + "\" uses a reserved prefix (gen_ai./git./workspace./event./trace_/user./cost_/agent./...)"); process.exit(1); }

--- a/src/core/config-loader.ts
+++ b/src/core/config-loader.ts
@@ -231,11 +231,11 @@ export async function loadConfig(): Promise<AnalyticsConfig> {
  * config. Reserved-prefix keys and non-string values are dropped.
  */
 function resolveGlobalSpanAttributes(file: ConfigFile | null): Record<string, string> {
-  const fromConfig = sanitizeAttributes(
-    (file?.globalSpanAttributes as Record<string, unknown>) ?? {},
-  );
+  const fromConfig = (file?.globalSpanAttributes as Record<string, unknown>) ?? {};
   const fromEnv = parseKeyValueAttributes(env('OTEL_SPAN_ATTRIBUTES'));
-  return { ...fromConfig, ...fromEnv };
+  // Sanitize the merged result so config and env are treated consistently
+  // (drop reserved-prefix keys and non-string values from both).
+  return sanitizeAttributes({ ...fromConfig, ...fromEnv });
 }
 
 function buildOtlpTraceRawConfig(file: ConfigFile | null): OtlpTraceRawConfig | undefined {

--- a/src/core/config-loader.ts
+++ b/src/core/config-loader.ts
@@ -18,6 +18,7 @@ import type {
 } from '../types/index.js';
 import { readJsonFile, resolveHome } from '../utils/fs-utils.js';
 import { createLogger } from '../utils/logger.js';
+import { parseKeyValueAttributes, sanitizeAttributes } from '../normalization/global-attributes.js';
 
 const logger = createLogger('ConfigLoader');
 
@@ -145,6 +146,9 @@ export interface ConfigFile {
 
   enableStatusBarApp?: boolean | string;
 
+  /** User-defined attributes injected into trace spans (merged with OTEL_SPAN_ATTRIBUTES env). */
+  globalSpanAttributes?: Record<string, unknown>;
+
   installId?: string;
   canary?: {
     policy?: 'auto' | 'latest' | 'off';
@@ -217,7 +221,21 @@ export async function loadConfig(): Promise<AnalyticsConfig> {
     hookWatchdog: buildHookWatchdogConfig(file),
     fileCollection: buildFileCollectionConfig(file),
     statusBar: buildStatusBarConfig(file),
+    globalSpanAttributes: resolveGlobalSpanAttributes(file),
   };
+}
+
+/**
+ * User-defined global span attributes: config.json `globalSpanAttributes` merged
+ * with the `OTEL_SPAN_ATTRIBUTES` env (key1=value1,key2=value2). Env wins over
+ * config. Reserved-prefix keys and non-string values are dropped.
+ */
+function resolveGlobalSpanAttributes(file: ConfigFile | null): Record<string, string> {
+  const fromConfig = sanitizeAttributes(
+    (file?.globalSpanAttributes as Record<string, unknown>) ?? {},
+  );
+  const fromEnv = parseKeyValueAttributes(env('OTEL_SPAN_ATTRIBUTES'));
+  return { ...fromConfig, ...fromEnv };
 }
 
 function buildOtlpTraceRawConfig(file: ConfigFile | null): OtlpTraceRawConfig | undefined {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -8,6 +8,7 @@ import { StateStore } from '../checkpoints/state-store.js';
 import { HookManager } from '../hooks/hook-manager.js';
 import { DeploymentManager } from '../deployment/deployment-manager.js';
 import { detectAgent } from '../deployment/detect-utils.js';
+import { GlobalAttributesProvider } from '../normalization/global-attributes.js';
 import { createLogger } from '../utils/logger.js';
 import { resolveHome, ensureDir, directoryExists, readJsonFile, writeJsonFile, fileExists, readInstalledVersion, cleanStaleTmpFiles } from '../utils/fs-utils.js';
 import * as path from 'node:path';
@@ -116,6 +117,7 @@ export class Orchestrator extends EventEmitter {
   private runtimeWriter: RuntimeWriter | null = null;
   private metricsSummaryWriter: MetricsSummaryWriter | null = null;
   private statusBarAppManager: StatusBarAppManager | null = null;
+  private globalAttributesProvider!: GlobalAttributesProvider;
   private isRunning = false;
 
   constructor(config: AnalyticsConfig) {
@@ -148,6 +150,10 @@ export class Orchestrator extends EventEmitter {
     await this.agentControlManager.load();
 
     // 3. Build flushers
+    this.globalAttributesProvider = new GlobalAttributesProvider(
+      this.config.globalSpanAttributes ?? {},
+      path.join(this.dataDir, 'span-attributes.json'),
+    );
     this.flusher = await this.buildFlusher();
 
     // 4. Build InputManager & AlarmManager
@@ -458,7 +464,10 @@ export class Orchestrator extends EventEmitter {
     if (otlpTraceCfg?.enabled) {
       try {
         const { OtlpTraceFlusher } = await import('../flushers/otlp-trace-flusher.js');
-        const r = new OtlpTraceFlusher({ ...otlpTraceCfg, dataDir: this.dataDir });
+        const r = new OtlpTraceFlusher(
+          { ...otlpTraceCfg, dataDir: this.dataDir },
+          this.globalAttributesProvider,
+        );
         flushers.push(r);
       } catch (err) {
         logger.warn('OtlpTraceFlusher unavailable, skipping', { error: String(err) });

--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -19,6 +19,10 @@ import type { AgentActivityEntry, OtlpTraceFlusherConfig } from '../types/index.
 import { BaseFlusher } from './base-flusher.js';
 import { normalizeAgentType } from '../utils/agent-type-normalize.js';
 import { resolveAgentSystem } from '../normalization/agent-system-map.js';
+import {
+  DEFAULT_GIT_PASSTHROUGH_KEYS,
+  type GlobalAttributesProvider,
+} from '../normalization/global-attributes.js';
 import { createLogger } from '../utils/logger.js';
 import { appendLine, ensureDir, getTodayDateString, readInstalledVersion } from '../utils/fs-utils.js';
 import { randomUUID } from 'node:crypto';
@@ -105,6 +109,7 @@ export class OtlpTraceFlusher extends BaseFlusher {
   private readonly debugDir: string;
   private readonly failedDir: string;
   private readonly resourceAttributeKeys: string[];
+  private readonly globalAttributesProvider?: GlobalAttributesProvider;
 
   private idleTimer?: ReturnType<typeof setInterval>;
   private inFlightExports = new Set<Promise<void>>();
@@ -117,7 +122,7 @@ export class OtlpTraceFlusher extends BaseFlusher {
   // 即时 flush 会把 key 加入 flushedTurnKeys，导致后续同 key 的子 records 被丢弃。
   private _deferSignalA = false;
 
-  constructor(cfg: OtlpTraceFlusherConfig) {
+  constructor(cfg: OtlpTraceFlusherConfig, globalAttributesProvider?: GlobalAttributesProvider) {
     super();
     if (!cfg.endpoint) {
       throw new Error('[otlp-trace-flusher] config.endpoint is required when enabled');
@@ -126,6 +131,7 @@ export class OtlpTraceFlusher extends BaseFlusher {
       throw new Error('[otlp-trace-flusher] config.serviceName is required when enabled');
     }
     this.cfg = cfg;
+    this.globalAttributesProvider = globalAttributesProvider;
     const dataDir = cfg.dataDir ?? os.homedir() + '/.loongsuite-pilot';
     this.pilotVersion = readInstalledVersion(dataDir);
     this.resolvedEndpointUrl = resolveEndpointUrl(cfg.endpoint);
@@ -355,9 +361,27 @@ export class OtlpTraceFlusher extends BaseFlusher {
 
     try {
       try {
+        // Inject user-defined custom attributes (config/env/file) into trace
+        // spans only — never the event log. Resolved per turn so the mutable
+        // file is picked up on change. Values are fill-only stamped onto record
+        // copies (originals untouched) so passthroughKeys can read them; git.*
+        // are already on the records and only need to be listed as keys.
+        const customAttrs = this.globalAttributesProvider?.resolve() ?? {};
+        const customKeys = Object.keys(customAttrs);
+        const passthroughKeys = [...new Set([...DEFAULT_GIT_PASSTHROUGH_KEYS, ...customKeys])];
+        const recordsForConversion = customKeys.length === 0
+          ? records
+          : records.map((r) => {
+              const copy: AgentActivityEntry = { ...r };
+              for (const [k, v] of Object.entries(customAttrs)) {
+                if (copy[k] === undefined) copy[k] = v;
+              }
+              return copy;
+            });
+
         const result = convertEventLogToTrace(
-          records as unknown as EventLogRecord[],
-          { handler, strict: false },
+          recordsForConversion as unknown as EventLogRecord[],
+          { handler, strict: false, passthroughKeys },
         );
         if (result.warnings.length > 0) {
           logger.warn(`Conversion warnings for ${agentType}`, { warnings: result.warnings.join('; ') });

--- a/src/normalization/global-attributes.ts
+++ b/src/normalization/global-attributes.ts
@@ -1,0 +1,143 @@
+import * as fs from 'node:fs';
+import { createLogger } from '../utils/logger.js';
+
+const logger = createLogger('GlobalAttributes');
+
+/**
+ * Git/workspace attributes produced by enrich-git-context.ts. Always passed
+ * through onto trace spans (independent of user-defined attributes).
+ */
+export const DEFAULT_GIT_PASSTHROUGH_KEYS = [
+  'git.repo',
+  'git.branch',
+  'git.domain',
+  'workspace.current_root',
+] as const;
+
+/**
+ * Prefixes reserved for converter-managed / pipeline fields. User-defined
+ * custom attributes matching these are dropped to avoid clobbering semantics.
+ */
+const RESERVED_PREFIXES = [
+  'gen_ai.',
+  'git.',
+  'workspace.',
+  'event.',
+  'trace_',
+  'user.',
+  'cost_',
+  'agent.',
+  'time_unix_nano',
+  'observed_time_unix_nano',
+];
+
+export function isReservedKey(key: string): boolean {
+  return RESERVED_PREFIXES.some((p) => key === p || key.startsWith(p));
+}
+
+/**
+ * Parse OTel-style `key1=value1,key2=value2` into a string map. Kept simple:
+ * split on `,`, then on the first `=`; trim; skip empty/malformed entries.
+ */
+export function parseKeyValueAttributes(raw: string | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!raw) return out;
+  for (const pair of raw.split(',')) {
+    const idx = pair.indexOf('=');
+    if (idx <= 0) continue;
+    const key = pair.slice(0, idx).trim();
+    const value = pair.slice(idx + 1).trim();
+    if (key.length === 0 || value.length === 0) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+/** Coerce a value to a string attribute, or undefined to skip (objects/arrays). */
+function coerceString(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return undefined;
+}
+
+/**
+ * Sanitize a candidate attribute map: drop reserved-prefix keys and
+ * non-string(-coercible) values.
+ */
+export function sanitizeAttributes(input: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, rawValue] of Object.entries(input)) {
+    if (isReservedKey(key)) continue;
+    const value = coerceString(rawValue);
+    if (value === undefined) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Resolves user-defined global span attributes from a static baseline
+ * (config + env, captured at startup) merged with a mutable JSON file that is
+ * re-read on change (mtime-cached). File values win over the baseline.
+ *
+ * These attributes are injected into trace spans only (not the event log).
+ */
+export class GlobalAttributesProvider {
+  private readonly baseline: Record<string, string>;
+  private readonly filePath: string;
+  private cachedMtimeMs = -1;
+  private cachedFileAttrs: Record<string, string> = {};
+  private cachedMerged: Record<string, string>;
+
+  constructor(baseline: Record<string, string>, filePath: string) {
+    this.baseline = sanitizeAttributes(baseline);
+    this.filePath = filePath;
+    this.cachedMerged = { ...this.baseline };
+  }
+
+  /** Merged attributes (baseline < file). Cheap: only re-reads file on mtime change. */
+  resolve(): Record<string, string> {
+    let mtimeMs: number;
+    try {
+      mtimeMs = fs.statSync(this.filePath).mtimeMs;
+    } catch {
+      // File missing (or stat failed): reset to baseline once.
+      if (this.cachedMtimeMs !== -1) {
+        this.cachedMtimeMs = -1;
+        this.cachedFileAttrs = {};
+        this.cachedMerged = { ...this.baseline };
+      }
+      return this.cachedMerged;
+    }
+
+    if (mtimeMs === this.cachedMtimeMs) return this.cachedMerged;
+
+    this.cachedMtimeMs = mtimeMs;
+    this.cachedFileAttrs = this.readFileAttrs();
+    this.cachedMerged = { ...this.baseline, ...this.cachedFileAttrs };
+    return this.cachedMerged;
+  }
+
+  /** Attribute keys of the current merged map. */
+  keys(): string[] {
+    return Object.keys(this.resolve());
+  }
+
+  private readFileAttrs(): Record<string, string> {
+    try {
+      const raw = fs.readFileSync(this.filePath, 'utf-8');
+      const parsed = JSON.parse(raw) as unknown;
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        logger.warn('span-attributes file is not a JSON object; ignoring', { filePath: this.filePath });
+        return {};
+      }
+      return sanitizeAttributes(parsed as Record<string, unknown>);
+    } catch (err) {
+      logger.warn('failed to read span-attributes file; falling back to baseline', {
+        filePath: this.filePath,
+        error: String(err),
+      });
+      return {};
+    }
+  }
+}

--- a/src/normalization/global-attributes.ts
+++ b/src/normalization/global-attributes.ts
@@ -112,9 +112,18 @@ export class GlobalAttributesProvider {
 
     if (mtimeMs === this.cachedMtimeMs) return this.cachedMerged;
 
+    const result = this.readFileAttrs();
+    if (!result.ok) {
+      // Read/parse failed (e.g. a concurrent non-atomic write left the file
+      // half-written). Keep the last-good value and retry on the next call —
+      // do NOT commit the mtime, otherwise we'd be stuck on stale data until
+      // the file changes again.
+      return this.cachedMerged;
+    }
+
     this.cachedMtimeMs = mtimeMs;
-    this.cachedFileAttrs = this.readFileAttrs();
-    this.cachedMerged = { ...this.baseline, ...this.cachedFileAttrs };
+    this.cachedFileAttrs = result.attrs;
+    this.cachedMerged = { ...this.baseline, ...result.attrs };
     return this.cachedMerged;
   }
 
@@ -123,21 +132,33 @@ export class GlobalAttributesProvider {
     return Object.keys(this.resolve());
   }
 
-  private readFileAttrs(): Record<string, string> {
+  private readFileAttrs(): { ok: boolean; attrs: Record<string, string> } {
+    let raw: string;
     try {
-      const raw = fs.readFileSync(this.filePath, 'utf-8');
-      const parsed = JSON.parse(raw) as unknown;
-      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-        logger.warn('span-attributes file is not a JSON object; ignoring', { filePath: this.filePath });
-        return {};
-      }
-      return sanitizeAttributes(parsed as Record<string, unknown>);
+      raw = fs.readFileSync(this.filePath, 'utf-8');
     } catch (err) {
-      logger.warn('failed to read span-attributes file; falling back to baseline', {
+      logger.warn('failed to read span-attributes file; will retry', {
         filePath: this.filePath,
         error: String(err),
       });
-      return {};
+      return { ok: false, attrs: {} };
     }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      // Malformed JSON — possibly a half-written file. Retry next time.
+      logger.warn('span-attributes file has invalid JSON; will retry', {
+        filePath: this.filePath,
+        error: String(err),
+      });
+      return { ok: false, attrs: {} };
+    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      // Parseable but wrong shape (not a transient write) — treat as empty.
+      logger.warn('span-attributes file is not a JSON object; ignoring', { filePath: this.filePath });
+      return { ok: true, attrs: {} };
+    }
+    return { ok: true, attrs: sanitizeAttributes(parsed as Record<string, unknown>) };
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -72,6 +72,8 @@ export interface AnalyticsConfig {
   fileCollection: FileCollectionToggle;
   statusBar: StatusBarConfig;
   autoUpdate?: AutoUpdateConfig;
+  /** User-defined attributes injected into trace spans only (config + env baseline). */
+  globalSpanAttributes?: Record<string, string>;
 }
 
 export interface AgentConfig {

--- a/tests/unit/core/config-loader.test.ts
+++ b/tests/unit/core/config-loader.test.ts
@@ -833,4 +833,36 @@ describe('ConfigLoader', () => {
       expect(result!.headers).toBeUndefined();
     });
   });
+
+  describe('globalSpanAttributes', () => {
+    afterEach(() => {
+      delete process.env.OTEL_SPAN_ATTRIBUTES;
+    });
+
+    it('reads from config file', async () => {
+      mockReadJsonFile.mockResolvedValueOnce({ globalSpanAttributes: { team: 'infra', env: 'prod' } });
+      const config = await loadConfig();
+      expect(config.globalSpanAttributes).toEqual({ team: 'infra', env: 'prod' });
+    });
+
+    it('OTEL_SPAN_ATTRIBUTES env overrides config on collision', async () => {
+      mockReadJsonFile.mockResolvedValueOnce({ globalSpanAttributes: { team: 'infra', env: 'prod' } });
+      vi.stubEnv('OTEL_SPAN_ATTRIBUTES', 'env=staging,extra=v');
+      const config = await loadConfig();
+      expect(config.globalSpanAttributes).toEqual({ team: 'infra', env: 'staging', extra: 'v' });
+    });
+
+    it('drops reserved-prefix keys and non-strings from config', async () => {
+      mockReadJsonFile.mockResolvedValueOnce({
+        globalSpanAttributes: { team: 'infra', 'git.repo': 'x', num: 5, obj: { a: 1 } },
+      });
+      const config = await loadConfig();
+      expect(config.globalSpanAttributes).toEqual({ team: 'infra', num: '5' });
+    });
+
+    it('is empty when neither config nor env set', async () => {
+      const config = await loadConfig();
+      expect(config.globalSpanAttributes).toEqual({});
+    });
+  });
 });

--- a/tests/unit/flushers/otlp-trace-flusher/conversion.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/conversion.test.ts
@@ -15,6 +15,7 @@ vi.mock('@opentelemetry/exporter-trace-otlp-proto', () => ({
 import { OtlpTraceFlusher } from '../../../../src/flushers/otlp-trace-flusher.js';
 import { convertEventLogToTrace } from '@loongsuite/otel-util-genai';
 import type { AgentActivityEntry } from '../../../../src/types/index.js';
+import { GlobalAttributesProvider } from '../../../../src/normalization/global-attributes.js';
 
 function makeConfig() {
   return {
@@ -136,5 +137,75 @@ describe('OtlpTraceFlusher - conversion', () => {
 
     await flusher.send(entry);
     // No error thrown, graceful skip
+  });
+
+  it('always passes DEFAULT_GIT_PASSTHROUGH_KEYS even without a provider', async () => {
+    const entry = {
+      'event.name': 'llm.response',
+      'gen_ai.agent.type': 'claude-code',
+      'gen_ai.turn.id': 't5',
+      'gen_ai.response.finish_reasons': ['stop'],
+    } as unknown as AgentActivityEntry;
+
+    await flusher.send(entry);
+
+    const opts = vi.mocked(convertEventLogToTrace).mock.calls[0][1] as { passthroughKeys?: string[] };
+    expect(opts.passthroughKeys).toEqual(
+      expect.arrayContaining(['git.repo', 'git.branch', 'git.domain', 'workspace.current_root']),
+    );
+  });
+
+  describe('with GlobalAttributesProvider', () => {
+    let p: OtlpTraceFlusher;
+
+    afterEach(async () => {
+      await p.shutdown();
+    });
+
+    it('injects custom attrs onto record copies + passthroughKeys, without mutating originals', async () => {
+      const provider = new GlobalAttributesProvider({ team: 'infra' }, '/nonexistent-span-attrs.json');
+      p = new OtlpTraceFlusher(makeConfig(), provider);
+
+      const entry = {
+        'event.name': 'llm.response',
+        'gen_ai.agent.type': 'claude-code',
+        'gen_ai.turn.id': 'tc1',
+        'gen_ai.response.finish_reasons': ['stop'],
+      } as unknown as AgentActivityEntry;
+
+      await p.send(entry);
+
+      const [records, opts] = vi.mocked(convertEventLogToTrace).mock.calls.at(-1) as [
+        Array<Record<string, unknown>>,
+        { passthroughKeys?: string[] },
+      ];
+      // custom key is in passthroughKeys (alongside git defaults)
+      expect(opts.passthroughKeys).toEqual(expect.arrayContaining(['team', 'git.repo']));
+      // custom value stamped onto the record copy fed to the converter
+      expect(records[0]['team']).toBe('infra');
+      // original entry NOT mutated -> custom attrs never reach the event log
+      expect((entry as Record<string, unknown>)['team']).toBeUndefined();
+    });
+
+    it('is fill-only: does not override a value already present on the record', async () => {
+      const provider = new GlobalAttributesProvider({ team: 'infra' }, '/nonexistent-span-attrs.json');
+      p = new OtlpTraceFlusher(makeConfig(), provider);
+
+      const entry = {
+        'event.name': 'llm.response',
+        'gen_ai.agent.type': 'claude-code',
+        'gen_ai.turn.id': 'tc2',
+        'gen_ai.response.finish_reasons': ['stop'],
+        team: 'local',
+      } as unknown as AgentActivityEntry;
+
+      await p.send(entry);
+
+      const [records] = vi.mocked(convertEventLogToTrace).mock.calls.at(-1) as [
+        Array<Record<string, unknown>>,
+        unknown,
+      ];
+      expect(records[0]['team']).toBe('local');
+    });
   });
 });

--- a/tests/unit/hooks/opencode-plugin-cwd.test.mjs
+++ b/tests/unit/hooks/opencode-plugin-cwd.test.mjs
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const PLUGIN_PATH = path.resolve(
+  fileURLToPath(import.meta.url),
+  '../../../../assets/plugins/opencode/plugin.mjs',
+);
+
+let tmpDir;
+let prevDataDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-cwd-'));
+  prevDataDir = process.env.LOONGSUITE_PILOT_DATA_DIR;
+  process.env.LOONGSUITE_PILOT_DATA_DIR = tmpDir;
+});
+
+afterEach(() => {
+  if (prevDataDir === undefined) delete process.env.LOONGSUITE_PILOT_DATA_DIR;
+  else process.env.LOONGSUITE_PILOT_DATA_DIR = prevDataDir;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function loadPlugin() {
+  const mod = await import(`${pathToFileURL(PLUGIN_PATH).href}?t=${Date.now()}_${Math.random()}`);
+  return mod.default;
+}
+
+async function firstRecord(serverInput) {
+  const plugin = await loadPlugin();
+  const hooks = await plugin.server(serverInput, {});
+  await hooks['chat.message'](
+    { sessionID: 'ses_cwd' },
+    { message: {}, parts: [{ type: 'text', text: 'hi' }] },
+  );
+  const dir = path.join(tmpDir, 'logs', 'opencode');
+  const lines = fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.jsonl'))
+    .flatMap((f) => fs.readFileSync(path.join(dir, f), 'utf8').trim().split('\n'))
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+  return lines[0];
+}
+
+describe('opencode plugin cwd capture', () => {
+  it('emits agent.opencode.cwd from the server input directory', async () => {
+    const rec = await firstRecord({ directory: '/tmp/fake-repo' });
+    expect(rec['agent.opencode.cwd']).toBe('/tmp/fake-repo');
+  });
+
+  it('falls back to process.cwd() when directory is absent', async () => {
+    const rec = await firstRecord({});
+    expect(rec['agent.opencode.cwd']).toBe(process.cwd());
+  });
+});

--- a/tests/unit/normalization/global-attributes.test.ts
+++ b/tests/unit/normalization/global-attributes.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  parseKeyValueAttributes,
+  sanitizeAttributes,
+  isReservedKey,
+  GlobalAttributesProvider,
+  DEFAULT_GIT_PASSTHROUGH_KEYS,
+} from '../../../src/normalization/global-attributes.js';
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+describe('parseKeyValueAttributes', () => {
+  it('parses OTel-style key=value,key=value', () => {
+    expect(parseKeyValueAttributes('team=infra,env=prod')).toEqual({ team: 'infra', env: 'prod' });
+  });
+  it('keeps only the first = as separator', () => {
+    expect(parseKeyValueAttributes('url=a=b')).toEqual({ url: 'a=b' });
+  });
+  it('trims and skips empty/malformed entries', () => {
+    expect(parseKeyValueAttributes(' a = 1 , , b, =x, c=2 ')).toEqual({ a: '1', c: '2' });
+  });
+  it('returns empty for undefined/empty', () => {
+    expect(parseKeyValueAttributes(undefined)).toEqual({});
+    expect(parseKeyValueAttributes('')).toEqual({});
+  });
+});
+
+describe('sanitizeAttributes', () => {
+  it('drops reserved-prefix keys', () => {
+    expect(sanitizeAttributes({ team: 'x', 'gen_ai.foo': 'y', 'git.repo': 'z', 'agent.o.cwd': 'w' }))
+      .toEqual({ team: 'x' });
+  });
+  it('coerces number/boolean, skips objects/arrays', () => {
+    expect(sanitizeAttributes({ a: 1, b: true, c: { x: 1 }, d: [1], e: 'ok' }))
+      .toEqual({ a: '1', b: 'true', e: 'ok' });
+  });
+});
+
+describe('isReservedKey', () => {
+  it('flags reserved prefixes', () => {
+    for (const k of ['gen_ai.x', 'git.repo', 'workspace.current_root', 'event.name', 'trace_id', 'user.id', 'cost_usd', 'agent.o.cwd']) {
+      expect(isReservedKey(k)).toBe(true);
+    }
+  });
+  it('allows plain custom keys', () => {
+    expect(isReservedKey('team')).toBe(false);
+    expect(isReservedKey('deployment.env')).toBe(false);
+  });
+});
+
+describe('GlobalAttributesProvider', () => {
+  let dir: string;
+  let filePath: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gattr-'));
+    filePath = path.join(dir, 'span-attributes.json');
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns baseline when file is absent', () => {
+    const p = new GlobalAttributesProvider({ team: 'infra' }, filePath);
+    expect(p.resolve()).toEqual({ team: 'infra' });
+    expect(p.keys()).toEqual(['team']);
+  });
+
+  it('file overrides baseline (config < env(baseline) < file)', () => {
+    fs.writeFileSync(filePath, JSON.stringify({ env: 'staging', extra: 'v' }));
+    const p = new GlobalAttributesProvider({ team: 'infra', env: 'prod' }, filePath);
+    expect(p.resolve()).toEqual({ team: 'infra', env: 'staging', extra: 'v' });
+  });
+
+  it('sanitizes file (reserved keys and non-strings dropped)', () => {
+    fs.writeFileSync(filePath, JSON.stringify({ ok: 'v', num: 3, 'git.repo': 'x', obj: { a: 1 } }));
+    const p = new GlobalAttributesProvider({}, filePath);
+    expect(p.resolve()).toEqual({ ok: 'v', num: '3' });
+  });
+
+  it('re-reads on mtime change (real-time file update)', () => {
+    fs.writeFileSync(filePath, JSON.stringify({ v: '1' }));
+    const p = new GlobalAttributesProvider({}, filePath);
+    expect(p.resolve()).toEqual({ v: '1' });
+    // bump mtime forward to guarantee a change is detected
+    fs.writeFileSync(filePath, JSON.stringify({ v: '2', w: '3' }));
+    const future = Date.now() / 1000 + 5;
+    fs.utimesSync(filePath, future, future);
+    expect(p.resolve()).toEqual({ v: '2', w: '3' });
+  });
+
+  it('falls back to baseline on bad JSON (fail-open)', () => {
+    fs.writeFileSync(filePath, '{ not json');
+    const p = new GlobalAttributesProvider({ team: 'infra' }, filePath);
+    expect(p.resolve()).toEqual({ team: 'infra' });
+  });
+
+  it('resets to baseline when file is deleted', () => {
+    fs.writeFileSync(filePath, JSON.stringify({ v: '1' }));
+    const p = new GlobalAttributesProvider({ team: 'infra' }, filePath);
+    expect(p.resolve()).toEqual({ team: 'infra', v: '1' });
+    fs.rmSync(filePath);
+    expect(p.resolve()).toEqual({ team: 'infra' });
+  });
+});
+
+describe('DEFAULT_GIT_PASSTHROUGH_KEYS', () => {
+  it('contains the git/workspace enrichment fields', () => {
+    expect([...DEFAULT_GIT_PASSTHROUGH_KEYS]).toEqual([
+      'git.repo',
+      'git.branch',
+      'git.domain',
+      'workspace.current_root',
+    ]);
+  });
+});

--- a/tests/unit/normalization/global-attributes.test.ts
+++ b/tests/unit/normalization/global-attributes.test.ts
@@ -100,6 +100,25 @@ describe('GlobalAttributesProvider', () => {
     expect(p.resolve()).toEqual({ team: 'infra' });
   });
 
+  it('keeps last-good and retries on bad JSON (does not drop to baseline or commit mtime)', () => {
+    fs.writeFileSync(filePath, JSON.stringify({ v: '1' }));
+    const p = new GlobalAttributesProvider({ team: 'infra' }, filePath);
+    expect(p.resolve()).toEqual({ team: 'infra', v: '1' });
+
+    // Simulate a concurrent/half write leaving malformed JSON (new mtime).
+    fs.writeFileSync(filePath, '{ half-written');
+    let future = Date.now() / 1000 + 5;
+    fs.utimesSync(filePath, future, future);
+    // Keeps last-good (v:1), NOT baseline — and did not commit the bad mtime.
+    expect(p.resolve()).toEqual({ team: 'infra', v: '1' });
+
+    // Once the file is valid again, the next read is picked up (retry worked).
+    fs.writeFileSync(filePath, JSON.stringify({ v: '2' }));
+    future = Date.now() / 1000 + 10;
+    fs.utimesSync(filePath, future, future);
+    expect(p.resolve()).toEqual({ team: 'infra', v: '2' });
+  });
+
   it('resets to baseline when file is deleted', () => {
     fs.writeFileSync(filePath, JSON.stringify({ v: '1' }));
     const p = new GlobalAttributesProvider({ team: 'infra' }, filePath);


### PR DESCRIPTION
## Summary

Gives OpenCode sessions full workspace/repo attribution and lets git + user-defined attributes reach **trace spans**. Four cohesive changes:

**1. Capture OpenCode working directory** (`assets/plugins/opencode/plugin.mjs`)
OpenCode was the only agent not emitting `agent.<ns>.cwd`. Capture the directory from the plugin's `server` context (`input.directory`, `process.cwd()` fallback) once at init and emit it as `agent.opencode.cwd`. The existing pipeline (`transformHookRecord` → `enrichCanonicalEntryWithGit`) then derives `git.repo` / `git.branch` / `git.domain` / `workspace.current_root` — no downstream change needed. Scope is intentionally minimal (cwd only).

**2. git.* into trace spans** (`src/flushers/otlp-trace-flusher.ts`)
Enrichment already produced `git.repo/git.branch/git.domain/workspace.current_root` on entries (so they reached SLS/JSONL), but the OTLP converter only mapped `gen_ai.*` to span attributes. Bump `@loongsuite/otel-util-genai` to `^0.1.0-beta.9` and use its new `passthroughKeys` to surface these git fields onto spans (turn-level broadcast, fill-only). Benefits **all** agents, not just OpenCode.

**3. User-defined custom span attributes** (`src/normalization/global-attributes.ts`)
Attach arbitrary key/value attributes to **trace spans only** (never the event log) from three sources merged `config < env < file`:
- `config.json` → `globalSpanAttributes` (startup)
- `OTEL_SPAN_ATTRIBUTES` env, `key=value,key=value` (startup)
- `~/.loongsuite-pilot/span-attributes.json`, re-read **per turn** (mtime-cached) so edits apply without restart

The OTLP flusher resolves them per turn, fill-only stamps them onto record **copies** (shared entries untouched → SLS/JSONL unaffected), and lists their keys in `passthroughKeys`. Reserved-prefix keys (`gen_ai./git./workspace./event./trace_/user./cost_/agent./...`) and non-string values are dropped.

**4. `span-attr` CLI** (`scripts/loongsuite-pilot.{sh,ps1}`)
`loongsuite-pilot span-attr <set|unset|list|clear>` to manage `span-attributes.json` safely (node-backed JSON write, same reserved-prefix rejection), instead of hand-editing.

## Notes
- Custom attributes go to **trace spans only**; git.* go to both SLS/JSONL (as before) and now spans.
- "Real-time" file updates are bounded by the input poll interval (~30s), not instant.
- Docs: `docs/trace-output.md` (+ zh-CN).

## Test plan

- [x] `npm run typecheck` + full suite green (**151 files / 1666 tests**)
- [x] Unit: real-plugin cwd emission; `GlobalAttributesProvider` (merge precedence / mtime / reserved-prefix / bad-JSON fail-open); config-loader env-over-config; flusher passes correct `passthroughKeys` + stamps custom onto record copies without mutating originals
- [x] Hermetic E2E (real git enrichment + real converter + real flusher debug dump): spans carry git.* and config/env/file attributes; event log has git.* but not custom attrs; a file edit reflects on the next turn
- [x] **Real reporting E2E to ARMS**: built + ran the daemon against the machine's real CMS/xtrace endpoint, ran real `opencode` in a git repo, and confirmed via `logstore-tracing` (SLS GetLogs) that all 4 spans (`enter`/`invoke_agent`/`react`/`chat`) carry `git.repo=e2e-org/e2e-trace-repo`, `git.branch=main`, `git.domain=github.com`, `workspace.current_root`, plus `team`/`custom.source` (config), `custom.env` (env), `custom.file` (file)
- [x] `span-attr` sh command functionally verified (set/unset/list/clear + reserved-prefix rejection + spaced values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)