### PR TITLE
fix: verify updater process before claiming self-heal success

### DIFF
--- a/scripts/loongsuite-pilot.sh
+++ b/scripts/loongsuite-pilot.sh
@@ -809,8 +809,13 @@ cmd_restart_updater() {
                 _new_init=$(detect_init_system "false")
                 if [ "$_new_init" != "none" ]; then
                     if autostart_install_updater_only "false" 2>>"$UPDATER_LOG_FILE"; then
-                        echo "✅ updater self-healed: registered as $_new_init"
-                        _restarted=true
+                        sleep 1
+                        if updater_process_exists; then
+                            echo "✅ updater self-healed: registered as $_new_init"
+                            _restarted=true
+                        else
+                            echo "⚠️  updater self-heal registered ($_new_init) but process not found" >&2
+                        fi
                     fi
                 fi
                 if [ "$_restarted" = false ]; then


### PR DESCRIPTION
## Summary

Follow-up to #149. The updater self-heal path in `cmd_restart_updater` ([scripts/loongsuite-pilot.sh](scripts/loongsuite-pilot.sh)) declared success without verifying the process actually came up — the one asymmetry left in the three self-heal implementations.

- **Collector** self-heal: `autostart_install_collector_only` → `sleep 1` → `is_running` check before `_restarted=true`.
- **Windows** `Cmd-RestartUpdater`: `Install-UpdaterTask` → `Get-TaskRunning` check before `$restarted=true`.
- **Bash updater** (before this PR): set `_restarted=true` immediately after the install helper returned — no verification.

### Why it matters

The install helpers (`autostart_install_updater_only`) end each branch with `echo "<type>" > "$INIT_TYPE_FILE"`, so the function returns `0` even when `systemctl --user enable --now` (or the sudo/initd equivalent) failed to actually start the service. In that case the updater was marked restarted, the nohup fallback was skipped, and the command only failed at the final `updater_process_exists` guard — whereas the collector path in the same situation keeps the process alive via nohup. This aligns the updater with the collector so a "registered but not running" service still gets the fallback.

### Change

```
if autostart_install_updater_only "false" 2>>"$UPDATER_LOG_FILE"; then
    sleep 1
    if updater_process_exists; then
        echo "✅ updater self-healed: registered as $_new_init"
        _restarted=true
    else
        echo "⚠️  updater self-heal registered ($_new_init) but process not found" >&2
    fi
fi
```

Now byte-for-byte parallel to the collector self-heal block directly above it.

## Test plan

- [x] `bash -n scripts/loongsuite-pilot.sh` — syntax clean
- [x] `scripts/e2e/test-detect-init-system.sh` — 10/10 scenarios pass (Docker)
- [ ] Manual: on a degraded (nohup/unknown) install where the updater unit registers but fails to start, confirm `restart-updater` now falls back to nohup instead of returning failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)