### PR TITLE
fix(metrics): reduce not-running alarm false positives

### DIFF
--- a/src/core/updater-watchdog.ts
+++ b/src/core/updater-watchdog.ts
@@ -1,11 +1,12 @@
 import { execFile } from 'node:child_process';
-import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { promisify } from 'node:util';
 import type { AlarmManager } from '../metrics/alarm-manager.js';
 import { readJsonFile } from '../utils/fs-utils.js';
 import { createLogger } from '../utils/logger.js';
+import { checkProcessLiveness, UPDATER_PROCESS_PATTERNS } from '../utils/pid-utils.js';
+import type { ProcessLiveness } from '../utils/pid-utils.js';
 import { updaterRuntimePath, type UpdaterRuntimeState } from '../updater/runtime-state.js';
 
 const execFileAsync = promisify(execFile);
@@ -56,6 +57,7 @@ export interface UpdaterWatchdogOptions {
   sleepWakeGraceMs?: number;
   restartCooldownMs?: number;
   alarmManager?: AlarmManager;
+  updaterLiveness?: (pidFile: string) => ProcessLiveness;
 }
 
 /**
@@ -75,6 +77,7 @@ export class UpdaterWatchdog {
   private readonly sleepWakeGraceMs: number;
   private readonly restartCooldownMs: number;
   private readonly alarmManager: AlarmManager | null;
+  private readonly updaterLiveness: (pidFile: string) => ProcessLiveness;
   private timer: ReturnType<typeof setInterval> | null = null;
   private startedAt = Date.now();
   private lastTickAt = 0;
@@ -91,6 +94,8 @@ export class UpdaterWatchdog {
     this.sleepWakeGraceMs = opts.sleepWakeGraceMs ?? DEFAULT_SLEEP_WAKE_GRACE_MS;
     this.restartCooldownMs = opts.restartCooldownMs ?? DEFAULT_RESTART_COOLDOWN_MS;
     this.alarmManager = opts.alarmManager ?? null;
+    this.updaterLiveness = opts.updaterLiveness
+      ?? ((pidFile: string) => checkProcessLiveness(pidFile, UPDATER_PROCESS_PATTERNS));
   }
 
   start(): void {
@@ -148,7 +153,7 @@ export class UpdaterWatchdog {
       return this.restart('missing-heartbeat', reason);
     }
 
-    if (heartbeat.pid !== processState.pid && process.platform !== 'win32') {
+    if (processState.pid !== undefined && heartbeat.pid !== processState.pid && process.platform !== 'win32') {
       const reason = `updater heartbeat pid ${heartbeat.pid} does not match running pid ${processState.pid}`;
       if (this.inGraceWindow(now)) return { status: 'grace', reason };
       this.recordFailureAlarm(reason);
@@ -173,107 +178,25 @@ export class UpdaterWatchdog {
     reason: string;
   }> {
     const pidFile = path.join(this.dataDir, 'loongsuite-pilot-updater.pid');
-    let pid: number;
-    try {
-      const raw = await fs.readFile(pidFile, 'utf-8');
-      pid = Number(raw.trim());
-    } catch {
-      if (process.platform === 'win32') {
-        return this.findWindowsUpdaterProcess('updater pid file is missing');
+    const liveness = this.updaterLiveness(pidFile);
+    if (!liveness.running) {
+      if (liveness.pid !== undefined && liveness.pidFileProcessAlive && liveness.pidFileCommandMatched === false) {
+        return {
+          running: true,
+          pid: liveness.pid,
+          commandOk: false,
+          reason: `unexpected updater command: ${liveness.pidFileCommand || 'unknown'}`,
+        };
       }
-      return { running: false, reason: 'updater pid file is missing' };
+      return { running: false, pid: liveness.pid, reason: liveness.reason };
     }
 
-    if (!Number.isInteger(pid) || pid <= 0) {
-      if (process.platform === 'win32') {
-        return this.findWindowsUpdaterProcess('updater pid file is invalid');
-      }
-      return { running: false, reason: 'updater pid file is invalid' };
-    }
-
-    try {
-      process.kill(pid, 0);
-    } catch {
-      if (process.platform === 'win32') {
-        return this.findWindowsUpdaterProcess(`updater process ${pid} is not running`);
-      }
-      return { running: false, pid, reason: `updater process ${pid} is not running` };
-    }
-
-    const command = await this.readProcessCommand(pid).catch(() => '');
-    const commandOk = this.isUpdaterCommand(command);
     return {
       running: true,
-      pid,
-      commandOk,
-      reason: commandOk ? 'updater process is running' : `unexpected updater command: ${command || 'unknown'}`,
+      pid: liveness.pid,
+      commandOk: true,
+      reason: liveness.reason,
     };
-  }
-
-  private async readProcessCommand(pid: number): Promise<string> {
-    if (process.platform === 'win32') {
-      const script = `Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}" | Select-Object -ExpandProperty CommandLine`;
-      const { stdout } = await execFileAsync('powershell.exe', [
-        '-NoProfile',
-        '-WindowStyle',
-        'Hidden',
-        '-Command',
-        script,
-      ], {
-        timeout: 5_000,
-        windowsHide: true,
-      });
-      return String(stdout).trim();
-    }
-
-    const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', 'command='], {
-      timeout: 5_000,
-    });
-    return String(stdout).trim();
-  }
-
-  private async findWindowsUpdaterProcess(fallbackReason: string): Promise<{
-    running: boolean;
-    pid?: number;
-    commandOk?: boolean;
-    reason: string;
-  }> {
-    try {
-      const script = '$p = Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like "*updater-daemon*" } | Select-Object -First 1; if ($p) { "$($p.ProcessId)`t$($p.CommandLine)" }';
-      const { stdout } = await execFileAsync('powershell.exe', [
-        '-NoProfile',
-        '-WindowStyle',
-        'Hidden',
-        '-Command',
-        script,
-      ], {
-        timeout: 8_000,
-        windowsHide: true,
-      });
-      const [pidRaw, command = ''] = String(stdout).trim().split(/\t/, 2);
-      const pid = Number(pidRaw);
-      if (!Number.isInteger(pid) || pid <= 0) {
-        return { running: false, reason: fallbackReason };
-      }
-      const commandOk = this.isUpdaterCommand(command);
-      return {
-        running: true,
-        pid,
-        commandOk,
-        reason: commandOk ? 'updater process is running' : `unexpected updater command: ${command || 'unknown'}`,
-      };
-    } catch {
-      return { running: false, reason: fallbackReason };
-    }
-  }
-
-  private isUpdaterCommand(command: string): boolean {
-    return command.includes('updater-daemon.js')
-      || command.includes('/bin/updater-daemon')
-      || command.includes('\\bin\\updater-daemon')
-      || command.includes('loongsuite-pilot run-updater')
-      || command.includes('loongsuite-pilot.ps1')
-      || command.includes('dist/updater/index.js');
   }
 
   private inGraceWindow(now: number): boolean {

--- a/src/metrics/metrics-collector.ts
+++ b/src/metrics/metrics-collector.ts
@@ -3,8 +3,8 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { formatTime } from '../utils/time-utils.js';
 import { resolveLocalIp } from '../utils/network-utils.js';
-import { isPidFileRunning } from '../utils/pid-utils.js';
-import { isUpdaterRunningOnWindowsSync } from '../utils/process-discovery.js';
+import { checkProcessLiveness, UPDATER_PROCESS_PATTERNS } from '../utils/pid-utils.js';
+import type { ProcessLiveness } from '../utils/pid-utils.js';
 import type { AgentsConfig, SlsEndpoint } from '../types/index.js';
 
 export interface L1Metrics {
@@ -144,6 +144,7 @@ export class MetricsCollector {
   private readonly agentsConfig: AgentsConfig;
   private readonly slsEndpoints: SlsEndpoint[];
   private readonly cmsWorkspace: string;
+  private readonly updaterLiveness: (pidFile: string) => ProcessLiveness;
   private readonly startTime: string;
   private readonly startTimestamp: number;
   private readonly instanceId: string;
@@ -161,7 +162,7 @@ export class MetricsCollector {
   private updaterConsecutiveFailures = 0;
   private lastInfraHealth: InfraHealthSnapshot | null = null;
 
-  constructor(opts: { version: string; userId: string; dataDir: string; canaryPolicy?: string; agentsConfig?: AgentsConfig; slsEndpoints?: SlsEndpoint[]; cmsWorkspace?: string }) {
+  constructor(opts: { version: string; userId: string; dataDir: string; canaryPolicy?: string; agentsConfig?: AgentsConfig; slsEndpoints?: SlsEndpoint[]; cmsWorkspace?: string; updaterLiveness?: (pidFile: string) => ProcessLiveness }) {
     this.version = opts.version;
     this.userId = opts.userId;
     this.dataDir = opts.dataDir;
@@ -169,6 +170,8 @@ export class MetricsCollector {
     this.agentsConfig = opts.agentsConfig ?? {};
     this.slsEndpoints = opts.slsEndpoints ?? [];
     this.cmsWorkspace = opts.cmsWorkspace ?? '';
+    this.updaterLiveness = opts.updaterLiveness
+      ?? ((pidFile: string) => checkProcessLiveness(pidFile, UPDATER_PROCESS_PATTERNS));
     this.startTimestamp = Math.floor(Date.now() / 1000);
     this.startTime = formatTime(new Date());
     this.localIp = resolveLocalIp();
@@ -350,10 +353,9 @@ export class MetricsCollector {
 
     let updaterPidAlive = true;
     if (this.l1CycleCount > 2) {
-      updaterPidAlive = isPidFileRunning(path.join(this.dataDir, 'loongsuite-pilot-updater.pid'));
-      if (!updaterPidAlive && process.platform === 'win32') {
-        updaterPidAlive = isUpdaterRunningOnWindowsSync();
-      }
+      updaterPidAlive = this.updaterLiveness(
+        path.join(this.dataDir, 'loongsuite-pilot-updater.pid'),
+      ).running;
       if (updaterPidAlive) {
         this.updaterConsecutiveFailures = 0;
       } else {

--- a/src/metrics/metrics-writer.ts
+++ b/src/metrics/metrics-writer.ts
@@ -7,6 +7,7 @@ import { MetricsCollector } from './metrics-collector.js';
 import type { DataflowSnapshot, L1Metrics } from './metrics-collector.js';
 import type { AlarmManager } from './alarm-manager.js';
 import type { AgentsConfig, SlsEndpoint } from '../types/index.js';
+import type { ProcessLiveness } from '../utils/pid-utils.js';
 
 const logger = createLogger('MetricsWriter');
 
@@ -27,6 +28,7 @@ export interface MetricsWriterOptions {
   agentsConfig?: AgentsConfig;
   slsEndpoints?: SlsEndpoint[];
   cmsWorkspace?: string;
+  updaterLiveness?: (pidFile: string) => ProcessLiveness;
 }
 
 export class MetricsWriter {
@@ -51,6 +53,7 @@ export class MetricsWriter {
       canaryPolicy: opts.canaryPolicy,
       slsEndpoints: opts.slsEndpoints,
       cmsWorkspace: opts.cmsWorkspace,
+      updaterLiveness: opts.updaterLiveness,
     });
     this.getSnapshot = opts.getSnapshot;
     this.alarmManager = opts.alarmManager ?? null;

--- a/src/updater/updater-metrics.ts
+++ b/src/updater/updater-metrics.ts
@@ -60,7 +60,7 @@ export class UpdaterMetrics {
   private eventQueue: UpdaterEvent[] = [];
   private alarmQueue: AlarmEntry[] = [];
   private userIdAlarmEmitted = false;
-  private readonly startedAt = Date.now();
+  private startedAt = 0;
   private collectorConsecutiveFailures = 0;
   private lastCollectorAlarmAt = 0;
 
@@ -75,6 +75,7 @@ export class UpdaterMetrics {
   }
 
   async start(): Promise<void> {
+    this.startedAt = Date.now();
     await ensureDir(this.logsDir);
     this.healthTimer = setInterval(
       () => void this.checkCollectorHealth(),

--- a/src/updater/updater-metrics.ts
+++ b/src/updater/updater-metrics.ts
@@ -1,17 +1,20 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { execFileSync } from 'node:child_process';
 import { appendLine, ensureDir } from '../utils/fs-utils.js';
 import { createLogger } from '../utils/logger.js';
 import { resolveLocalIp } from '../utils/network-utils.js';
 import { flattenToStrings } from '../utils/record-utils.js';
-import { isPidFileRunning } from '../utils/pid-utils.js';
+import { checkProcessLiveness, COLLECTOR_PROCESS_PATTERNS } from '../utils/pid-utils.js';
+import type { ProcessLiveness } from '../utils/pid-utils.js';
 import { sendAlarm, sendStatus } from '../internal/sender.js';
 import type { AlarmLevel, AlarmType, AlarmEntry } from '../metrics/alarm-manager.js';
 
 const logger = createLogger('UpdaterMetrics');
 
 const COLLECTOR_HEALTH_INTERVAL_MS = 60_000;
+const COLLECTOR_HEALTH_STARTUP_GRACE_MS = 3 * 60_000;
+const COLLECTOR_HEALTH_FAILURE_THRESHOLD = 2;
+const COLLECTOR_HEALTH_ALARM_COOLDOWN_MS = 60 * 60_000;
 const FLUSH_INTERVAL_MS = 30_000;
 
 export type UpdaterEventType =
@@ -42,6 +45,7 @@ export interface UpdaterMetricsOptions {
   version: string;
   collectorPidFile: string;
   userId: string;
+  collectorLiveness?: (pidFile: string) => ProcessLiveness;
 }
 
 export class UpdaterMetrics {
@@ -50,16 +54,22 @@ export class UpdaterMetrics {
   private readonly ip: string;
   private readonly userId: string;
   private readonly collectorPidFile: string;
+  private readonly collectorLiveness: (pidFile: string) => ProcessLiveness;
   private healthTimer: ReturnType<typeof setInterval> | null = null;
   private flushTimer: ReturnType<typeof setInterval> | null = null;
   private eventQueue: UpdaterEvent[] = [];
   private alarmQueue: AlarmEntry[] = [];
   private userIdAlarmEmitted = false;
+  private readonly startedAt = Date.now();
+  private collectorConsecutiveFailures = 0;
+  private lastCollectorAlarmAt = 0;
 
   constructor(opts: UpdaterMetricsOptions) {
     this.logsDir = path.join(opts.dataDir, 'logs', 'metric_alarm');
     this.version = opts.version;
     this.collectorPidFile = opts.collectorPidFile;
+    this.collectorLiveness = opts.collectorLiveness
+      ?? ((pidFile: string) => checkProcessLiveness(pidFile, COLLECTOR_PROCESS_PATTERNS));
     this.userId = opts.userId;
     this.ip = resolveLocalIp();
   }
@@ -160,31 +170,40 @@ export class UpdaterMetrics {
   }
 
   private checkCollectorHealth(): void {
-    if (!isCollectorRunning(this.collectorPidFile)) {
-      logger.warn('collector process not running');
-      this.writeAlarm(
-        'SERVICE_NOT_RUNNING_ALARM', '3',
-        'loongsuite-pilot collector process is not running',
-      );
+    const liveness = this.collectorLiveness(this.collectorPidFile);
+    if (liveness.running) {
+      if (this.collectorConsecutiveFailures > 0 || liveness.source === 'process-scan') {
+        logger.warn('collector liveness recovered or pid file inconsistent', {
+          source: liveness.source,
+          reason: liveness.reason,
+          pid: liveness.pid,
+          pidFileState: liveness.pidFileState,
+        });
+      }
+      this.collectorConsecutiveFailures = 0;
+      return;
     }
-  }
-}
 
-function isCollectorRunning(pidFile: string): boolean {
-  if (isPidFileRunning(pidFile)) return true;
-  if (process.platform !== 'win32') return false;
+    const now = Date.now();
+    if (now - this.startedAt < COLLECTOR_HEALTH_STARTUP_GRACE_MS) {
+      logger.warn('collector process not running during startup grace', { reason: liveness.reason });
+      return;
+    }
 
-  // On Windows, Task Scheduler launches the collector without writing a PID file.
-  // Fall back to checking if a node process running collector-daemon.js exists.
-  try {
-    const ps = 'Get-CimInstance Win32_Process | Where-Object { $_.Name -eq "node.exe" -and $_.CommandLine -like "*collector-daemon*" } | Select-Object -ExpandProperty ProcessId';
-    const out = execFileSync('powershell.exe', [
-      '-NoProfile', '-WindowStyle', 'Hidden', '-Command', ps,
-    ], { timeout: 8000, encoding: 'utf-8', windowsHide: true });
-    const pids = out.split(/\r?\n/).map(l => l.trim()).filter(l => /^\d+$/.test(l));
-    return pids.length > 0;
-  } catch {
-    return false;
+    this.collectorConsecutiveFailures++;
+    logger.warn('collector process not running', {
+      reason: liveness.reason,
+      consecutiveFailures: this.collectorConsecutiveFailures,
+    });
+
+    if (this.collectorConsecutiveFailures < COLLECTOR_HEALTH_FAILURE_THRESHOLD) return;
+    if (now - this.lastCollectorAlarmAt < COLLECTOR_HEALTH_ALARM_COOLDOWN_MS) return;
+
+    this.lastCollectorAlarmAt = now;
+    this.writeAlarm(
+      'SERVICE_NOT_RUNNING_ALARM', '3',
+      `loongsuite-pilot collector process is not running after ${this.collectorConsecutiveFailures} checks: ${liveness.reason}`,
+    );
   }
 }
 

--- a/src/utils/pid-utils.ts
+++ b/src/utils/pid-utils.ts
@@ -1,19 +1,206 @@
 import * as fs from 'node:fs';
+import { execFileSync } from 'node:child_process';
 
-// EPERM from kill(pid, 0) means the process exists but the caller cannot signal it
-// (different uid/capabilities) — treat as alive. This differs from the original inline
-// implementation in updater-metrics.ts which returned false on any exception.
+export type ProcessLivenessSource = 'pid-file' | 'process-scan' | 'none';
+export type PidFileState = 'missing' | 'invalid' | 'stale' | 'matched';
+export type ProcessCommandPattern = string | RegExp;
+
+export interface ProcessLiveness {
+  running: boolean;
+  pid?: number;
+  source: ProcessLivenessSource;
+  reason: string;
+  pidFileState?: PidFileState;
+  pidFileProcessAlive?: boolean;
+  pidFileCommand?: string;
+  pidFileCommandMatched?: boolean;
+}
+
+export const COLLECTOR_PROCESS_PATTERNS: readonly ProcessCommandPattern[] = [
+  'collector-daemon.js',
+  '/bin/collector-daemon',
+  '\\bin\\collector-daemon',
+  /(?:^|\s)loongsuite-pilot(?:\.ps1)?\s+run(?:\s|$)/,
+];
+
+export const UPDATER_PROCESS_PATTERNS: readonly ProcessCommandPattern[] = [
+  'updater-daemon.js',
+  '/bin/updater-daemon',
+  '\\bin\\updater-daemon',
+  /(?:^|\s)loongsuite-pilot(?:\.ps1)?\s+run-updater(?:\s|$)/,
+  'dist/updater/index.js',
+];
+
 export function isPidFileRunning(pidFile: string): boolean {
+  const pid = readPidFile(pidFile);
+  return pid !== null && isProcessAlive(pid);
+}
+
+export function readPidFile(pidFile: string): number | null {
   try {
     const raw = fs.readFileSync(pidFile, 'utf-8');
     const pid = Number(raw.trim());
-    if (!Number.isInteger(pid) || pid <= 0) return false;
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+export function isProcessAlive(pid: number): boolean {
+  try {
     process.kill(pid, 0);
     return true;
   } catch (err: unknown) {
-    if (err && typeof err === 'object' && 'code' in err && (err as NodeJS.ErrnoException).code === 'EPERM') {
-      return true;
-    }
-    return false;
+    return isErrnoCode(err, 'EPERM');
   }
+}
+
+export function isCommandMatch(command: string, patterns: readonly ProcessCommandPattern[]): boolean {
+  return patterns.some(pattern => typeof pattern === 'string'
+    ? command.includes(pattern)
+    : pattern.test(command));
+}
+
+export function findProcessByCommand(patterns: readonly ProcessCommandPattern[]): ProcessLiveness {
+  if (process.platform === 'win32') {
+    return findWindowsProcessByCommand(patterns);
+  }
+  return findUnixProcessByCommand(patterns);
+}
+
+export function checkProcessLiveness(pidFile: string, patterns: readonly ProcessCommandPattern[]): ProcessLiveness {
+  const pid = readPidFile(pidFile);
+  const pidFileStateWhenMissing: PidFileState = fs.existsSync(pidFile) ? 'invalid' : 'missing';
+  let pidFileProcessAlive = false;
+  let pidFileCommand = '';
+  let pidFileCommandMatched = false;
+
+  if (pid !== null) {
+    pidFileProcessAlive = isProcessAlive(pid);
+    if (pidFileProcessAlive) {
+      pidFileCommand = readProcessCommand(pid);
+      pidFileCommandMatched = !pidFileCommand || isCommandMatch(pidFileCommand, patterns);
+      if (pidFileCommandMatched) {
+        return {
+          running: true,
+          pid,
+          source: 'pid-file',
+          reason: pidFileCommand ? 'process is running with matching command' : 'process is running; command unavailable',
+          pidFileState: 'matched',
+          pidFileProcessAlive,
+          pidFileCommand,
+          pidFileCommandMatched,
+        };
+      }
+    }
+  }
+
+  const discovered = findProcessByCommand(patterns);
+  if (discovered.running) {
+    return {
+      ...discovered,
+      reason: pid === null
+        ? `${discovered.reason}; pid file is ${pidFileStateWhenMissing}`
+        : `${discovered.reason}; pid file points to stale or mismatched pid ${pid}`,
+      pidFileState: pid === null ? pidFileStateWhenMissing : 'stale',
+      pidFileProcessAlive,
+      pidFileCommand,
+      pidFileCommandMatched,
+    };
+  }
+
+  return {
+    running: false,
+    pid: pid ?? undefined,
+    source: 'none',
+    reason: pid === null
+      ? `pid file is ${pidFileStateWhenMissing}; no matching process found`
+      : `pid file points to stale or mismatched pid ${pid}; no matching process found`,
+    pidFileState: pid === null ? pidFileStateWhenMissing : 'stale',
+    pidFileProcessAlive,
+    pidFileCommand,
+    pidFileCommandMatched,
+  };
+}
+
+function readProcessCommand(pid: number): string {
+  try {
+    if (process.platform === 'win32') {
+      return execFileSync('powershell.exe', [
+        '-NoProfile',
+        '-WindowStyle',
+        'Hidden',
+        '-Command',
+        `Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}" | Select-Object -ExpandProperty CommandLine`,
+      ], { timeout: 5000, encoding: 'utf-8', windowsHide: true }).trim();
+    }
+    return execFileSync('ps', ['-p', String(pid), '-o', 'command='], {
+      timeout: 5000,
+      encoding: 'utf-8',
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function findUnixProcessByCommand(patterns: readonly ProcessCommandPattern[]): ProcessLiveness {
+  try {
+    const out = execFileSync('ps', ['-axo', 'pid=,command='], {
+      timeout: 5000,
+      encoding: 'utf-8',
+    });
+    for (const line of out.split(/\r?\n/)) {
+      const match = line.match(/^\s*(\d+)\s+(.+)$/);
+      if (!match) continue;
+      const pid = Number(match[1]);
+      const command = match[2] ?? '';
+      if (pid === process.pid || !Number.isInteger(pid) || pid <= 0) continue;
+      if (isCommandMatch(command, patterns)) {
+        return {
+          running: true,
+          pid,
+          source: 'process-scan',
+          reason: 'matching process command found',
+        };
+      }
+    }
+  } catch {
+    // best effort
+  }
+  return { running: false, source: 'none', reason: 'no matching process found' };
+}
+
+function findWindowsProcessByCommand(patterns: readonly ProcessCommandPattern[]): ProcessLiveness {
+  try {
+    const out = execFileSync('powershell.exe', [
+      '-NoProfile',
+      '-WindowStyle',
+      'Hidden',
+      '-Command',
+      'Get-CimInstance Win32_Process | Select-Object ProcessId,CommandLine | ForEach-Object { "$($_.ProcessId)`t$($_.CommandLine)" }',
+    ], { timeout: 8000, encoding: 'utf-8', windowsHide: true });
+    for (const line of out.split(/\r?\n/)) {
+      const [pidRaw, command = ''] = line.split(/\t/, 2);
+      const pid = Number(pidRaw);
+      if (pid === process.pid || !Number.isInteger(pid) || pid <= 0) continue;
+      if (isCommandMatch(command, patterns)) {
+        return {
+          running: true,
+          pid,
+          source: 'process-scan',
+          reason: 'matching process command found',
+        };
+      }
+    }
+  } catch {
+    // best effort
+  }
+  return { running: false, source: 'none', reason: 'no matching process found' };
+}
+
+function isErrnoCode(err: unknown, code: string): boolean {
+  return err !== null
+    && typeof err === 'object'
+    && 'code' in err
+    && (err as NodeJS.ErrnoException).code === code;
 }

--- a/src/utils/pid-utils.ts
+++ b/src/utils/pid-utils.ts
@@ -20,14 +20,14 @@ export const COLLECTOR_PROCESS_PATTERNS: readonly ProcessCommandPattern[] = [
   'collector-daemon.js',
   '/bin/collector-daemon',
   '\\bin\\collector-daemon',
-  /(?:^|\s)loongsuite-pilot(?:\.ps1)?\s+run(?:\s|$)/,
+  /(?:^|[\s/\\])loongsuite-pilot(?:\.ps1)?\s+run(?:\s|$)/,
 ];
 
 export const UPDATER_PROCESS_PATTERNS: readonly ProcessCommandPattern[] = [
   'updater-daemon.js',
   '/bin/updater-daemon',
   '\\bin\\updater-daemon',
-  /(?:^|\s)loongsuite-pilot(?:\.ps1)?\s+run-updater(?:\s|$)/,
+  /(?:^|[\s/\\])loongsuite-pilot(?:\.ps1)?\s+run-updater(?:\s|$)/,
   'dist/updater/index.js',
 ];
 
@@ -73,19 +73,19 @@ export function checkProcessLiveness(pidFile: string, patterns: readonly Process
   const pidFileStateWhenMissing: PidFileState = fs.existsSync(pidFile) ? 'invalid' : 'missing';
   let pidFileProcessAlive = false;
   let pidFileCommand = '';
-  let pidFileCommandMatched = false;
+  let pidFileCommandMatched: boolean | undefined;
 
   if (pid !== null) {
     pidFileProcessAlive = isProcessAlive(pid);
     if (pidFileProcessAlive) {
       pidFileCommand = readProcessCommand(pid);
-      pidFileCommandMatched = !pidFileCommand || isCommandMatch(pidFileCommand, patterns);
-      if (pidFileCommandMatched) {
+      pidFileCommandMatched = pidFileCommand ? isCommandMatch(pidFileCommand, patterns) : undefined;
+      if (pidFileCommandMatched === true) {
         return {
           running: true,
           pid,
           source: 'pid-file',
-          reason: pidFileCommand ? 'process is running with matching command' : 'process is running; command unavailable',
+          reason: 'process is running with matching command',
           pidFileState: 'matched',
           pidFileProcessAlive,
           pidFileCommand,

--- a/src/utils/process-discovery.ts
+++ b/src/utils/process-discovery.ts
@@ -1,19 +1,6 @@
-import { execFileSync } from 'node:child_process';
-
-const UPDATER_QUERY_SCRIPT =
-  'Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like "*updater-daemon*" } | Select-Object -ExpandProperty ProcessId';
+import { findProcessByCommand, UPDATER_PROCESS_PATTERNS } from './pid-utils.js';
 
 export function isUpdaterRunningOnWindowsSync(): boolean {
   if (process.platform !== 'win32') return false;
-
-  try {
-    const out = execFileSync(
-      'powershell.exe',
-      ['-NoProfile', '-WindowStyle', 'Hidden', '-Command', UPDATER_QUERY_SCRIPT],
-      { timeout: 3000, encoding: 'utf-8', windowsHide: true },
-    );
-    return out.split(/\r?\n/).some(line => /^\d+$/.test(line.trim()));
-  } catch {
-    return false;
-  }
+  return findProcessByCommand(UPDATER_PROCESS_PATTERNS).running;
 }

--- a/tests/unit/core/updater-watchdog.test.ts
+++ b/tests/unit/core/updater-watchdog.test.ts
@@ -137,13 +137,33 @@ describe('UpdaterWatchdog', () => {
     });
   });
 
-  it('restarts when updater command does not look like the updater daemon', async () => {
-    await writePid(tmpDir);
-    await writeHeartbeat(tmpDir);
-    mockExecFileAsync.mockImplementation((cmd: string) => {
-      if (cmd === 'ps') return Promise.resolve({ stdout: 'node /tmp/other.js\n', stderr: '' });
-      return Promise.resolve({ stdout: '', stderr: '' });
+  it('reports healthy when updater PID changed but process identity matches heartbeat', async () => {
+    await writeHeartbeat(tmpDir, { pid: 456 });
+    const alarms = makeAlarmManager();
+
+    const wd = new UpdaterWatchdog({
+      enabled: true,
+      dataDir: tmpDir,
+      loongsuitePilotBin: '/bin/loongsuite-pilot',
+      startupGraceMs: 0,
+      alarmManager: alarms,
+      updaterLiveness: () => ({
+        running: true,
+        pid: 456,
+        source: 'process-scan',
+        reason: 'matching process command found; pid file points to stale or mismatched pid 123',
+        pidFileState: 'stale',
+      }),
     });
+
+    const result = await wd.runCheck();
+
+    expect(result.status).toBe('healthy');
+    expect(alarms.serialize()).toEqual([]);
+  });
+
+  it('restarts when updater command does not look like the updater daemon', async () => {
+    await writeHeartbeat(tmpDir);
 
     const alarms = makeAlarmManager();
     const wd = new UpdaterWatchdog({
@@ -152,6 +172,16 @@ describe('UpdaterWatchdog', () => {
       loongsuitePilotBin: '/bin/loongsuite-pilot',
       startupGraceMs: 0,
       alarmManager: alarms,
+      updaterLiveness: () => ({
+        running: false,
+        pid: UPDATER_PID,
+        source: 'none',
+        reason: 'pid file points to mismatched process',
+        pidFileState: 'stale',
+        pidFileProcessAlive: true,
+        pidFileCommand: 'node /tmp/other.js',
+        pidFileCommandMatched: false,
+      }),
     });
 
     const result = await wd.runCheck();

--- a/tests/unit/core/updater-watchdog.test.ts
+++ b/tests/unit/core/updater-watchdog.test.ts
@@ -14,8 +14,10 @@ vi.mock('../../../src/utils/logger.js', () => ({
 }));
 
 const mockExecFileAsync = vi.fn();
+const mockExecFileSync = vi.fn();
 vi.mock('node:child_process', () => ({
   execFile: vi.fn(),
+  execFileSync: (...args: unknown[]) => mockExecFileSync(...args),
 }));
 vi.mock('node:util', () => ({
   promisify: () => (...args: unknown[]) => mockExecFileAsync(...args),
@@ -68,6 +70,16 @@ describe('UpdaterWatchdog', () => {
 
   beforeEach(async () => {
     tmpDir = await createTempDir('updater-watchdog-test-');
+    mockExecFileSync.mockReset();
+    mockExecFileSync.mockImplementation((cmd: string, args: string[] = []) => {
+      if (cmd === 'ps' && args.includes('-p')) {
+        return 'node /home/test/.loongsuite-pilot/bin/updater-daemon.js\n';
+      }
+      if (cmd === 'powershell.exe' && args.includes('-Command')) {
+        return 'node C:\\Users\\test\\.loongsuite-pilot\\bin\\updater-daemon.js\n';
+      }
+      return '';
+    });
     mockExecFileAsync.mockReset();
     mockExecFileAsync.mockImplementation((cmd: string, args: string[]) => {
       if (cmd === 'ps') {

--- a/tests/unit/metrics/metrics-collector.test.ts
+++ b/tests/unit/metrics/metrics-collector.test.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { MetricsCollector } from '../../../src/metrics/metrics-collector.js';
 import type { DataflowSnapshot } from '../../../src/metrics/metrics-collector.js';
+import type { ProcessLiveness } from '../../../src/utils/pid-utils.js';
 
 function buildSnapshot(overrides: Partial<DataflowSnapshot> = {}): DataflowSnapshot {
   return {
@@ -293,50 +294,70 @@ describe('MetricsCollector', () => {
   });
 
   describe('infra health (via collectL1)', () => {
-    it('reports updater_pid_alive=true during grace period even if PID file missing', () => {
-      const col = new MetricsCollector({ version: '1.0.0', userId: 'test-user', dataDir: tmpDir });
+    it('reports updater_pid_alive=true during grace period even if updater liveness is down', () => {
+      const col = new MetricsCollector({
+        version: '1.0.0',
+        userId: 'test-user',
+        dataDir: tmpDir,
+        updaterLiveness: () => down('pid file is missing'),
+      });
       const r1 = col.collectL1(buildSnapshot());
       const r2 = col.collectL1(buildSnapshot());
       expect(r1.updater_pid_alive).toBe('true');
       expect(r2.updater_pid_alive).toBe('true');
     });
 
-    it('reports updater_pid_alive=false after grace period when PID file missing', () => {
-      const col = new MetricsCollector({ version: '1.0.0', userId: 'test-user', dataDir: tmpDir });
-      col.collectL1(buildSnapshot()); // cycle 1
-      col.collectL1(buildSnapshot()); // cycle 2
-      const r3 = col.collectL1(buildSnapshot()); // cycle 3 - past grace
+    it('reports updater_pid_alive=false after grace period when updater identity is absent', () => {
+      const col = new MetricsCollector({
+        version: '1.0.0',
+        userId: 'test-user',
+        dataDir: tmpDir,
+        updaterLiveness: () => down('no matching updater command found'),
+      });
+      col.collectL1(buildSnapshot());
+      col.collectL1(buildSnapshot());
+      const r3 = col.collectL1(buildSnapshot());
       expect(r3.updater_pid_alive).toBe('false');
-    });
-
-    it('reports updater_pid_alive=true when PID file contains current process PID', () => {
-      fs.writeFileSync(path.join(tmpDir, 'loongsuite-pilot-updater.pid'), String(process.pid));
-      const col = new MetricsCollector({ version: '1.0.0', userId: 'test-user', dataDir: tmpDir });
-      col.collectL1(buildSnapshot()); // cycle 1
-      col.collectL1(buildSnapshot()); // cycle 2
-      const r3 = col.collectL1(buildSnapshot()); // cycle 3
-      expect(r3.updater_pid_alive).toBe('true');
-    });
-
-    it('reports updater_pid_alive=false when PID file contains malformed content', () => {
-      fs.writeFileSync(path.join(tmpDir, 'loongsuite-pilot-updater.pid'), 'abc\n');
-      const col = new MetricsCollector({ version: '1.0.0', userId: 'test-user', dataDir: tmpDir });
-      col.collectL1(buildSnapshot()); // grace 1
-      col.collectL1(buildSnapshot()); // grace 2
-      const r3 = col.collectL1(buildSnapshot()); // past grace
-      expect(r3.updater_pid_alive).toBe('false');
-    });
-
-    it('increments consecutive failures and resets on alive', () => {
-      const col = new MetricsCollector({ version: '1.0.0', userId: 'test-user', dataDir: tmpDir });
-      col.collectL1(buildSnapshot()); // grace 1
-      col.collectL1(buildSnapshot()); // grace 2
-      col.collectL1(buildSnapshot()); // fail 1
       expect(col.getLastInfraHealth()!.updaterConsecutiveFailures).toBe(1);
-      col.collectL1(buildSnapshot()); // fail 2
-      expect(col.getLastInfraHealth()!.updaterConsecutiveFailures).toBe(2);
+    });
 
-      fs.writeFileSync(path.join(tmpDir, 'loongsuite-pilot-updater.pid'), String(process.pid));
+    it('reports updater_pid_alive=true when stale PID is recovered by process identity scan', () => {
+      const col = new MetricsCollector({
+        version: '1.0.0',
+        userId: 'test-user',
+        dataDir: tmpDir,
+        updaterLiveness: () => ({
+          running: true,
+          pid: 456,
+          source: 'process-scan',
+          reason: 'matching process command found; pid file points to stale or mismatched pid 123',
+          pidFileState: 'stale',
+        }),
+      });
+      col.collectL1(buildSnapshot());
+      col.collectL1(buildSnapshot());
+      const r3 = col.collectL1(buildSnapshot());
+      expect(r3.updater_pid_alive).toBe('true');
+      expect(col.getLastInfraHealth()!.updaterConsecutiveFailures).toBe(0);
+    });
+
+    it('increments consecutive failures and resets on identity match', () => {
+      const liveness = vi.fn<[], ProcessLiveness>()
+        .mockReturnValueOnce(down('no matching updater command found'))
+        .mockReturnValueOnce(down('no matching updater command found'))
+        .mockReturnValueOnce({ running: true, pid: 456, source: 'process-scan', reason: 'matching process command found' });
+      const col = new MetricsCollector({
+        version: '1.0.0',
+        userId: 'test-user',
+        dataDir: tmpDir,
+        updaterLiveness: liveness,
+      });
+      col.collectL1(buildSnapshot());
+      col.collectL1(buildSnapshot());
+      col.collectL1(buildSnapshot());
+      expect(col.getLastInfraHealth()!.updaterConsecutiveFailures).toBe(1);
+      col.collectL1(buildSnapshot());
+      expect(col.getLastInfraHealth()!.updaterConsecutiveFailures).toBe(2);
       col.collectL1(buildSnapshot());
       expect(col.getLastInfraHealth()!.updaterConsecutiveFailures).toBe(0);
       expect(col.getLastInfraHealth()!.updaterPidAlive).toBe(true);
@@ -457,3 +478,12 @@ describe('MetricsCollector', () => {
     });
   });
 });
+
+function down(reason: string): ProcessLiveness {
+  return {
+    running: false,
+    source: 'none',
+    reason,
+    pidFileState: 'missing',
+  };
+}

--- a/tests/unit/metrics/metrics-writer.test.ts
+++ b/tests/unit/metrics/metrics-writer.test.ts
@@ -310,6 +310,12 @@ describe('MetricsWriter', () => {
         userId: 'u1',
         getSnapshot: buildSnapshot,
         alarmManager,
+        updaterLiveness: () => ({
+          running: false,
+          source: 'none',
+          reason: 'no matching updater command found',
+          pidFileState: 'missing',
+        }),
       });
 
       vi.useRealTimers();

--- a/tests/unit/updater/updater-metrics.test.ts
+++ b/tests/unit/updater/updater-metrics.test.ts
@@ -22,11 +22,14 @@ vi.mock('../../../src/internal/sender.js', () => ({
 }));
 
 const mockReadFileSync = vi.fn<[string, string], string>();
+const mockExistsSync = vi.fn<[string], boolean>();
 vi.mock('node:fs', () => ({
   readFileSync: (...args: [string, string]) => mockReadFileSync(...args),
+  existsSync: (...args: [string]) => mockExistsSync(...args),
 }));
 
 import { UpdaterMetrics } from '../../../src/updater/updater-metrics.js';
+import type { ProcessLiveness } from '../../../src/utils/pid-utils.js';
 
 describe('UpdaterMetrics', () => {
   let killSpy: ReturnType<typeof vi.spyOn> | null = null;
@@ -38,6 +41,7 @@ describe('UpdaterMetrics', () => {
     mockSendAlarm.mockClear();
     mockSendStatus.mockClear();
     mockReadFileSync.mockReturnValue('12345\n');
+    mockExistsSync.mockReturnValue(true);
     killSpy = vi.spyOn(process, 'kill').mockImplementation(((pid: number, signal?: number) => {
       if (signal === 0) return true;
       throw new Error('not supported');
@@ -50,12 +54,13 @@ describe('UpdaterMetrics', () => {
     vi.useRealTimers();
   });
 
-  function createMetrics(userId = 'test-user') {
+  function createMetrics(userId = 'test-user', collectorLiveness?: () => ProcessLiveness) {
     return new UpdaterMetrics({
       dataDir: '/tmp/test-data',
       version: '1.0.0',
       collectorPidFile: '/tmp/test-data/loongsuite-pilot.pid',
       userId,
+      collectorLiveness,
     });
   }
 
@@ -244,58 +249,87 @@ describe('UpdaterMetrics', () => {
   });
 
   describe('collector health check', () => {
-    it('writes SERVICE_NOT_RUNNING_ALARM when collector PID file is missing', async () => {
-      mockReadFileSync.mockImplementation(() => {
-        throw new Error('ENOENT');
-      });
+    it('suppresses SERVICE_NOT_RUNNING_ALARM during startup grace', async () => {
+      const m = createMetrics('test-user', () => down('pid file is missing'));
 
-      const m = createMetrics();
-      await m.start();
-      await m.stop();
-
-      const alarmLines = appendedLines.filter(l => l.path.includes('pilot-alarms.jsonl'));
-      expect(alarmLines.length).toBeGreaterThanOrEqual(1);
-      const parsed = JSON.parse(alarmLines[0].line);
-      expect(parsed.alarm_type).toBe('SERVICE_NOT_RUNNING_ALARM');
-      expect(parsed.alarm_level).toBe('3');
-    });
-
-    it('does NOT write alarm when collector process is running', async () => {
-      mockReadFileSync.mockReturnValue('12345\n');
-      const killSpy = vi.spyOn(process, 'kill').mockImplementation(((pid: number, signal?: number) => {
-        if (signal === 0) return true;
-        throw new Error('not supported');
-      }) as typeof process.kill);
-
-      const m = createMetrics();
       await m.start();
       await m.stop();
 
       const alarmLines = appendedLines.filter(l => l.path.includes('pilot-alarms.jsonl'));
       expect(alarmLines).toHaveLength(0);
-
-      killSpy.mockRestore();
     });
 
-    it('fires health check every 60 seconds', async () => {
-      mockReadFileSync.mockImplementation(() => {
-        throw new Error('ENOENT');
-      });
+    it('requires two consecutive misses after startup grace before alarming', async () => {
+      const m = createMetrics('test-user', () => down('no matching collector command found'));
 
-      const m = createMetrics();
       await m.start();
+      await vi.advanceTimersByTimeAsync(3 * 60_000 + 60_000);
+      await vi.advanceTimersByTimeAsync(60_000);
 
-      await vi.advanceTimersByTimeAsync(30_000);
-      await vi.advanceTimersByTimeAsync(0);
-      const before = appendedLines.filter(l => l.path.includes('pilot-alarms.jsonl')).length;
+      const alarmLines = appendedLines.filter(l => l.path.includes('pilot-alarms.jsonl'));
+      expect(alarmLines).toHaveLength(1);
+      const parsed = JSON.parse(alarmLines[0].line);
+      expect(parsed.alarm_type).toBe('SERVICE_NOT_RUNNING_ALARM');
+      expect(parsed.alarm_message).toContain('no matching collector command found');
+      await m.stop();
+    });
 
-      await vi.advanceTimersByTimeAsync(30_000);
-      await vi.advanceTimersByTimeAsync(0);
+    it('does not alarm when collector PID changes but command identity is found', async () => {
+      const m = createMetrics('test-user', () => ({
+        running: true,
+        pid: 456,
+        source: 'process-scan',
+        reason: 'matching process command found; pid file points to stale or mismatched pid 123',
+        pidFileState: 'stale',
+      }));
 
-      const after = appendedLines.filter(l => l.path.includes('pilot-alarms.jsonl')).length;
-      expect(after).toBeGreaterThan(before);
+      await m.start();
+      await vi.advanceTimersByTimeAsync(3 * 60_000 + 60_000);
+      await vi.advanceTimersByTimeAsync(60_000);
+      await m.stop();
 
+      const alarmLines = appendedLines.filter(l => l.path.includes('pilot-alarms.jsonl'));
+      expect(alarmLines).toHaveLength(0);
+    });
+
+    it('resets collector failures after process identity recovery', async () => {
+      let call = 0;
+      const liveness = vi.fn<[], ProcessLiveness>().mockImplementation(() => {
+        call++;
+        if (call <= 4) return down('no matching collector command found');
+        return { running: true, pid: 456, source: 'process-scan', reason: 'matching process command found' };
+      });
+      const m = createMetrics('test-user', liveness);
+
+      await m.start();
+      await vi.advanceTimersByTimeAsync(3 * 60_000 + 60_000);
+      await m.stop();
+
+      const alarmLines = appendedLines.filter(l => l.path.includes('pilot-alarms.jsonl'));
+      expect(alarmLines).toHaveLength(0);
+    });
+
+    it('respects service alarm cooldown for persistent misses', async () => {
+      const m = createMetrics('test-user', () => down('no matching collector command found'));
+
+      await m.start();
+      await vi.advanceTimersByTimeAsync(3 * 60_000 + 60_000);
+      await vi.advanceTimersByTimeAsync(60_000);
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      const alarmLines = appendedLines.filter(l => l.path.includes('pilot-alarms.jsonl'));
+      expect(alarmLines).toHaveLength(1);
       await m.stop();
     });
   });
 });
+
+function down(reason: string): ProcessLiveness {
+  return {
+    running: false,
+    source: 'none',
+    reason,
+    pidFileState: 'missing',
+  };
+}
+

--- a/tests/unit/utils/pid-utils.test.ts
+++ b/tests/unit/utils/pid-utils.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import {
+  checkProcessLiveness,
+  COLLECTOR_PROCESS_PATTERNS,
+  isCommandMatch,
+  isProcessAlive,
+  UPDATER_PROCESS_PATTERNS,
+} from '../../../src/utils/pid-utils.js';
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    readFileSync: vi.fn(),
+    existsSync: vi.fn(),
+  };
+});
+
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  return {
+    ...actual,
+    execFileSync: vi.fn(),
+  };
+});
+
+const readFileSyncMock = vi.mocked(fs.readFileSync);
+const existsSyncMock = vi.mocked(fs.existsSync);
+const execFileSyncMock = vi.mocked(execFileSync);
+
+describe('pid-utils identity-first liveness', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('matches strict collector and updater command identities', () => {
+    expect(isCommandMatch('/usr/bin/node /home/a/.loongsuite-pilot/bin/collector-daemon.js', COLLECTOR_PROCESS_PATTERNS)).toBe(true);
+    expect(isCommandMatch('/usr/bin/node /home/a/.loongsuite-pilot/bin/updater-daemon.js', UPDATER_PROCESS_PATTERNS)).toBe(true);
+    expect(isCommandMatch('/usr/bin/node unrelated.js', COLLECTOR_PROCESS_PATTERNS)).toBe(false);
+    expect(isCommandMatch('/usr/bin/node unrelated.js', UPDATER_PROCESS_PATTERNS)).toBe(false);
+  });
+
+  it('treats EPERM from kill zero as alive', () => {
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      const err = new Error('not permitted') as NodeJS.ErrnoException;
+      err.code = 'EPERM';
+      throw err;
+    });
+
+    expect(isProcessAlive(123)).toBe(true);
+  });
+
+  it('uses pid file as fast path when pid command matches identity', () => {
+    readFileSyncMock.mockReturnValueOnce('123\n');
+    vi.spyOn(process, 'kill').mockReturnValue(true);
+    execFileSyncMock.mockReturnValueOnce('/usr/bin/node /tmp/collector-daemon.js\n');
+
+    const result = checkProcessLiveness('/tmp/pilot.pid', COLLECTOR_PROCESS_PATTERNS);
+
+    expect(result).toMatchObject({
+      running: true,
+      pid: 123,
+      source: 'pid-file',
+      pidFileState: 'matched',
+    });
+  });
+
+  it('does not report down when pid changed but command identity is present', () => {
+    readFileSyncMock.mockReturnValueOnce('123\n');
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      const err = new Error('missing') as NodeJS.ErrnoException;
+      err.code = 'ESRCH';
+      throw err;
+    });
+    execFileSyncMock.mockReturnValueOnce('456 /usr/bin/node /tmp/collector-daemon.js\n');
+
+    const result = checkProcessLiveness('/tmp/pilot.pid', COLLECTOR_PROCESS_PATTERNS);
+
+    expect(result).toMatchObject({
+      running: true,
+      pid: 456,
+      source: 'process-scan',
+      pidFileState: 'stale',
+    });
+  });
+
+  it('reports unhealthy when pid is stale and no matching command exists', () => {
+    readFileSyncMock.mockReturnValueOnce('123\n');
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      const err = new Error('missing') as NodeJS.ErrnoException;
+      err.code = 'ESRCH';
+      throw err;
+    });
+    execFileSyncMock.mockReturnValueOnce('456 /usr/bin/node unrelated.js\n');
+
+    const result = checkProcessLiveness('/tmp/pilot.pid', COLLECTOR_PROCESS_PATTERNS);
+
+    expect(result).toMatchObject({
+      running: false,
+      pid: 123,
+      source: 'none',
+      pidFileState: 'stale',
+    });
+  });
+
+  it('falls back to command identity when pid file is missing', () => {
+    readFileSyncMock.mockImplementationOnce(() => {
+      throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+    });
+    existsSyncMock.mockReturnValueOnce(false);
+    execFileSyncMock.mockReturnValueOnce('789 /usr/bin/node /tmp/updater-daemon.js\n');
+
+    const result = checkProcessLiveness('/tmp/updater.pid', UPDATER_PROCESS_PATTERNS);
+
+    expect(result).toMatchObject({
+      running: true,
+      pid: 789,
+      source: 'process-scan',
+      pidFileState: 'missing',
+    });
+  });
+});

--- a/tests/unit/utils/pid-utils.test.ts
+++ b/tests/unit/utils/pid-utils.test.ts
@@ -67,6 +67,42 @@ describe('pid-utils identity-first liveness', () => {
     });
   });
 
+  it('falls through to process scan when pid file command is unreadable', () => {
+    readFileSyncMock.mockReturnValueOnce('123\n');
+    vi.spyOn(process, 'kill').mockReturnValue(true);
+    execFileSyncMock.mockReturnValueOnce('');
+    execFileSyncMock.mockReturnValueOnce('456 /usr/bin/node /tmp/collector-daemon.js\n');
+
+    const result = checkProcessLiveness('/tmp/pilot.pid', COLLECTOR_PROCESS_PATTERNS);
+
+    expect(result).toMatchObject({
+      running: true,
+      pid: 456,
+      source: 'process-scan',
+      pidFileState: 'stale',
+      pidFileProcessAlive: true,
+      pidFileCommandMatched: undefined,
+    });
+  });
+
+  it('reports unhealthy when pid file command is unreadable and scan finds nothing', () => {
+    readFileSyncMock.mockReturnValueOnce('123\n');
+    vi.spyOn(process, 'kill').mockReturnValue(true);
+    execFileSyncMock.mockReturnValueOnce('');
+    execFileSyncMock.mockReturnValueOnce('456 /usr/bin/node unrelated.js\n');
+
+    const result = checkProcessLiveness('/tmp/pilot.pid', COLLECTOR_PROCESS_PATTERNS);
+
+    expect(result).toMatchObject({
+      running: false,
+      pid: 123,
+      source: 'none',
+      pidFileState: 'stale',
+      pidFileProcessAlive: true,
+      pidFileCommandMatched: undefined,
+    });
+  });
+
   it('does not report down when pid changed but command identity is present', () => {
     readFileSyncMock.mockReturnValueOnce('123\n');
     vi.spyOn(process, 'kill').mockImplementation(() => {

--- a/tests/unit/utils/process-discovery.test.ts
+++ b/tests/unit/utils/process-discovery.test.ts
@@ -27,15 +27,22 @@ describe('isUpdaterRunningOnWindowsSync', () => {
     setPlatform(originalPlatform);
   });
 
-  it('returns true when powershell output contains a numeric PID line', () => {
+  it('returns true when powershell output contains a matching updater command line', () => {
     setPlatform('win32');
-    mockedExecFileSync.mockReturnValueOnce('12345\r\n' as unknown as Buffer);
+    mockedExecFileSync.mockReturnValueOnce('12345\tnode C:\\Users\\test\\.loongsuite-pilot\\bin\\updater-daemon.js\r\n' as unknown as Buffer);
     expect(isUpdaterRunningOnWindowsSync()).toBe(true);
     expect(mockedExecFileSync).toHaveBeenCalledWith(
       'powershell.exe',
       expect.arrayContaining(['-NoProfile', '-WindowStyle', 'Hidden', '-Command']),
-      expect.objectContaining({ timeout: 3000, encoding: 'utf-8', windowsHide: true }),
+      expect.objectContaining({ timeout: 8000, encoding: 'utf-8', windowsHide: true }),
     );
+    setPlatform(originalPlatform);
+  });
+
+  it('returns false when powershell output has no matching updater command', () => {
+    setPlatform('win32');
+    mockedExecFileSync.mockReturnValueOnce('12345\tnode unrelated.js\r\n' as unknown as Buffer);
+    expect(isUpdaterRunningOnWindowsSync()).toBe(false);
     setPlatform(originalPlatform);
   });
 


### PR DESCRIPTION
## Summary
- Switch collector/updater liveness checks to identity-first process matching, using PID files as a fast path and diagnostic signal.
- Debounce collector service-not-running alarms with startup grace, consecutive failure threshold, and cooldown.
- Keep updater watchdog failure semantics for command mismatch and heartbeat issues, while accepting PID changes when updater identity is found.

## Test plan
- [x] npm run typecheck --silent
- [x] npx vitest run tests/unit/utils/pid-utils.test.ts tests/unit/utils/process-discovery.test.ts tests/unit/updater/updater-metrics.test.ts tests/unit/metrics/metrics-collector.test.ts tests/unit/metrics/metrics-writer.test.ts tests/unit/core/updater-watchdog.test.ts --silent