### PR TITLE
fix(codex): incrementally recover transcript turns

### DIFF
--- a/src/core/input-manager.ts
+++ b/src/core/input-manager.ts
@@ -40,6 +40,7 @@ export interface InputCounter {
 export class InputManager extends EventEmitter {
   private readonly inputs: Map<string, BaseInput> = new Map();
   private readonly counters: Map<string, InputCounter> = new Map();
+  private readonly entryQueues: Map<string, Promise<void>> = new Map();
   private flusher: BaseFlusher | null = null;
   private alarmManager: AlarmManager | null = null;
   private userId: string = '';
@@ -90,7 +91,17 @@ export class InputManager extends EventEmitter {
       lastActiveTime: 0,
     });
     input.on('entries', (entries: AgentActivityEntry[]) => {
-      void this.handleEntries(input.id, entries);
+      const previous = this.entryQueues.get(input.id) ?? Promise.resolve();
+      const next = previous
+        .catch(() => undefined)
+        .then(() => this.handleEntries(input.id, entries))
+        .catch(err => {
+          logger.error('entry handling failed', { inputId: input.id, error: String(err) });
+        });
+      this.entryQueues.set(input.id, next);
+      void next.finally(() => {
+        if (this.entryQueues.get(input.id) === next) this.entryQueues.delete(input.id);
+      });
     });
     logger.info('input registered', { id: input.id });
   }
@@ -109,6 +120,7 @@ export class InputManager extends EventEmitter {
     const input = this.inputs.get(id);
     if (!input) return;
     await input.stop();
+    await this.drainInputQueue(id);
     logger.info('input stopped', { id });
   }
 
@@ -117,6 +129,25 @@ export class InputManager extends EventEmitter {
       if (input.running) {
         await input.stop();
       }
+    }
+    await this.drainAllEntryQueues();
+  }
+
+  private async drainInputQueue(id: string): Promise<void> {
+    while (true) {
+      const queue = this.entryQueues.get(id);
+      if (!queue) return;
+      await queue;
+      if (this.entryQueues.get(id) === queue) {
+        this.entryQueues.delete(id);
+        return;
+      }
+    }
+  }
+
+  private async drainAllEntryQueues(): Promise<void> {
+    while (this.entryQueues.size > 0) {
+      await Promise.all([...this.entryQueues.keys()].map(id => this.drainInputQueue(id)));
     }
   }
 

--- a/src/inputs/codex-transcript/codex-transcript-builder.ts
+++ b/src/inputs/codex-transcript/codex-transcript-builder.ts
@@ -117,7 +117,6 @@ export function buildCodexTranscriptSegment(
         ? { 'gen_ai.output.messages': responseMessages(turn, step, terminalStep) }
         : {}),
       ...usageFields(step.tokenUsage),
-      ...sharedLlmFields(turn),
     }));
 
     for (const [toolIndex, tool] of step.tools.entries()) {

--- a/src/inputs/codex-transcript/codex-transcript-builder.ts
+++ b/src/inputs/codex-transcript/codex-transcript-builder.ts
@@ -213,7 +213,7 @@ function finishReasons(
 ): JsonValue {
   if (terminalStep && turn.status === 'interrupted') return ['cancelled'];
   if (step.tools.length > 0) return ['tool_call'];
-  if (terminalStep && turn.status === 'completed') return ['stop'];
+  if (step.tokenUsage || (terminalStep && turn.status === 'completed')) return ['stop'];
   return [];
 }
 

--- a/src/inputs/codex-transcript/codex-transcript-builder.ts
+++ b/src/inputs/codex-transcript/codex-transcript-builder.ts
@@ -3,12 +3,41 @@ import { buildAgentActivityEntry, timestampToUnixNanos } from '../../normalizati
 import type { AgentActivityEntry, JsonValue } from '../../types/index.js';
 import type {
   CodexExtractedTranscriptTurn,
+  CodexTranscriptInputContext,
   CodexTranscriptStep,
   CodexTranscriptTool,
   CodexTranscriptUsage,
 } from './codex-transcript-types.js';
 
-export function buildCodexTranscriptEntries(turn: CodexExtractedTranscriptTurn): AgentActivityEntry[] {
+const MAX_INPUT_MESSAGES_BYTES = 1024 * 1024;
+const INITIAL_INPUT_HASH = crypto.createHash('sha256').update('').digest('hex').slice(0, 32);
+
+export interface CodexTranscriptBuildOptions {
+  includePrompt?: boolean;
+  startStepNumber?: number;
+  inputContext?: CodexTranscriptInputContext;
+  /** Number of leading steps whose output should be committed into returned context. */
+  contextStepCount?: number;
+}
+
+export interface CodexTranscriptBuildResult {
+  entries: AgentActivityEntry[];
+  nextInputContext: CodexTranscriptInputContext;
+}
+
+export function buildCodexTranscriptEntries(
+  turn: CodexExtractedTranscriptTurn,
+  opts: CodexTranscriptBuildOptions = {},
+): AgentActivityEntry[] {
+  return buildCodexTranscriptSegment(turn, opts).entries;
+}
+
+export function buildCodexTranscriptSegment(
+  turn: CodexExtractedTranscriptTurn,
+  opts: CodexTranscriptBuildOptions = {},
+): CodexTranscriptBuildResult {
+  const includePrompt = opts.includePrompt ?? true;
+  const startStepNumber = opts.startStepNumber ?? 1;
   const traceId = hashId([turn.sessionId, turn.transcriptTurnId, 'trace'], 32);
   const agentSpanId = hashId([turn.sessionId, turn.transcriptTurnId, 'agent'], 16);
   const turnId = `${turn.sessionId}:${turn.transcriptTurnId}`;
@@ -25,8 +54,11 @@ export function buildCodexTranscriptEntries(turn: CodexExtractedTranscriptTurn):
     ...(turn.cwd ? { 'agent.codex.cwd': turn.cwd } : {}),
   };
   const records: AgentActivityEntry[] = [];
+  let inputContext = opts.inputContext ?? initialInputContext(turn);
+  const contextStepCount = opts.contextStepCount ?? turn.steps.length;
+  let nextInputContext = inputContext;
 
-  if (turn.prompt) {
+  if (includePrompt && turn.prompt) {
     records.push(buildEntry({
       ...base,
       timestamp: turn.startedAtMs,
@@ -44,15 +76,13 @@ export function buildCodexTranscriptEntries(turn: CodexExtractedTranscriptTurn):
   }
 
   for (const [index, step] of turn.steps.entries()) {
-    const stepNumber = index + 1;
+    const stepNumber = startStepNumber + index;
     const stepId = `${turnId}:s${stepNumber}`;
     const stepSpanId = hashId([turn.sessionId, turn.transcriptTurnId, 'step', String(stepNumber)], 16);
     const llmSpanId = hashId([turn.sessionId, turn.transcriptTurnId, 'llm', String(stepNumber)], 16);
     const responseId = step.responseId ?? `${turnId}:r${stepNumber}`;
-    const previousStep = turn.steps[index - 1];
-    const inputMessages = stepInputMessages(index, turn, previousStep);
-    const fullInputMessages = fullStepInputMessages(index, turn);
-    const fullInputHash = hashJsonValue(fullInputMessages);
+    const inputMessages = inputContext.delta ?? [];
+    const outputInputMessages = inputContext.fullMessages ?? inputMessages;
 
     records.push(buildEntry({
       ...base,
@@ -64,9 +94,9 @@ export function buildCodexTranscriptEntries(turn: CodexExtractedTranscriptTurn):
       'gen_ai.step.id': stepId,
       'gen_ai.request.model': model,
       'gen_ai.response.id': responseId,
-      'gen_ai.input.messages_hash': fullInputHash,
+      'gen_ai.input.messages_hash': inputContext.hash,
       ...(inputMessages.length > 0 ? { 'gen_ai.input.messages_delta': inputMessages } : {}),
-      ...(fullInputMessages.length > 0 ? { 'gen_ai.input.messages': fullInputMessages } : {}),
+      ...(outputInputMessages.length > 0 ? { 'gen_ai.input.messages': outputInputMessages } : {}),
       ...sharedLlmFields(turn),
     }));
 
@@ -93,40 +123,57 @@ export function buildCodexTranscriptEntries(turn: CodexExtractedTranscriptTurn):
     for (const [toolIndex, tool] of step.tools.entries()) {
       records.push(...buildToolEntries(turn, tool, toolIndex, base, stepId, stepSpanId));
     }
+
+    inputContext = advanceInputContext(inputContext, step);
+    if (index + 1 === contextStepCount) nextInputContext = inputContext;
   }
 
-  return records;
+  return { entries: records, nextInputContext };
 }
 
-function stepInputMessages(
-  index: number,
-  turn: CodexExtractedTranscriptTurn,
-  previousStep: CodexTranscriptStep | undefined,
-): JsonValue[] {
-  if (index === 0) {
-    if (turn.inputMessages.length > 0) return turn.inputMessages;
-    return turn.prompt
-      ? [{ role: 'user', parts: [{ type: 'text', content: turn.prompt }] }]
-      : [];
-  }
-  const completedTools = previousStep?.tools.filter(tool => tool.completedAtMs !== undefined) ?? [];
+function initialInputContext(turn: CodexExtractedTranscriptTurn): CodexTranscriptInputContext {
+  const delta = turn.steps[0]?.inputMessages?.length
+    ? turn.steps[0].inputMessages
+    : turn.inputMessages.length > 0
+      ? turn.inputMessages
+      : turn.prompt
+        ? [{ role: 'user', parts: [{ type: 'text', content: turn.prompt }] }]
+        : [];
+  return contextFromMessages(INITIAL_INPUT_HASH, [], delta);
+}
+
+function advanceInputContext(
+  context: CodexTranscriptInputContext,
+  step: CodexTranscriptStep,
+): CodexTranscriptInputContext {
+  const delta = nextInputMessagesForStep(step);
+  return contextFromMessages(context.hash, context.fullMessages, delta);
+}
+
+function contextFromMessages(
+  previousHash: string,
+  previousFullMessages: JsonValue[] | undefined,
+  delta: JsonValue[],
+): CodexTranscriptInputContext {
+  const fullMessages = previousFullMessages === undefined
+    ? undefined
+    : [...previousFullMessages, ...delta];
+  const retainFullMessages = fullMessages !== undefined
+    && Buffer.byteLength(JSON.stringify(fullMessages), 'utf8') <= MAX_INPUT_MESSAGES_BYTES;
+  return {
+    hash: hashInputMessages(previousHash, delta),
+    delta,
+    ...(retainFullMessages ? { fullMessages } : {}),
+  };
+}
+
+export function nextInputMessagesForStep(step: CodexTranscriptStep): JsonValue[] {
+  const completedTools = step.tools.filter(tool => tool.completedAtMs !== undefined);
+  const messages: JsonValue[] = [];
+  const toolCallMessage = assistantToolCallMessage(completedTools);
+  if (toolCallMessage) messages.push(toolCallMessage);
   const toolMessage = toolResponseMessage(completedTools);
-  return toolMessage ? [toolMessage] : [];
-}
-
-function fullStepInputMessages(index: number, turn: CodexExtractedTranscriptTurn): JsonValue[] {
-  const messages: JsonValue[] = turn.inputMessages.length > 0
-    ? [...turn.inputMessages]
-    : turn.prompt
-      ? [{ role: 'user', parts: [{ type: 'text', content: turn.prompt }] }]
-      : [];
-  for (const previousStep of turn.steps.slice(0, index)) {
-    const completedTools = previousStep.tools.filter(tool => tool.completedAtMs !== undefined);
-    const toolCallMessage = assistantToolCallMessage(completedTools);
-    if (toolCallMessage) messages.push(toolCallMessage);
-    const toolMessage = toolResponseMessage(completedTools);
-    if (toolMessage) messages.push(toolMessage);
-  }
+  if (toolMessage) messages.push(toolMessage);
   return messages;
 }
 
@@ -284,6 +331,23 @@ function hashId(parts: string[], length: number): string {
   return crypto.createHash('sha256').update(parts.join('\0')).digest('hex').slice(0, length);
 }
 
-function hashJsonValue(value: JsonValue): string {
-  return crypto.createHash('sha256').update(JSON.stringify(value)).digest('hex');
+function hashInputMessages(previousHash: string, messages: JsonValue[]): string {
+  let hash = previousHash;
+  for (const message of messages) {
+    hash = crypto.createHash('sha256')
+      .update(hash)
+      .update(stableSerialize(message))
+      .digest('hex')
+      .slice(0, 32);
+  }
+  return hash;
+}
+
+function stableSerialize(value: JsonValue): string {
+  if (value === null) return 'null';
+  if (typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableSerialize).join(',')}]`;
+  return `{${Object.keys(value).sort()
+    .map(key => `${JSON.stringify(key)}:${stableSerialize(value[key]!)}`)
+    .join(',')}}`;
 }

--- a/src/inputs/codex-transcript/codex-transcript-extractor.ts
+++ b/src/inputs/codex-transcript/codex-transcript-extractor.ts
@@ -1,9 +1,12 @@
 import * as path from 'node:path';
 import type { JsonValue } from '../../types/index.js';
 import type {
+  CodexPartialTurnExtraction,
   CodexExtractedTranscriptTurn,
   CodexTerminalStatus,
   CodexTranscriptMeta,
+  CodexTranscriptSourceRecord,
+  CodexTranscriptSourceRange,
   CodexTranscriptStep,
   CodexTranscriptTool,
   CodexTranscriptUsage,
@@ -33,9 +36,9 @@ export function extractCodexTerminalTurn(
   fallbackSessionId: string,
   expectedTurnId: string,
 ): CodexExtractedTranscriptTurn | null {
-  return extractCodexTurn(records, meta, fallbackSessionId, expectedTurnId, {
+  return extractCodexTurn(toSourceRecords(records), meta, fallbackSessionId, expectedTurnId, {
     requireTerminal: true,
-  });
+  })?.turn ?? null;
 }
 
 export function extractCodexPartialTurn(
@@ -50,6 +53,27 @@ export function extractCodexPartialTurn(
     developerInstructions?: string;
   } = {},
 ): CodexExtractedTranscriptTurn | null {
+  return extractCodexTurn(toSourceRecords(records), meta, fallbackSessionId, expectedTurnId, {
+    requireTerminal: false,
+    startedAtMs: opts.startedAtMs,
+    model: opts.model,
+    cwd: opts.cwd,
+    developerInstructions: opts.developerInstructions,
+  })?.turn ?? null;
+}
+
+export function extractCodexPartialTurnWithBoundaries(
+  records: CodexTranscriptSourceRecord[],
+  meta: CodexTranscriptMeta | null,
+  fallbackSessionId: string,
+  expectedTurnId: string,
+  opts: {
+    startedAtMs?: number;
+    model?: string;
+    cwd?: string;
+    developerInstructions?: string;
+  } = {},
+): CodexPartialTurnExtraction | null {
   return extractCodexTurn(records, meta, fallbackSessionId, expectedTurnId, {
     requireTerminal: false,
     startedAtMs: opts.startedAtMs,
@@ -59,8 +83,15 @@ export function extractCodexPartialTurn(
   });
 }
 
+interface StepEnvelope {
+  step: CodexTranscriptStep;
+  sourceRange: CodexTranscriptSourceRange;
+  llmClosed: boolean;
+  followedByAnotherWave: boolean;
+}
+
 function extractCodexTurn(
-  records: Record<string, unknown>[],
+  records: CodexTranscriptSourceRecord[],
   meta: CodexTranscriptMeta | null,
   fallbackSessionId: string,
   expectedTurnId: string,
@@ -71,11 +102,12 @@ function extractCodexTurn(
     cwd?: string;
     developerInstructions?: string;
   },
-): CodexExtractedTranscriptTurn | null {
+): CodexPartialTurnExtraction | null {
   let currentTurnId = opts.requireTerminal ? '' : expectedTurnId;
   let startedAtMs = opts.startedAtMs ?? 0;
   let terminalAtMs = 0;
   let status: CodexTerminalStatus | null = null;
+  let sawTerminal = false;
   let finalText: string | undefined;
   let model = opts.model ?? 'unknown';
   let cwd = opts.cwd;
@@ -83,27 +115,42 @@ function extractCodexTurn(
   let prompt: string | undefined;
   const promptParts: string[] = [];
   const inputMessages: JsonValue[] = [];
-  const steps: CodexTranscriptStep[] = [];
+  const stepEnvelopes: StepEnvelope[] = [];
   const unmatchedTokenUsages: CodexTranscriptUsage[] = [];
-  const toolSteps = new Map<string, CodexTranscriptStep>();
+  const toolSteps = new Map<string, StepEnvelope>();
   const webSearchStarts = new Map<string, number>();
   const webSearchEnds = new Map<string, number>();
-  let currentStep: CodexTranscriptStep | null = null;
+  let currentStep: StepEnvelope | null = null;
   let lastUsage: CodexTranscriptUsage | undefined;
   let lastActivityAtMs = 0;
 
-  const beginStep = (timestamp: number): CodexTranscriptStep => {
+  const beginStep = (timestamp: number, source: CodexTranscriptSourceRecord): StepEnvelope => {
     if (!currentStep) {
+      const previous = stepEnvelopes.at(-1);
+      if (previous?.llmClosed) previous.followedByAnotherWave = true;
       currentStep = {
-        startedAtMs: timestamp,
-        responseAtMs: timestamp,
-        hasResponseEvidence: false,
-        completedAtMs: timestamp,
-        reasoning: [],
-        tools: [],
+        step: {
+          startedAtMs: timestamp,
+          responseAtMs: timestamp,
+          hasResponseEvidence: false,
+          completedAtMs: timestamp,
+          reasoning: [],
+          tools: [],
+        },
+        sourceRange: {
+          startOffset: source.startOffset,
+          endOffset: source.endOffset,
+        },
+        llmClosed: false,
+        followedByAnotherWave: false,
       };
     }
     return currentStep;
+  };
+
+  const touchStep = (envelope: StepEnvelope, source: CodexTranscriptSourceRecord): void => {
+    envelope.sourceRange.startOffset = Math.min(envelope.sourceRange.startOffset, source.startOffset);
+    envelope.sourceRange.endOffset = Math.max(envelope.sourceRange.endOffset, source.endOffset);
   };
 
   const stepToolsComplete = (step: CodexTranscriptStep): boolean => (
@@ -112,14 +159,15 @@ function extractCodexTurn(
 
   const flushCurrentStep = (force = false): void => {
     if (!currentStep) return;
-    if (force || currentStep.reasoning.length > 0 || currentStep.tools.length > 0 || currentStep.finalText) {
-      steps.push(currentStep);
+    const step = currentStep.step;
+    if (force || step.reasoning.length > 0 || step.tools.length > 0 || step.finalText) {
+      stepEnvelopes.push(currentStep);
     }
     currentStep = null;
   };
   // TypeScript cannot infer mutations made by beginStep/flushCurrentStep through
   // their closures, so read the mutable step through an explicitly typed getter.
-  const activeStep = (): CodexTranscriptStep | null => currentStep;
+  const activeStep = (): StepEnvelope | null => currentStep;
   const appendPrompt = (value: string | undefined): void => {
     if (!value || promptParts.includes(value)) return;
     promptParts.push(value);
@@ -129,7 +177,8 @@ function extractCodexTurn(
     if (timestamp > 0) lastActivityAtMs = timestamp;
   };
 
-  for (const record of records) {
+  for (const source of records) {
+    const record = source.record;
     const payload = asRecord(record.payload);
     if (!payload) continue;
     const timestamp = timestampMs(record, Date.now());
@@ -165,11 +214,13 @@ function extractCodexTurn(
         continue;
       }
       if (payload.type === 'agent_message') {
-        const step = activeStep();
-        if (step && stepToolsComplete(step)) flushCurrentStep();
+        const active = activeStep();
+        if (active && stepToolsComplete(active.step)) flushCurrentStep();
         const message = stringValue(payload.message);
         if (message) {
-          const nextStep = beginStep(lastActivityAtMs || timestamp);
+          const next = beginStep(lastActivityAtMs || timestamp, source);
+          touchStep(next, source);
+          const nextStep = next.step;
           nextStep.responseAtMs = timestamp;
           nextStep.hasResponseEvidence = true;
           if (nextStep.reasoning[nextStep.reasoning.length - 1] !== message) {
@@ -182,9 +233,11 @@ function extractCodexTurn(
       if (payload.type === 'web_search_start') {
         const callId = stringValue(payload.call_id);
         if (callId) webSearchStarts.set(callId, timestamp);
-        const step = activeStep();
-        if (step && stepToolsComplete(step)) flushCurrentStep();
-        const nextStep = beginStep(lastActivityAtMs || timestamp);
+        const active = activeStep();
+        if (active && stepToolsComplete(active.step)) flushCurrentStep();
+        const next = beginStep(lastActivityAtMs || timestamp, source);
+        touchStep(next, source);
+        const nextStep = next.step;
         nextStep.responseAtMs = timestamp;
         nextStep.hasResponseEvidence = true;
         markActivity(timestamp);
@@ -194,37 +247,46 @@ function extractCodexTurn(
         const callId = stringValue(payload.call_id);
         if (callId) {
           webSearchEnds.set(callId, timestamp);
-          const step = toolSteps.get(callId);
+          const envelope = toolSteps.get(callId);
+          const step = envelope?.step;
           const tool = step?.tools.find(candidate => candidate.callId === callId);
           if (tool) {
             tool.completedAtMs = timestamp;
             step!.completedAtMs = Math.max(step!.completedAtMs, timestamp);
+            touchStep(envelope!, source);
           }
         }
         continue;
       }
       if (payload.type === 'token_count') {
         const usage = extractLastTokenUsage(payload.info);
-        if (!usage || sameUsage(lastUsage, usage)) continue;
-        lastUsage = usage;
-        const step = activeStep();
-        if (step && (step.tools.length === 0 || stepToolsComplete(step))) {
-          step.tokenUsage = usage;
-          if (step.tools.length > 0) flushCurrentStep();
-        } else {
+        if (!usage) continue;
+        const envelope = activeStep();
+        if (envelope?.step.hasResponseEvidence) {
+          envelope.step.tokenUsage = usage;
+          envelope.step.completedAtMs = Math.max(envelope.step.completedAtMs, timestamp);
+          envelope.llmClosed = true;
+          touchStep(envelope, source);
+          lastUsage = usage;
+          markActivity(timestamp);
+          flushCurrentStep();
+        } else if (!sameUsage(lastUsage, usage)) {
           // Do not shift an unanchored sample onto a later response wave.
           unmatchedTokenUsages.push(usage);
+          lastUsage = usage;
         }
         continue;
       }
       if (payload.type === 'task_complete' && stringValue(payload.turn_id) === expectedTurnId) {
         status = 'completed';
+        sawTerminal = true;
         terminalAtMs = timestamp;
         finalText = stringValue(payload.last_agent_message);
         break;
       }
       if (payload.type === 'turn_aborted' && stringValue(payload.turn_id) === expectedTurnId) {
         status = 'interrupted';
+        sawTerminal = true;
         terminalAtMs = timestamp;
         break;
       }
@@ -237,8 +299,10 @@ function extractCodexTurn(
       const role = stringValue(payload.role);
       if (role === 'assistant') {
         const active = activeStep();
-        if (active && stepToolsComplete(active)) flushCurrentStep();
-        const step = beginStep(lastActivityAtMs || timestamp);
+        if (active && stepToolsComplete(active.step)) flushCurrentStep();
+        const envelope = beginStep(lastActivityAtMs || timestamp, source);
+        touchStep(envelope, source);
+        const step = envelope.step;
         step.responseId ??= stringValue(payload.id);
         step.responseAtMs = timestamp;
         step.hasResponseEvidence = true;
@@ -259,8 +323,10 @@ function extractCodexTurn(
 
     if (itemType === 'reasoning') {
       const active = activeStep();
-      if (active && stepToolsComplete(active)) flushCurrentStep();
-      const step = beginStep(lastActivityAtMs || timestamp);
+      if (active && stepToolsComplete(active.step)) flushCurrentStep();
+      const envelope = beginStep(lastActivityAtMs || timestamp, source);
+      touchStep(envelope, source);
+      const step = envelope.step;
       step.responseId ??= stringValue(payload.id);
       step.responseAtMs = timestamp;
       step.hasResponseEvidence = true;
@@ -271,12 +337,14 @@ function extractCodexTurn(
     const call = transcriptToolCall(itemType, payload, timestamp);
     if (call) {
       const active = activeStep();
-      if (active && stepToolsComplete(active)) flushCurrentStep();
+      if (active && stepToolsComplete(active.step)) flushCurrentStep();
       if (call.name === 'web_search') {
         call.startedAtMs = webSearchStarts.get(call.callId) ?? (lastActivityAtMs || timestamp);
         call.completedAtMs = webSearchEnds.get(call.callId) ?? timestamp;
       }
-      const step = beginStep(lastActivityAtMs || call.startedAtMs);
+      const envelope = beginStep(lastActivityAtMs || call.startedAtMs, source);
+      touchStep(envelope, source);
+      const step = envelope.step;
       step.responseId ??= stringValue(payload.id);
       if (call.name !== 'web_search') {
         step.responseAtMs = step.tools.length === 0
@@ -290,48 +358,61 @@ function extractCodexTurn(
         step.hasResponseEvidence = true;
       }
       step.tools.push(call);
-      toolSteps.set(call.callId, step);
+      toolSteps.set(call.callId, envelope);
       markActivity(call.completedAtMs ?? timestamp);
       continue;
     }
 
     const toolOutput = transcriptToolOutput(itemType, payload);
     if (!toolOutput) continue;
-    const step = toolSteps.get(toolOutput.callId);
-    if (!step) continue;
-    const tool = step?.tools.find(candidate => candidate.callId === toolOutput.callId);
+    const envelope = toolSteps.get(toolOutput.callId);
+    if (!envelope) continue;
+    const step = envelope.step;
+    const tool = step.tools.find(candidate => candidate.callId === toolOutput.callId);
     if (!tool) continue;
     tool.completedAtMs = timestamp;
     tool.output = toolOutput.output;
     step.completedAtMs = Math.max(step.completedAtMs, timestamp);
+    touchStep(envelope, source);
     markActivity(timestamp);
   }
 
   if (opts.requireTerminal && (!status || !terminalAtMs)) return null;
 
   const finalActiveStep = activeStep();
-  if (finalActiveStep && stepToolsComplete(finalActiveStep)) flushCurrentStep();
+  if (finalActiveStep && stepToolsComplete(finalActiveStep.step)) flushCurrentStep();
   if (!status && !opts.requireTerminal) {
-    if (steps.length === 0 && !prompt) return null;
+    if (stepEnvelopes.length === 0 && !prompt) return null;
     terminalAtMs = lastActivityAtMs || startedAtMs || Date.now();
     status = 'completed';
   } else if (status === 'completed') {
-    const hadActiveStep = activeStep() !== null;
-    const step = activeStep() ?? beginStep(lastActivityAtMs || startedAtMs || terminalAtMs);
-    if (!hadActiveStep) step.responseAtMs = terminalAtMs;
-    if (finalText) {
-      if (step.reasoning[step.reasoning.length - 1] === finalText) step.reasoning.pop();
-      step.finalText = finalText;
+    let terminalEnvelope = activeStep() ?? stepEnvelopes.at(-1) ?? null;
+    if (!terminalEnvelope) {
+      const terminalSource = records.at(-1) ?? {
+        startOffset: 0,
+        endOffset: 0,
+        record: {},
+      };
+      terminalEnvelope = beginStep(lastActivityAtMs || startedAtMs || terminalAtMs, terminalSource);
+      terminalEnvelope.step.responseAtMs = terminalAtMs;
     }
-    step.completedAtMs = terminalAtMs;
-    flushCurrentStep(true);
+    if (terminalEnvelope) {
+      const step = terminalEnvelope.step;
+      if (finalText) {
+        if (step.reasoning[step.reasoning.length - 1] === finalText) step.reasoning.pop();
+        step.finalText = finalText;
+      }
+      step.completedAtMs = terminalAtMs;
+      if (terminalEnvelope === activeStep()) flushCurrentStep(true);
+    }
   } else if (activeStep()) {
-    activeStep()!.completedAtMs = terminalAtMs;
+    activeStep()!.step.completedAtMs = terminalAtMs;
     flushCurrentStep();
   }
 
   const resolvedStatus = status ?? 'completed';
-  return {
+  const steps = stepEnvelopes.map(envelope => envelope.step);
+  const turn: CodexExtractedTranscriptTurn = {
     sessionId: meta?.sessionId || fallbackSessionId,
     transcriptTurnId: expectedTurnId,
     provider: meta?.provider ?? 'openai',
@@ -348,6 +429,35 @@ function extractCodexTurn(
     steps,
     unmatchedTokenUsages,
   };
+  const committedEnvelopes = sawTerminal
+    ? stepEnvelopes
+    : leadingIncrementallyCommittableSteps(stepEnvelopes);
+  return {
+    turn,
+    committedStepCount: committedEnvelopes.length,
+    committedStepRanges: committedEnvelopes.map(envelope => ({ ...envelope.sourceRange })),
+    consumedEndOffset: committedEnvelopes.at(-1)?.sourceRange.endOffset ?? records[0]?.startOffset ?? 0,
+  };
+}
+
+function leadingIncrementallyCommittableSteps(envelopes: StepEnvelope[]): StepEnvelope[] {
+  const committed: StepEnvelope[] = [];
+  for (const envelope of envelopes) {
+    if (!envelope.llmClosed) break;
+    const toolsComplete = envelope.step.tools.length > 0
+      && envelope.step.tools.every(tool => tool.completedAtMs !== undefined);
+    if (!toolsComplete && !envelope.followedByAnotherWave) break;
+    committed.push(envelope);
+  }
+  return committed;
+}
+
+function toSourceRecords(records: Record<string, unknown>[]): CodexTranscriptSourceRecord[] {
+  return records.map((record, index) => ({
+    startOffset: index,
+    endOffset: index + 1,
+    record,
+  }));
 }
 
 export function sessionIdFromTranscriptPath(filePath: string): string {

--- a/src/inputs/codex-transcript/codex-transcript-extractor.ts
+++ b/src/inputs/codex-transcript/codex-transcript-extractor.ts
@@ -33,14 +33,53 @@ export function extractCodexTerminalTurn(
   fallbackSessionId: string,
   expectedTurnId: string,
 ): CodexExtractedTranscriptTurn | null {
-  let currentTurnId = '';
-  let startedAtMs = 0;
+  return extractCodexTurn(records, meta, fallbackSessionId, expectedTurnId, {
+    requireTerminal: true,
+  });
+}
+
+export function extractCodexPartialTurn(
+  records: Record<string, unknown>[],
+  meta: CodexTranscriptMeta | null,
+  fallbackSessionId: string,
+  expectedTurnId: string,
+  opts: {
+    startedAtMs?: number;
+    model?: string;
+    cwd?: string;
+    developerInstructions?: string;
+  } = {},
+): CodexExtractedTranscriptTurn | null {
+  return extractCodexTurn(records, meta, fallbackSessionId, expectedTurnId, {
+    requireTerminal: false,
+    startedAtMs: opts.startedAtMs,
+    model: opts.model,
+    cwd: opts.cwd,
+    developerInstructions: opts.developerInstructions,
+  });
+}
+
+function extractCodexTurn(
+  records: Record<string, unknown>[],
+  meta: CodexTranscriptMeta | null,
+  fallbackSessionId: string,
+  expectedTurnId: string,
+  opts: {
+    requireTerminal: boolean;
+    startedAtMs?: number;
+    model?: string;
+    cwd?: string;
+    developerInstructions?: string;
+  },
+): CodexExtractedTranscriptTurn | null {
+  let currentTurnId = opts.requireTerminal ? '' : expectedTurnId;
+  let startedAtMs = opts.startedAtMs ?? 0;
   let terminalAtMs = 0;
   let status: CodexTerminalStatus | null = null;
   let finalText: string | undefined;
-  let model = 'unknown';
-  let cwd: string | undefined;
-  let developerInstructions: string | undefined;
+  let model = opts.model ?? 'unknown';
+  let cwd = opts.cwd;
+  let developerInstructions = opts.developerInstructions;
   let prompt: string | undefined;
   const promptParts: string[] = [];
   const inputMessages: JsonValue[] = [];
@@ -268,11 +307,15 @@ export function extractCodexTerminalTurn(
     markActivity(timestamp);
   }
 
-  if (!status || !terminalAtMs) return null;
+  if (opts.requireTerminal && (!status || !terminalAtMs)) return null;
 
   const finalActiveStep = activeStep();
   if (finalActiveStep && stepToolsComplete(finalActiveStep)) flushCurrentStep();
-  if (status === 'completed') {
+  if (!status && !opts.requireTerminal) {
+    if (steps.length === 0 && !prompt) return null;
+    terminalAtMs = lastActivityAtMs || startedAtMs || Date.now();
+    status = 'completed';
+  } else if (status === 'completed') {
     const hadActiveStep = activeStep() !== null;
     const step = activeStep() ?? beginStep(lastActivityAtMs || startedAtMs || terminalAtMs);
     if (!hadActiveStep) step.responseAtMs = terminalAtMs;
@@ -287,12 +330,13 @@ export function extractCodexTerminalTurn(
     flushCurrentStep();
   }
 
+  const resolvedStatus = status ?? 'completed';
   return {
     sessionId: meta?.sessionId || fallbackSessionId,
     transcriptTurnId: expectedTurnId,
     provider: meta?.provider ?? 'openai',
     model,
-    status,
+    status: resolvedStatus,
     startedAtMs: startedAtMs || terminalAtMs,
     terminalAtMs,
     ...(prompt ? { prompt } : {}),

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -13,6 +13,7 @@ import {
 } from './codex-transcript-builder.js';
 import {
   extractCodexPartialTurn,
+  extractCodexPartialTurnWithBoundaries,
   extractCodexTranscriptMeta,
   sessionIdFromTranscriptPath,
 } from './codex-transcript-extractor.js';
@@ -24,7 +25,7 @@ import {
   type CodexTranscriptInputContext,
   type CodexTranscriptCheckpoint,
   type CodexTranscriptGlobalState,
-  type CodexTranscriptStep,
+  type CodexTranscriptSourceRange,
 } from './codex-transcript-types.js';
 import { stringValue, timestampMs } from './codex-transcript-utils.js';
 
@@ -47,11 +48,6 @@ interface JsonLine {
   startOffset: number;
   endOffset: number;
   record: Record<string, unknown>;
-}
-
-interface ClosedWaveRange {
-  startOffset: number;
-  endOffset: number;
 }
 
 interface SegmentRecoveryDiagnostics {
@@ -407,15 +403,15 @@ export class CodexTranscriptInput extends BaseInput {
       ? null
       : await readJsonLineAt(filePath, checkpoint.latestSessionMetaOffset);
     const meta = metaRecord ? extractCodexTranscriptMeta(metaRecord) : null;
-    const turn = extractCodexPartialTurn(
-      records.items.map(item => item.record),
+    const extraction = extractCodexPartialTurnWithBoundaries(
+      records.items,
       meta,
       sessionIdFromTranscriptPath(filePath),
       activeTurn.turnId,
       partialTurnOptions(activeTurn),
     );
     const previouslyEmittedStepCount = activeTurn.emittedStepCount ?? 0;
-    if (!turn) {
+    if (!extraction) {
       return {
         kind: 'unparseable',
         entries: [],
@@ -423,6 +419,7 @@ export class CodexTranscriptInput extends BaseInput {
         diagnostics: emptySegmentRecoveryDiagnostics(records.items.length, previouslyEmittedStepCount),
       };
     }
+    const turn = extraction.turn;
     updateActiveTurnFromExtractedTurn(activeTurn, turn);
     if (turn.unmatchedTokenUsages.length > 0) {
       this.logger.warn('Codex transcript token samples could not be assigned to a response wave', {
@@ -436,24 +433,18 @@ export class CodexTranscriptInput extends BaseInput {
     const stepStart = (activeTurn.emittedStepCount ?? 0) + 1;
     const closedStepCount = terminal
       ? turn.steps.length
-      : countLeadingClosedSteps(turn.steps);
+      : extraction.committedStepCount;
+    const committedTurn = closedStepCount === turn.steps.length
+      ? turn
+      : { ...turn, steps: turn.steps.slice(0, closedStepCount) };
     const inputContext = await this.resolveInputContext(filePath, activeTurn, meta);
-    const built = buildCodexTranscriptSegment(turn, {
+    const built = buildCodexTranscriptSegment(committedTurn, {
       includePrompt: activeTurn.emittedPrompt !== true,
       startStepNumber: stepStart,
       ...(inputContext ? { inputContext } : {}),
-      contextStepCount: closedStepCount,
+      contextStepCount: committedTurn.steps.length,
     });
-    const closedStepIds = new Set(
-      Array.from({ length: closedStepCount }, (_, index) => (
-        `${turn.sessionId}:${turn.transcriptTurnId}:s${stepStart + index}`
-      )),
-    );
-    const readyEntries = built.entries.filter(entry => {
-      const eventName = entry['event.name'];
-      if (eventName !== 'llm.request' && eventName !== 'llm.response') return true;
-      return closedStepIds.has(String(entry['gen_ai.step.id'] ?? ''));
-    });
+    const readyEntries = built.entries;
     const entries = this.filterNewSegmentEntries(readyEntries, activeTurn);
     const diagnostics: SegmentRecoveryDiagnostics = {
       sourceRecordCount: records.items.length,
@@ -496,9 +487,8 @@ export class CodexTranscriptInput extends BaseInput {
     if (turn.prompt) activeTurn.emittedPrompt = true;
     activeTurn.emittedStepCount = (activeTurn.emittedStepCount ?? 0) + closedStepCount;
 
-    const closedWaveRanges = findClosedWaveRanges(records.items);
     const lastClosedRange = closedStepCount > 0
-      ? closedWaveRanges[Math.min(closedStepCount, closedWaveRanges.length) - 1]
+      ? extraction.committedStepRanges[closedStepCount - 1]
       : undefined;
     if (closedStepCount > 0) {
       activeTurn.inputContext = persistedInputContext(built.nextInputContext, lastClosedRange);
@@ -506,7 +496,7 @@ export class CodexTranscriptInput extends BaseInput {
 
     const consumedEndOffset = terminal
       ? endOffset
-      : lastClosedRange?.endOffset ?? activeTurn.startOffset;
+      : extraction.consumedEndOffset;
 
     const resourceAttributes = await this.readWakeupResourceAttributes(turn.sessionId);
     const outputEntries = resourceAttributes ? attachWakeupResourceAttributes(entries, resourceAttributes) : entries;
@@ -1100,69 +1090,9 @@ function attachWakeupResourceAttributes(
   return entries;
 }
 
-function countLeadingClosedSteps(steps: CodexTranscriptStep[]): number {
-  let count = 0;
-  for (const step of steps) {
-    if (!step.tokenUsage) break;
-    count++;
-  }
-  return count;
-}
-
-function findClosedWaveRanges(items: JsonLine[]): ClosedWaveRange[] {
-  const ranges: ClosedWaveRange[] = [];
-  const pendingToolCalls = new Set<string>();
-  let waveStartOffset = items[0]?.startOffset ?? 0;
-  let hasResponseEvidence = false;
-
-  for (const line of items) {
-    const payload = asRecord(line.record.payload);
-    if (!payload) continue;
-
-    if (line.record.type === 'event_msg') {
-      if (payload.type === 'agent_message' || payload.type === 'web_search_start') {
-        hasResponseEvidence = true;
-      }
-      if (payload.type === 'token_count'
-        && hasResponseEvidence
-        && pendingToolCalls.size === 0
-        && asRecord(asRecord(payload.info)?.last_token_usage)) {
-        ranges.push({ startOffset: waveStartOffset, endOffset: line.endOffset });
-        waveStartOffset = line.endOffset;
-        hasResponseEvidence = false;
-      }
-      continue;
-    }
-
-    if (line.record.type !== 'response_item') continue;
-    const itemType = stringValue(payload.type);
-    if (itemType === 'message' && stringValue(payload.role) === 'assistant') {
-      hasResponseEvidence = true;
-      continue;
-    }
-    if (itemType === 'reasoning' || itemType === 'web_search_call') {
-      hasResponseEvidence = true;
-      continue;
-    }
-    if (itemType === 'function_call' || itemType === 'custom_tool_call' || itemType === 'tool_search_call') {
-      const callId = stringValue(payload.call_id) ?? stringValue(payload.id);
-      if (callId) pendingToolCalls.add(callId);
-      hasResponseEvidence = true;
-      continue;
-    }
-    if (itemType === 'function_call_output'
-      || itemType === 'custom_tool_call_output'
-      || itemType === 'tool_search_output') {
-      const callId = stringValue(payload.call_id) ?? stringValue(payload.id);
-      if (callId) pendingToolCalls.delete(callId);
-    }
-  }
-  return ranges;
-}
-
 function persistedInputContext(
   context: CodexTranscriptInputContext,
-  sourceRange: ClosedWaveRange | undefined,
+  sourceRange: CodexTranscriptSourceRange | undefined,
 ): CodexTranscriptInputContext {
   const delta = context.delta ?? [];
   const deltaBytes = Buffer.byteLength(JSON.stringify(delta), 'utf8');

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -7,9 +7,12 @@ import { ClientType, CollectionMethod } from '../../types/index.js';
 import type { AgentActivityEntry, JsonValue } from '../../types/index.js';
 import { directoryExists, resolveHome } from '../../utils/fs-utils.js';
 import { BaseInput, type InputOptions } from '../base/base-input.js';
-import { buildCodexTranscriptEntries } from './codex-transcript-builder.js';
 import {
-  extractCodexTerminalTurn,
+  buildCodexTranscriptSegment,
+  nextInputMessagesForStep,
+} from './codex-transcript-builder.js';
+import {
+  extractCodexPartialTurn,
   extractCodexTranscriptMeta,
   sessionIdFromTranscriptPath,
 } from './codex-transcript-extractor.js';
@@ -17,13 +20,18 @@ import {
   MAX_EMITTED_TERMINAL_TURNS,
   MAX_GLOBAL_EMITTED_TERMINAL_TURNS,
   type CodexActiveTranscriptTurn,
+  type CodexTranscriptInputContext,
   type CodexTranscriptCheckpoint,
   type CodexTranscriptGlobalState,
+  type CodexTranscriptStep,
 } from './codex-transcript-types.js';
 import { stringValue, timestampMs } from './codex-transcript-utils.js';
 
 const DEFAULT_SESSION_DIR = '~/.codex/sessions';
 const READ_CHUNK_SIZE = 1024 * 1024;
+const MAX_EMIT_BATCH_ENTRIES = 256;
+const MAX_EMIT_BATCH_BYTES = 1024 * 1024;
+const MAX_PERSISTED_INPUT_CONTEXT_BYTES = 1024 * 1024;
 // Values emitted by DEFAULT_RESOURCE_ENV_FIELD_MAP in assets/hooks/shared/resource-context.mjs.
 // Add new AgentTeams resource fields to both lists together.
 const WAKEUP_RESOURCE_ATTRIBUTE_KEYS = [
@@ -36,6 +44,16 @@ interface JsonLine {
   startOffset: number;
   endOffset: number;
   record: Record<string, unknown>;
+}
+
+interface ClosedWaveRange {
+  startOffset: number;
+  endOffset: number;
+}
+
+interface SegmentRecoveryResult {
+  entries: AgentActivityEntry[];
+  consumedEndOffset: number;
 }
 
 export interface CodexTranscriptInputOptions extends InputOptions {
@@ -99,19 +117,50 @@ export class CodexTranscriptInput extends BaseInput {
   }
 
   protected override async collect(): Promise<AgentActivityEntry[]> {
-    const entries: AgentActivityEntry[] = [];
+    let emittedCount = 0;
     for (const filePath of await this.discoverSessionFiles()) {
-      entries.push(...await this.processFile(filePath));
+      emittedCount += await this.processFile(filePath);
     }
-    return entries;
+    if (emittedCount > 0) {
+      this.logger.debug('cycle produced entries', { count: emittedCount });
+    }
+    return [];
   }
 
-  private async processFile(filePath: string): Promise<AgentActivityEntry[]> {
+  private emitEntryBatches(entries: AgentActivityEntry[]): number {
+    let emittedCount = 0;
+    let batch: AgentActivityEntry[] = [];
+    let batchBytes = 0;
+
+    const flush = (): void => {
+      if (batch.length === 0) return;
+      this.emit('entries', batch);
+      emittedCount += batch.length;
+      batch = [];
+      batchBytes = 0;
+    };
+
+    for (const entry of entries) {
+      const entryBytes = serializedEntryBytes(entry);
+      if (
+        batch.length > 0
+        && (batch.length >= MAX_EMIT_BATCH_ENTRIES || batchBytes + entryBytes > MAX_EMIT_BATCH_BYTES)
+      ) {
+        flush();
+      }
+      batch.push(entry);
+      batchBytes += entryBytes;
+    }
+    flush();
+    return emittedCount;
+  }
+
+  private async processFile(filePath: string): Promise<number> {
     let stat;
     try {
       stat = await fs.stat(filePath);
     } catch {
-      return [];
+      return 0;
     }
     const key = this.stateKey(filePath);
     let checkpoint = this.readCheckpoint(key);
@@ -127,7 +176,7 @@ export class CodexTranscriptInput extends BaseInput {
     } else if (checkpoint.inode !== stat.ino) {
       await this.baselineFile(filePath, key);
       this.saveGlobalEmittedTurnIds();
-      return [];
+      return 0;
     }
 
     const hadPendingTerminal = checkpoint.pendingTerminal !== null;
@@ -135,74 +184,85 @@ export class CodexTranscriptInput extends BaseInput {
     if (recoveredPending === null) {
       this.saveCheckpoint(key, checkpoint);
       this.saveGlobalEmittedTurnIds();
-      return [];
+      return 0;
     }
+    let emittedCount = this.emitEntryBatches(recoveredPending);
     const checkpointChangedByPending = hadPendingTerminal;
 
     if (stat.size <= checkpoint.scanOffset) {
       if (checkpointChangedByPending || recoveredPending.length > 0) this.saveCheckpoint(key, checkpoint);
       this.saveGlobalEmittedTurnIds();
-      return recoveredPending;
+      return emittedCount;
     }
-    const lines = await readJsonLines(filePath, checkpoint.scanOffset, stat.size);
-    if (lines.nextOffset === checkpoint.scanOffset) {
-      if (checkpointChangedByPending || recoveredPending.length > 0) this.saveCheckpoint(key, checkpoint);
-      this.saveGlobalEmittedTurnIds();
-      return recoveredPending;
-    }
-
-    const entries: AgentActivityEntry[] = recoveredPending;
-    let nextScanOffset = lines.nextOffset;
-    for (const line of lines.items) {
+    let terminalTurnId: string | null = null;
+    let terminalEndOffset: number | null = null;
+    const scan = await scanJsonLines(filePath, checkpoint.scanOffset, stat.size, line => {
       const payload = asRecord(line.record.payload);
-      if (!payload) continue;
+      if (!payload) return;
       if (line.record.type === 'session_meta') {
         checkpoint.latestSessionMetaOffset = line.startOffset;
-        continue;
+        return;
       }
 
       const turnId = turnIdForStart(line.record, payload);
       if (turnId) {
         if (!checkpoint.activeTurn || checkpoint.activeTurn.turnId !== turnId) {
-          checkpoint.activeTurn = {
-            turnId,
-            startOffset: line.startOffset,
-            startedAtMs: timestampMs(line.record, Date.now()),
-          };
+          checkpoint.activeTurn = createActiveTurn(turnId, line.startOffset, timestampMs(line.record, Date.now()));
         }
-        continue;
+        updateActiveTurnMetadata(checkpoint.activeTurn, line.record, payload);
+        return;
       }
 
-      const terminalTurnId = terminalTurnIdFor(line.record, payload);
-      if (!terminalTurnId || checkpoint.activeTurn?.turnId !== terminalTurnId) continue;
-      if (!checkpoint.emittedTerminalTurnIds.includes(terminalTurnId)) {
-        if (this.isGloballyEmittedTurn(terminalTurnId)) {
-          this.rememberCheckpointTurnId(checkpoint, terminalTurnId);
-          checkpoint.activeTurn = null;
-        } else {
-          const recovered = await this.recoverTurn(filePath, checkpoint, line.endOffset);
-          if (recovered.length > 0) {
-            entries.push(...recovered);
+      const terminal = terminalTurnIdFor(line.record, payload);
+      if (!terminal || checkpoint.activeTurn?.turnId !== terminal) return;
+      terminalTurnId = terminal;
+      terminalEndOffset = line.endOffset;
+      return false;
+    });
+    if (scan.nextOffset === checkpoint.scanOffset) {
+      if (checkpointChangedByPending || recoveredPending.length > 0) this.saveCheckpoint(key, checkpoint);
+      this.saveGlobalEmittedTurnIds();
+      return emittedCount;
+    }
+
+    const nextScanOffset = terminalEndOffset ?? scan.nextOffset;
+    if (checkpoint.activeTurn && nextScanOffset > checkpoint.activeTurn.startOffset) {
+      if (terminalTurnId && checkpoint.emittedTerminalTurnIds.includes(terminalTurnId)) {
+        checkpoint.activeTurn = null;
+      } else if (terminalTurnId && this.isGloballyEmittedTurn(terminalTurnId)) {
+        this.rememberCheckpointTurnId(checkpoint, terminalTurnId);
+        checkpoint.activeTurn = null;
+      } else {
+        const recovered = await this.recoverTurnSegment(
+          filePath,
+          checkpoint,
+          nextScanOffset,
+          terminalTurnId !== null,
+        );
+        emittedCount += this.emitEntryBatches(recovered.entries);
+        if (recovered.consumedEndOffset > checkpoint.activeTurn.startOffset) {
+          checkpoint.activeTurn.startOffset = recovered.consumedEndOffset;
+        }
+        if (terminalTurnId && checkpoint.activeTurn.turnId === terminalTurnId) {
+          if (recovered.entries.length > 0) {
             this.rememberCheckpointTurnId(checkpoint, terminalTurnId);
             this.rememberGlobalEmittedTurnId(terminalTurnId);
+            checkpoint.activeTurn = null;
           } else {
-            checkpoint.pendingTerminal = { turnId: terminalTurnId, terminalEndOffset: line.endOffset };
+            checkpoint.pendingTerminal = { turnId: terminalTurnId, terminalEndOffset: nextScanOffset };
             this.logger.warn('terminal Codex turn could not be reconstructed; retaining it for the next scan', {
               transcriptPath: filePath,
               turnId: terminalTurnId,
             });
-            nextScanOffset = line.endOffset;
-            break;
           }
         }
       }
-      checkpoint.activeTurn = null;
     }
 
     checkpoint.scanOffset = nextScanOffset;
     this.saveCheckpoint(key, checkpoint);
     this.saveGlobalEmittedTurnIds();
-    return entries;
+    return emittedCount;
   }
 
   /**
@@ -225,8 +285,8 @@ export class CodexTranscriptInput extends BaseInput {
       checkpoint.pendingTerminal = null;
       return [];
     }
-    const recovered = await this.recoverTurn(filePath, checkpoint, pending.terminalEndOffset);
-    if (recovered.length === 0) {
+    const recovered = await this.recoverTurnSegment(filePath, checkpoint, pending.terminalEndOffset, true);
+    if (recovered.entries.length === 0) {
       this.logger.warn('pending Codex terminal turn still could not be reconstructed; will retry', {
         transcriptPath: filePath,
         turnId: pending.turnId,
@@ -237,28 +297,32 @@ export class CodexTranscriptInput extends BaseInput {
     this.rememberGlobalEmittedTurnId(pending.turnId);
     checkpoint.activeTurn = null;
     checkpoint.pendingTerminal = null;
-    return recovered;
+    return recovered.entries;
   }
 
-  private async recoverTurn(
+  private async recoverTurnSegment(
     filePath: string,
     checkpoint: CodexTranscriptCheckpoint,
-    terminalEndOffset: number,
-  ): Promise<AgentActivityEntry[]> {
+    endOffset: number,
+    terminal: boolean,
+  ): Promise<SegmentRecoveryResult> {
     const activeTurn = checkpoint.activeTurn;
-    if (!activeTurn) return [];
-    const records = await readJsonLines(filePath, activeTurn.startOffset, terminalEndOffset);
+    if (!activeTurn) return { entries: [], consumedEndOffset: endOffset };
+    const records = await readJsonLines(filePath, activeTurn.startOffset, endOffset);
     const metaRecord = checkpoint.latestSessionMetaOffset === null
       ? null
       : await readJsonLineAt(filePath, checkpoint.latestSessionMetaOffset);
     const meta = metaRecord ? extractCodexTranscriptMeta(metaRecord) : null;
-    const turn = extractCodexTerminalTurn(
+    const turn = extractCodexPartialTurn(
       records.items.map(item => item.record),
       meta,
       sessionIdFromTranscriptPath(filePath),
       activeTurn.turnId,
+      partialTurnOptions(activeTurn),
     );
-    if (turn && turn.unmatchedTokenUsages.length > 0) {
+    if (!turn) return { entries: [], consumedEndOffset: activeTurn.startOffset };
+    updateActiveTurnFromExtractedTurn(activeTurn, turn);
+    if (turn.unmatchedTokenUsages.length > 0) {
       this.logger.warn('Codex transcript token samples could not be assigned to a response wave', {
         transcriptPath: filePath,
         turnId: activeTurn.turnId,
@@ -266,10 +330,134 @@ export class CodexTranscriptInput extends BaseInput {
         lastUsage: turn.unmatchedTokenUsages.at(-1),
       });
     }
-    if (!turn) return [];
-    const entries = buildCodexTranscriptEntries(turn);
+
+    const stepStart = (activeTurn.emittedStepCount ?? 0) + 1;
+    const closedStepCount = terminal
+      ? turn.steps.length
+      : countLeadingClosedSteps(turn.steps);
+    const inputContext = await this.resolveInputContext(filePath, activeTurn, meta);
+    const built = buildCodexTranscriptSegment(turn, {
+      includePrompt: activeTurn.emittedPrompt !== true,
+      startStepNumber: stepStart,
+      ...(inputContext ? { inputContext } : {}),
+      contextStepCount: closedStepCount,
+    });
+    const closedStepIds = new Set(
+      Array.from({ length: closedStepCount }, (_, index) => (
+        `${turn.sessionId}:${turn.transcriptTurnId}:s${stepStart + index}`
+      )),
+    );
+    const readyEntries = built.entries.filter(entry => {
+      const eventName = entry['event.name'];
+      if (eventName !== 'llm.request' && eventName !== 'llm.response') return true;
+      return closedStepIds.has(String(entry['gen_ai.step.id'] ?? ''));
+    });
+    const entries = this.filterNewSegmentEntries(readyEntries, activeTurn);
+
+    if (turn.prompt) activeTurn.emittedPrompt = true;
+    activeTurn.emittedStepCount = (activeTurn.emittedStepCount ?? 0) + closedStepCount;
+
+    const closedWaveRanges = findClosedWaveRanges(records.items);
+    const lastClosedRange = closedStepCount > 0
+      ? closedWaveRanges[Math.min(closedStepCount, closedWaveRanges.length) - 1]
+      : undefined;
+    if (closedStepCount > 0) {
+      activeTurn.inputContext = persistedInputContext(built.nextInputContext, lastClosedRange);
+    }
+
+    const consumedEndOffset = terminal
+      ? endOffset
+      : lastClosedRange?.endOffset ?? activeTurn.startOffset;
+
     const resourceAttributes = await this.readWakeupResourceAttributes(turn.sessionId);
-    return resourceAttributes ? attachWakeupResourceAttributes(entries, resourceAttributes) : entries;
+    return {
+      entries: resourceAttributes ? attachWakeupResourceAttributes(entries, resourceAttributes) : entries,
+      consumedEndOffset,
+    };
+  }
+
+  private async resolveInputContext(
+    filePath: string,
+    activeTurn: CodexActiveTranscriptTurn,
+    meta: ReturnType<typeof extractCodexTranscriptMeta>,
+  ): Promise<CodexTranscriptInputContext | undefined> {
+    const context = activeTurn.inputContext;
+    if (!context || context.delta) return context;
+    const range = context.deltaRange;
+    if (!range) return context;
+
+    const records = await readJsonLines(filePath, range.startOffset, range.endOffset);
+    const previous = extractCodexPartialTurn(
+      records.items.map(item => item.record),
+      meta,
+      sessionIdFromTranscriptPath(filePath),
+      activeTurn.turnId,
+      partialTurnOptions(activeTurn),
+    );
+    const lastStep = previous?.steps.at(-1);
+    if (!lastStep) {
+      this.logger.warn('could not rebuild oversized Codex input delta from transcript range', {
+        transcriptPath: filePath,
+        turnId: activeTurn.turnId,
+        range,
+      });
+      return context;
+    }
+    return { ...context, delta: nextInputMessagesForStep(lastStep) };
+  }
+
+  private filterNewSegmentEntries(
+    entries: AgentActivityEntry[],
+    activeTurn: NonNullable<CodexTranscriptCheckpoint['activeTurn']>,
+  ): AgentActivityEntry[] {
+    const out: AgentActivityEntry[] = [];
+    activeTurn.emittedStepRequestIds ??= [];
+    activeTurn.emittedStepResponseIds ??= [];
+    activeTurn.emittedToolCallIds ??= [];
+    activeTurn.emittedToolResultIds ??= [];
+
+    const stepRequests = new Set(activeTurn.emittedStepRequestIds);
+    const stepResponses = new Set(activeTurn.emittedStepResponseIds);
+    const toolCalls = new Set(activeTurn.emittedToolCallIds);
+    const toolResults = new Set(activeTurn.emittedToolResultIds);
+
+    for (const entry of entries) {
+      const eventName = entry['event.name'];
+      if (eventName === 'other') {
+        if (activeTurn.emittedPrompt) continue;
+        activeTurn.emittedPrompt = true;
+        out.push(entry);
+        continue;
+      }
+
+      const stepId = typeof entry['gen_ai.step.id'] === 'string' ? entry['gen_ai.step.id'] : '';
+      const toolCallId = typeof entry['gen_ai.tool.call.id'] === 'string' ? entry['gen_ai.tool.call.id'] : '';
+      if (eventName === 'llm.request') {
+        if (!stepId || stepRequests.has(stepId)) continue;
+        stepRequests.add(stepId);
+        out.push(entry);
+      } else if (eventName === 'llm.response') {
+        if (!stepId || stepResponses.has(stepId)) continue;
+        stepResponses.add(stepId);
+        out.push(entry);
+      } else if (eventName === 'tool.call') {
+        if (!toolCallId || toolCalls.has(toolCallId)) continue;
+        toolCalls.add(toolCallId);
+        out.push(entry);
+      } else if (eventName === 'tool.result') {
+        if (!toolCallId || toolResults.has(toolCallId)) continue;
+        toolResults.add(toolCallId);
+        out.push(entry);
+      } else {
+        out.push(entry);
+      }
+    }
+
+    activeTurn.emittedStepRequestIds = [...stepRequests];
+    activeTurn.emittedStepResponseIds = [...stepResponses];
+    activeTurn.emittedToolCallIds = [...toolCalls];
+    activeTurn.emittedToolResultIds = [...toolResults];
+    return out;
   }
 
   private async readWakeupResourceAttributes(sessionId: string): Promise<Record<string, JsonValue> | undefined> {
@@ -326,32 +514,38 @@ export class CodexTranscriptInput extends BaseInput {
     } catch {
       return;
     }
-    const lines = await readJsonLines(filePath, 0, stat.size);
     let latestSessionMetaOffset: number | null = null;
     let activeTurn: CodexActiveTranscriptTurn | null = null;
     const completedTurnIds: string[] = [];
-    for (const line of lines.items) {
+    const { nextOffset } = await scanJsonLines(filePath, 0, stat.size, line => {
       const payload = asRecord(line.record.payload);
-      if (!payload) continue;
+      if (!payload) return;
       if (line.record.type === 'session_meta') {
         latestSessionMetaOffset = line.startOffset;
-        continue;
+        return;
       }
       const turnId = turnIdForStart(line.record, payload);
       if (turnId && (!activeTurn || activeTurn.turnId !== turnId)) {
-        activeTurn = { turnId, startOffset: line.startOffset, startedAtMs: timestampMs(line.record, Date.now()) };
-        continue;
+        activeTurn = createActiveTurn(turnId, line.startOffset, timestampMs(line.record, Date.now()), true);
+      }
+      if (turnId && activeTurn?.turnId === turnId) {
+        updateActiveTurnMetadata(activeTurn, line.record, payload);
+        return;
       }
       const terminalTurnId = terminalTurnIdFor(line.record, payload);
       if (terminalTurnId === activeTurn?.turnId) {
         completedTurnIds.push(terminalTurnId);
         activeTurn = null;
       }
+    });
+    const baselineActiveTurn = activeTurn as CodexActiveTranscriptTurn | null;
+    if (baselineActiveTurn) {
+      baselineActiveTurn.startOffset = nextOffset;
     }
     for (const turnId of completedTurnIds) this.rememberGlobalEmittedTurnId(turnId);
     this.saveCheckpoint(key, {
       inode: stat.ino,
-      scanOffset: lines.nextOffset,
+      scanOffset: nextOffset,
       activeTurn,
       pendingTerminal: null,
       latestSessionMetaOffset,
@@ -374,11 +568,28 @@ export class CodexTranscriptInput extends BaseInput {
     const value = asRecord(raw);
     if (!value || typeof value.inode !== 'number' || typeof value.scanOffset !== 'number') return null;
     const active = asRecord(value.activeTurn);
+    const model = stringValue(active?.model);
+    const cwd = stringValue(active?.cwd);
+    const developerInstructions = stringValue(active?.developerInstructions);
     const activeTurn = active
       && typeof active.turnId === 'string'
       && typeof active.startOffset === 'number'
       && typeof active.startedAtMs === 'number'
-      ? { turnId: active.turnId, startOffset: active.startOffset, startedAtMs: active.startedAtMs }
+      ? {
+          turnId: active.turnId,
+          startOffset: active.startOffset,
+          startedAtMs: active.startedAtMs,
+          ...(model ? { model } : {}),
+          ...(cwd ? { cwd } : {}),
+          ...(developerInstructions ? { developerInstructions } : {}),
+          emittedPrompt: active.emittedPrompt === true,
+          emittedStepCount: typeof active.emittedStepCount === 'number' ? active.emittedStepCount : 0,
+          emittedStepRequestIds: stringArray(active.emittedStepRequestIds),
+          emittedStepResponseIds: stringArray(active.emittedStepResponseIds),
+          emittedToolCallIds: stringArray(active.emittedToolCallIds),
+          emittedToolResultIds: stringArray(active.emittedToolResultIds),
+          inputContext: parseInputContext(active.inputContext),
+        }
       : null;
     const pending = asRecord(value.pendingTerminal);
     const pendingTerminal = pending
@@ -509,9 +720,22 @@ async function readJsonLines(filePath: string, startOffset: number, endOffset: n
   nextOffset: number;
 }> {
   if (endOffset <= startOffset) return { items: [], nextOffset: startOffset };
+  const items: JsonLine[] = [];
+  const { nextOffset } = await scanJsonLines(filePath, startOffset, endOffset, line => {
+    items.push(line);
+  });
+  return { items, nextOffset };
+}
+
+async function scanJsonLines(
+  filePath: string,
+  startOffset: number,
+  endOffset: number,
+  onLine: (line: JsonLine) => void | false | Promise<void | false>,
+): Promise<{ nextOffset: number }> {
+  if (endOffset <= startOffset) return { nextOffset: startOffset };
   const handle = await fs.open(filePath, 'r');
   try {
-    const items: JsonLine[] = [];
     let nextOffset = startOffset;
     let position = startOffset;
     let pending = Buffer.alloc(0);
@@ -537,11 +761,15 @@ async function readJsonLines(filePath: string, startOffset: number, endOffset: n
           try {
             const record = JSON.parse(text);
             if (record && typeof record === 'object' && !Array.isArray(record)) {
-              items.push({
+              const keepGoing = await onLine({
                 startOffset: dataStartOffset + cursor,
                 endOffset: dataStartOffset + newline + 1,
                 record,
               });
+              if (keepGoing === false) {
+                nextOffset = dataStartOffset + newline + 1;
+                return { nextOffset };
+              }
             }
           } catch {
             // Invalid completed lines are ignored but their bytes are consumed.
@@ -555,7 +783,7 @@ async function readJsonLines(filePath: string, startOffset: number, endOffset: n
       pendingStartOffset = dataStartOffset + cursor;
     }
 
-    return { items, nextOffset };
+    return { nextOffset };
   } finally {
     await handle.close();
   }
@@ -593,6 +821,62 @@ function turnIdForStart(record: Record<string, unknown>, payload: Record<string,
   return stringValue(payload.turn_id) ?? null;
 }
 
+function createActiveTurn(
+  turnId: string,
+  startOffset: number,
+  startedAtMs: number,
+  emittedPrompt = false,
+): CodexActiveTranscriptTurn {
+  return {
+    turnId,
+    startOffset,
+    startedAtMs,
+    emittedPrompt,
+    emittedStepCount: 0,
+    emittedStepRequestIds: [],
+    emittedStepResponseIds: [],
+    emittedToolCallIds: [],
+    emittedToolResultIds: [],
+  };
+}
+
+function updateActiveTurnMetadata(
+  activeTurn: CodexActiveTranscriptTurn,
+  record: Record<string, unknown>,
+  payload: Record<string, unknown>,
+): void {
+  if (record.type !== 'turn_context') return;
+  const model = stringValue(payload.model);
+  const cwd = stringValue(payload.cwd);
+  const developerInstructions = stringValue(payload.developer_instructions);
+  if (model) activeTurn.model = model;
+  if (cwd) activeTurn.cwd = cwd;
+  if (developerInstructions) activeTurn.developerInstructions = developerInstructions;
+}
+
+function partialTurnOptions(activeTurn: CodexActiveTranscriptTurn): {
+  startedAtMs: number;
+  model?: string;
+  cwd?: string;
+  developerInstructions?: string;
+} {
+  return {
+    startedAtMs: activeTurn.startedAtMs,
+    ...(activeTurn.model ? { model: activeTurn.model } : {}),
+    ...(activeTurn.cwd ? { cwd: activeTurn.cwd } : {}),
+    ...(activeTurn.developerInstructions ? { developerInstructions: activeTurn.developerInstructions } : {}),
+  };
+}
+
+function updateActiveTurnFromExtractedTurn(
+  activeTurn: CodexActiveTranscriptTurn,
+  turn: { model: string; cwd?: string; developerInstructions?: string },
+): void {
+  if (turn.model && turn.model !== 'unknown') activeTurn.model = turn.model;
+  if (turn.cwd) activeTurn.cwd = turn.cwd;
+  if (turn.developerInstructions) activeTurn.developerInstructions = turn.developerInstructions;
+}
+
 function terminalTurnIdFor(record: Record<string, unknown>, payload: Record<string, unknown>): string | null {
   if (record.type !== 'event_msg' || (payload.type !== 'task_complete' && payload.type !== 'turn_aborted')) return null;
   return stringValue(payload.turn_id) ?? null;
@@ -602,6 +886,20 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
     ? value as Record<string, unknown>
     : null;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : [];
+}
+
+function serializedEntryBytes(entry: AgentActivityEntry): number {
+  try {
+    return Buffer.byteLength(JSON.stringify(entry), 'utf8');
+  } catch {
+    return MAX_EMIT_BATCH_BYTES;
+  }
 }
 
 function attachWakeupResourceAttributes(
@@ -616,6 +914,95 @@ function attachWakeupResourceAttributes(
     }
   }
   return entries;
+}
+
+function countLeadingClosedSteps(steps: CodexTranscriptStep[]): number {
+  let count = 0;
+  for (const step of steps) {
+    if (!step.tokenUsage) break;
+    count++;
+  }
+  return count;
+}
+
+function findClosedWaveRanges(items: JsonLine[]): ClosedWaveRange[] {
+  const ranges: ClosedWaveRange[] = [];
+  const pendingToolCalls = new Set<string>();
+  let waveStartOffset = items[0]?.startOffset ?? 0;
+  let hasResponseEvidence = false;
+
+  for (const line of items) {
+    const payload = asRecord(line.record.payload);
+    if (!payload) continue;
+
+    if (line.record.type === 'event_msg') {
+      if (payload.type === 'agent_message' || payload.type === 'web_search_start') {
+        hasResponseEvidence = true;
+      }
+      if (payload.type === 'token_count'
+        && hasResponseEvidence
+        && pendingToolCalls.size === 0
+        && asRecord(asRecord(payload.info)?.last_token_usage)) {
+        ranges.push({ startOffset: waveStartOffset, endOffset: line.endOffset });
+        waveStartOffset = line.endOffset;
+        hasResponseEvidence = false;
+      }
+      continue;
+    }
+
+    if (line.record.type !== 'response_item') continue;
+    const itemType = stringValue(payload.type);
+    if (itemType === 'message' && stringValue(payload.role) === 'assistant') {
+      hasResponseEvidence = true;
+      continue;
+    }
+    if (itemType === 'reasoning' || itemType === 'web_search_call') {
+      hasResponseEvidence = true;
+      continue;
+    }
+    if (itemType === 'function_call' || itemType === 'custom_tool_call' || itemType === 'tool_search_call') {
+      const callId = stringValue(payload.call_id) ?? stringValue(payload.id);
+      if (callId) pendingToolCalls.add(callId);
+      hasResponseEvidence = true;
+      continue;
+    }
+    if (itemType === 'function_call_output'
+      || itemType === 'custom_tool_call_output'
+      || itemType === 'tool_search_output') {
+      const callId = stringValue(payload.call_id) ?? stringValue(payload.id);
+      if (callId) pendingToolCalls.delete(callId);
+    }
+  }
+  return ranges;
+}
+
+function persistedInputContext(
+  context: CodexTranscriptInputContext,
+  sourceRange: ClosedWaveRange | undefined,
+): CodexTranscriptInputContext {
+  const delta = context.delta ?? [];
+  const deltaBytes = Buffer.byteLength(JSON.stringify(delta), 'utf8');
+  return {
+    hash: context.hash,
+    ...(context.fullMessages ? { fullMessages: context.fullMessages } : {}),
+    ...(deltaBytes <= MAX_PERSISTED_INPUT_CONTEXT_BYTES || !sourceRange
+      ? { delta }
+      : { deltaRange: sourceRange }),
+  };
+}
+
+function parseInputContext(value: unknown): CodexTranscriptInputContext | undefined {
+  const context = asRecord(value);
+  if (!context || typeof context.hash !== 'string') return undefined;
+  const range = asRecord(context.deltaRange);
+  return {
+    hash: context.hash,
+    ...(Array.isArray(context.delta) ? { delta: context.delta as JsonValue[] } : {}),
+    ...(Array.isArray(context.fullMessages) ? { fullMessages: context.fullMessages as JsonValue[] } : {}),
+    ...(range && typeof range.startOffset === 'number' && typeof range.endOffset === 'number'
+      ? { deltaRange: { startOffset: range.startOffset, endOffset: range.endOffset } }
+      : {}),
+  };
 }
 
 function safeWakeupSessionPart(value: string): string {

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -20,6 +20,7 @@ import {
   MAX_EMITTED_TERMINAL_TURNS,
   MAX_GLOBAL_EMITTED_TERMINAL_TURNS,
   type CodexActiveTranscriptTurn,
+  type CodexPendingTerminalTurn,
   type CodexTranscriptInputContext,
   type CodexTranscriptCheckpoint,
   type CodexTranscriptGlobalState,
@@ -32,6 +33,8 @@ const READ_CHUNK_SIZE = 1024 * 1024;
 const MAX_EMIT_BATCH_ENTRIES = 256;
 const MAX_EMIT_BATCH_BYTES = 1024 * 1024;
 const MAX_PERSISTED_INPUT_CONTEXT_BYTES = 1024 * 1024;
+const MAX_TERMINALS_PER_FILE_CYCLE = 100;
+const MAX_SCAN_BYTES_PER_FILE_CYCLE = 16 * 1024 * 1024;
 // Values emitted by DEFAULT_RESOURCE_ENV_FIELD_MAP in assets/hooks/shared/resource-context.mjs.
 // Add new AgentTeams resource fields to both lists together.
 const WAKEUP_RESOURCE_ATTRIBUTE_KEYS = [
@@ -51,9 +54,36 @@ interface ClosedWaveRange {
   endOffset: number;
 }
 
-interface SegmentRecoveryResult {
+interface SegmentRecoveryDiagnostics {
+  sourceRecordCount: number;
+  stepCount: number;
+  toolCount: number;
+  tokenUsageCount: number;
+  unmatchedTokenUsageCount: number;
+  builtEntryCount: number;
+  readyEntryCount: number;
+  deduplicatedEntryCount: number;
+  emittedEntryCount: number;
+  previouslyEmittedStepCount: number;
+}
+
+type SegmentRecoveryResult = {
+  kind: 'unparseable';
+  entries: [];
+  consumedEndOffset: number;
+  diagnostics: SegmentRecoveryDiagnostics;
+} | {
+  kind: 'processed-empty' | 'processed-emitted';
   entries: AgentActivityEntry[];
   consumedEndOffset: number;
+  terminalStatus: 'completed' | 'interrupted';
+  diagnostics: SegmentRecoveryDiagnostics;
+};
+
+interface PendingRecoveryResult {
+  blocked: boolean;
+  emittedCount: number;
+  processedTerminalCount: number;
 }
 
 export interface CodexTranscriptInputOptions extends InputOptions {
@@ -69,10 +99,10 @@ export class CodexTranscriptInput extends BaseInput {
   private readonly sessionDir: string;
   private readonly wakeupDir: string;
   private wakeupWatcher: FSWatcher | null = null;
-  private emittedTurnIdsLoaded = false;
-  private emittedTurnIdsDirty = false;
-  private emittedTurnIds = new Set<string>();
-  private emittedTurnIdOrder: string[] = [];
+  private processedTerminalTurnIdsLoaded = false;
+  private processedTerminalTurnIdsDirty = false;
+  private processedTerminalTurnIds = new Set<string>();
+  private processedTerminalTurnIdOrder: string[] = [];
 
   constructor(opts: CodexTranscriptInputOptions) {
     super({ stateStore: opts.stateStore, pollIntervalMs: opts.pollIntervalMs ?? 30_000 });
@@ -89,12 +119,12 @@ export class CodexTranscriptInput extends BaseInput {
   }
 
   protected override async onStart(): Promise<void> {
-    this.loadGlobalEmittedTurnIds();
+    this.loadGlobalProcessedTerminalTurnIds();
     for (const filePath of await this.discoverSessionFiles()) {
       const key = this.stateKey(filePath);
       if (!this.readCheckpoint(key)) await this.baselineFile(filePath, key);
     }
-    this.saveGlobalEmittedTurnIds();
+    this.saveGlobalProcessedTerminalTurnIds();
     await fs.mkdir(this.wakeupDir, { recursive: true });
     try {
       this.wakeupWatcher = fsSync.watch(this.wakeupDir, { persistent: false }, () => {
@@ -164,6 +194,7 @@ export class CodexTranscriptInput extends BaseInput {
     }
     const key = this.stateKey(filePath);
     let checkpoint = this.readCheckpoint(key);
+    let checkpointChanged = false;
     if (!checkpoint) {
       checkpoint = {
         inode: stat.ino,
@@ -173,95 +204,137 @@ export class CodexTranscriptInput extends BaseInput {
         latestSessionMetaOffset: null,
         emittedTerminalTurnIds: [],
       };
+      checkpointChanged = true;
     } else if (checkpoint.inode !== stat.ino) {
       await this.baselineFile(filePath, key);
-      this.saveGlobalEmittedTurnIds();
+      this.saveGlobalProcessedTerminalTurnIds();
       return 0;
     }
+
+    let emittedCount = 0;
+    let processedTerminalCount = 0;
+    let scannedBytes = 0;
 
     const hadPendingTerminal = checkpoint.pendingTerminal !== null;
-    const recoveredPending = await this.recoverPendingTerminal(filePath, checkpoint);
-    if (recoveredPending === null) {
-      this.saveCheckpoint(key, checkpoint);
-      this.saveGlobalEmittedTurnIds();
-      return 0;
-    }
-    let emittedCount = this.emitEntryBatches(recoveredPending);
-    const checkpointChangedByPending = hadPendingTerminal;
-
-    if (stat.size <= checkpoint.scanOffset) {
-      if (checkpointChangedByPending || recoveredPending.length > 0) this.saveCheckpoint(key, checkpoint);
-      this.saveGlobalEmittedTurnIds();
-      return emittedCount;
-    }
-    let terminalTurnId: string | null = null;
-    let terminalEndOffset: number | null = null;
-    const scan = await scanJsonLines(filePath, checkpoint.scanOffset, stat.size, line => {
-      const payload = asRecord(line.record.payload);
-      if (!payload) return;
-      if (line.record.type === 'session_meta') {
-        checkpoint.latestSessionMetaOffset = line.startOffset;
-        return;
-      }
-
-      const turnId = turnIdForStart(line.record, payload);
-      if (turnId) {
-        if (!checkpoint.activeTurn || checkpoint.activeTurn.turnId !== turnId) {
-          checkpoint.activeTurn = createActiveTurn(turnId, line.startOffset, timestampMs(line.record, Date.now()));
-        }
-        updateActiveTurnMetadata(checkpoint.activeTurn, line.record, payload);
-        return;
-      }
-
-      const terminal = terminalTurnIdFor(line.record, payload);
-      if (!terminal || checkpoint.activeTurn?.turnId !== terminal) return;
-      terminalTurnId = terminal;
-      terminalEndOffset = line.endOffset;
-      return false;
-    });
-    if (scan.nextOffset === checkpoint.scanOffset) {
-      if (checkpointChangedByPending || recoveredPending.length > 0) this.saveCheckpoint(key, checkpoint);
-      this.saveGlobalEmittedTurnIds();
+    const pendingResult = await this.recoverPendingTerminal(filePath, checkpoint);
+    checkpointChanged ||= hadPendingTerminal;
+    emittedCount += pendingResult.emittedCount;
+    processedTerminalCount += pendingResult.processedTerminalCount;
+    if (pendingResult.blocked) {
+      if (checkpointChanged) this.saveCheckpoint(key, checkpoint);
+      this.saveGlobalProcessedTerminalTurnIds();
       return emittedCount;
     }
 
-    const nextScanOffset = terminalEndOffset ?? scan.nextOffset;
-    if (checkpoint.activeTurn && nextScanOffset > checkpoint.activeTurn.startOffset) {
-      if (terminalTurnId && checkpoint.emittedTerminalTurnIds.includes(terminalTurnId)) {
-        checkpoint.activeTurn = null;
-      } else if (terminalTurnId && this.isGloballyEmittedTurn(terminalTurnId)) {
-        this.rememberCheckpointTurnId(checkpoint, terminalTurnId);
-        checkpoint.activeTurn = null;
-      } else {
-        const recovered = await this.recoverTurnSegment(
-          filePath,
-          checkpoint,
-          nextScanOffset,
-          terminalTurnId !== null,
-        );
-        emittedCount += this.emitEntryBatches(recovered.entries);
-        if (recovered.consumedEndOffset > checkpoint.activeTurn.startOffset) {
-          checkpoint.activeTurn.startOffset = recovered.consumedEndOffset;
+    while (
+      checkpoint.scanOffset < stat.size
+      && processedTerminalCount < MAX_TERMINALS_PER_FILE_CYCLE
+      && scannedBytes < MAX_SCAN_BYTES_PER_FILE_CYCLE
+    ) {
+      const scanStartOffset = checkpoint.scanOffset;
+      const scanEndOffset = Math.min(
+        stat.size,
+        scanStartOffset + (MAX_SCAN_BYTES_PER_FILE_CYCLE - scannedBytes),
+      );
+      let terminalTurnId: string | null = null;
+      let terminalEndOffset: number | null = null;
+      const processScannedLine = (line: JsonLine): void | false => {
+        const payload = asRecord(line.record.payload);
+        if (!payload) return;
+        if (line.record.type === 'session_meta') {
+          checkpoint.latestSessionMetaOffset = line.startOffset;
+          return;
         }
-        if (terminalTurnId && checkpoint.activeTurn.turnId === terminalTurnId) {
-          if (recovered.entries.length > 0) {
-            this.rememberCheckpointTurnId(checkpoint, terminalTurnId);
-            this.rememberGlobalEmittedTurnId(terminalTurnId);
-            checkpoint.activeTurn = null;
-          } else {
-            checkpoint.pendingTerminal = { turnId: terminalTurnId, terminalEndOffset: nextScanOffset };
-            this.logger.warn('terminal Codex turn could not be reconstructed; retaining it for the next scan', {
-              transcriptPath: filePath,
-              turnId: terminalTurnId,
-            });
+
+        const turnId = turnIdForStart(line.record, payload);
+        if (turnId) {
+          if (!checkpoint.activeTurn || checkpoint.activeTurn.turnId !== turnId) {
+            checkpoint.activeTurn = createActiveTurn(turnId, line.startOffset, timestampMs(line.record, Date.now()));
+          }
+          updateActiveTurnMetadata(checkpoint.activeTurn, line.record, payload);
+          return;
+        }
+
+        const terminal = terminalTurnIdFor(line.record, payload);
+        if (!terminal || checkpoint.activeTurn?.turnId !== terminal) return;
+        terminalTurnId = terminal;
+        terminalEndOffset = line.endOffset;
+        return false;
+      };
+      let scan = await scanJsonLines(filePath, scanStartOffset, scanEndOffset, processScannedLine);
+
+      // A single JSONL record may exceed the byte budget. Read far enough to
+      // consume one complete line so this file can make forward progress.
+      if (scan.nextOffset === scanStartOffset && scanEndOffset < stat.size) {
+        scan = await scanJsonLines(filePath, scanStartOffset, stat.size, line => {
+          processScannedLine(line);
+          return false;
+        });
+      }
+      if (scan.nextOffset === scanStartOffset) break;
+      checkpointChanged = true;
+
+      const nextScanOffset = terminalEndOffset ?? scan.nextOffset;
+      scannedBytes += nextScanOffset - scanStartOffset;
+      let blocked = false;
+
+      if (checkpoint.activeTurn && nextScanOffset > checkpoint.activeTurn.startOffset) {
+        if (terminalTurnId && checkpoint.emittedTerminalTurnIds.includes(terminalTurnId)) {
+          checkpoint.activeTurn = null;
+          checkpoint.pendingTerminal = null;
+          processedTerminalCount++;
+        } else if (terminalTurnId && this.isGloballyProcessedTerminalTurn(terminalTurnId)) {
+          this.rememberProcessedTerminalTurnId(checkpoint, terminalTurnId);
+          checkpoint.activeTurn = null;
+          checkpoint.pendingTerminal = null;
+          processedTerminalCount++;
+        } else {
+          const recovered = await this.recoverTurnSegment(
+            filePath,
+            checkpoint,
+            nextScanOffset,
+            terminalTurnId !== null,
+          );
+          emittedCount += this.emitEntryBatches(recovered.entries);
+          if (
+            recovered.kind !== 'unparseable'
+            && recovered.consumedEndOffset > checkpoint.activeTurn.startOffset
+          ) {
+            checkpoint.activeTurn.startOffset = recovered.consumedEndOffset;
+          }
+
+          if (terminalTurnId && checkpoint.activeTurn.turnId === terminalTurnId) {
+            if (recovered.kind === 'unparseable') {
+              checkpoint.pendingTerminal = newPendingTerminal(
+                terminalTurnId,
+                nextScanOffset,
+                recovered.diagnostics.sourceRecordCount,
+              );
+              this.logger.warn('terminal Codex turn could not be parsed; retaining it for the next scan', {
+                transcriptPath: filePath,
+                turnId: terminalTurnId,
+                range: { startOffset: checkpoint.activeTurn.startOffset, endOffset: nextScanOffset },
+                retryCount: checkpoint.pendingTerminal.retryCount,
+                sourceRecordCount: recovered.diagnostics.sourceRecordCount,
+              });
+              blocked = true;
+            } else {
+              this.rememberProcessedTerminalTurnId(checkpoint, terminalTurnId);
+              this.rememberGlobalProcessedTerminalTurnId(terminalTurnId);
+              checkpoint.activeTurn = null;
+              checkpoint.pendingTerminal = null;
+              processedTerminalCount++;
+            }
           }
         }
       }
+
+      checkpoint.scanOffset = nextScanOffset;
+      if (blocked || terminalTurnId === null) break;
     }
 
-    checkpoint.scanOffset = nextScanOffset;
-    this.saveCheckpoint(key, checkpoint);
-    this.saveGlobalEmittedTurnIds();
+    if (checkpointChanged) this.saveCheckpoint(key, checkpoint);
+    this.saveGlobalProcessedTerminalTurnIds();
     return emittedCount;
   }
 
@@ -272,32 +345,46 @@ export class CodexTranscriptInput extends BaseInput {
   private async recoverPendingTerminal(
     filePath: string,
     checkpoint: CodexTranscriptCheckpoint,
-  ): Promise<AgentActivityEntry[] | null> {
+  ): Promise<PendingRecoveryResult> {
     const pending = checkpoint.pendingTerminal;
-    if (!pending) return [];
+    if (!pending) return { blocked: false, emittedCount: 0, processedTerminalCount: 0 };
     if (checkpoint.activeTurn?.turnId !== pending.turnId) {
       checkpoint.pendingTerminal = null;
-      return [];
+      return { blocked: false, emittedCount: 0, processedTerminalCount: 0 };
     }
-    if (this.isGloballyEmittedTurn(pending.turnId)) {
-      this.rememberCheckpointTurnId(checkpoint, pending.turnId);
+    if (this.isGloballyProcessedTerminalTurn(pending.turnId)) {
+      this.rememberProcessedTerminalTurnId(checkpoint, pending.turnId);
       checkpoint.activeTurn = null;
       checkpoint.pendingTerminal = null;
-      return [];
+      return { blocked: false, emittedCount: 0, processedTerminalCount: 1 };
     }
     const recovered = await this.recoverTurnSegment(filePath, checkpoint, pending.terminalEndOffset, true);
-    if (recovered.entries.length === 0) {
-      this.logger.warn('pending Codex terminal turn still could not be reconstructed; will retry', {
+    if (recovered.kind === 'unparseable') {
+      const now = Date.now();
+      checkpoint.pendingTerminal = {
+        ...pending,
+        retryCount: (pending.retryCount ?? 0) + 1,
+        firstPendingAtMs: pending.firstPendingAtMs ?? now,
+        lastAttemptAtMs: now,
+        sourceRecordCount: recovered.diagnostics.sourceRecordCount,
+      };
+      this.logger.warn('pending Codex terminal turn still could not be parsed; will retry', {
         transcriptPath: filePath,
         turnId: pending.turnId,
+        range: { startOffset: checkpoint.activeTurn.startOffset, endOffset: pending.terminalEndOffset },
+        retryCount: checkpoint.pendingTerminal.retryCount,
+        firstPendingAtMs: checkpoint.pendingTerminal.firstPendingAtMs,
+        sourceRecordCount: recovered.diagnostics.sourceRecordCount,
       });
-      return null;
+      return { blocked: true, emittedCount: 0, processedTerminalCount: 0 };
     }
-    this.rememberCheckpointTurnId(checkpoint, pending.turnId);
-    this.rememberGlobalEmittedTurnId(pending.turnId);
+
+    const emittedCount = this.emitEntryBatches(recovered.entries);
+    this.rememberProcessedTerminalTurnId(checkpoint, pending.turnId);
+    this.rememberGlobalProcessedTerminalTurnId(pending.turnId);
     checkpoint.activeTurn = null;
     checkpoint.pendingTerminal = null;
-    return recovered.entries;
+    return { blocked: false, emittedCount, processedTerminalCount: 1 };
   }
 
   private async recoverTurnSegment(
@@ -307,7 +394,14 @@ export class CodexTranscriptInput extends BaseInput {
     terminal: boolean,
   ): Promise<SegmentRecoveryResult> {
     const activeTurn = checkpoint.activeTurn;
-    if (!activeTurn) return { entries: [], consumedEndOffset: endOffset };
+    if (!activeTurn) {
+      return {
+        kind: 'unparseable',
+        entries: [],
+        consumedEndOffset: endOffset,
+        diagnostics: emptySegmentRecoveryDiagnostics(),
+      };
+    }
     const records = await readJsonLines(filePath, activeTurn.startOffset, endOffset);
     const metaRecord = checkpoint.latestSessionMetaOffset === null
       ? null
@@ -320,7 +414,15 @@ export class CodexTranscriptInput extends BaseInput {
       activeTurn.turnId,
       partialTurnOptions(activeTurn),
     );
-    if (!turn) return { entries: [], consumedEndOffset: activeTurn.startOffset };
+    const previouslyEmittedStepCount = activeTurn.emittedStepCount ?? 0;
+    if (!turn) {
+      return {
+        kind: 'unparseable',
+        entries: [],
+        consumedEndOffset: activeTurn.startOffset,
+        diagnostics: emptySegmentRecoveryDiagnostics(records.items.length, previouslyEmittedStepCount),
+      };
+    }
     updateActiveTurnFromExtractedTurn(activeTurn, turn);
     if (turn.unmatchedTokenUsages.length > 0) {
       this.logger.warn('Codex transcript token samples could not be assigned to a response wave', {
@@ -353,6 +455,43 @@ export class CodexTranscriptInput extends BaseInput {
       return closedStepIds.has(String(entry['gen_ai.step.id'] ?? ''));
     });
     const entries = this.filterNewSegmentEntries(readyEntries, activeTurn);
+    const diagnostics: SegmentRecoveryDiagnostics = {
+      sourceRecordCount: records.items.length,
+      stepCount: turn.steps.length,
+      toolCount: turn.steps.reduce((count, step) => count + step.tools.length, 0),
+      tokenUsageCount: turn.steps.filter(step => step.tokenUsage !== undefined).length,
+      unmatchedTokenUsageCount: turn.unmatchedTokenUsages.length,
+      builtEntryCount: built.entries.length,
+      readyEntryCount: readyEntries.length,
+      deduplicatedEntryCount: readyEntries.length - entries.length,
+      emittedEntryCount: entries.length,
+      previouslyEmittedStepCount,
+    };
+
+    if (terminal && entries.length === 0) {
+      if (built.entries.length === 0) {
+        this.logger.debug('processed terminal Codex turn without observable entries', {
+          transcriptPath: filePath,
+          turnId: activeTurn.turnId,
+          terminalStatus: turn.status,
+          diagnostics,
+        });
+      } else if (readyEntries.length > 0 && diagnostics.deduplicatedEntryCount === readyEntries.length) {
+        this.logger.debug('terminal Codex turn entries were already emitted incrementally', {
+          transcriptPath: filePath,
+          turnId: activeTurn.turnId,
+          terminalStatus: turn.status,
+          diagnostics,
+        });
+      } else {
+        this.logger.warn('processed terminal Codex turn produced no explainable new entries', {
+          transcriptPath: filePath,
+          turnId: activeTurn.turnId,
+          terminalStatus: turn.status,
+          diagnostics,
+        });
+      }
+    }
 
     if (turn.prompt) activeTurn.emittedPrompt = true;
     activeTurn.emittedStepCount = (activeTurn.emittedStepCount ?? 0) + closedStepCount;
@@ -370,9 +509,13 @@ export class CodexTranscriptInput extends BaseInput {
       : lastClosedRange?.endOffset ?? activeTurn.startOffset;
 
     const resourceAttributes = await this.readWakeupResourceAttributes(turn.sessionId);
+    const outputEntries = resourceAttributes ? attachWakeupResourceAttributes(entries, resourceAttributes) : entries;
     return {
-      entries: resourceAttributes ? attachWakeupResourceAttributes(entries, resourceAttributes) : entries,
+      kind: outputEntries.length > 0 ? 'processed-emitted' : 'processed-empty',
+      entries: outputEntries,
       consumedEndOffset,
+      terminalStatus: turn.status,
+      diagnostics,
     };
   }
 
@@ -542,7 +685,7 @@ export class CodexTranscriptInput extends BaseInput {
     if (baselineActiveTurn) {
       baselineActiveTurn.startOffset = nextOffset;
     }
-    for (const turnId of completedTurnIds) this.rememberGlobalEmittedTurnId(turnId);
+    for (const turnId of completedTurnIds) this.rememberGlobalProcessedTerminalTurnId(turnId);
     this.saveCheckpoint(key, {
       inode: stat.ino,
       scanOffset: nextOffset,
@@ -595,7 +738,14 @@ export class CodexTranscriptInput extends BaseInput {
     const pendingTerminal = pending
       && typeof pending.turnId === 'string'
       && typeof pending.terminalEndOffset === 'number'
-      ? { turnId: pending.turnId, terminalEndOffset: pending.terminalEndOffset }
+      ? {
+          turnId: pending.turnId,
+          terminalEndOffset: pending.terminalEndOffset,
+          ...(typeof pending.retryCount === 'number' ? { retryCount: pending.retryCount } : {}),
+          ...(typeof pending.firstPendingAtMs === 'number' ? { firstPendingAtMs: pending.firstPendingAtMs } : {}),
+          ...(typeof pending.lastAttemptAtMs === 'number' ? { lastAttemptAtMs: pending.lastAttemptAtMs } : {}),
+          ...(typeof pending.sourceRecordCount === 'number' ? { sourceRecordCount: pending.sourceRecordCount } : {}),
+        }
       : null;
     return {
       inode: value.inode,
@@ -623,16 +773,16 @@ export class CodexTranscriptInput extends BaseInput {
     });
   }
 
-  private loadGlobalEmittedTurnIds(): void {
-    if (this.emittedTurnIdsLoaded) return;
-    this.emittedTurnIdsLoaded = true;
+  private loadGlobalProcessedTerminalTurnIds(): void {
+    if (this.processedTerminalTurnIdsLoaded) return;
+    this.processedTerminalTurnIdsLoaded = true;
 
     const global = this.readGlobalState();
     const hasPersistedGlobalState = global.emittedTerminalTurnIds.length > 0;
     for (const turnId of global.emittedTerminalTurnIds) {
-      if (this.emittedTurnIds.has(turnId)) continue;
-      this.emittedTurnIds.add(turnId);
-      this.emittedTurnIdOrder.push(turnId);
+      if (this.processedTerminalTurnIds.has(turnId)) continue;
+      this.processedTerminalTurnIds.add(turnId);
+      this.processedTerminalTurnIdOrder.push(turnId);
     }
 
     if (hasPersistedGlobalState) return;
@@ -644,7 +794,7 @@ export class CodexTranscriptInput extends BaseInput {
         ? value.emittedTerminalTurnIds
         : [];
       for (const turnId of emittedTerminalTurnIds) {
-        if (typeof turnId === 'string') this.rememberGlobalEmittedTurnId(turnId);
+        if (typeof turnId === 'string') this.rememberGlobalProcessedTerminalTurnId(turnId);
       }
     }
   }
@@ -661,40 +811,40 @@ export class CodexTranscriptInput extends BaseInput {
     };
   }
 
-  private saveGlobalEmittedTurnIds(): void {
-    if (!this.emittedTurnIdsDirty) return;
+  private saveGlobalProcessedTerminalTurnIds(): void {
+    if (!this.processedTerminalTurnIdsDirty) return;
     const current = this.stateStore.get(this.id);
     this.stateStore.update(this.id, {
-      lastOffset: this.emittedTurnIdOrder.length,
+      lastOffset: this.processedTerminalTurnIdOrder.length,
       extra: {
         ...(current.extra ?? {}),
         codexTranscriptGlobal: {
-          emittedTerminalTurnIds: this.emittedTurnIdOrder,
+          emittedTerminalTurnIds: this.processedTerminalTurnIdOrder,
         },
       },
     });
-    this.emittedTurnIdsDirty = false;
+    this.processedTerminalTurnIdsDirty = false;
   }
 
-  private isGloballyEmittedTurn(turnId: string): boolean {
-    this.loadGlobalEmittedTurnIds();
-    return this.emittedTurnIds.has(turnId);
+  private isGloballyProcessedTerminalTurn(turnId: string): boolean {
+    this.loadGlobalProcessedTerminalTurnIds();
+    return this.processedTerminalTurnIds.has(turnId);
   }
 
-  private rememberCheckpointTurnId(checkpoint: CodexTranscriptCheckpoint, turnId: string): void {
+  private rememberProcessedTerminalTurnId(checkpoint: CodexTranscriptCheckpoint, turnId: string): void {
     checkpoint.emittedTerminalTurnIds = [turnId, ...checkpoint.emittedTerminalTurnIds.filter(id => id !== turnId)]
       .slice(0, MAX_EMITTED_TERMINAL_TURNS);
   }
 
-  private rememberGlobalEmittedTurnId(turnId: string, markDirty = true): void {
-    if (this.emittedTurnIds.has(turnId)) return;
-    this.emittedTurnIds.add(turnId);
-    this.emittedTurnIdOrder.unshift(turnId);
-    while (this.emittedTurnIdOrder.length > MAX_GLOBAL_EMITTED_TERMINAL_TURNS) {
-      const removed = this.emittedTurnIdOrder.pop();
-      if (removed) this.emittedTurnIds.delete(removed);
+  private rememberGlobalProcessedTerminalTurnId(turnId: string, markDirty = true): void {
+    if (this.processedTerminalTurnIds.has(turnId)) return;
+    this.processedTerminalTurnIds.add(turnId);
+    this.processedTerminalTurnIdOrder.unshift(turnId);
+    while (this.processedTerminalTurnIdOrder.length > MAX_GLOBAL_EMITTED_TERMINAL_TURNS) {
+      const removed = this.processedTerminalTurnIdOrder.pop();
+      if (removed) this.processedTerminalTurnIds.delete(removed);
     }
-    if (markDirty) this.emittedTurnIdsDirty = true;
+    if (markDirty) this.processedTerminalTurnIdsDirty = true;
   }
 }
 
@@ -900,6 +1050,40 @@ function serializedEntryBytes(entry: AgentActivityEntry): number {
   } catch {
     return MAX_EMIT_BATCH_BYTES;
   }
+}
+
+function newPendingTerminal(
+  turnId: string,
+  terminalEndOffset: number,
+  sourceRecordCount: number,
+): CodexPendingTerminalTurn {
+  const now = Date.now();
+  return {
+    turnId,
+    terminalEndOffset,
+    retryCount: 1,
+    firstPendingAtMs: now,
+    lastAttemptAtMs: now,
+    sourceRecordCount,
+  };
+}
+
+function emptySegmentRecoveryDiagnostics(
+  sourceRecordCount = 0,
+  previouslyEmittedStepCount = 0,
+): SegmentRecoveryDiagnostics {
+  return {
+    sourceRecordCount,
+    stepCount: 0,
+    toolCount: 0,
+    tokenUsageCount: 0,
+    unmatchedTokenUsageCount: 0,
+    builtEntryCount: 0,
+    readyEntryCount: 0,
+    deduplicatedEntryCount: 0,
+    emittedEntryCount: 0,
+    previouslyEmittedStepCount,
+  };
 }
 
 function attachWakeupResourceAttributes(

--- a/src/inputs/codex-transcript/codex-transcript-types.ts
+++ b/src/inputs/codex-transcript/codex-transcript-types.ts
@@ -103,6 +103,29 @@ export interface CodexTranscriptStep {
   finalText?: string;
 }
 
+export interface CodexTranscriptSourceRecord {
+  startOffset: number;
+  endOffset: number;
+  record: Record<string, unknown>;
+}
+
+export interface CodexTranscriptSourceRange {
+  startOffset: number;
+  endOffset: number;
+}
+
+/**
+ * Partial extraction keeps semantic LLM-wave boundaries and byte-consumption
+ * boundaries together so the input cannot advance by a different unit than it
+ * emits.
+ */
+export interface CodexPartialTurnExtraction {
+  turn: CodexExtractedTranscriptTurn;
+  committedStepCount: number;
+  committedStepRanges: CodexTranscriptSourceRange[];
+  consumedEndOffset: number;
+}
+
 export interface CodexExtractedTranscriptTurn {
   sessionId: string;
   transcriptTurnId: string;

--- a/src/inputs/codex-transcript/codex-transcript-types.ts
+++ b/src/inputs/codex-transcript/codex-transcript-types.ts
@@ -5,10 +5,35 @@ export const MAX_GLOBAL_EMITTED_TERMINAL_TURNS = 10_000;
 
 export type CodexTerminalStatus = 'completed' | 'interrupted';
 
+export interface CodexTranscriptInputContext {
+  /** Chain hash for the complete request context represented by this state. */
+  hash: string;
+  /** Incremental messages required by the next LLM request. */
+  delta?: JsonValue[];
+  /** Full context is retained only while it remains below the configured limit. */
+  fullMessages?: JsonValue[];
+  /** Transcript range used to rebuild an oversized delta without bloating input-state.json. */
+  deltaRange?: {
+    startOffset: number;
+    endOffset: number;
+  };
+}
+
 export interface CodexActiveTranscriptTurn {
   turnId: string;
   startOffset: number;
   startedAtMs: number;
+  /** Turn-scoped context is needed after incremental recovery advances past turn_context. */
+  model?: string;
+  cwd?: string;
+  developerInstructions?: string;
+  emittedPrompt?: boolean;
+  emittedStepCount?: number;
+  emittedStepRequestIds?: string[];
+  emittedStepResponseIds?: string[];
+  emittedToolCallIds?: string[];
+  emittedToolResultIds?: string[];
+  inputContext?: CodexTranscriptInputContext;
 }
 
 /**
@@ -65,6 +90,7 @@ export interface CodexTranscriptStep {
   hasResponseEvidence: boolean;
   completedAtMs: number;
   responseId?: string;
+  inputMessages?: JsonValue[];
   reasoning: string[];
   tools: CodexTranscriptTool[];
   tokenUsage?: CodexTranscriptUsage;

--- a/src/inputs/codex-transcript/codex-transcript-types.ts
+++ b/src/inputs/codex-transcript/codex-transcript-types.ts
@@ -44,6 +44,10 @@ export interface CodexActiveTranscriptTurn {
 export interface CodexPendingTerminalTurn {
   turnId: string;
   terminalEndOffset: number;
+  retryCount?: number;
+  firstPendingAtMs?: number;
+  lastAttemptAtMs?: number;
+  sourceRecordCount?: number;
 }
 
 export interface CodexTranscriptCheckpoint {
@@ -52,10 +56,12 @@ export interface CodexTranscriptCheckpoint {
   activeTurn: CodexActiveTranscriptTurn | null;
   pendingTerminal: CodexPendingTerminalTurn | null;
   latestSessionMetaOffset: number | null;
+  /** Terminal turns already processed by this transcript, including empty control turns. */
   emittedTerminalTurnIds: string[];
 }
 
 export interface CodexTranscriptGlobalState {
+  /** Bounded cross-transcript registry; the persisted name is retained for compatibility. */
   emittedTerminalTurnIds: string[];
 }
 

--- a/tests/unit/core/input-manager.test.ts
+++ b/tests/unit/core/input-manager.test.ts
@@ -62,6 +62,31 @@ describe('InputManager', () => {
 
       expect(flusher.batchCalls.length).toBeGreaterThanOrEqual(1);
     });
+
+    it('serializes multiple entry batches from the same input', async () => {
+      const input = new StubInput('test-input');
+      const order: string[] = [];
+      let releaseFirst!: () => void;
+      const firstBlocked = new Promise<void>(resolve => {
+        releaseFirst = resolve;
+      });
+      flusher.sendBatch = vi.fn(async (entries: AgentActivityEntry[]) => {
+        const id = String(entries[0]['event.id']);
+        order.push(`start:${id}`);
+        if (id === 'first') await firstBlocked;
+        order.push(`finish:${id}`);
+      });
+      manager.registerInput(input as any);
+
+      input.emit('entries', [buildTestEntry({ 'event.id': 'first' })]);
+      input.emit('entries', [buildTestEntry({ 'event.id': 'second' })]);
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      expect(order).toEqual(['start:first']);
+      releaseFirst();
+      await new Promise(resolve => setTimeout(resolve, 20));
+      expect(order).toEqual(['start:first', 'finish:first', 'start:second', 'finish:second']);
+    });
   });
 
   describe('userId injection (T031)', () => {
@@ -339,6 +364,38 @@ describe('InputManager', () => {
       await manager.stopAll();
       expect(i1.stopCalls).toBe(1);
       expect(i2.stopCalls).toBe(1);
+    });
+
+    it('waits for queued entries before completing shutdown', async () => {
+      const input = new StubInput('queued-input');
+      let releaseBatch!: () => void;
+      let batchStarted!: () => void;
+      const started = new Promise<void>(resolve => {
+        batchStarted = resolve;
+      });
+      const blocked = new Promise<void>(resolve => {
+        releaseBatch = resolve;
+      });
+      flusher.sendBatch = vi.fn(async () => {
+        batchStarted();
+        await blocked;
+      });
+      manager.registerInput(input as any);
+      await input.start();
+      input.emit('entries', [buildTestEntry({ 'event.id': 'queued' })]);
+      await started;
+
+      let stopped = false;
+      const stopping = manager.stopAll().then(() => {
+        stopped = true;
+      });
+      await new Promise(resolve => setTimeout(resolve, 20));
+      expect(stopped).toBe(false);
+
+      releaseBatch();
+      await stopping;
+      expect(stopped).toBe(true);
+      expect(flusher.sendBatch).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -207,7 +207,23 @@ function simpleCompletedTurn(
   ];
 }
 
-async function createInput(root: string): Promise<{
+function controlOnlyAbortedTurn(sessionId: string, turnId: string, start: string): string[] {
+  const baseMs = Date.parse(start);
+  const at = (offsetMs: number) => new Date(baseMs + offsetMs).toISOString();
+  return [
+    record(at(0), 'event_msg', { type: 'task_started', turn_id: turnId }),
+    record(at(1_000), 'turn_context', { turn_id: turnId, model: 'gpt-5.5' }),
+    record(at(2_000), 'session_meta', { id: sessionId, model_provider: 'openai' }),
+    record(at(3_000), 'response_item', {
+      type: 'message',
+      role: 'developer',
+      content: [{ type: 'input_text', text: '<turn_aborted> previous turn interrupted' }],
+    }),
+    record(at(4_000), 'event_msg', { type: 'turn_aborted', turn_id: turnId }),
+  ];
+}
+
+async function createInput(root: string, pollIntervalMs = 10): Promise<{
   input: CodexTranscriptInput;
   entries: AgentActivityEntry[];
   batches: AgentActivityEntry[][];
@@ -219,7 +235,7 @@ async function createInput(root: string): Promise<{
   await stateStore.load();
   const sessionDir = path.join(root, 'sessions');
   const wakeupDir = path.join(root, 'wakeups');
-  const input = new CodexTranscriptInput({ stateStore, sessionDir, wakeupDir, pollIntervalMs: 10 });
+  const input = new CodexTranscriptInput({ stateStore, sessionDir, wakeupDir, pollIntervalMs });
   const entries: AgentActivityEntry[] = [];
   const batches: AgentActivityEntry[][] = [];
   input.on('entries', batch => {
@@ -227,6 +243,28 @@ async function createInput(root: string): Promise<{
     entries.push(...batch);
   });
   await input.start();
+  return { input, entries, batches, sessionDir, wakeupDir, stateStore };
+}
+
+async function createDormantInput(root: string): Promise<{
+  input: CodexTranscriptInput;
+  entries: AgentActivityEntry[];
+  batches: AgentActivityEntry[][];
+  sessionDir: string;
+  wakeupDir: string;
+  stateStore: StateStore;
+}> {
+  const stateStore = new StateStore(path.join(root, 'input-state.json'));
+  await stateStore.load();
+  const sessionDir = path.join(root, 'sessions');
+  const wakeupDir = path.join(root, 'wakeups');
+  const input = new CodexTranscriptInput({ stateStore, sessionDir, wakeupDir, pollIntervalMs: 60_000 });
+  const entries: AgentActivityEntry[] = [];
+  const batches: AgentActivityEntry[][] = [];
+  input.on('entries', batch => {
+    batches.push([...batch]);
+    entries.push(...batch);
+  });
   return { input, entries, batches, sessionDir, wakeupDir, stateStore };
 }
 
@@ -254,6 +292,24 @@ function responsesForTurn(entries: AgentActivityEntry[], turnId: string): AgentA
     entry['event.name'] === 'llm.response'
     && entry['agent.codex.transcript_turn_id'] === turnId,
   );
+}
+
+async function processTranscriptOnce(input: CodexTranscriptInput, transcript: string): Promise<number> {
+  return (input as unknown as { processFile(filePath: string): Promise<number> }).processFile(transcript);
+}
+
+function transcriptCheckpoint(
+  stateStore: StateStore,
+  transcript: string,
+): Record<string, unknown> {
+  return stateStore.get(`codex-transcript:${transcript}`).extra?.codexTranscript as Record<string, unknown>;
+}
+
+function globalProcessedTurnIds(stateStore: StateStore): string[] {
+  const global = stateStore.get('codex-transcript').extra?.codexTranscriptGlobal as {
+    emittedTerminalTurnIds?: string[];
+  } | undefined;
+  return global?.emittedTerminalTurnIds ?? [];
 }
 
 describe('CodexTranscriptInput', () => {
@@ -577,6 +633,289 @@ describe('CodexTranscriptInput', () => {
     expect(debug).toHaveBeenCalledWith(
       'Codex wakeup marker has no resourceAttributes; attribution skipped',
       { marker: path.join(wakeupDir, 'session-1.json') },
+    );
+  });
+
+  it('consumes a control-only aborted turn and emits later normal work in the same cycle', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-control-abort-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
+    const debug = vi.fn();
+    const warn = vi.fn();
+    (input as unknown as { logger: { debug: typeof debug; warn: typeof warn } }).logger.debug = debug;
+    (input as unknown as { logger: { debug: typeof debug; warn: typeof warn } }).logger.warn = warn;
+    const controlTurnId = 'turn-control';
+    const normalTurnId = 'turn-normal';
+    const transcript = await writeTranscript(
+      sessionDir,
+      [
+        ...controlOnlyAbortedTurn('session-1', controlTurnId, '2026-06-24T06:00:00.000Z'),
+        ...simpleCompletedTurn(
+          'session-1', normalTurnId, 'continue work', 'work completed', 120, 12,
+          '2026-06-24T06:01:00.000Z',
+        ).slice(1),
+      ].join('\n') + '\n',
+    );
+
+    await processTranscriptOnce(input, transcript);
+
+    expect(entries.filter(entry => entry['agent.codex.transcript_turn_id'] === controlTurnId)).toHaveLength(0);
+    expect(responsesForTurn(entries, normalTurnId)).toHaveLength(1);
+    const checkpoint = transcriptCheckpoint(stateStore, transcript) as {
+      activeTurn?: unknown;
+      pendingTerminal?: unknown;
+      emittedTerminalTurnIds?: string[];
+    };
+    expect(checkpoint.activeTurn).toBeNull();
+    expect(checkpoint.pendingTerminal).toBeNull();
+    expect(checkpoint.emittedTerminalTurnIds).toEqual(expect.arrayContaining([controlTurnId, normalTurnId]));
+    expect(globalProcessedTurnIds(stateStore)).toEqual(expect.arrayContaining([controlTurnId, normalTurnId]));
+    expect(debug).toHaveBeenCalledWith(
+      'processed terminal Codex turn without observable entries',
+      expect.objectContaining({ turnId: controlTurnId, terminalStatus: 'interrupted' }),
+    );
+    expect(warn).not.toHaveBeenCalledWith(
+      'processed terminal Codex turn produced no explainable new entries',
+      expect.anything(),
+    );
+  });
+
+  it('limits terminal recovery per file cycle and resumes from the saved offset', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-terminal-budget-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
+    const lines: string[] = [];
+    for (let index = 0; index < 101; index++) {
+      const turn = simpleCompletedTurn(
+        'session-1', `turn-${index}`, `prompt ${index}`, `response ${index}`, 100 + index, 10,
+        new Date(Date.parse('2026-06-24T06:00:00.000Z') + index * 10_000).toISOString(),
+      );
+      lines.push(...(index === 0 ? turn : turn.slice(1)));
+    }
+    const transcript = await writeTranscript(sessionDir, lines.join('\n') + '\n');
+    const transcriptSize = (await fs.stat(transcript)).size;
+
+    await processTranscriptOnce(input, transcript);
+    expect(entries.filter(entry => entry['event.name'] === 'llm.response')).toHaveLength(100);
+    expect((transcriptCheckpoint(stateStore, transcript) as { scanOffset?: number }).scanOffset)
+      .toBeLessThan(transcriptSize);
+
+    await processTranscriptOnce(input, transcript);
+    expect(entries.filter(entry => entry['event.name'] === 'llm.response')).toHaveLength(101);
+    expect((transcriptCheckpoint(stateStore, transcript) as { scanOffset?: number }).scanOffset)
+      .toBe(transcriptSize);
+  });
+
+  it('skips copied history, consumes a control abort, and emits new fork work in one cycle', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-fork-control-abort-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
+    const historyTurnId = 'turn-history';
+    const controlTurnId = 'turn-control';
+    const forkTurnId = 'turn-fork-new';
+    const history = simpleCompletedTurn(
+      'session-parent', historyTurnId, 'parent work', 'parent done', 100, 10,
+      '2026-06-24T06:00:00.000Z',
+    );
+    const parent = await writeTranscriptNamed(sessionDir, 'rollout-parent.jsonl', history.join('\n') + '\n');
+    await processTranscriptOnce(input, parent);
+
+    const fork = await writeTranscriptNamed(
+      sessionDir,
+      'rollout-fork.jsonl',
+      [
+        record('2026-06-24T06:10:00.000Z', 'session_meta', {
+          id: 'session-fork', model_provider: 'openai', forked_from_id: 'session-parent',
+        }),
+        ...history.slice(1),
+        ...controlOnlyAbortedTurn('session-fork', controlTurnId, '2026-06-24T06:11:00.000Z'),
+        ...simpleCompletedTurn(
+          'session-fork', forkTurnId, 'continue fork work', 'fork work completed', 130, 13,
+          '2026-06-24T06:12:00.000Z',
+        ).slice(1),
+      ].join('\n') + '\n',
+    );
+    await processTranscriptOnce(input, fork);
+
+    expect(responsesForTurn(entries, historyTurnId)).toHaveLength(1);
+    expect(entries.filter(entry => entry['agent.codex.transcript_turn_id'] === controlTurnId)).toHaveLength(0);
+    expect(responsesForTurn(entries, forkTurnId)).toHaveLength(1);
+    const checkpoint = transcriptCheckpoint(stateStore, fork) as {
+      activeTurn?: unknown;
+      pendingTerminal?: unknown;
+      emittedTerminalTurnIds?: string[];
+    };
+    expect(checkpoint.activeTurn).toBeNull();
+    expect(checkpoint.pendingTerminal).toBeNull();
+    expect(checkpoint.emittedTerminalTurnIds).toEqual(
+      expect.arrayContaining([historyTurnId, controlTurnId, forkTurnId]),
+    );
+    expect(globalProcessedTurnIds(stateStore)).toContain(controlTurnId);
+
+    await stateStore.save();
+    const restarted = await createDormantInput(root);
+    const debug = vi.fn();
+    (restarted.input as unknown as { logger: { debug: typeof debug } }).logger.debug = debug;
+    const restartedTurnId = 'turn-fork-after-restart';
+    const secondFork = await writeTranscriptNamed(
+      restarted.sessionDir,
+      'rollout-fork-after-restart.jsonl',
+      [
+        record('2026-06-24T06:20:00.000Z', 'session_meta', {
+          id: 'session-fork-2', model_provider: 'openai', forked_from_id: 'session-fork',
+        }),
+        ...controlOnlyAbortedTurn('session-fork-2', controlTurnId, '2026-06-24T06:21:00.000Z'),
+        ...simpleCompletedTurn(
+          'session-fork-2', restartedTurnId, 'continue after restart', 'restart work completed', 140, 14,
+          '2026-06-24T06:22:00.000Z',
+        ).slice(1),
+      ].join('\n') + '\n',
+    );
+    await processTranscriptOnce(restarted.input, secondFork);
+
+    expect(responsesForTurn(restarted.entries, restartedTurnId)).toHaveLength(1);
+    expect((transcriptCheckpoint(restarted.stateStore, secondFork) as {
+      emittedTerminalTurnIds?: string[];
+    }).emittedTerminalTurnIds).toContain(controlTurnId);
+    expect(debug).not.toHaveBeenCalledWith(
+      'processed terminal Codex turn without observable entries',
+      expect.objectContaining({ turnId: controlTurnId }),
+    );
+  });
+
+  it('clears a legacy empty pending terminal and emits later work during startup collection', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-legacy-empty-pending-'));
+    tempDirs.push(root);
+    const sessionDir = path.join(root, 'sessions');
+    const controlTurnId = 'turn-control';
+    const normalTurnId = 'turn-normal';
+    const controlLines = controlOnlyAbortedTurn('session-1', controlTurnId, '2026-06-24T06:00:00.000Z');
+    const controlText = controlLines.join('\n') + '\n';
+    const transcript = await writeTranscriptNamed(
+      sessionDir,
+      'rollout-session-1.jsonl',
+      controlText + simpleCompletedTurn(
+        'session-1', normalTurnId, 'continue work', 'work completed', 120, 12,
+        '2026-06-24T06:01:00.000Z',
+      ).slice(1).join('\n') + '\n',
+    );
+    const stat = await fs.stat(transcript);
+    const terminalEndOffset = Buffer.byteLength(controlText);
+    const sessionMetaOffset = Buffer.byteLength(controlLines.slice(0, 2).join('\n') + '\n');
+    const persistedState = new StateStore(path.join(root, 'input-state.json'));
+    await persistedState.load();
+    persistedState.update(`codex-transcript:${transcript}`, {
+      lastOffset: terminalEndOffset,
+      extra: {
+        codexTranscript: {
+          inode: stat.ino,
+          scanOffset: terminalEndOffset,
+          activeTurn: {
+            turnId: controlTurnId,
+            startOffset: 0,
+            startedAtMs: Date.parse('2026-06-24T06:00:00.000Z'),
+            model: 'gpt-5.5',
+          },
+          pendingTerminal: { turnId: controlTurnId, terminalEndOffset },
+          latestSessionMetaOffset: sessionMetaOffset,
+          emittedTerminalTurnIds: [],
+        },
+      },
+    });
+    await persistedState.save();
+
+    const recovered = await createInput(root, 60_000);
+    await recovered.input.stop();
+
+    expect(recovered.entries.filter(entry => entry['agent.codex.transcript_turn_id'] === controlTurnId)).toHaveLength(0);
+    expect(responsesForTurn(recovered.entries, normalTurnId)).toHaveLength(1);
+    const checkpoint = transcriptCheckpoint(recovered.stateStore, transcript) as {
+      activeTurn?: unknown;
+      pendingTerminal?: unknown;
+      emittedTerminalTurnIds?: string[];
+    };
+    expect(checkpoint.activeTurn).toBeNull();
+    expect(checkpoint.pendingTerminal).toBeNull();
+    expect(checkpoint.emittedTerminalTurnIds).toEqual(expect.arrayContaining([controlTurnId, normalTurnId]));
+    expect(globalProcessedTurnIds(recovered.stateStore)).toEqual(
+      expect.arrayContaining([controlTurnId, normalTurnId]),
+    );
+  });
+
+  it('retains a truly unparseable pending range and does not scan later work', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-unparseable-pending-'));
+    tempDirs.push(root);
+    const sessionDir = path.join(root, 'sessions');
+    const pendingTurnId = 'turn-unparseable';
+    const normalTurnId = 'turn-normal';
+    const pendingText = record('2026-06-24T06:00:00.000Z', 'event_msg', {
+      type: 'task_started', turn_id: pendingTurnId,
+    }) + '\n';
+    const transcript = await writeTranscriptNamed(
+      sessionDir,
+      'rollout-session-1.jsonl',
+      pendingText + simpleCompletedTurn(
+        'session-1', normalTurnId, 'later work', 'later work completed', 120, 12,
+        '2026-06-24T06:01:00.000Z',
+      ).join('\n') + '\n',
+    );
+    const stat = await fs.stat(transcript);
+    const terminalEndOffset = Buffer.byteLength(pendingText);
+    const stateStore = new StateStore(path.join(root, 'input-state.json'));
+    await stateStore.load();
+    stateStore.update(`codex-transcript:${transcript}`, {
+      lastOffset: terminalEndOffset,
+      extra: {
+        codexTranscript: {
+          inode: stat.ino,
+          scanOffset: terminalEndOffset,
+          activeTurn: {
+            turnId: pendingTurnId,
+            startOffset: 0,
+            startedAtMs: Date.parse('2026-06-24T06:00:00.000Z'),
+          },
+          pendingTerminal: { turnId: pendingTurnId, terminalEndOffset },
+          latestSessionMetaOffset: null,
+          emittedTerminalTurnIds: [],
+        },
+      },
+    });
+    await stateStore.save();
+
+    const loadedState = new StateStore(path.join(root, 'input-state.json'));
+    await loadedState.load();
+    const input = new CodexTranscriptInput({
+      stateStore: loadedState,
+      sessionDir,
+      wakeupDir: path.join(root, 'wakeups'),
+      pollIntervalMs: 60_000,
+    });
+    const entries: AgentActivityEntry[] = [];
+    const warn = vi.fn();
+    input.on('entries', batch => entries.push(...batch));
+    (input as unknown as { logger: { warn: typeof warn } }).logger.warn = warn;
+    await input.start();
+    await input.stop();
+
+    expect(responsesForTurn(entries, normalTurnId)).toHaveLength(0);
+    const checkpoint = transcriptCheckpoint(loadedState, transcript) as {
+      scanOffset?: number;
+      pendingTerminal?: { turnId?: string; retryCount?: number; sourceRecordCount?: number };
+    };
+    expect(checkpoint.scanOffset).toBe(terminalEndOffset);
+    expect(checkpoint.pendingTerminal).toMatchObject({
+      turnId: pendingTurnId,
+      retryCount: 1,
+      sourceRecordCount: 1,
+    });
+    expect(warn).toHaveBeenCalledWith(
+      'pending Codex terminal turn still could not be parsed; will retry',
+      expect.objectContaining({
+        transcriptPath: transcript,
+        turnId: pendingTurnId,
+        retryCount: 1,
+        sourceRecordCount: 1,
+      }),
     );
   });
 

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -48,6 +48,7 @@ function completedTurn(): string {
   return [
     record('2026-06-24T06:00:00.000Z', 'session_meta', {
       id: 'session-1', model_provider: 'openai',
+      dynamic_tools: [{ name: 'exec_command', description: 'Run a command' }],
     }),
     record('2026-06-24T06:00:01.000Z', 'turn_context', {
       turn_id: 'turn-1',
@@ -1371,13 +1372,16 @@ describe('CodexTranscriptInput', () => {
       'gen_ai.request.model': 'gpt-5.5',
       'agent.codex.cwd': '/tmp/project',
       'gen_ai.system_instructions': [{ type: 'text', content: 'Follow the project conventions.' }],
+      'gen_ai.tool.definitions': [{ name: 'exec_command', description: 'Run a command' }],
     });
-    expect(restarted.entries.find(entry => entry['gen_ai.step.id'] === 'session-1:turn-1:s2'
-      && entry['event.name'] === 'llm.response')).toMatchObject({
+    const secondResponse = restarted.entries.find(entry => entry['gen_ai.step.id'] === 'session-1:turn-1:s2'
+      && entry['event.name'] === 'llm.response');
+    expect(secondResponse).toMatchObject({
       'gen_ai.response.model': 'gpt-5.5',
       'agent.codex.cwd': '/tmp/project',
-      'gen_ai.system_instructions': [{ type: 'text', content: 'Follow the project conventions.' }],
     });
+    expect(secondResponse?.['gen_ai.system_instructions']).toBeUndefined();
+    expect(secondResponse?.['gen_ai.tool.definitions']).toBeUndefined();
   });
 
   it('rebuilds an oversized persisted delta from transcript offsets', async () => {

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -1178,6 +1178,149 @@ describe('CodexTranscriptInput', () => {
     await input.stop();
   });
 
+  it('keeps token-delimited message waves as separate steps across collection cycles', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-message-waves-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, stateStore } = await createInput(root, 60_000);
+    const firstWave = [
+      record('2026-06-24T06:00:00.000Z', 'session_meta', { id: 'session-1', model_provider: 'openai' }),
+      record('2026-06-24T06:00:01.000Z', 'turn_context', { turn_id: 'turn-1', model: 'gpt-5.5' }),
+      record('2026-06-24T06:00:02.000Z', 'event_msg', { type: 'task_started', turn_id: 'turn-1' }),
+      record('2026-06-24T06:00:03.000Z', 'response_item', {
+        type: 'message', role: 'user', content: [{ type: 'input_text', text: 'run it' }],
+      }),
+      record('2026-06-24T06:00:04.000Z', 'event_msg', {
+        type: 'agent_message', message: 'A', phase: 'commentary',
+      }),
+      record('2026-06-24T06:00:05.000Z', 'event_msg', tokenUsage(10, 2)),
+    ];
+    const transcript = await writeTranscript(sessionDir, firstWave.join('\n') + '\n');
+
+    await processTranscriptOnce(input, transcript);
+    expect(entries.filter(entry => entry['event.name'] === 'llm.response')).toHaveLength(0);
+
+    const checkpointAfterA = transcriptCheckpoint(stateStore, transcript) as {
+      activeTurn?: { startOffset?: number };
+    };
+    expect(checkpointAfterA.activeTurn?.startOffset).toBeLessThan(Buffer.byteLength(firstWave.join('\n') + '\n'));
+
+    const secondWave = [
+      record('2026-06-24T06:00:06.000Z', 'event_msg', {
+        type: 'agent_message', message: 'B', phase: 'commentary',
+      }),
+      record('2026-06-24T06:00:07.000Z', 'response_item', {
+        type: 'function_call', id: 'fc-1', call_id: 'call-1', name: 'exec_command', arguments: '{"cmd":"pwd"}',
+      }),
+      record('2026-06-24T06:00:08.000Z', 'response_item', {
+        type: 'function_call_output', call_id: 'call-1', output: '"/tmp"',
+      }),
+      // Deliberately identical to wave A: equal token values are not a cross-wave dedupe key.
+      record('2026-06-24T06:00:09.000Z', 'event_msg', tokenUsage(10, 2)),
+    ];
+    await fs.appendFile(transcript, secondWave.join('\n') + '\n', 'utf8');
+    await processTranscriptOnce(input, transcript);
+
+    expect(entries.filter(entry => entry['event.name'] === 'llm.response').map(entry => ({
+      stepId: entry['gen_ai.step.id'],
+      totalTokens: entry['gen_ai.usage.total_tokens'],
+      finishReasons: entry['gen_ai.response.finish_reasons'],
+    }))).toEqual([
+      { stepId: 'session-1:turn-1:s1', totalTokens: 12, finishReasons: ['stop'] },
+      { stepId: 'session-1:turn-1:s2', totalTokens: 12, finishReasons: ['tool_call'] },
+    ]);
+    expect(entries.filter(entry => entry['event.name'] === 'tool.call')).toHaveLength(1);
+    expect(entries.filter(entry => entry['event.name'] === 'tool.result')).toHaveLength(1);
+
+    const finalWave = [
+      record('2026-06-24T06:00:10.000Z', 'event_msg', {
+        type: 'agent_message', message: 'C', phase: 'final',
+      }),
+      record('2026-06-24T06:00:11.000Z', 'event_msg', tokenUsage(20, 3)),
+    ];
+    await fs.appendFile(transcript, finalWave.join('\n') + '\n', 'utf8');
+    await processTranscriptOnce(input, transcript);
+    expect(entries.filter(entry => entry['event.name'] === 'llm.response')).toHaveLength(2);
+
+    await fs.appendFile(transcript, record('2026-06-24T06:00:12.000Z', 'event_msg', {
+      type: 'task_complete', turn_id: 'turn-1', last_agent_message: 'C',
+    }) + '\n', 'utf8');
+    await processTranscriptOnce(input, transcript);
+    await input.stop();
+
+    const responses = entries.filter(entry => entry['event.name'] === 'llm.response');
+    expect(responses.map(entry => entry['gen_ai.step.id'])).toEqual([
+      'session-1:turn-1:s1',
+      'session-1:turn-1:s2',
+      'session-1:turn-1:s3',
+    ]);
+    expect(responses[2]).toMatchObject({
+      'gen_ai.response.finish_reasons': ['stop'],
+      'gen_ai.usage.total_tokens': 23,
+      'gen_ai.output.messages': [{
+        role: 'assistant',
+        parts: [{ type: 'text', content: 'C' }],
+        finish_reason: 'stop',
+      }],
+    });
+    const finalRequest = entries.find(entry => (
+      entry['event.name'] === 'llm.request'
+      && entry['gen_ai.step.id'] === 'session-1:turn-1:s3'
+    ));
+    expect(finalRequest?.['gen_ai.input.messages_delta']).toEqual([
+      {
+        role: 'assistant',
+        parts: [{
+          type: 'tool_call', id: 'call-1', name: 'exec_command', arguments: { command: 'pwd' },
+        }],
+      },
+      {
+        role: 'tool',
+        parts: [{ type: 'tool_call_response', id: 'call-1', response: '/tmp' }],
+      },
+    ]);
+    expect(finalRequest?.['gen_ai.input.messages']).toEqual([
+      { role: 'user', parts: [{ type: 'text', content: 'run it' }] },
+      ...(finalRequest?.['gen_ai.input.messages_delta'] as JsonValue[]),
+    ]);
+  });
+
+  it('does not commit a tool wave until an output written after token_count is present', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-token-before-tool-output-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir } = await createInput(root, 60_000);
+    const initial = [
+      record('2026-06-24T06:00:00.000Z', 'session_meta', { id: 'session-1', model_provider: 'openai' }),
+      record('2026-06-24T06:00:01.000Z', 'turn_context', { turn_id: 'turn-1', model: 'gpt-5.5' }),
+      record('2026-06-24T06:00:02.000Z', 'event_msg', { type: 'task_started', turn_id: 'turn-1' }),
+      record('2026-06-24T06:00:03.000Z', 'response_item', {
+        type: 'message', role: 'user', content: [{ type: 'input_text', text: 'inspect' }],
+      }),
+      record('2026-06-24T06:00:04.000Z', 'response_item', {
+        type: 'function_call', id: 'fc-1', call_id: 'call-1', name: 'exec_command', arguments: '{"cmd":"pwd"}',
+      }),
+      record('2026-06-24T06:00:05.000Z', 'event_msg', tokenUsage(30, 4)),
+    ];
+    const transcript = await writeTranscript(sessionDir, initial.join('\n') + '\n');
+
+    await processTranscriptOnce(input, transcript);
+    expect(entries.some(entry => entry['event.name'] === 'llm.response')).toBe(false);
+    expect(entries.some(entry => entry['event.name'] === 'tool.call')).toBe(false);
+
+    await fs.appendFile(transcript, record('2026-06-24T06:00:06.000Z', 'response_item', {
+      type: 'function_call_output', call_id: 'call-1', output: '"/tmp"',
+    }) + '\n', 'utf8');
+    await processTranscriptOnce(input, transcript);
+    await input.stop();
+
+    expect(entries.filter(entry => entry['event.name'] === 'llm.response')).toHaveLength(1);
+    expect(entries.filter(entry => entry['event.name'] === 'tool.call')).toHaveLength(1);
+    expect(entries.filter(entry => entry['event.name'] === 'tool.result')).toHaveLength(1);
+    expect(entries.find(entry => entry['event.name'] === 'tool.result')).toMatchObject({
+      'gen_ai.tool.call.id': 'call-1',
+      'gen_ai.tool.call.result': '/tmp',
+    });
+  });
+
   it('retains an incomplete suffix after a closed wave and recovers it after restart', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-partial-suffix-'));
     tempDirs.push(root);

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -680,6 +680,68 @@ describe('CodexTranscriptInput', () => {
     );
   });
 
+  it('keeps collecting normal turns after a control abort in a rollout created while running', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-live-control-abort-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, stateStore } = await createInput(root);
+    const debug = vi.fn();
+    (input as unknown as { logger: { debug: typeof debug } }).logger.debug = debug;
+
+    const beforeTurnIds = ['turn-before-1', 'turn-before-2', 'turn-before-3'];
+    const controlTurnId = 'turn-control';
+    const afterTurnId = 'turn-after';
+    const transcriptLines = [
+      ...simpleCompletedTurn(
+        'session-1', beforeTurnIds[0]!, 'first request', 'first response', 100, 10,
+        '2026-06-24T06:00:00.000Z',
+      ),
+      ...simpleCompletedTurn(
+        'session-1', beforeTurnIds[1]!, 'second request', 'second response', 110, 11,
+        '2026-06-24T06:01:00.000Z',
+      ).slice(1),
+      ...simpleCompletedTurn(
+        'session-1', beforeTurnIds[2]!, 'third request', 'third response', 120, 12,
+        '2026-06-24T06:02:00.000Z',
+      ).slice(1),
+      ...controlOnlyAbortedTurn('session-1', controlTurnId, '2026-06-24T06:03:00.000Z'),
+      ...simpleCompletedTurn(
+        'session-1', afterTurnId, 'request after abort', 'response after abort', 130, 13,
+        '2026-06-24T06:04:00.000Z',
+      ).slice(1),
+    ];
+    const transcript = await writeTranscript(sessionDir, transcriptLines.join('\n') + '\n');
+
+    await waitFor(() => responsesForTurn(entries, afterTurnId).length === 1);
+    await input.stop();
+
+    const normalTurnIds = [...beforeTurnIds, afterTurnId];
+    expect(normalTurnIds.map(turnId => responsesForTurn(entries, turnId).length)).toEqual([1, 1, 1, 1]);
+    expect(entries.filter(entry => entry['agent.codex.transcript_turn_id'] === controlTurnId)).toHaveLength(0);
+    expect(entries.filter(entry => entry['event.name'] === 'llm.response')
+      .map(entry => entry['gen_ai.usage.total_tokens'])).toEqual([110, 121, 132, 143]);
+    expect(new Set(entries.map(entry => entry['event.id'])).size).toBe(entries.length);
+
+    const checkpoint = transcriptCheckpoint(stateStore, transcript) as {
+      scanOffset?: number;
+      activeTurn?: unknown;
+      pendingTerminal?: unknown;
+      emittedTerminalTurnIds?: string[];
+    };
+    expect(checkpoint.scanOffset).toBe((await fs.stat(transcript)).size);
+    expect(checkpoint.activeTurn).toBeNull();
+    expect(checkpoint.pendingTerminal).toBeNull();
+    expect(checkpoint.emittedTerminalTurnIds).toEqual(
+      expect.arrayContaining([...normalTurnIds, controlTurnId]),
+    );
+    expect(globalProcessedTurnIds(stateStore)).toEqual(
+      expect.arrayContaining([...normalTurnIds, controlTurnId]),
+    );
+    expect(debug).toHaveBeenCalledWith(
+      'processed terminal Codex turn without observable entries',
+      expect.objectContaining({ turnId: controlTurnId, terminalStatus: 'interrupted' }),
+    );
+  });
+
   it('limits terminal recovery per file cycle and resumes from the saved offset', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-terminal-budget-'));
     tempDirs.push(root);

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 import { DEFAULT_RESOURCE_ENV_FIELD_MAP } from '../../../../assets/hooks/shared/resource-context.mjs';
 import { StateStore } from '../../../../src/checkpoints/state-store.js';
 import { CodexTranscriptInput } from '../../../../src/inputs/codex-transcript/codex-transcript-input.js';
-import type { AgentActivityEntry } from '../../../../src/types/index.js';
+import type { AgentActivityEntry, JsonValue } from '../../../../src/types/index.js';
 
 const tempDirs: string[] = [];
 
@@ -50,7 +50,10 @@ function completedTurn(): string {
       id: 'session-1', model_provider: 'openai',
     }),
     record('2026-06-24T06:00:01.000Z', 'turn_context', {
-      turn_id: 'turn-1', model: 'gpt-5.5', cwd: '/tmp/project',
+      turn_id: 'turn-1',
+      model: 'gpt-5.5',
+      cwd: '/tmp/project',
+      developer_instructions: 'Follow the project conventions.',
     }),
     record('2026-06-24T06:00:02.000Z', 'event_msg', {
       type: 'task_started', turn_id: 'turn-1',
@@ -86,6 +89,88 @@ function completedTurn(): string {
       type: 'task_complete', turn_id: 'turn-1', last_agent_message: 'fixed', completed_at: 1_719_208_011,
     }),
   ].join('\n') + '\n';
+}
+
+function completedTurnWithLargeToolOutput(toolOutput: string): string {
+  return [
+    record('2026-06-24T06:00:00.000Z', 'session_meta', {
+      id: 'session-1', model_provider: 'openai',
+    }),
+    record('2026-06-24T06:00:01.000Z', 'turn_context', {
+      turn_id: 'turn-1', model: 'gpt-5.5',
+    }),
+    record('2026-06-24T06:00:02.000Z', 'event_msg', {
+      type: 'task_started', turn_id: 'turn-1',
+    }),
+    record('2026-06-24T06:00:03.000Z', 'response_item', {
+      type: 'message', role: 'user', content: [{ type: 'input_text', text: 'inspect it' }],
+    }),
+    record('2026-06-24T06:00:04.000Z', 'response_item', {
+      type: 'function_call', id: 'fc-1', call_id: 'call-1', name: 'exec_command', arguments: JSON.stringify({ cmd: 'cat large.txt' }),
+    }),
+    record('2026-06-24T06:00:05.000Z', 'response_item', {
+      type: 'function_call_output', call_id: 'call-1', output: JSON.stringify(toolOutput),
+    }),
+    record('2026-06-24T06:00:06.000Z', 'event_msg', tokenUsage(100, 10)),
+    record('2026-06-24T06:00:07.000Z', 'response_item', {
+      type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'done' }],
+    }),
+    record('2026-06-24T06:00:08.000Z', 'event_msg', {
+      type: 'task_complete', turn_id: 'turn-1', last_agent_message: 'done',
+    }),
+  ].join('\n') + '\n';
+}
+
+function completedTurnWithManyToolWaves(count: number): string {
+  const baseMs = Date.parse('2026-06-24T06:00:00.000Z');
+  const ts = (seconds: number): string => new Date(baseMs + seconds * 1_000).toISOString();
+  const lines = [
+    record('2026-06-24T06:00:00.000Z', 'session_meta', {
+      id: 'session-1', model_provider: 'openai',
+    }),
+    record('2026-06-24T06:00:01.000Z', 'turn_context', {
+      turn_id: 'turn-1', model: 'gpt-5.5',
+    }),
+    record('2026-06-24T06:00:02.000Z', 'event_msg', {
+      type: 'task_started', turn_id: 'turn-1',
+    }),
+    record('2026-06-24T06:00:03.000Z', 'response_item', {
+      type: 'message', role: 'user', content: [{ type: 'input_text', text: 'run many checks' }],
+    }),
+  ];
+
+  for (let index = 0; index < count; index++) {
+    const second = 4 + index * 3;
+    lines.push(
+      record(ts(second), 'event_msg', {
+        type: 'agent_message', message: `checking ${index}`, phase: 'commentary',
+      }),
+      record(ts(second + 1), 'response_item', {
+        type: 'function_call',
+        id: `fc-${index}`,
+        call_id: `call-${index}`,
+        name: 'exec_command',
+        arguments: JSON.stringify({ cmd: `echo ${index}` }),
+      }),
+      record(ts(second + 2), 'response_item', {
+        type: 'function_call_output',
+        call_id: `call-${index}`,
+        output: JSON.stringify(String(index)),
+      }),
+      record(new Date(baseMs + (second + 2) * 1_000 + 100).toISOString(), 'event_msg', tokenUsage(100 + index, 10)),
+    );
+  }
+
+  lines.push(
+    record('2026-06-24T06:10:00.000Z', 'event_msg', {
+      type: 'agent_message', message: 'done', phase: 'final',
+    }),
+    record('2026-06-24T06:10:00.100Z', 'event_msg', tokenUsage(1_000, 20)),
+    record('2026-06-24T06:10:01.000Z', 'event_msg', {
+      type: 'task_complete', turn_id: 'turn-1', last_agent_message: 'done',
+    }),
+  );
+  return lines.join('\n') + '\n';
 }
 
 function simpleCompletedTurn(
@@ -125,6 +210,7 @@ function simpleCompletedTurn(
 async function createInput(root: string): Promise<{
   input: CodexTranscriptInput;
   entries: AgentActivityEntry[];
+  batches: AgentActivityEntry[][];
   sessionDir: string;
   wakeupDir: string;
   stateStore: StateStore;
@@ -135,9 +221,13 @@ async function createInput(root: string): Promise<{
   const wakeupDir = path.join(root, 'wakeups');
   const input = new CodexTranscriptInput({ stateStore, sessionDir, wakeupDir, pollIntervalMs: 10 });
   const entries: AgentActivityEntry[] = [];
-  input.on('entries', batch => entries.push(...batch));
+  const batches: AgentActivityEntry[][] = [];
+  input.on('entries', batch => {
+    batches.push([...batch]);
+    entries.push(...batch);
+  });
   await input.start();
-  return { input, entries, sessionDir, wakeupDir, stateStore };
+  return { input, entries, batches, sessionDir, wakeupDir, stateStore };
 }
 
 async function writeTranscript(sessionDir: string, text: string): Promise<string> {
@@ -346,6 +436,49 @@ describe('CodexTranscriptInput', () => {
     expect(tools.map(entry => entry['gen_ai.step.id'])).toEqual([
       'session-1:turn-1:s1', 'session-1:turn-1:s2',
     ]);
+  });
+
+  it('falls back to input message delta when the reconstructed request context exceeds 1MB', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-large-input-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir } = await createInput(root);
+    const largeToolOutput = 'x'.repeat(1024 * 1024 + 1);
+    await writeTranscript(sessionDir, completedTurnWithLargeToolOutput(largeToolOutput));
+
+    await waitFor(() => entries.filter(entry => entry['event.name'] === 'llm.request').length === 2);
+    await input.stop();
+
+    const requests = entries.filter(entry => entry['event.name'] === 'llm.request');
+    const secondRequest = requests[1]!;
+    const expectedDelta = [
+      {
+        role: 'assistant',
+        parts: [{
+          type: 'tool_call', id: 'call-1', name: 'exec_command', arguments: { command: 'cat large.txt' },
+        }],
+      },
+      {
+        role: 'tool',
+        parts: [{ type: 'tool_call_response', id: 'call-1', response: largeToolOutput }],
+      },
+    ];
+    expect(secondRequest['gen_ai.input.messages_delta']).toEqual(expectedDelta);
+    expect(secondRequest['gen_ai.input.messages']).toEqual(expectedDelta);
+    expect(secondRequest['gen_ai.input.messages_hash']).toEqual(expect.any(String));
+  });
+
+  it('emits long transcript turns in bounded batches', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-batches-'));
+    tempDirs.push(root);
+    const { input, entries, batches, sessionDir } = await createInput(root);
+    await writeTranscript(sessionDir, completedTurnWithManyToolWaves(80));
+
+    await waitFor(() => entries.filter(entry => entry['event.name'] === 'tool.result').length === 80);
+    await input.stop();
+
+    expect(entries.length).toBeGreaterThan(256);
+    expect(batches.length).toBeGreaterThan(1);
+    expect(Math.max(...batches.map(batch => batch.length))).toBeLessThanOrEqual(256);
   });
 
   it('projects AgentTeams resource context from the Stop wakeup marker', async () => {
@@ -629,7 +762,7 @@ describe('CodexTranscriptInput', () => {
     expect(responsesForTurn(restarted.entries, 'turn-3')[0]?.['gen_ai.usage.total_tokens']).toBe(330);
   });
 
-  it('waits for task_complete before exporting a Stop-triggered transcript', async () => {
+  it('exports completed transcript waves before task_complete and flushes stop at terminal', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-pending-'));
     tempDirs.push(root);
     const { input, entries, sessionDir } = await createInput(root);
@@ -637,11 +770,96 @@ describe('CodexTranscriptInput', () => {
     const terminal = lines.pop()!;
     const transcript = await writeTranscript(sessionDir, lines.join('\n') + '\n');
 
-    await new Promise(resolve => setTimeout(resolve, 50));
-    expect(entries).toEqual([]);
+    await waitFor(() => entries.some(entry => entry['event.name'] === 'tool.result'));
+    expect(entries.some(entry => entry['gen_ai.response.finish_reasons']?.includes('stop'))).toBe(false);
     await fs.appendFile(transcript, terminal + '\n', 'utf8');
     await waitFor(() => entries.some(entry => entry['gen_ai.response.finish_reasons']?.includes('stop')));
     await input.stop();
+  });
+
+  it('retains an incomplete suffix after a closed wave and recovers it after restart', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-partial-suffix-'));
+    tempDirs.push(root);
+    const first = await createInput(root);
+    const lines = completedTurn().trimEnd().split('\n');
+    const call2Index = lines.findIndex(line => line.includes('"call_id":"call-2"'));
+    const transcript = await writeTranscript(first.sessionDir, lines.slice(0, call2Index + 1).join('\n') + '\n');
+
+    await waitFor(() => first.entries.filter(entry => entry['event.name'] === 'llm.response').length === 1);
+    await first.input.stop();
+
+    await fs.appendFile(transcript, lines.slice(call2Index + 1).join('\n') + '\n', 'utf8');
+    const restarted = await createInput(root);
+    await waitFor(() => restarted.entries.some(entry => entry['gen_ai.response.finish_reasons']?.includes('stop')));
+    await restarted.input.stop();
+
+    const responses = [...first.entries, ...restarted.entries]
+      .filter(entry => entry['event.name'] === 'llm.response');
+    expect(responses.map(entry => entry['gen_ai.step.id'])).toEqual([
+      'session-1:turn-1:s1',
+      'session-1:turn-1:s2',
+      'session-1:turn-1:s3',
+    ]);
+    expect(responses.map(entry => entry['gen_ai.usage.total_tokens'])).toEqual([110, 132, 143]);
+    expect([...first.entries, ...restarted.entries]
+      .filter(entry => entry['event.name'] === 'tool.call')
+      .map(entry => entry['gen_ai.tool.call.id'])).toEqual(['call-1', 'call-2']);
+
+    const secondRequest = restarted.entries.find(entry => entry['gen_ai.step.id'] === 'session-1:turn-1:s2'
+      && entry['event.name'] === 'llm.request')!;
+    expect(secondRequest['gen_ai.input.messages_delta']).toEqual([
+      {
+        role: 'assistant',
+        parts: [{
+          type: 'tool_call', id: 'call-1', name: 'exec_command', arguments: { command: 'pwd' },
+        }],
+      },
+      {
+        role: 'tool',
+        parts: [{ type: 'tool_call_response', id: 'call-1', response: '/tmp/project' }],
+      },
+    ]);
+    expect(secondRequest['gen_ai.input.messages']).toEqual([
+      { role: 'user', parts: [{ type: 'text', content: 'fix it' }] },
+      ...(secondRequest['gen_ai.input.messages_delta'] as JsonValue[]),
+    ]);
+    expect(secondRequest).toMatchObject({
+      'gen_ai.request.model': 'gpt-5.5',
+      'agent.codex.cwd': '/tmp/project',
+      'gen_ai.system_instructions': [{ type: 'text', content: 'Follow the project conventions.' }],
+    });
+    expect(restarted.entries.find(entry => entry['gen_ai.step.id'] === 'session-1:turn-1:s2'
+      && entry['event.name'] === 'llm.response')).toMatchObject({
+      'gen_ai.response.model': 'gpt-5.5',
+      'agent.codex.cwd': '/tmp/project',
+      'gen_ai.system_instructions': [{ type: 'text', content: 'Follow the project conventions.' }],
+    });
+  });
+
+  it('rebuilds an oversized persisted delta from transcript offsets', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-large-persisted-delta-'));
+    tempDirs.push(root);
+    const first = await createInput(root);
+    const largeToolOutput = 'x'.repeat(1024 * 1024 + 1);
+    const lines = completedTurnWithLargeToolOutput(largeToolOutput).trimEnd().split('\n');
+    const firstTokenIndex = lines.findIndex(line => line.includes('"type":"token_count"'));
+    const transcript = await writeTranscript(first.sessionDir, lines.slice(0, firstTokenIndex + 1).join('\n') + '\n');
+
+    await waitFor(() => first.entries.some(entry => entry['event.name'] === 'llm.response'));
+    await first.input.stop();
+    const stateStat = await fs.stat(path.join(root, 'input-state.json'));
+    expect(stateStat.size).toBeLessThan(128 * 1024);
+
+    await fs.appendFile(transcript, lines.slice(firstTokenIndex + 1).join('\n') + '\n', 'utf8');
+    const restarted = await createInput(root);
+    await waitFor(() => restarted.entries.some(entry => entry['gen_ai.response.finish_reasons']?.includes('stop')));
+    await restarted.input.stop();
+
+    const request = restarted.entries.find(entry => entry['event.name'] === 'llm.request')!;
+    const delta = request['gen_ai.input.messages_delta'] as Array<Record<string, unknown>>;
+    expect(delta.map(message => message.role)).toEqual(['assistant', 'tool']);
+    expect(JSON.stringify(delta)).toContain(largeToolOutput);
+    expect(request['gen_ai.input.messages']).toEqual(delta);
   });
 
   it('falls back malformed transcript timestamps without emitting Unix epoch spans', async () => {


### PR DESCRIPTION
## Summary
- emit completed Codex transcript waves incrementally in bounded batches
- preserve input context and turn metadata across recovery cycles and restarts
- retain model, cwd, and developer instructions after scan offsets advance

## Verification
- npm test -- --run tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
- npm run typecheck (blocked by pre-existing main error: src/flushers/otlp-trace-flusher.ts:384, passthroughKeys is absent from ConvertOptions)