### PR TITLE
fix: remove nohup fallback, auto-cascade init system detection

### DIFF
--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -362,12 +362,12 @@ if (lang === 'zh') {
 '@ $LANG_MODE
     $ErrorActionPreference = $prevEAP
 
-    $selectInput = Read-Host "    >"
+    $selectInput = (Read-Host "    >").Trim() -replace '[，、；]', ','
 
     $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
     $script:SELECTED_AGENTS = $script:PROBE_RESULT | & $script:NODE_BIN -e @'
 const r = JSON.parse(require('fs').readFileSync(0,'utf-8'));
-const input = process.argv[1] || '';
+const input = (process.argv[1] || '').replace(/[，、；]/g, ',');
 let indices;
 if (!input.trim()) {
   indices = r.map((a, i) => a.detected ? i : -1).filter(i => i >= 0);

--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -57,7 +57,6 @@ MASK_MODE=""
 MASK_TYPES=""
 HAS_SUDO=0
 PURGE=0
-SYSTEM_SERVICE=0
 
 # First arg is sub-command (or option -> default to install)
 if [[ $# -gt 0 ]]; then
@@ -116,7 +115,9 @@ while [[ $# -gt 0 ]]; do
         --mask-types)         MASK_TYPES="$2"; shift 2 ;;
         --mask-types=*)       MASK_TYPES="${1#*=}"; shift ;;
         --purge)              PURGE=1; shift ;;
-        --system-service)     SYSTEM_SERVICE=1; shift ;;
+        --system-service)
+            echo "⚠️  --system-service is deprecated and ignored. Auto-detection is now the default." >&2
+            shift ;;
         *)
             echo "Unknown option: $1" >&2
             exit 1 ;;
@@ -148,27 +149,11 @@ validate_install_user() {
             current_user=$(whoami)
             if [ "$(id -u)" -eq 0 ]; then
                 HAS_SUDO=1
-                SYSTEM_SERVICE=1
                 msg "   ✅ 以 root 身份安装（自动使用系统级服务）" \
                     "   ✅ Installing as root (auto system-level service)"
-            elif [ "$SYSTEM_SERVICE" -eq 1 ]; then
-                if sudo -n true 2>/dev/null; then
-                    HAS_SUDO=1
-                    msg "   ✅ sudo 权限校验通过 (user: $current_user)" \
-                        "   ✅ sudo access verified (user: $current_user)"
-                elif sudo -v 2>/dev/null; then
-                    HAS_SUDO=1
-                    msg "   ✅ sudo 权限校验通过 (user: $current_user)" \
-                        "   ✅ sudo access verified (user: $current_user)"
-                else
-                    HAS_SUDO=0
-                    SYSTEM_SERVICE=0
-                    msg "⚠️  无 sudo 权限 — 无法注册系统级服务。将使用用户态 systemd 服务。" \
-                        "⚠️  No sudo access — cannot register system-level service. Using user-level systemd."
-                fi
             else
-                msg "   Install user: $current_user（服务类型将在启动时检测）" \
-                    "   Install user: $current_user (service type determined at start)"
+                msg "   Install user: $current_user（服务类型将在启动时自动检测）" \
+                    "   Install user: $current_user (service type auto-detected at start)"
             fi
             ;;
     esac
@@ -427,14 +412,27 @@ if (lang === 'zh') {
 }
 " "$PROBE_RESULT" "$LANG_MODE"
 
-    # Read user input
+    # Read user input (Node readline handles UTF-8 editing; normalize Chinese punctuation).
+    # Prompt must go to stderr so it is visible and not captured by $().
     local select_input
-    read -r select_input
+    select_input=$("$NODE_BIN" -e "
+const readline = require('readline');
+const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+rl.question('    > ', (answer) => {
+  const normalized = answer.replace(/[，、；]/g, ',').trim();
+  process.stdout.write(normalized);
+  rl.close();
+});
+") || {
+        printf "    > " >&2
+        read -r select_input
+        select_input=$(printf '%s' "$select_input" | sed 's/，/,/g; s/、/,/g; s/；/,/g')
+    }
 
     # Compute final selection: empty input = detected agents, otherwise use exact input
     SELECTED_AGENTS=$("$NODE_BIN" -e "
 const r = JSON.parse(process.argv[1]);
-const input = process.argv[2] || '';
+const input = (process.argv[2] || '').replace(/[，、；]/g, ',');
 let indices;
 if (!input.trim()) {
   indices = r.map((a, i) => a.detected ? i : -1).filter(i => i >= 0);
@@ -1427,11 +1425,7 @@ cmd_install() {
     inject_claude_code_fetch_intercept
 
     msg "==> 启动服务..." "==> Starting service..."
-    local _start_args=""
-    if [ "$SYSTEM_SERVICE" -eq 1 ]; then
-        _start_args="--system-service"
-    fi
-    if loongsuite-pilot start $_start_args; then
+    if loongsuite-pilot start; then
         sleep 2
         local _status_out
         _status_out="$(loongsuite-pilot status 2>/dev/null || true)"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -87,7 +87,7 @@ The Linux/macOS installer uses `--kebab-case` options. The Windows PowerShell in
 | `--cms-endpoint <url>` | CMS or ARMS trace endpoint. |
 | `--cms-workspace <name>` | CMS workspace value. |
 | `--service-name-prefix <name>` | Service name prefix used by reporting backends. |
-| `--system-service` | Register as a system-level service instead of a user-level service. |
+| `--system-service` | **Deprecated** — ignored. Init system is now auto-detected (systemd-user → systemd-system → init.d). |
 | `--lang <lang>` | Output language: `zh` or `en`. |
 
 ## Verify Installation

--- a/docs/zh-CN/installation.md
+++ b/docs/zh-CN/installation.md
@@ -87,7 +87,7 @@ Linux/macOS 安装器使用 `--kebab-case` 参数；Windows PowerShell 安装器
 | `--cms-endpoint <url>` | CMS 或 ARMS Trace endpoint。 |
 | `--cms-workspace <name>` | CMS workspace 值。 |
 | `--service-name-prefix <name>` | 上报后端使用的 service name 前缀。 |
-| `--system-service` | 注册为系统级服务，而不是用户级服务。 |
+| `--system-service` | **已废弃** — 忽略。Init 系统现在自动检测（systemd-user → systemd-system → init.d）。 |
 | `--lang <lang>` | 输出语言：`zh` 或 `en`。 |
 
 ## 验证安装

--- a/scripts/e2e/test-detect-init-runner.sh
+++ b/scripts/e2e/test-detect-init-runner.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+# test-detect-init-runner.sh — Runs inside Docker container
+# Called by test-detect-init-system.sh
+
+set -e
+
+PASS=0
+FAIL=0
+
+# --- Inline the functions under test ---
+DATA_DIR_BASE="/tmp/pilot-test"
+
+has_sudo_interactive() {
+    [ "$(id -u)" -eq 0 ] && return 0
+    if sudo -n true 2>/dev/null; then
+        return 0
+    elif sudo -v 2>/dev/null; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+has_sudo_noninteractive() {
+    [ "$(id -u)" -eq 0 ] && return 0
+    sudo -n true 2>/dev/null
+}
+
+_detect_system_level_init() {
+    if [ -d /run/systemd/system ] && command -v systemctl &>/dev/null; then
+        echo "systemd-system"
+    elif [ -d /etc/init.d ]; then
+        echo "initd"
+    else
+        echo "none"
+    fi
+}
+
+detect_init_system() {
+    local interactive="${1:-true}"
+    local INIT_TYPE_FILE="$DATA_DIR/init-type"
+
+    if [ -f "$INIT_TYPE_FILE" ]; then
+        local saved
+        saved=$(cat "$INIT_TYPE_FILE" 2>/dev/null | tr -d '[:space:]')
+        case "$saved" in
+            launchd|systemd-user|systemd-system|initd)
+                echo "$saved"
+                return
+                ;;
+        esac
+    fi
+    case "$(uname -s)" in
+        Darwin) echo "launchd" ;;
+        Linux)
+            if [ "$(id -u)" -eq 0 ]; then
+                _detect_system_level_init
+            else
+                if command -v systemctl &>/dev/null && systemctl --user show-environment &>/dev/null 2>&1; then
+                    echo "systemd-user"
+                elif [ "$interactive" = "true" ] && has_sudo_interactive; then
+                    _detect_system_level_init
+                elif [ "$interactive" = "false" ] && has_sudo_noninteractive; then
+                    _detect_system_level_init
+                else
+                    echo "none"
+                fi
+            fi
+            ;;
+        *) echo "none" ;;
+    esac
+}
+
+export -f has_sudo_interactive has_sudo_noninteractive _detect_system_level_init detect_init_system
+
+check() {
+    local num="$1" desc="$2" expected="$3" actual="$4"
+    actual=$(echo "$actual" | tr -d '[:space:]')
+    if [ "$actual" = "$expected" ]; then
+        echo "  ✅ Scenario $num: $desc → $actual"
+        PASS=$((PASS + 1))
+    else
+        echo "  ❌ Scenario $num: $desc → $actual (expected: $expected)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ========== Setup ==========
+mkdir -p /run/systemd/system
+mkdir -p /etc/init.d
+
+# ========== Scenario 1: systemd-user (mocked) ==========
+# Mock systemctl --user show-environment to succeed
+cat > /usr/local/bin/systemctl <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "--user" && "$2" == "show-environment" ]]; then exit 0; fi
+exec /usr/bin/systemctl "$@"
+MOCK
+chmod +x /usr/local/bin/systemctl
+
+export DATA_DIR="/home/testuser/.loongsuite-pilot"
+mkdir -p "$DATA_DIR"
+chown testuser:testuser "$DATA_DIR"
+result=$(su -s /bin/bash testuser -c 'export DATA_DIR=/home/testuser/.loongsuite-pilot; eval "$(declare -f has_sudo_interactive has_sudo_noninteractive _detect_system_level_init detect_init_system)"; detect_init_system true' 2>/dev/null)
+check 1 "systemd-user (mocked systemctl --user)" "systemd-user" "$result"
+
+# Remove mock
+rm -f /usr/local/bin/systemctl
+
+# ========== Scenario 2: No systemd-user, sudo + systemd-system ==========
+result=$(su -s /bin/bash testuser -c 'export DATA_DIR=/home/testuser/.loongsuite-pilot; eval "$(declare -f has_sudo_interactive has_sudo_noninteractive _detect_system_level_init detect_init_system)"; detect_init_system true' 2>/dev/null)
+check 2 "No systemd-user, sudo + systemd-system" "systemd-system" "$result"
+
+# ========== Scenario 3: No systemd, only init.d ==========
+mv /usr/bin/systemctl /usr/bin/systemctl.bak 2>/dev/null || true
+result=$(su -s /bin/bash testuser -c 'export DATA_DIR=/home/testuser/.loongsuite-pilot; eval "$(declare -f has_sudo_interactive has_sudo_noninteractive _detect_system_level_init detect_init_system)"; detect_init_system true' 2>/dev/null)
+check 3 "No systemd, only init.d" "initd" "$result"
+mv /usr/bin/systemctl.bak /usr/bin/systemctl 2>/dev/null || true
+
+# ========== Scenario 4: Root + systemd ==========
+export DATA_DIR="/root/.loongsuite-pilot"
+mkdir -p "$DATA_DIR"
+result=$(detect_init_system true)
+check 4 "Root + systemd-system" "systemd-system" "$result"
+
+# ========== Scenario 5: Root + no systemd, only init.d ==========
+mv /usr/bin/systemctl /usr/bin/systemctl.bak 2>/dev/null || true
+rm -rf /run/systemd/system
+result=$(detect_init_system true)
+check 5 "Root + no systemd, only init.d" "initd" "$result"
+mv /usr/bin/systemctl.bak /usr/bin/systemctl 2>/dev/null || true
+mkdir -p /run/systemd/system
+
+# ========== Scenario 6: No init system, no sudo ==========
+mv /usr/bin/systemctl /usr/bin/systemctl.bak 2>/dev/null || true
+rm -rf /run/systemd/system /etc/init.d
+export DATA_DIR="/home/nopwduser/.loongsuite-pilot"
+mkdir -p "$DATA_DIR"
+chown nopwduser:nopwduser "$DATA_DIR"
+result=$(su -s /bin/bash nopwduser -c 'export DATA_DIR=/home/nopwduser/.loongsuite-pilot; eval "$(declare -f has_sudo_interactive has_sudo_noninteractive _detect_system_level_init detect_init_system)"; detect_init_system true' 2>/dev/null)
+check 6 "No init system + sudo needs password" "none" "$result"
+mv /usr/bin/systemctl.bak /usr/bin/systemctl 2>/dev/null || true
+mkdir -p /run/systemd/system /etc/init.d
+
+# ========== Scenario 7: interactive=false + sudo needs password ==========
+result=$(su -s /bin/bash nopwduser -c 'export DATA_DIR=/home/nopwduser/.loongsuite-pilot; eval "$(declare -f has_sudo_interactive has_sudo_noninteractive _detect_system_level_init detect_init_system)"; detect_init_system false' 2>/dev/null)
+check 7 "interactive=false, sudo needs password" "none" "$result"
+
+# ========== Scenario 8: Cached init-type=nohup → ignored ==========
+export DATA_DIR="/home/testuser/.loongsuite-pilot"
+echo "nohup" > "$DATA_DIR/init-type"
+chown testuser:testuser "$DATA_DIR/init-type"
+result=$(su -s /bin/bash testuser -c 'export DATA_DIR=/home/testuser/.loongsuite-pilot; eval "$(declare -f has_sudo_interactive has_sudo_noninteractive _detect_system_level_init detect_init_system)"; detect_init_system true' 2>/dev/null)
+check 8 "Cached nohup ignored → re-detects systemd-system" "systemd-system" "$result"
+rm -f "$DATA_DIR/init-type"
+
+# ========== Scenario 9: Valid cached init-type=initd → honored ==========
+echo "initd" > "$DATA_DIR/init-type"
+chown testuser:testuser "$DATA_DIR/init-type"
+result=$(su -s /bin/bash testuser -c 'export DATA_DIR=/home/testuser/.loongsuite-pilot; eval "$(declare -f has_sudo_interactive has_sudo_noninteractive _detect_system_level_init detect_init_system)"; detect_init_system true' 2>/dev/null)
+check 9 "Valid cached init-type=initd honored" "initd" "$result"
+rm -f "$DATA_DIR/init-type"
+
+# ========== Scenario 10: interactive=false + NOPASSWD sudo ==========
+result=$(su -s /bin/bash testuser -c 'export DATA_DIR=/home/testuser/.loongsuite-pilot; eval "$(declare -f has_sudo_interactive has_sudo_noninteractive _detect_system_level_init detect_init_system)"; detect_init_system false' 2>/dev/null)
+check 10 "interactive=false + NOPASSWD sudo → systemd-system" "systemd-system" "$result"
+
+# ========== Results ==========
+echo ""
+echo "============================================"
+echo " Results: $PASS passed, $FAIL failed"
+echo "============================================"
+
+[ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/e2e/test-detect-init-system.sh
+++ b/scripts/e2e/test-detect-init-system.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# test-detect-init-system.sh — Docker-based test for detect_init_system() scenarios
+#
+# Usage: ./scripts/e2e/test-detect-init-system.sh
+#
+# Builds a single test image then runs all scenarios inside one container.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+IMAGE_NAME="detect-init-test"
+
+echo "============================================"
+echo " detect_init_system() Scenario Tests"
+echo "============================================"
+echo ""
+echo "[build] Building test image..."
+
+docker build -t "$IMAGE_NAME" -f - "$REPO_ROOT" <<'DOCKERFILE'
+FROM ubuntu:22.04
+RUN sed -i 's|http://archive.ubuntu.com|http://mirrors.aliyun.com|g; s|http://security.ubuntu.com|http://mirrors.aliyun.com|g; s|http://ports.ubuntu.com|http://mirrors.aliyun.com|g' /etc/apt/sources.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
+    systemd sudo bash coreutils procps \
+    && rm -rf /var/lib/apt/lists/*
+RUN useradd -m testuser && echo "testuser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+RUN useradd -m nopwduser && echo "nopwduser ALL=(ALL) ALL" >> /etc/sudoers
+COPY scripts/e2e/test-detect-init-runner.sh /opt/run-tests.sh
+RUN chmod +x /opt/run-tests.sh
+DOCKERFILE
+
+echo "[build] Done."
+echo ""
+
+docker run --rm "$IMAGE_NAME" /opt/run-tests.sh

--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -557,46 +557,14 @@ function Cmd-Start {
         Write-Host "Task Scheduler registration failed$hr : $($_.Exception.Message)" -ForegroundColor Yellow
     }
 
-    # Fallback: background process (like nohup on Linux).
-    # Remove any task that may have been registered before we hit the error above
-    # (e.g. collector registered, then updater registration threw): leaving it in
-    # place would let its logon/watchdog trigger start a second collector alongside
-    # the background process below. Background mode owns the lifecycle from here.
+    # No background fallback — Task Scheduler registration is required.
     Remove-AllTasks
-    Write-Host "Using background process fallback." -ForegroundColor Yellow
-    Write-Host "   Service will NOT auto-start on boot." -ForegroundColor Yellow
-    Write-Host "   stdout log: $LOG_FILE" -ForegroundColor Yellow
-    Write-Host "   stderr log: $(Join-Path $LOG_DIR 'loongsuite-pilot-service-err.log')" -ForegroundColor Yellow
-
-    $entry = Join-Path $BOOTSTRAP_DIR "collector-daemon.js"
-    if (-not (Test-Path $entry)) {
-        Write-Error "Bootstrap script missing"
-        exit 1
-    }
-
-    $errLog = Join-Path $LOG_DIR "loongsuite-pilot-service-err.log"
-    $proc = Start-Process -FilePath "powershell.exe" `
-        -ArgumentList "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$entry' >> '$LOG_FILE' 2>> '$errLog'`"" `
-        -WorkingDirectory $CACHE_DIR `
-        -WindowStyle Hidden `
-        -PassThru
-
-    Set-Content -Path $PID_FILE -Value $proc.Id
-    Set-Content -Path $INIT_TYPE_FILE -Value "background"
-    Write-Host "loongsuite-pilot started (PID $($proc.Id), background)"
-
-    # Also start updater
-    $updaterEntry = Join-Path $BOOTSTRAP_DIR "updater-daemon.js"
-    if ((Test-Path $updaterEntry) -and -not (Test-PidRunning $UPDATER_PID_FILE)) {
-        $updaterErrLog = Join-Path $LOG_DIR "loongsuite-pilot-updater-err.log"
-        $uproc = Start-Process -FilePath "powershell.exe" `
-            -ArgumentList "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$updaterEntry' >> '$UPDATER_LOG_FILE' 2>> '$updaterErrLog'`"" `
-            -WorkingDirectory $CACHE_DIR `
-            -WindowStyle Hidden `
-            -PassThru
-        Set-Content -Path $UPDATER_PID_FILE -Value $uproc.Id
-        Write-Host "loongsuite-pilot updater started (PID $($uproc.Id))"
-    }
+    Write-Error "Failed to register system service via Task Scheduler."
+    Write-Host "   Possible causes:" -ForegroundColor Yellow
+    Write-Host "     - 'Log on as a batch job' right not granted (S4U)" -ForegroundColor Yellow
+    Write-Host "     - Task Scheduler service not running" -ForegroundColor Yellow
+    Write-Host "     - Insufficient permissions for task registration" -ForegroundColor Yellow
+    exit 1
 }
 
 # ============================================================
@@ -671,23 +639,52 @@ function Cmd-RestartCollector {
             Start-ScheduledTask -TaskName $TASK_NAME_COLLECTOR -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
             Write-Host "collector restarted (Task Scheduler)"
             $restarted = $true
-        } catch {}
+        } catch {
+            Write-Host "Task Scheduler restart failed: $($_.Exception.Message)" -ForegroundColor Yellow
+        }
     }
 
     if (-not $restarted) {
-        $entry = Join-Path $BOOTSTRAP_DIR "collector-daemon.js"
-        if (-not (Test-Path $entry)) {
-            Write-Error "Bootstrap script missing"
-            exit 1
+        # Self-healing: try to register Task Scheduler for degraded (background/unknown) installs
+        $initType = ""
+        if (Test-Path $INIT_TYPE_FILE) { $initType = (Get-Content $INIT_TYPE_FILE -ErrorAction SilentlyContinue).Trim() }
+        # "background" is a legacy init-type value from pre-Task-Scheduler installs (aligned with Linux nohup/unknown)
+        if ($initType -in @("background", "unknown", "")) {
+            try {
+                $ok = Install-CollectorTask $nodeBin
+                if ($ok) {
+                    Start-ScheduledTask -TaskName $TASK_NAME_COLLECTOR -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
+                    Start-Sleep -Seconds 1
+                    if (Get-TaskRunning $TASK_NAME_COLLECTOR) {
+                        Set-Content -Path $INIT_TYPE_FILE -Value "taskscheduler"
+                        Write-Host "collector self-healed: registered with Task Scheduler"
+                        $restarted = $true
+                    }
+                }
+            } catch {
+                Write-Host "Self-heal failed: $($_.Exception.Message)" -ForegroundColor Yellow
+            }
         }
-        $errLog = Join-Path $LOG_DIR "loongsuite-pilot-service-err.log"
-        $proc = Start-Process -FilePath "powershell.exe" `
-            -ArgumentList "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$entry' >> '$LOG_FILE' 2>> '$errLog'`"" `
-            -WorkingDirectory $CACHE_DIR `
-            -WindowStyle Hidden `
-            -PassThru
-        Set-Content -Path $PID_FILE -Value $proc.Id
-        Write-Host "collector restarted (PID $($proc.Id))"
+        if (-not $restarted) {
+            if ($initType -in @("background", "unknown", "")) {
+                $entry = Join-Path $BOOTSTRAP_DIR "collector-daemon.js"
+                if (-not (Test-Path $entry)) {
+                    Write-Error "Bootstrap script missing"
+                    exit 1
+                }
+                $errLog = Join-Path $LOG_DIR "loongsuite-pilot-service-err.log"
+                $proc = Start-Process -FilePath "powershell.exe" `
+                    -ArgumentList "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$entry' >> '$LOG_FILE' 2>> '$errLog'`"" `
+                    -WorkingDirectory $CACHE_DIR `
+                    -WindowStyle Hidden `
+                    -PassThru
+                Set-Content -Path $PID_FILE -Value $proc.Id
+                Write-Host "collector restarted (background fallback, self-heal failed)" -ForegroundColor Yellow
+            } else {
+                Write-Error "Service manager failed to restart collector (init_type=$initType)"
+                exit 1
+            }
+        }
     }
 
     # Schedule updater restart in background (equivalent to setsid on Linux)
@@ -739,23 +736,52 @@ function Cmd-RestartUpdater {
                 Write-Host "updater restarted (Task Scheduler)"
                 $restarted = $true
             }
-        } catch {}
+        } catch {
+            Write-Host "Task Scheduler restart failed: $($_.Exception.Message)" -ForegroundColor Yellow
+        }
     }
 
     if (-not $restarted) {
-        $entry = Join-Path $BOOTSTRAP_DIR "updater-daemon.js"
-        if (-not (Test-Path $entry)) {
-            Write-Host "Updater bootstrap script missing"
-            return
+        # Self-healing: try to register Task Scheduler for degraded (background/unknown) installs
+        $initType = ""
+        if (Test-Path $INIT_TYPE_FILE) { $initType = (Get-Content $INIT_TYPE_FILE -ErrorAction SilentlyContinue).Trim() }
+        # "background" is a legacy init-type value from pre-Task-Scheduler installs (aligned with Linux nohup/unknown)
+        if ($initType -in @("background", "unknown", "")) {
+            try {
+                $ok = Install-UpdaterTask $nodeBin
+                if ($ok) {
+                    Start-ScheduledTask -TaskName $TASK_NAME_UPDATER -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
+                    Start-Sleep -Seconds 1
+                    if (Get-TaskRunning $TASK_NAME_UPDATER) {
+                        Set-Content -Path $INIT_TYPE_FILE -Value "taskscheduler"
+                        Write-Host "updater self-healed: registered with Task Scheduler"
+                        $restarted = $true
+                    }
+                }
+            } catch {
+                Write-Host "Self-heal failed: $($_.Exception.Message)" -ForegroundColor Yellow
+            }
         }
-        $updaterErrLog = Join-Path $LOG_DIR "loongsuite-pilot-updater-err.log"
-        $proc = Start-Process -FilePath "powershell.exe" `
-            -ArgumentList "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$entry' >> '$UPDATER_LOG_FILE' 2>> '$updaterErrLog'`"" `
-            -WorkingDirectory $CACHE_DIR `
-            -WindowStyle Hidden `
-            -PassThru
-        Set-Content -Path $UPDATER_PID_FILE -Value $proc.Id
-        Write-Host "updater restarted (PID $($proc.Id))"
+        if (-not $restarted) {
+            if ($initType -in @("background", "unknown", "")) {
+                $entry = Join-Path $BOOTSTRAP_DIR "updater-daemon.js"
+                if (-not (Test-Path $entry)) {
+                    Write-Host "Updater bootstrap script missing"
+                    return
+                }
+                $updaterErrLog = Join-Path $LOG_DIR "loongsuite-pilot-updater-err.log"
+                $proc = Start-Process -FilePath "powershell.exe" `
+                    -ArgumentList "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$entry' >> '$UPDATER_LOG_FILE' 2>> '$updaterErrLog'`"" `
+                    -WorkingDirectory $CACHE_DIR `
+                    -WindowStyle Hidden `
+                    -PassThru
+                Set-Content -Path $UPDATER_PID_FILE -Value $proc.Id
+                Write-Host "updater restarted (background fallback, self-heal failed)" -ForegroundColor Yellow
+            } else {
+                Write-Error "Service manager failed to restart updater (init_type=$initType)"
+                return
+            }
+        }
     }
 }
 

--- a/scripts/loongsuite-pilot.sh
+++ b/scripts/loongsuite-pilot.sh
@@ -34,17 +34,20 @@ validate_current_user() {
     whoami
 }
 
-check_sudo_access() {
+has_sudo_interactive() {
     [ "$(id -u)" -eq 0 ] && return 0
     if sudo -n true 2>/dev/null; then
         return 0
     elif sudo -v 2>/dev/null; then
         return 0
     else
-        echo "⚠️  No sudo access — cannot register system-level service." >&2
-        echo "   Falling back to user-level systemd service." >&2
         return 1
     fi
+}
+
+has_sudo_noninteractive() {
+    [ "$(id -u)" -eq 0 ] && return 0
+    sudo -n true 2>/dev/null
 }
 
 resolve_user_home() {
@@ -230,35 +233,41 @@ resolve_node() {
     return 1
 }
 
+_detect_system_level_init() {
+    if [ -d /run/systemd/system ] && command -v systemctl &>/dev/null; then
+        echo "systemd-system"
+    elif [ -d /etc/init.d ]; then
+        echo "initd"
+    else
+        echo "none"
+    fi
+}
+
 detect_init_system() {
-    local system_service="${1:-false}"
+    local interactive="${1:-true}"
 
     if [ -f "$INIT_TYPE_FILE" ]; then
         local saved
         saved=$(cat "$INIT_TYPE_FILE" 2>/dev/null | tr -d '[:space:]')
-        if [ -n "$saved" ]; then
-            echo "$saved"
-            return
-        fi
+        case "$saved" in
+            launchd|systemd-user|systemd-system|initd)
+                echo "$saved"
+                return
+                ;;
+        esac
     fi
     case "$(uname -s)" in
         Darwin) echo "launchd" ;;
         Linux)
-            if [ "$system_service" = "true" ]; then
-                if [ "$(id -u)" -ne 0 ] && ! check_sudo_access; then
-                    echo "systemd-user"
-                    return
-                fi
-                if [ -d /run/systemd/system ] && command -v systemctl &>/dev/null; then
-                    echo "systemd-system"
-                elif [ -d /etc/init.d ]; then
-                    echo "initd"
-                else
-                    echo "systemd-user"
-                fi
+            if [ "$(id -u)" -eq 0 ]; then
+                _detect_system_level_init
             else
                 if command -v systemctl &>/dev/null && systemctl --user show-environment &>/dev/null 2>&1; then
                     echo "systemd-user"
+                elif [ "$interactive" = "true" ] && has_sudo_interactive; then
+                    _detect_system_level_init
+                elif [ "$interactive" = "false" ] && has_sudo_noninteractive; then
+                    _detect_system_level_init
                 else
                     echo "none"
                 fi
@@ -277,7 +286,7 @@ enable_linger() {
     else
         echo "⚠️  Cannot enable linger (requires polkit policy or root privilege)." >&2
         echo "   Service may stop when you log out." >&2
-        echo "   To fix: run 'sudo loginctl enable-linger $user' or use --system-service." >&2
+        echo "   To fix: run 'sudo loginctl enable-linger $user'." >&2
         return 1
     fi
 }
@@ -390,10 +399,11 @@ cmd_run_updater() {
 # ---- User-facing commands ----
 
 cmd_start() {
-    local system_service="false"
     for arg in "$@"; do
         case "$arg" in
-            --system-service) system_service="true" ;;
+            --system-service)
+                echo "⚠️  --system-service is deprecated and ignored. Auto-detection is now the default." >&2
+                ;;
         esac
     done
 
@@ -405,51 +415,33 @@ cmd_start() {
     ensure_dirs
     sync_bootstrap_scripts
 
-    if autostart_install "$system_service" 2>/dev/null; then
+    if autostart_install "true"; then
         sleep 2
-        if is_managed_by_launchd || is_managed_by_systemd_user || is_managed_by_systemd_system || is_managed_by_initd; then
-            echo "✅ loongsuite-pilot started ($(detect_init_system))"
+        if is_running; then
+            local init_type
+            init_type=$(cat "$INIT_TYPE_FILE" 2>/dev/null | tr -d '[:space:]')
+            echo "✅ loongsuite-pilot started ($init_type)"
             return 0
         fi
+        local init_type
+        init_type=$(cat "$INIT_TYPE_FILE" 2>/dev/null | tr -d '[:space:]')
+        echo "⚠️  Service registered (${init_type:-unknown}) but collector process not found after 2s. Check logs: $LOG_FILE" >&2
+        echo "   Autostart is configured; the service manager will keep retrying." >&2
+        return 0
     fi
 
-    # Fallback to nohup
-    echo "⚠️  No service manager available — using nohup fallback." >&2
-    echo "   Service will NOT auto-start on boot or survive session logout." >&2
+    echo "❌ Failed to register system service." >&2
+    echo "   No supported init system could be configured." >&2
     case "$(uname -s)" in
         Linux)
-            echo "   To fix: use '--system-service' (requires sudo) or enable systemd user session." >&2
+            echo "   Tried: systemd-user, systemd-system, init.d" >&2
+            echo "   Possible causes:" >&2
+            echo "     - No systemd user session (XDG_RUNTIME_DIR not set)" >&2
+            echo "     - No sudo access for system-level service" >&2
+            echo "     - Container without init system or /etc/init.d" >&2
             ;;
     esac
-
-    local entry="$BOOTSTRAP_DIR/collector-daemon.js"
-    if [ ! -f "$entry" ]; then
-        echo "❌ Bootstrap script missing"
-        exit 1
-    fi
-
-    local node_bin
-    node_bin=$(resolve_node) || {
-        echo "❌ node runtime not found" >&2
-        exit 1
-    }
-
-    export AGENT_DATA_COLLECTION_CONFIG="$CONFIG_FILE"
-    nohup "$node_bin" "$entry" >> "$LOG_FILE" 2>&1 &
-    local pid=$!
-    echo "$pid" > "$PID_FILE"
-    echo "nohup" > "$INIT_TYPE_FILE"
-    echo "✅ loongsuite-pilot started (PID $pid, nohup)"
-
-    # Also start the updater daemon if available
-    local updater_entry="$BOOTSTRAP_DIR/updater-daemon.js"
-    if [ -f "$updater_entry" ]; then
-        if ! is_pid_file_running "$UPDATER_PID_FILE"; then
-            nohup "$node_bin" "$updater_entry" >> "$UPDATER_LOG_FILE" 2>&1 &
-            echo "$!" > "$UPDATER_PID_FILE"
-            echo "✅ loongsuite-pilot updater started (PID $!)"
-        fi
-    fi
+    exit 1
 }
 
 cmd_stop() {
@@ -665,21 +657,57 @@ cmd_restart_collector() {
             esac
             ;;
     esac
-    if [ "$_restarted" = false ]; then
-        local entry="$BOOTSTRAP_DIR/collector-daemon.js"
-        if [ ! -f "$entry" ]; then
-            echo "❌ Bootstrap script missing"
-            exit 1
+    if [ "$_restarted" = true ]; then
+        sleep 1
+        if ! is_running; then
+            echo "⚠️  service manager reported success but collector process not found"
+            _restarted=false
         fi
-        local node_bin
-        node_bin=$(resolve_node) || {
-            echo "❌ node runtime not found" >&2
-            exit 1
-        }
-        export AGENT_DATA_COLLECTION_CONFIG="$CONFIG_FILE"
-        nohup "$node_bin" "$entry" >> "$LOG_FILE" 2>&1 &
-        echo "$!" > "$PID_FILE"
-        echo "✅ collector restarted (PID $!)"
+    fi
+    if [ "$_restarted" = false ]; then
+        # Self-healing: try to register a proper service for degraded (nohup/unknown) installs
+        case "$init_type" in
+            nohup|unknown|"")
+                local _new_init
+                _new_init=$(detect_init_system "false")
+                if [ "$_new_init" != "none" ]; then
+                    if autostart_install_collector_only "false" 2>>"$LOG_FILE"; then
+                        sleep 1
+                        if is_running; then
+                            echo "✅ collector self-healed: registered as $_new_init"
+                            _restarted=true
+                        else
+                            echo "⚠️  collector self-heal registered ($_new_init) but process not found" >&2
+                        fi
+                    fi
+                fi
+                if [ "$_restarted" = false ]; then
+                    local entry="$BOOTSTRAP_DIR/collector-daemon.js"
+                    if [ ! -f "$entry" ]; then
+                        echo "❌ Bootstrap script missing"
+                        exit 1
+                    fi
+                    local node_bin
+                    node_bin=$(resolve_node) || {
+                        echo "❌ node runtime not found" >&2
+                        exit 1
+                    }
+                    export AGENT_DATA_COLLECTION_CONFIG="$CONFIG_FILE"
+                    nohup "$node_bin" "$entry" >> "$LOG_FILE" 2>&1 &
+                    echo "$!" > "$PID_FILE"
+                    echo "⚠️  collector restarted (nohup fallback, self-heal failed)"
+                fi
+                ;;
+            *)
+                echo "❌ Service manager failed to restart collector (init_type=$init_type)" >&2
+                exit 1
+                ;;
+        esac
+    fi
+
+    if ! is_running; then
+        echo "❌ collector process not found after restart" >&2
+        exit 1
     fi
 
     # Schedule updater restart in a NEW process group so that
@@ -769,25 +797,44 @@ cmd_restart_updater() {
     if [ "$_restarted" = true ]; then
         sleep 1
         if ! updater_process_exists; then
-            echo "⚠️  service manager reported success but updater process not found, falling back to nohup"
+            echo "⚠️  service manager reported success but updater process not found"
             _restarted=false
         fi
     fi
     if [ "$_restarted" = false ]; then
-        local entry="$BOOTSTRAP_DIR/updater-daemon.js"
-        if [ ! -f "$entry" ]; then
-            echo "❌ Updater bootstrap script missing"
-            return 1
-        fi
-        local node_bin
-        node_bin=$(resolve_node) || {
-            echo "❌ node runtime not found" >&2
-            return 1
-        }
-        export AGENT_DATA_COLLECTION_CONFIG="$CONFIG_FILE"
-        nohup "$node_bin" "$entry" >> "$UPDATER_LOG_FILE" 2>&1 &
-        echo "$!" > "$UPDATER_PID_FILE"
-        echo "✅ updater restarted (PID $!)"
+        # Self-healing: try to register a proper service for degraded installs
+        case "$init_type" in
+            nohup|unknown|"")
+                local _new_init
+                _new_init=$(detect_init_system "false")
+                if [ "$_new_init" != "none" ]; then
+                    if autostart_install_updater_only "false" 2>>"$UPDATER_LOG_FILE"; then
+                        echo "✅ updater self-healed: registered as $_new_init"
+                        _restarted=true
+                    fi
+                fi
+                if [ "$_restarted" = false ]; then
+                    local entry="$BOOTSTRAP_DIR/updater-daemon.js"
+                    if [ ! -f "$entry" ]; then
+                        echo "❌ Updater bootstrap script missing"
+                        return 1
+                    fi
+                    local node_bin
+                    node_bin=$(resolve_node) || {
+                        echo "❌ node runtime not found" >&2
+                        return 1
+                    }
+                    export AGENT_DATA_COLLECTION_CONFIG="$CONFIG_FILE"
+                    nohup "$node_bin" "$entry" >> "$UPDATER_LOG_FILE" 2>&1 &
+                    echo "$!" > "$UPDATER_PID_FILE"
+                    echo "⚠️  updater restarted (nohup fallback, self-heal failed)"
+                fi
+                ;;
+            *)
+                echo "❌ Service manager failed to restart updater (init_type=$init_type)" >&2
+                return 1
+                ;;
+        esac
     fi
 
     if ! updater_process_exists; then
@@ -1461,16 +1508,91 @@ _unregister_initd_boot() {
     fi
 }
 
-autostart_install() {
-    local system_service="${1:-false}"
-
-    # Root users have no user session — auto-escalate to system-level
-    if [ "$(id -u)" -eq 0 ]; then
-        system_service="true"
-    fi
+autostart_install_collector_only() {
+    local interactive="${1:-true}"
 
     local init_system
-    init_system=$(detect_init_system "$system_service")
+    init_system=$(detect_init_system "$interactive")
+    local target_user
+    target_user=$(whoami)
+
+    case "$init_system" in
+        launchd)
+            launchctl unload -w "$LAUNCHD_PLIST" 2>/dev/null || true
+            _write_launchd_plist
+            launchctl load -w "$LAUNCHD_PLIST"
+            echo "launchd" > "$INIT_TYPE_FILE"
+            ;;
+        systemd-user)
+            _write_systemd_user_unit
+            systemctl --user daemon-reload &>/dev/null
+            systemctl --user enable --now loongsuite-pilot.service &>/dev/null
+            enable_linger || true
+            echo "systemd-user" > "$INIT_TYPE_FILE"
+            ;;
+        systemd-system)
+            _write_systemd_system_unit "$target_user"
+            sudo systemctl daemon-reload &>/dev/null
+            sudo systemctl enable --now "loongsuite-pilot-${target_user}.service" &>/dev/null
+            echo "systemd-system" > "$INIT_TYPE_FILE"
+            ;;
+        initd)
+            _write_initd_script "$target_user"
+            _register_initd_boot "loongsuite-pilot-${target_user}"
+            sudo "/etc/init.d/loongsuite-pilot-${target_user}" start &>/dev/null || true
+            echo "initd" > "$INIT_TYPE_FILE"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+autostart_install_updater_only() {
+    local interactive="${1:-true}"
+
+    local init_system
+    init_system=$(detect_init_system "$interactive")
+    local target_user
+    target_user=$(whoami)
+
+    case "$init_system" in
+        launchd)
+            launchctl unload -w "$UPDATER_PLIST" 2>/dev/null || true
+            _write_launchd_updater_plist
+            launchctl load -w "$UPDATER_PLIST"
+            echo "launchd" > "$INIT_TYPE_FILE"
+            ;;
+        systemd-user)
+            _write_systemd_user_updater_unit
+            systemctl --user daemon-reload &>/dev/null
+            systemctl --user enable --now loongsuite-pilot-updater.service &>/dev/null
+            enable_linger || true
+            echo "systemd-user" > "$INIT_TYPE_FILE"
+            ;;
+        systemd-system)
+            _write_systemd_system_updater_unit "$target_user"
+            sudo systemctl daemon-reload &>/dev/null
+            sudo systemctl enable --now "loongsuite-pilot-updater-${target_user}.service" &>/dev/null
+            echo "systemd-system" > "$INIT_TYPE_FILE"
+            ;;
+        initd)
+            _write_initd_updater_script "$target_user"
+            _register_initd_boot "loongsuite-pilot-updater-${target_user}"
+            sudo "/etc/init.d/loongsuite-pilot-updater-${target_user}" start &>/dev/null || true
+            echo "initd" > "$INIT_TYPE_FILE"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+autostart_install() {
+    local interactive="${1:-true}"
+
+    local init_system
+    init_system=$(detect_init_system "$interactive")
     local target_user
     target_user=$(whoami)
 
@@ -1530,7 +1652,7 @@ autostart_install() {
 
 autostart_remove() {
     local init_system
-    init_system=$(detect_init_system)
+    init_system=$(detect_init_system "false")
     local target_user
     target_user=$(whoami)
 
@@ -1609,8 +1731,8 @@ autostart_status() {
                 echo "   autostart: disabled"
             fi
             ;;
-        nohup)
-            echo "   autostart: disabled (nohup fallback, no service manager)"
+        none)
+            echo "   autostart: not available"
             ;;
         *)
             echo "   autostart: not available"
@@ -1689,9 +1811,6 @@ cmd_help() {
     echo "  worker ...      Manage local remote-controlled workers"
     echo "  rollback        Roll back to the previous version"
     echo "  help            Show this help message"
-    echo ""
-    echo "Options:"
-    echo "  --system-service  Use system-level service registration (requires sudo)"
 }
 
 cmd_monitor() {

--- a/src/updater/updater.ts
+++ b/src/updater/updater.ts
@@ -686,16 +686,25 @@ export class Updater {
     logger.info('restarting collector service');
     try {
       const bin = this.paths.loongsuitePilotBin;
+      let result: { stdout: string; stderr: string };
       if (process.platform === 'win32') {
-        await execFileAsync('powershell.exe', [
+        result = await execFileAsync('powershell.exe', [
           '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', bin, 'restart-collector',
         ], { timeout: 30_000 });
       } else {
-        await execFileAsync(bin, ['restart-collector'], { timeout: 30_000 });
+        result = await execFileAsync(bin, ['restart-collector'], { timeout: 30_000 });
       }
+      const output = (result.stdout || '').trim();
+      if (output) logger.info('restart-collector output', { output });
       logger.info('collector restarted');
-    } catch (err) {
-      logger.warn('collector restart failed', { error: String(err) });
+    } catch (err: any) {
+      const stderr = err?.stderr?.trim?.() || '';
+      const stdout = err?.stdout?.trim?.() || '';
+      logger.warn('collector restart failed', {
+        error: String(err?.message || err),
+        stdout: stdout || undefined,
+        stderr: stderr || undefined,
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- Remove nohup/background fallback; hard-fail when service registration fails
- Auto-cascade init detection: systemd-user → systemd-system → initd
- Self-heal degraded installs on restart-collector/updater
- Deprecate `--system-service` in opensource installers and docs
- Updater restart logging + detect_init_system e2e coverage

Split from https://code.alibaba-inc.com/sls/loongsuite-pilot/codereview/28555577
Internal-only files (`deploy/installer.sh`, `deploy/installer.ps1`) are in a separate GitLab MR.

## Test plan
- [ ] Linux install auto-detects init and starts without nohup
- [ ] Windows Task Scheduler failure hard-exits on start
- [ ] restart-collector self-heals nohup/degraded init-type
- [ ] e2e detect_init_system scenarios pass

Made with [Cursor](https://cursor.com)