### PR TITLE
fix: use opensource release package script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - run: npm test
       - run: npm run build
       - name: Package
-        run: bash deploy/package.sh --opensource
+        run: bash deploy/package-opensource.sh --skip-build
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -31,4 +31,6 @@ jobs:
             --title "${{ github.ref_name }}" \
             --generate-notes \
             loongsuite-pilot.tar.gz \
-            deploy/installer-opensource.sh#installer.sh
+            loongsuite-pilot.zip \
+            deploy/installer-opensource.sh#installer.sh \
+            deploy/installer-opensource.ps1#installer.ps1


### PR DESCRIPTION
## Summary
- switch the release workflow package step to deploy/package-opensource.sh
- reuse the existing build output with --skip-build
- attach the Windows zip package and PowerShell installer to GitHub Releases

## Root cause
The GitHub release workflow called deploy/package.sh --opensource, but the open-source checkout only has deploy/package-opensource.sh. Tag-triggered releases would fail before creating the GitHub Release assets.

## Validation
- git diff --check
- verified deploy/package-opensource.sh supports --skip-build and produces both tar.gz and zip assets