### PR TITLE
Fix Wukong activity snapshot tool field mapping

### DIFF
--- a/src/inputs/wukong/wukong-input.ts
+++ b/src/inputs/wukong/wukong-input.ts
@@ -1223,12 +1223,10 @@ export class WukongInput extends BaseInput {
           args = content.command ? { command: content.command } : undefined;
           result = { output: content.output, exit_code: content.exit_code };
           break;
-        case 'FILE_WRITE': {
-          const filePath = content.path ?? content.file_path;
-          args = filePath !== undefined ? { path: filePath } : undefined;
+        case 'FILE_WRITE':
+          args = compactObject({ path: content.path ?? content.file_path });
           result = { status: content.status ?? 'done' };
           break;
-        }
         case 'FILE_READ':
           args = compactObject({ path: content.path, start_line: content.start_line });
           result = compactObject({
@@ -1294,7 +1292,10 @@ export class WukongInput extends BaseInput {
       attributes: { source: 'wukong', message_id: msg.id },
     });
 
-    const hasError = content?.exit_code !== undefined && content.exit_code !== 0;
+    const toolResultStatus = resolveActivityResultStatus(content);
+    const errorMessage = typeof content?.error_message === 'string' && content.error_message.length > 0
+      ? content.error_message
+      : undefined;
     const toolResultEntry = buildAgentActivityEntry({
       timestamp: finishTime,
       'event.id': hashId([task.session_id, msg.id, 'activity_result', toolCallId, String(toolIdx + 1)]),
@@ -1307,7 +1308,8 @@ export class WukongInput extends BaseInput {
       'gen_ai.tool.call.id': toolCallId,
       ...(result !== undefined ? { 'gen_ai.tool.call.result': toJsonValue(result) } : {}),
       ...(duration !== undefined ? { 'gen_ai.tool.call.duration': duration } : {}),
-      'tool.result.status': hasError ? 'failure' : 'success',
+      'tool.result.status': toolResultStatus,
+      ...(errorMessage !== undefined ? { 'error.message': errorMessage } : {}),
       'trace_id': traceId,
       'span_id': resultSpanId,
       'parent_span_id': parentSpanId,
@@ -1402,6 +1404,18 @@ function numOr(value: unknown): number | undefined {
 function compactObject(fields: Record<string, unknown>): Record<string, unknown> | undefined {
   const entries = Object.entries(fields).filter(([, value]) => value !== undefined && value !== null);
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function resolveActivityResultStatus(content: Record<string, unknown> | undefined): 'success' | 'failure' | 'cancelled' {
+  if (!content) return 'success';
+  if (content.exit_code !== undefined && content.exit_code !== 0) return 'failure';
+  if (typeof content.error_message === 'string' && content.error_message.length > 0) return 'failure';
+  if (typeof content.status !== 'string') return 'success';
+
+  const status = content.status.toLowerCase();
+  if (status === 'error' || status === 'failed' || status === 'failure') return 'failure';
+  if (status === 'cancelled' || status === 'canceled') return 'cancelled';
+  return 'success';
 }
 
 function resolveTurnId(sessionId: string, msg: WukongMessage): string {

--- a/src/inputs/wukong/wukong-input.ts
+++ b/src/inputs/wukong/wukong-input.ts
@@ -83,7 +83,9 @@ interface StepContext {
 const ACTIVITY_TYPE_TO_TOOL_NAME: Record<string, string> = {
   TERMINAL: 'terminal',
   FILE_WRITE: 'file_write',
+  FILE_READ: 'file_read',
   GREP_SEARCH: 'grep_search',
+  SEARCH: 'search',
   DIRECTORY_LIST: 'directory_list',
   SKILL: 'skill',
   ARTIFACT: 'artifact',
@@ -1221,17 +1223,48 @@ export class WukongInput extends BaseInput {
           args = content.command ? { command: content.command } : undefined;
           result = { output: content.output, exit_code: content.exit_code };
           break;
-        case 'FILE_WRITE':
-          args = content.path ? { path: content.path } : undefined;
+        case 'FILE_WRITE': {
+          const filePath = content.path ?? content.file_path;
+          args = filePath !== undefined ? { path: filePath } : undefined;
           result = { status: content.status ?? 'done' };
+          break;
+        }
+        case 'FILE_READ':
+          args = compactObject({ path: content.path, start_line: content.start_line });
+          result = compactObject({
+            content: content.content,
+            snippet: content.snippet,
+            total_lines: content.total_lines,
+            status: content.status,
+            error_message: content.error_message,
+          });
           break;
         case 'GREP_SEARCH':
           args = content.query ? { query: content.query } : undefined;
           result = content.matches ?? content.output;
           break;
+        case 'SEARCH':
+          args = compactObject({ queries: content.queries, search_type: content.search_type });
+          result = compactObject({ results: content.results, status: content.status });
+          break;
         case 'DIRECTORY_LIST':
           args = content.path ? { path: content.path } : undefined;
-          result = content.entries ?? content.output;
+          result = content.entries ?? content.output ?? compactObject({
+            files: content.files,
+            total_count: content.total_count,
+            status: content.status,
+          });
+          break;
+        case 'SKILL':
+          args = compactObject({ skill_name: content.skill_name, purpose: content.purpose, meta: content.meta });
+          result = compactObject({
+            output: content.output,
+            status: content.status,
+            error_message: content.error_message,
+          });
+          break;
+        case 'ARTIFACT':
+          result = compactObject({ artifactsMetadata: content.artifactsMetadata, generatedAt: content.generatedAt });
           break;
         default:
           args = content.input ?? undefined;
@@ -1364,6 +1397,11 @@ function hashId(parts: Array<string | number | undefined>): string {
 
 function numOr(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function compactObject(fields: Record<string, unknown>): Record<string, unknown> | undefined {
+  const entries = Object.entries(fields).filter(([, value]) => value !== undefined && value !== null);
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
 function resolveTurnId(sessionId: string, msg: WukongMessage): string {

--- a/tests/unit/inputs/wukong-input.test.ts
+++ b/tests/unit/inputs/wukong-input.test.ts
@@ -1042,6 +1042,73 @@ describe('WukongInput', () => {
     expect(fileWriteCall!['gen_ai.tool.call.arguments']).toEqual({ path: '/repo/src/new-file.ts' });
   });
 
+  it('omits null activity arguments and marks failed activity snapshots consistently', async () => {
+    const activityMessages = [
+      SAMPLE_MESSAGES[0],
+      {
+        id: 'msg-activity-failure',
+        conversationId: 'sess-1',
+        role: 'assistant' as const,
+        content: null,
+        events: [
+          { type: 'RUN_STARTED', runId: 'run-act-failure', threadId: 'sess-1', timestamp: 1779240560000 },
+          {
+            type: 'ACTIVITY_SNAPSHOT', activityType: 'FILE_WRITE', timestamp: 1779240560100,
+            content: { file_path: null, status: 'done', start_time: 1779240560100, finish_time: 1779240560200 },
+          },
+          {
+            type: 'ACTIVITY_SNAPSHOT', activityType: 'FILE_READ', timestamp: 1779240560300,
+            content: {
+              path: '/missing.ts', status: 'failed', error_message: 'file not found',
+              start_time: 1779240560300, finish_time: 1779240560400,
+            },
+          },
+          {
+            type: 'ACTIVITY_SNAPSHOT', activityType: 'SKILL', timestamp: 1779240560500,
+            content: {
+              skill_name: 'missing_skill', status: 'error', error_message: 'skill failed',
+              start_time: 1779240560500, finish_time: 1779240560600,
+            },
+          },
+          { type: 'TEXT_MESSAGE_CONTENT', delta: 'Done.', messageId: 'text-3', timestamp: 1779240560700 },
+          { type: 'USAGE', prompt_tokens: 100, completion_tokens: 10, total_tokens: 110, timestamp: 1779240560800 },
+          { type: 'RUN_FINISHED', runId: 'run-act-failure', threadId: 'sess-1', timestamp: 1779240560800 },
+        ],
+        createdAt: 1779240560000,
+        timestamp: 1779240560000,
+        turnIndex: 1,
+      },
+    ];
+
+    mockExecFile.mockImplementation(makeExecFileImpl({
+      list_tasks: JSON.stringify({ hasMore: false, items: [SAMPLE_TASK] }),
+      get_spark_agui_messages: JSON.stringify({ messages: activityMessages }),
+    }));
+
+    createInput();
+    seedSeenCounts();
+    const entries: AgentActivityEntry[] = [];
+    input.on('entries', (e: AgentActivityEntry[]) => entries.push(...e));
+    await input.start();
+    await input.stop();
+
+    const toolCallByName = (name: string) => entries.find(e => e['event.name'] === 'tool.call' && e['gen_ai.tool.name'] === name);
+    const toolResultByName = (name: string) => entries.find(e => e['event.name'] === 'tool.result' && e['gen_ai.tool.name'] === name);
+
+    expect(toolCallByName('file_write')!['gen_ai.tool.call.arguments']).toBeUndefined();
+
+    const fileReadResult = toolResultByName('file_read');
+    expect(fileReadResult!['tool.result.status']).toBe('failure');
+    expect(fileReadResult!['error.type']).toBe('_OTHER');
+    expect(fileReadResult!['error.message']).toBe('file not found');
+    expect(fileReadResult!['gen_ai.tool.call.result']).toEqual({ status: 'failed', error_message: 'file not found' });
+
+    const skillResult = toolResultByName('skill');
+    expect(skillResult!['tool.result.status']).toBe('failure');
+    expect(skillResult!['error.type']).toBe('_OTHER');
+    expect(skillResult!['error.message']).toBe('skill failed');
+  });
+
   it('generates trace_id and span_id on all assistant-derived entries', async () => {
     const listResp = JSON.stringify({ hasMore: false, items: [SAMPLE_TASK] });
     const msgsResp = JSON.stringify({ messages: SAMPLE_MESSAGES });

--- a/tests/unit/inputs/wukong-input.test.ts
+++ b/tests/unit/inputs/wukong-input.test.ts
@@ -934,6 +934,114 @@ describe('WukongInput', () => {
     expect(toolResult!['gen_ai.tool.call.duration']).toBe(200);
   });
 
+  it('maps FILE_READ, SEARCH, DIRECTORY_LIST, SKILL, ARTIFACT, and FILE_WRITE activity snapshots to canonical fields', async () => {
+    const activityMessages = [
+      SAMPLE_MESSAGES[0],
+      {
+        id: 'msg-activity-2',
+        conversationId: 'sess-1',
+        role: 'assistant' as const,
+        content: null,
+        events: [
+          { type: 'RUN_STARTED', runId: 'run-act-2', threadId: 'sess-1', timestamp: 1779240560000 },
+          {
+            type: 'ACTIVITY_SNAPSHOT', activityType: 'FILE_READ', timestamp: 1779240560100,
+            content: {
+              path: '/repo/src/index.ts', content: 'export const a = 1;', snippet: 'export const a = 1;',
+              total_lines: 1, status: 'success', start_time: 1779240560100, finish_time: 1779240560200,
+            },
+          },
+          {
+            type: 'ACTIVITY_SNAPSHOT', activityType: 'SEARCH', timestamp: 1779240560300,
+            content: {
+              queries: ['loongsuite pilot'], search_type: 'web', results: [{ title: 'result-1' }],
+              status: 'success', start_time: 1779240560300, finish_time: 1779240560400,
+            },
+          },
+          {
+            type: 'ACTIVITY_SNAPSHOT', activityType: 'DIRECTORY_LIST', timestamp: 1779240560500,
+            content: {
+              path: '/repo/src', files: ['index.ts', 'utils.ts'], total_count: 2,
+              status: 'success', start_time: 1779240560500, finish_time: 1779240560600,
+            },
+          },
+          {
+            type: 'ACTIVITY_SNAPSHOT', activityType: 'SKILL', timestamp: 1779240560700,
+            content: {
+              skill_name: 'search_skills', purpose: 'find relevant skill', output: 'skill-output',
+              status: 'success', start_time: 1779240560700, finish_time: 1779240560800,
+            },
+          },
+          {
+            type: 'ACTIVITY_SNAPSHOT', activityType: 'ARTIFACT', timestamp: 1779240560900,
+            content: {
+              artifactsMetadata: [{ id: 'artifact-1', name: 'report.md' }], generatedAt: 1779240560900,
+              start_time: 1779240560900, finish_time: 1779240561000,
+            },
+          },
+          {
+            type: 'ACTIVITY_SNAPSHOT', activityType: 'FILE_WRITE', timestamp: 1779240561100,
+            content: {
+              file_path: '/repo/src/new-file.ts', status: 'done',
+              start_time: 1779240561100, finish_time: 1779240561200,
+            },
+          },
+          { type: 'TEXT_MESSAGE_CONTENT', delta: 'Done.', messageId: 'text-2', timestamp: 1779240561300 },
+          { type: 'USAGE', prompt_tokens: 100, completion_tokens: 10, total_tokens: 110, timestamp: 1779240561400 },
+          { type: 'RUN_FINISHED', runId: 'run-act-2', threadId: 'sess-1', timestamp: 1779240561400 },
+        ],
+        createdAt: 1779240560000,
+        timestamp: 1779240560000,
+        turnIndex: 1,
+      },
+    ];
+
+    mockExecFile.mockImplementation(makeExecFileImpl({
+      list_tasks: JSON.stringify({ hasMore: false, items: [SAMPLE_TASK] }),
+      get_spark_agui_messages: JSON.stringify({ messages: activityMessages }),
+    }));
+
+    createInput();
+    seedSeenCounts();
+    const entries: AgentActivityEntry[] = [];
+    input.on('entries', (e: AgentActivityEntry[]) => entries.push(...e));
+    await input.start();
+    await input.stop();
+
+    const toolCallByName = (name: string) => entries.find(e => e['event.name'] === 'tool.call' && e['gen_ai.tool.name'] === name);
+    const toolResultByName = (name: string) => entries.find(e => e['event.name'] === 'tool.result' && e['gen_ai.tool.name'] === name);
+
+    const fileReadCall = toolCallByName('file_read');
+    expect(fileReadCall!['gen_ai.tool.call.arguments']).toEqual({ path: '/repo/src/index.ts' });
+    const fileReadResult = toolResultByName('file_read');
+    expect(fileReadResult!['gen_ai.tool.call.result']).toEqual({
+      content: 'export const a = 1;', snippet: 'export const a = 1;', total_lines: 1, status: 'success',
+    });
+
+    const searchCall = toolCallByName('search');
+    expect(searchCall!['gen_ai.tool.call.arguments']).toEqual({ queries: ['loongsuite pilot'], search_type: 'web' });
+    const searchResult = toolResultByName('search');
+    expect(searchResult!['gen_ai.tool.call.result']).toEqual({ results: [{ title: 'result-1' }], status: 'success' });
+
+    const dirListResult = toolResultByName('directory_list');
+    expect(dirListResult!['gen_ai.tool.call.result']).toEqual({ files: ['index.ts', 'utils.ts'], total_count: 2, status: 'success' });
+
+    const skillCall = toolCallByName('skill');
+    expect(skillCall!['gen_ai.tool.call.arguments']).toEqual({ skill_name: 'search_skills', purpose: 'find relevant skill' });
+    const skillResult = toolResultByName('skill');
+    expect(skillResult!['gen_ai.tool.call.result']).toEqual({ output: 'skill-output', status: 'success' });
+
+    const artifactCall = toolCallByName('artifact');
+    expect(artifactCall!['gen_ai.tool.call.arguments']).toBeUndefined();
+    const artifactResult = toolResultByName('artifact');
+    expect(artifactResult!['gen_ai.tool.call.result']).toEqual({
+      artifactsMetadata: [{ id: 'artifact-1', name: 'report.md' }], generatedAt: 1779240560900,
+    });
+
+    const fileWriteCall = toolCallByName('file_write');
+    expect(fileWriteCall!['gen_ai.tool.call.arguments']).toEqual({ path: '/repo/src/new-file.ts' });
+  });
+
   it('generates trace_id and span_id on all assistant-derived entries', async () => {
     const listResp = JSON.stringify({ hasMore: false, items: [SAMPLE_TASK] });
     const msgsResp = JSON.stringify({ messages: SAMPLE_MESSAGES });


### PR DESCRIPTION
## Summary
- Map Wukong `FILE_READ`, `SEARCH`, `DIRECTORY_LIST`, `SKILL`, and `ARTIFACT` activity snapshots to canonical tool arguments/results.
- Preserve `FILE_WRITE.file_path` as canonical tool call arguments.
- Add Wukong unit coverage for activity snapshot payload shapes observed from the API.

## Test plan
- [x] `npm test -- tests/unit/inputs/wukong-input.test.ts`
- [x] `npm run typecheck --silent`