### PR TITLE
feat: add Pi Coding Agent observability support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@
 | Claude Code | `claude-code` | Plugin-Probe | `BaseHookInput` | `inputs/claude-code-log/` | `agents.d/claude-code.json` |
 | Codex | `codex` | Plugin-Probe | `BaseHookInput` | `inputs/codex-log/` | `agents.d/codex.json` |
 | OpenCode | `opencode` | Plugin-Probe | `BaseHookInput` | `inputs/opencode-log/` | `agents.d/opencode.json` |
+| Pi Coding Agent | `pi-coding-agent` | Extension Inject | `BaseHookInput` | `inputs/pi-coding-agent-log/` | `agents.d/pi-coding-agent.json` |
 | Qwen Code CLI | `qwen-code-cli` | Hook | `BaseHookInput` | `inputs/qwen-code-cli-log/` | `agents.d/qwen-code-cli.json` |
 | Wukong | `wukong` | CLI API Polling | `BaseInput` | `inputs/wukong/` | N/A |
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Pilot is designed to answer practical questions:
 | Codex         | Hook                      | Yes          | Yes        | Yes         | Yes                       |
 | Cursor        | Hook                      | Yes          | Yes        | Yes         | Yes                       |
 | OpenCode      | Plugin injection          | Yes          | Yes        | Yes         | Yes                       |
+| Pi Coding Agent | Extension injection     | Yes          | Yes        | Yes         | Yes                       |
 | Qoder         | Hook                      | Yes          | Yes        | Yes         | Yes                       |
 | Qoder CN      | Hook                      | Yes          | Yes        | Yes         | Yes                       |
 | Qoder for JetBrains | Detection-only      | Yes          | Yes        | Yes         | Yes                       |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -43,6 +43,7 @@ Pilot 主要帮助回答这些问题：
 | Codex | Hook | Yes | Yes | Yes | Yes |
 | Cursor | Hook | Yes | Yes | Yes | Yes |
 | OpenCode | 插件注入 | Yes | Yes | Yes | Yes |
+| Pi Coding Agent | Extension 注入 | Yes | Yes | Yes | Yes |
 | Qoder | Hook | Yes | Yes | Yes | Yes |
 | Qoder CN | Hook | Yes | Yes | Yes | Yes |
 | Qoder for JetBrains | 自动检测 | Yes | Yes | Yes | Yes |

--- a/agents.d/pi-coding-agent.json
+++ b/agents.d/pi-coding-agent.json
@@ -1,0 +1,20 @@
+{
+  "id": "pi-coding-agent",
+  "displayName": "Pi Coding Agent",
+  "deployMode": "plugin-inject",
+  "detection": {
+    "paths": ["~/.pi/agent"],
+    "commands": ["pi"]
+  },
+  "pluginInject": {
+    "configPaths": ["~/.pi/agent/settings.json"],
+    "pluginSpec": "$PILOT_DATA/plugins/pi-coding-agent/index.mjs",
+    "pluginId": "loongsuite-pilot-pi-coding-agent",
+    "configKey": "extensions",
+    "createIfMissing": true
+  },
+  "input": {
+    "type": "hook-jsonl",
+    "logDir": "$PILOT_DATA/logs/pi-coding-agent"
+  }
+}

--- a/assets/plugins/pi-coding-agent/index.mjs
+++ b/assets/plugins/pi-coding-agent/index.mjs
@@ -42,9 +42,20 @@ function todayStamp() {
   ].join('-');
 }
 
+function timestampMillis(timestamp = Date.now()) {
+  return Number.isFinite(timestamp) ? Math.trunc(timestamp) : Date.now();
+}
+
 function timestampNanos(timestamp = Date.now()) {
-  const millis = Number.isFinite(timestamp) ? Math.trunc(timestamp) : Date.now();
+  const millis = timestampMillis(timestamp);
   return String(BigInt(millis) * 1_000_000n);
+}
+
+function timestampStrictlyAfter(timestamp, startedAt) {
+  const millis = timestampMillis(timestamp);
+  // The downstream OTel converter consumes numeric timestamps in milliseconds,
+  // so a 1ns adjustment would be truncated back to a zero-duration span.
+  return Number.isFinite(startedAt) ? Math.max(millis, Math.trunc(startedAt) + 1) : millis;
 }
 
 function traceId() {
@@ -307,12 +318,14 @@ function activeToolDefinitions(pi) {
 function commonFields(ctx, state, timestamp = Date.now()) {
   const sessionId = ctx.sessionManager.getSessionId();
   const model = ctx.model;
+  const eventTime = timestampMillis(timestamp);
+  const observedTime = Math.max(Date.now(), eventTime);
   state.traceId ||= traceId();
   state.turnId ||= crypto.randomUUID();
   state.stepId ||= `${state.turnId}:s1`;
   return {
-    time_unix_nano: timestampNanos(timestamp),
-    observed_time_unix_nano: timestampNanos(),
+    time_unix_nano: timestampNanos(eventTime),
+    observed_time_unix_nano: timestampNanos(observedTime),
     'event.id': crypto.randomUUID(),
     trace_id: state.traceId,
     span_id: spanId(),
@@ -337,6 +350,7 @@ export default function loongSuitePilotPiCodingAgent(pi) {
     stepId: null,
     stepStartedAt: 0,
     requestEmitted: false,
+    requestStartedAt: 0,
     systemPrompt: null,
     toolStarts: new Map(),
   };
@@ -352,7 +366,9 @@ export default function loongSuitePilotPiCodingAgent(pi) {
     state.traceId = null;
     state.turnId = null;
     state.stepId = null;
+    state.stepStartedAt = 0;
     state.requestEmitted = false;
+    state.requestStartedAt = 0;
     state.toolStarts.clear();
   }));
 
@@ -361,7 +377,9 @@ export default function loongSuitePilotPiCodingAgent(pi) {
     state.traceId = traceId();
     state.turnId = crypto.randomUUID();
     state.stepId = null;
+    state.stepStartedAt = 0;
     state.requestEmitted = false;
+    state.requestStartedAt = 0;
     state.systemPrompt = event.systemPrompt;
     state.toolStarts.clear();
   }));
@@ -369,16 +387,18 @@ export default function loongSuitePilotPiCodingAgent(pi) {
   pi.on('turn_start', safeHandler('turn_start', async (event) => {
     state.turnId ||= crypto.randomUUID();
     state.stepId = `${state.turnId}:s${event.turnIndex + 1}`;
-    state.stepStartedAt = event.timestamp || Date.now();
+    state.stepStartedAt = timestampMillis(event.timestamp);
     state.requestEmitted = false;
+    state.requestStartedAt = 0;
   }));
 
-  pi.on('context', safeHandler('context', async (event, ctx) => {
+  const emitLlmRequest = (event, ctx) => {
     if (state.requestEmitted) return;
     state.requestEmitted = true;
+    state.requestStartedAt = timestampMillis(state.stepStartedAt || Date.now());
 
     const record = {
-      ...commonFields(ctx, state, state.stepStartedAt || Date.now()),
+      ...commonFields(ctx, state, state.requestStartedAt),
       'event.name': 'llm.request',
     };
     if (state.captureContent) {
@@ -393,11 +413,22 @@ export default function loongSuitePilotPiCodingAgent(pi) {
       if (tools.length > 0) record['gen_ai.tool.definitions'] = tools;
     }
     writeRecord(record);
+  };
+
+  pi.on('context', safeHandler('context', async (event, ctx) => {
+    emitLlmRequest(event, ctx);
   }));
 
   pi.on('message_end', safeHandler('message_end', async (event, ctx) => {
     const message = event.message;
     if (!message || message.role !== 'assistant') return;
+
+    // A response without a preceding context event would otherwise be
+    // converted into a zero-duration response-only LLM span downstream.
+    emitLlmRequest({ messages: [] }, ctx);
+    // Pi assigns AssistantMessage.timestamp when provider streaming starts;
+    // handler receipt time is the closest available response-completion time.
+    const responseAt = timestampStrictlyAfter(Date.now(), state.requestStartedAt);
 
     const usage = message.usage || {};
     const cacheRead = Number(usage.cacheRead) || 0;
@@ -406,7 +437,7 @@ export default function loongSuitePilotPiCodingAgent(pi) {
     const outputTokens = Number(usage.output) || 0;
     const cost = usage.cost || {};
     const record = {
-      ...commonFields(ctx, state, message.timestamp || Date.now()),
+      ...commonFields(ctx, state, responseAt),
       'event.name': 'llm.response',
       'gen_ai.provider.name': normalizeProvider(message.provider || ctx.model?.provider),
       'gen_ai.request.model': message.model || ctx.model?.id || 'unknown',
@@ -438,7 +469,7 @@ export default function loongSuitePilotPiCodingAgent(pi) {
   }));
 
   pi.on('tool_execution_start', safeHandler('tool_execution_start', async (event, ctx) => {
-    const startedAt = Date.now();
+    const startedAt = timestampMillis();
     state.toolStarts.set(event.toolCallId, startedAt);
     const record = {
       ...commonFields(ctx, state, startedAt),
@@ -453,8 +484,8 @@ export default function loongSuitePilotPiCodingAgent(pi) {
   }));
 
   pi.on('tool_execution_end', safeHandler('tool_execution_end', async (event, ctx) => {
-    const endedAt = Date.now();
     const startedAt = state.toolStarts.get(event.toolCallId);
+    const endedAt = timestampStrictlyAfter(Date.now(), startedAt);
     state.toolStarts.delete(event.toolCallId);
     const record = {
       ...commonFields(ctx, state, endedAt),
@@ -464,7 +495,7 @@ export default function loongSuitePilotPiCodingAgent(pi) {
       'tool.result.status': event.isError ? 'error' : 'success',
     };
     if (startedAt !== undefined) {
-      record['gen_ai.tool.call.duration'] = Math.max(0, endedAt - startedAt);
+      record['gen_ai.tool.call.duration'] = endedAt - startedAt;
     }
     if (state.captureContent) {
       record['gen_ai.tool.call.result'] = toSerializable(event.result);

--- a/assets/plugins/pi-coding-agent/index.mjs
+++ b/assets/plugins/pi-coding-agent/index.mjs
@@ -116,13 +116,17 @@ function ensureLogDir() {
 }
 
 function appendLogFile(fileName, content) {
+  const filePath = path.join(resolveLogDir(), fileName);
   for (let attempt = 0; attempt < 2; attempt++) {
+    let fd;
     try {
       ensureLogDir();
-      fs.appendFileSync(path.join(resolveLogDir(), fileName), content, {
-        encoding: 'utf8',
-        mode: 0o600,
-      });
+      fd = fs.openSync(filePath, 'a', 0o600);
+      // `mode` only applies when creating a file. Tighten the actual opened
+      // inode before every append so log rotation/replacement cannot leave a
+      // permissive file receiving sensitive telemetry.
+      if (process.platform !== 'win32') fs.fchmodSync(fd, 0o600);
+      fs.writeFileSync(fd, content, { encoding: 'utf8' });
       return;
     } catch (error) {
       if (attempt === 0 && error?.code === 'ENOENT') {
@@ -130,6 +134,8 @@ function appendLogFile(fileName, content) {
         continue;
       }
       throw error;
+    } finally {
+      if (fd !== undefined) fs.closeSync(fd);
     }
   }
 }
@@ -315,14 +321,12 @@ function activeToolDefinitions(pi) {
     }));
 }
 
-function commonFields(ctx, state, timestamp = Date.now()) {
+function turnFields(ctx, state, timestamp = Date.now()) {
   const sessionId = ctx.sessionManager.getSessionId();
-  const model = ctx.model;
   const eventTime = timestampMillis(timestamp);
   const observedTime = Math.max(Date.now(), eventTime);
   state.traceId ||= traceId();
   state.turnId ||= crypto.randomUUID();
-  state.stepId ||= `${state.turnId}:s1`;
   return {
     time_unix_nano: timestampNanos(eventTime),
     observed_time_unix_nano: timestampNanos(observedTime),
@@ -332,13 +336,45 @@ function commonFields(ctx, state, timestamp = Date.now()) {
     'user.id': state.userId,
     'gen_ai.session.id': sessionId,
     'gen_ai.turn.id': state.turnId,
-    'gen_ai.step.id': state.stepId,
     'gen_ai.agent.type': AGENT_TYPE,
     'gen_ai.agent.name': 'Pi Coding Agent',
-    'gen_ai.provider.name': normalizeProvider(model?.provider),
-    'gen_ai.request.model': model?.id || 'unknown',
     [`agent.${AGENT_TYPE}.cwd`]: ctx.cwd,
   };
+}
+
+function commonFields(ctx, state, timestamp = Date.now()) {
+  const model = ctx.model;
+  state.turnId ||= crypto.randomUUID();
+  state.stepId ||= `${state.turnId}:s1`;
+  return {
+    ...turnFields(ctx, state, timestamp),
+    'gen_ai.step.id': state.stepId,
+    'gen_ai.provider.name': normalizeProvider(model?.provider),
+    'gen_ai.request.model': model?.id || 'unknown',
+  };
+}
+
+function promptInputMessages(event) {
+  const content = [];
+  if (typeof event?.prompt === 'string' && event.prompt.length > 0) {
+    content.push({ type: 'text', text: event.prompt });
+  }
+  if (Array.isArray(event?.images)) content.push(...event.images);
+  const message = canonicalMessage({ role: 'user', content });
+  return message?.parts?.length > 0 ? [message] : [];
+}
+
+function trailingUserInputMessages(messages) {
+  if (!Array.isArray(messages)) return [];
+  const out = [];
+  const recent = messages.slice(-MAX_MESSAGES);
+  for (let index = recent.length - 1; index >= 0; index--) {
+    const message = recent[index];
+    if (message?.role !== 'user' && message?.role !== 'custom') break;
+    const canonical = canonicalMessage(message);
+    if (canonical?.parts?.length > 0) out.unshift(canonical);
+  }
+  return out;
 }
 
 export default function loongSuitePilotPiCodingAgent(pi) {
@@ -352,6 +388,8 @@ export default function loongSuitePilotPiCodingAgent(pi) {
     requestEmitted: false,
     requestStartedAt: 0,
     systemPrompt: null,
+    pendingUserInput: [],
+    userInputEmitted: false,
     toolStarts: new Map(),
   };
 
@@ -369,6 +407,8 @@ export default function loongSuitePilotPiCodingAgent(pi) {
     state.stepStartedAt = 0;
     state.requestEmitted = false;
     state.requestStartedAt = 0;
+    state.pendingUserInput = [];
+    state.userInputEmitted = false;
     state.toolStarts.clear();
   }));
 
@@ -381,6 +421,8 @@ export default function loongSuitePilotPiCodingAgent(pi) {
     state.requestEmitted = false;
     state.requestStartedAt = 0;
     state.systemPrompt = event.systemPrompt;
+    state.pendingUserInput = promptInputMessages(event);
+    state.userInputEmitted = false;
     state.toolStarts.clear();
   }));
 
@@ -390,7 +432,22 @@ export default function loongSuitePilotPiCodingAgent(pi) {
     state.stepStartedAt = timestampMillis(event.timestamp);
     state.requestEmitted = false;
     state.requestStartedAt = 0;
+    state.userInputEmitted = false;
   }));
+
+  const emitUserInput = (event, ctx) => {
+    if (state.userInputEmitted || !state.captureContent) return;
+    const messages = trailingUserInputMessages(event.messages);
+    const inputDelta = messages.length > 0 ? messages : state.pendingUserInput;
+    if (inputDelta.length === 0) return;
+    state.userInputEmitted = true;
+    state.pendingUserInput = [];
+    writeRecord({
+      ...turnFields(ctx, state, state.stepStartedAt || Date.now()),
+      'event.name': 'other',
+      'gen_ai.input.messages_delta': inputDelta,
+    });
+  };
 
   const emitLlmRequest = (event, ctx) => {
     if (state.requestEmitted) return;
@@ -416,6 +473,7 @@ export default function loongSuitePilotPiCodingAgent(pi) {
   };
 
   pi.on('context', safeHandler('context', async (event, ctx) => {
+    emitUserInput(event, ctx);
     emitLlmRequest(event, ctx);
   }));
 
@@ -425,6 +483,7 @@ export default function loongSuitePilotPiCodingAgent(pi) {
 
     // A response without a preceding context event would otherwise be
     // converted into a zero-duration response-only LLM span downstream.
+    emitUserInput({ messages: [] }, ctx);
     emitLlmRequest({ messages: [] }, ctx);
     // Pi assigns AssistantMessage.timestamp when provider streaming starts;
     // handler receipt time is the closest available response-completion time.
@@ -505,6 +564,7 @@ export default function loongSuitePilotPiCodingAgent(pi) {
   }));
 
   pi.on('session_shutdown', safeHandler('session_shutdown', async () => {
+    state.pendingUserInput = [];
     state.toolStarts.clear();
   }));
 }

--- a/assets/plugins/pi-coding-agent/index.mjs
+++ b/assets/plugins/pi-coding-agent/index.mjs
@@ -22,6 +22,7 @@ const MAX_OBJECT_KEYS = 100;
 const MAX_DEPTH = 8;
 
 const pluginDir = path.dirname(fileURLToPath(import.meta.url));
+// Installed layout: $PILOT_DATA/plugins/pi-coding-agent/index.mjs.
 const installedDataDir = path.resolve(pluginDir, '..', '..');
 
 function resolveDataDir() {
@@ -93,18 +94,40 @@ function safeStringify(value) {
   return JSON.stringify(toSerializable(value));
 }
 
+let logDirReady = false;
+
 function ensureLogDir() {
-  fs.mkdirSync(resolveLogDir(), { recursive: true, mode: 0o700 });
+  if (logDirReady) return;
+  const dir = resolveLogDir();
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  if (process.platform !== 'win32') fs.chmodSync(dir, 0o700);
+  logDirReady = true;
+}
+
+function appendLogFile(fileName, content) {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      ensureLogDir();
+      fs.appendFileSync(path.join(resolveLogDir(), fileName), content, {
+        encoding: 'utf8',
+        mode: 0o600,
+      });
+      return;
+    } catch (error) {
+      if (attempt === 0 && error?.code === 'ENOENT') {
+        logDirReady = false;
+        continue;
+      }
+      throw error;
+    }
+  }
 }
 
 function writeError(source, error) {
   try {
-    ensureLogDir();
-    const file = path.join(resolveLogDir(), `${AGENT_TYPE}-error-${todayStamp()}.log`);
-    fs.appendFileSync(
-      file,
+    appendLogFile(
+      `${AGENT_TYPE}-error-${todayStamp()}.log`,
       `${new Date().toISOString()} [${source}] ${error?.stack || error}\n`,
-      { encoding: 'utf8', mode: 0o600 },
     );
   } catch {
     // Telemetry errors are intentionally ignored.
@@ -113,9 +136,7 @@ function writeError(source, error) {
 
 function writeRecord(record) {
   try {
-    ensureLogDir();
-    const file = path.join(resolveLogDir(), `${AGENT_TYPE}-${todayStamp()}.jsonl`);
-    fs.appendFileSync(file, `${safeStringify(record)}\n`, { encoding: 'utf8', mode: 0o600 });
+    appendLogFile(`${AGENT_TYPE}-${todayStamp()}.jsonl`, `${safeStringify(record)}\n`);
   } catch (error) {
     writeError('writeRecord', error);
   }
@@ -204,6 +225,15 @@ function contentParts(content) {
   return parts;
 }
 
+function toolResultResponse(content) {
+  if (typeof content === 'string') return truncate(content);
+  const parts = contentParts(content);
+  if (parts.every(part => part.type === 'text')) {
+    return truncate(parts.map(part => part.content).join('\n'));
+  }
+  return truncate(safeStringify(parts));
+}
+
 function canonicalMessage(message) {
   if (!message || typeof message !== 'object') return null;
 
@@ -213,7 +243,7 @@ function canonicalMessage(message) {
       parts: [{
         type: 'tool_call_response',
         id: message.toolCallId || null,
-        response: contentParts(message.content),
+        response: toolResultResponse(message.content),
         name: message.toolName || 'unknown',
         is_error: message.isError === true,
       }],
@@ -337,7 +367,8 @@ export default function loongSuitePilotPiCodingAgent(pi) {
   }));
 
   pi.on('turn_start', safeHandler('turn_start', async (event) => {
-    state.stepId = `${state.turnId || crypto.randomUUID()}:s${event.turnIndex + 1}`;
+    state.turnId ||= crypto.randomUUID();
+    state.stepId = `${state.turnId}:s${event.turnIndex + 1}`;
     state.stepStartedAt = event.timestamp || Date.now();
     state.requestEmitted = false;
   }));
@@ -399,7 +430,9 @@ export default function loongSuitePilotPiCodingAgent(pi) {
     }
     if (message.stopReason === 'error') {
       record['error.type'] = 'llm_error';
-      if (message.errorMessage) record['error.message'] = truncate(message.errorMessage, 8 * 1024);
+      if (state.captureContent && message.errorMessage) {
+        record['error.message'] = truncate(message.errorMessage, 8 * 1024);
+      }
     }
     writeRecord(record);
   }));

--- a/assets/plugins/pi-coding-agent/index.mjs
+++ b/assets/plugins/pi-coding-agent/index.mjs
@@ -1,0 +1,446 @@
+/**
+ * LoongSuite Pilot extension for Pi Coding Agent.
+ *
+ * Runs inside the Pi process and converts Pi extension lifecycle events into
+ * canonical GenAI JSONL records consumed by PiCodingAgentLogInput.
+ *
+ * The extension is deliberately dependency-free and fail-open: telemetry
+ * failures must never interrupt an agent turn or tool execution.
+ */
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const AGENT_TYPE = 'pi-coding-agent';
+const MAX_STRING_LENGTH = 64 * 1024;
+const MAX_MESSAGES = 40;
+const MAX_ARRAY_ITEMS = 100;
+const MAX_OBJECT_KEYS = 100;
+const MAX_DEPTH = 8;
+
+const pluginDir = path.dirname(fileURLToPath(import.meta.url));
+const installedDataDir = path.resolve(pluginDir, '..', '..');
+
+function resolveDataDir() {
+  return process.env.LOONGSUITE_PILOT_DATA_DIR || installedDataDir;
+}
+
+function resolveLogDir() {
+  return path.join(resolveDataDir(), 'logs', AGENT_TYPE);
+}
+
+function todayStamp() {
+  const d = new Date();
+  return [
+    d.getFullYear(),
+    String(d.getMonth() + 1).padStart(2, '0'),
+    String(d.getDate()).padStart(2, '0'),
+  ].join('-');
+}
+
+function timestampNanos(timestamp = Date.now()) {
+  const millis = Number.isFinite(timestamp) ? Math.trunc(timestamp) : Date.now();
+  return String(BigInt(millis) * 1_000_000n);
+}
+
+function traceId() {
+  return crypto.randomBytes(16).toString('hex');
+}
+
+function spanId() {
+  return crypto.randomBytes(8).toString('hex');
+}
+
+function truncate(value, max = MAX_STRING_LENGTH) {
+  if (typeof value !== 'string' || value.length <= max) return value;
+  return `${value.slice(0, max)}...[truncated]`;
+}
+
+function toSerializable(value, depth = 0, seen = new WeakSet()) {
+  if (value === undefined) return undefined;
+  if (value === null || typeof value === 'boolean' || typeof value === 'number') return value;
+  if (typeof value === 'string') return truncate(value);
+  if (typeof value === 'bigint') return value.toString();
+  if (typeof value === 'function' || typeof value === 'symbol') return undefined;
+  if (depth >= MAX_DEPTH) return '[Max depth]';
+
+  if (Array.isArray(value)) {
+    return value
+      .slice(0, MAX_ARRAY_ITEMS)
+      .map(item => toSerializable(item, depth + 1, seen))
+      .filter(item => item !== undefined);
+  }
+
+  if (typeof value === 'object') {
+    if (seen.has(value)) return '[Circular]';
+    seen.add(value);
+    const out = {};
+    for (const [key, nested] of Object.entries(value).slice(0, MAX_OBJECT_KEYS)) {
+      const serializable = toSerializable(nested, depth + 1, seen);
+      if (serializable !== undefined) out[key] = serializable;
+    }
+    seen.delete(value);
+    return out;
+  }
+
+  return String(value);
+}
+
+function safeStringify(value) {
+  return JSON.stringify(toSerializable(value));
+}
+
+function ensureLogDir() {
+  fs.mkdirSync(resolveLogDir(), { recursive: true, mode: 0o700 });
+}
+
+function writeError(source, error) {
+  try {
+    ensureLogDir();
+    const file = path.join(resolveLogDir(), `${AGENT_TYPE}-error-${todayStamp()}.log`);
+    fs.appendFileSync(
+      file,
+      `${new Date().toISOString()} [${source}] ${error?.stack || error}\n`,
+      { encoding: 'utf8', mode: 0o600 },
+    );
+  } catch {
+    // Telemetry errors are intentionally ignored.
+  }
+}
+
+function writeRecord(record) {
+  try {
+    ensureLogDir();
+    const file = path.join(resolveLogDir(), `${AGENT_TYPE}-${todayStamp()}.jsonl`);
+    fs.appendFileSync(file, `${safeStringify(record)}\n`, { encoding: 'utf8', mode: 0o600 });
+  } catch (error) {
+    writeError('writeRecord', error);
+  }
+}
+
+function safeHandler(name, handler) {
+  return async (event, ctx) => {
+    try {
+      await handler(event, ctx);
+    } catch (error) {
+      writeError(name, error);
+    }
+  };
+}
+
+function loadPilotConfig() {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(resolveDataDir(), 'config.json'), 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function resolveUserId(config) {
+  return process.env.LOONGSUITE_PILOT_USER_ID
+    || process.env.LOONGSUITE_USER_ID
+    || config.userId
+    || config['user.id']
+    || os.hostname()
+    || 'unknown';
+}
+
+function shouldCaptureContent(config) {
+  const value = config.agents?.[AGENT_TYPE]?.captureMessageContent;
+  if (typeof value === 'string') return value.trim().toLowerCase() !== 'false';
+  return value !== false;
+}
+
+function normalizeProvider(provider) {
+  if (typeof provider !== 'string' || provider.length === 0) return 'unknown';
+  const value = provider.toLowerCase();
+  if (value.includes('anthropic')) return 'anthropic';
+  if (value.includes('openai')) return 'openai';
+  if (value.includes('google') || value.includes('gemini')) return 'gcp.gemini';
+  if (value.includes('bedrock')) return 'aws.bedrock';
+  if (value.includes('azure')) return 'azure.ai.openai';
+  if (value.includes('qwen') || value.includes('dashscope')) return 'qwen';
+  if (value.includes('deepseek')) return 'deepseek';
+  return provider;
+}
+
+function normalizeFinishReason(reason) {
+  if (reason === 'toolUse') return 'tool_call';
+  if (reason === 'aborted') return 'cancelled';
+  return reason || 'stop';
+}
+
+function contentParts(content) {
+  if (typeof content === 'string') {
+    return [{ type: 'text', content: truncate(content) }];
+  }
+  if (!Array.isArray(content)) return [];
+
+  const parts = [];
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue;
+    if (block.type === 'text') {
+      parts.push({ type: 'text', content: truncate(block.text || '') });
+    } else if (block.type === 'thinking') {
+      parts.push({ type: 'reasoning', content: truncate(block.thinking || '') });
+    } else if (block.type === 'toolCall') {
+      parts.push({
+        type: 'tool_call',
+        id: block.id || null,
+        name: block.name || 'unknown',
+        arguments: toSerializable(block.arguments),
+      });
+    } else if (block.type === 'image') {
+      parts.push({
+        type: 'image',
+        mime_type: block.mimeType || 'application/octet-stream',
+        modality: 'image',
+      });
+    }
+  }
+  return parts;
+}
+
+function canonicalMessage(message) {
+  if (!message || typeof message !== 'object') return null;
+
+  if (message.role === 'toolResult') {
+    return {
+      role: 'tool',
+      parts: [{
+        type: 'tool_call_response',
+        id: message.toolCallId || null,
+        response: contentParts(message.content),
+        name: message.toolName || 'unknown',
+        is_error: message.isError === true,
+      }],
+    };
+  }
+
+  if (message.role === 'assistant' || message.role === 'user') {
+    return { role: message.role, parts: contentParts(message.content) };
+  }
+
+  if (message.role === 'custom') {
+    return { role: 'user', parts: contentParts(message.content) };
+  }
+
+  if (message.role === 'bashExecution') {
+    return {
+      role: 'tool',
+      parts: [{
+        type: 'tool_call_response',
+        id: null,
+        response: truncate(message.output || ''),
+        name: 'bash',
+        is_error: typeof message.exitCode === 'number' && message.exitCode !== 0,
+      }],
+    };
+  }
+
+  return null;
+}
+
+function canonicalMessages(messages) {
+  if (!Array.isArray(messages)) return [];
+  return messages
+    .slice(-MAX_MESSAGES)
+    .map(canonicalMessage)
+    .filter(Boolean);
+}
+
+function canonicalOutputMessage(message) {
+  const canonical = canonicalMessage(message);
+  if (!canonical) return undefined;
+  return [{
+    ...canonical,
+    role: 'assistant',
+    finish_reason: normalizeFinishReason(message.stopReason),
+  }];
+}
+
+function activeToolDefinitions(pi) {
+  const active = new Set(pi.getActiveTools());
+  return pi.getAllTools()
+    .filter(tool => active.has(tool.name))
+    .map(tool => ({
+      type: 'function',
+      name: tool.name,
+      description: truncate(tool.description || '', 8 * 1024),
+      parameters: toSerializable(tool.parameters),
+    }));
+}
+
+function commonFields(ctx, state, timestamp = Date.now()) {
+  const sessionId = ctx.sessionManager.getSessionId();
+  const model = ctx.model;
+  state.traceId ||= traceId();
+  state.turnId ||= crypto.randomUUID();
+  state.stepId ||= `${state.turnId}:s1`;
+  return {
+    time_unix_nano: timestampNanos(timestamp),
+    observed_time_unix_nano: timestampNanos(),
+    'event.id': crypto.randomUUID(),
+    trace_id: state.traceId,
+    span_id: spanId(),
+    'user.id': state.userId,
+    'gen_ai.session.id': sessionId,
+    'gen_ai.turn.id': state.turnId,
+    'gen_ai.step.id': state.stepId,
+    'gen_ai.agent.type': AGENT_TYPE,
+    'gen_ai.agent.name': 'Pi Coding Agent',
+    'gen_ai.provider.name': normalizeProvider(model?.provider),
+    'gen_ai.request.model': model?.id || 'unknown',
+    [`agent.${AGENT_TYPE}.cwd`]: ctx.cwd,
+  };
+}
+
+export default function loongSuitePilotPiCodingAgent(pi) {
+  const state = {
+    userId: 'unknown',
+    captureContent: true,
+    traceId: null,
+    turnId: null,
+    stepId: null,
+    stepStartedAt: 0,
+    requestEmitted: false,
+    systemPrompt: null,
+    toolStarts: new Map(),
+  };
+
+  const resetSessionConfig = () => {
+    const config = loadPilotConfig();
+    state.userId = resolveUserId(config);
+    state.captureContent = shouldCaptureContent(config);
+  };
+
+  pi.on('session_start', safeHandler('session_start', async () => {
+    resetSessionConfig();
+    state.traceId = null;
+    state.turnId = null;
+    state.stepId = null;
+    state.requestEmitted = false;
+    state.toolStarts.clear();
+  }));
+
+  pi.on('before_agent_start', safeHandler('before_agent_start', async (event) => {
+    resetSessionConfig();
+    state.traceId = traceId();
+    state.turnId = crypto.randomUUID();
+    state.stepId = null;
+    state.requestEmitted = false;
+    state.systemPrompt = event.systemPrompt;
+    state.toolStarts.clear();
+  }));
+
+  pi.on('turn_start', safeHandler('turn_start', async (event) => {
+    state.stepId = `${state.turnId || crypto.randomUUID()}:s${event.turnIndex + 1}`;
+    state.stepStartedAt = event.timestamp || Date.now();
+    state.requestEmitted = false;
+  }));
+
+  pi.on('context', safeHandler('context', async (event, ctx) => {
+    if (state.requestEmitted) return;
+    state.requestEmitted = true;
+
+    const record = {
+      ...commonFields(ctx, state, state.stepStartedAt || Date.now()),
+      'event.name': 'llm.request',
+    };
+    if (state.captureContent) {
+      const messages = canonicalMessages(event.messages);
+      if (messages.length > 0) record['gen_ai.input.messages'] = messages;
+      if (state.systemPrompt) {
+        record['gen_ai.system_instructions'] = [
+          { type: 'text', content: truncate(state.systemPrompt) },
+        ];
+      }
+      const tools = activeToolDefinitions(pi);
+      if (tools.length > 0) record['gen_ai.tool.definitions'] = tools;
+    }
+    writeRecord(record);
+  }));
+
+  pi.on('message_end', safeHandler('message_end', async (event, ctx) => {
+    const message = event.message;
+    if (!message || message.role !== 'assistant') return;
+
+    const usage = message.usage || {};
+    const cacheRead = Number(usage.cacheRead) || 0;
+    const cacheWrite = Number(usage.cacheWrite) || 0;
+    const inputTokens = (Number(usage.input) || 0) + cacheRead + cacheWrite;
+    const outputTokens = Number(usage.output) || 0;
+    const cost = usage.cost || {};
+    const record = {
+      ...commonFields(ctx, state, message.timestamp || Date.now()),
+      'event.name': 'llm.response',
+      'gen_ai.provider.name': normalizeProvider(message.provider || ctx.model?.provider),
+      'gen_ai.request.model': message.model || ctx.model?.id || 'unknown',
+      'gen_ai.response.model': message.responseModel || message.model || ctx.model?.id || 'unknown',
+      'gen_ai.response.finish_reasons': [normalizeFinishReason(message.stopReason)],
+      'gen_ai.usage.input_tokens': inputTokens,
+      'gen_ai.usage.output_tokens': outputTokens,
+      'gen_ai.usage.cache_read.input_tokens': cacheRead,
+      'gen_ai.usage.cache_creation.input_tokens': cacheWrite,
+      'gen_ai.usage.total_tokens': Number(usage.totalTokens) || inputTokens + outputTokens,
+      'gen_ai.usage.input_cost': Number(cost.input) || 0,
+      'gen_ai.usage.output_cost': Number(cost.output) || 0,
+      'gen_ai.usage.cache_read.input_cost': Number(cost.cacheRead) || 0,
+      'gen_ai.usage.cache_creation.input_cost': Number(cost.cacheWrite) || 0,
+      'gen_ai.usage.total_cost': Number(cost.total) || 0,
+    };
+    if (message.responseId) record['gen_ai.response.id'] = message.responseId;
+    if (state.captureContent) {
+      const output = canonicalOutputMessage(message);
+      if (output) record['gen_ai.output.messages'] = output;
+    }
+    if (message.stopReason === 'error') {
+      record['error.type'] = 'llm_error';
+      if (message.errorMessage) record['error.message'] = truncate(message.errorMessage, 8 * 1024);
+    }
+    writeRecord(record);
+  }));
+
+  pi.on('tool_execution_start', safeHandler('tool_execution_start', async (event, ctx) => {
+    const startedAt = Date.now();
+    state.toolStarts.set(event.toolCallId, startedAt);
+    const record = {
+      ...commonFields(ctx, state, startedAt),
+      'event.name': 'tool.call',
+      'gen_ai.tool.name': event.toolName,
+      'gen_ai.tool.call.id': event.toolCallId,
+    };
+    if (state.captureContent) {
+      record['gen_ai.tool.call.arguments'] = toSerializable(event.args);
+    }
+    writeRecord(record);
+  }));
+
+  pi.on('tool_execution_end', safeHandler('tool_execution_end', async (event, ctx) => {
+    const endedAt = Date.now();
+    const startedAt = state.toolStarts.get(event.toolCallId);
+    state.toolStarts.delete(event.toolCallId);
+    const record = {
+      ...commonFields(ctx, state, endedAt),
+      'event.name': 'tool.result',
+      'gen_ai.tool.name': event.toolName,
+      'gen_ai.tool.call.id': event.toolCallId,
+      'tool.result.status': event.isError ? 'error' : 'success',
+    };
+    if (startedAt !== undefined) {
+      record['gen_ai.tool.call.duration'] = Math.max(0, endedAt - startedAt);
+    }
+    if (state.captureContent) {
+      record['gen_ai.tool.call.result'] = toSerializable(event.result);
+    }
+    if (event.isError) record['error.type'] = 'tool_error';
+    writeRecord(record);
+  }));
+
+  pi.on('session_shutdown', safeHandler('session_shutdown', async () => {
+    state.toolStarts.clear();
+  }));
+}

--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -1024,6 +1024,44 @@ try {
 }
 
 # ============================================================
+# Remove Pi Coding Agent extension injection
+# ============================================================
+function Remove-PiCodingAgentExtension {
+    $cfg = Join-Path $env:USERPROFILE ".pi\agent\settings.json"
+    if (-not (Test-Path $cfg)) { return }
+    $short = $cfg -replace [regex]::Escape($env:USERPROFILE), "~"
+
+    if (-not $script:NODE_BIN) {
+        Msg "    ⚠️  跳过: $short (无 node,需手动清理)" "    ⚠️  Skipped: $short (node unavailable, manual cleanup needed)"
+        return
+    }
+
+    $result = & $script:NODE_BIN -e @'
+const fs = require('fs');
+const f = process.argv[1];
+const isOurs = s => typeof s === 'string' && (
+  s.includes('loongsuite-pilot-pi-coding-agent') ||
+  s.includes('plugins/pi-coding-agent/index.mjs')
+);
+try {
+  const data = JSON.parse(fs.readFileSync(f, 'utf-8'));
+  if (!Array.isArray(data.extensions)) { process.stdout.write('nochange'); process.exit(0); }
+  const before = data.extensions.length;
+  data.extensions = data.extensions.filter(entry => !isOurs(typeof entry === 'string' ? entry : ''));
+  if (data.extensions.length === before) { process.stdout.write('nochange'); process.exit(0); }
+  fs.writeFileSync(f, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+  process.stdout.write('cleaned');
+} catch (e) { process.stderr.write(e.message); process.exit(1); }
+'@ $cfg 2>$null
+
+    switch ($result) {
+        "cleaned"  { Msg "    ✅ 已清理: $short" "    ✅ Cleaned: $short" }
+        "nochange" { }
+        default    { Msg "    ⚠️  跳过: $short (需手动清理)" "    ⚠️  Skipped: $short (manual cleanup needed)" }
+    }
+}
+
+# ============================================================
 # Remove OTel plugin (Claude/Codex)
 # ============================================================
 function Remove-OtelPlugin {
@@ -1262,6 +1300,10 @@ function Cmd-Uninstall {
 
     Msg "==> 清理 OpenCode 插件配置..." "==> Cleaning up OpenCode plugin config..."
     Remove-OpenCodePlugin
+    Write-Host ""
+
+    Msg "==> 清理 Pi Coding Agent Extension 配置..." "==> Cleaning up Pi Coding Agent extension config..."
+    Remove-PiCodingAgentExtension
     Write-Host ""
 
     if ($Purge) {

--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -1697,6 +1697,48 @@ try {
 }
 
 # ============================================================
+# Remove Pi Coding Agent extension injection
+# ============================================================
+remove_pi_coding_agent_extension() {
+    local cfg="$HOME/.pi/agent/settings.json"
+    [ -f "$cfg" ] || return 0
+
+    local short="${cfg/#$HOME/\~}"
+    if ! command -v node &>/dev/null; then
+        msg "    ⚠️  跳过: $short (无 node,需手动清理)" "    ⚠️  Skipped: $short (node unavailable, manual cleanup needed)"
+        return 0
+    fi
+
+    local result
+    result=$(node -e "
+const fs = require('fs');
+const f = process.argv[1];
+const isOurs = s => typeof s === 'string' && (
+  s.includes('loongsuite-pilot-pi-coding-agent') ||
+  s.includes('plugins/pi-coding-agent/index.mjs')
+);
+try {
+  const data = JSON.parse(fs.readFileSync(f, 'utf-8'));
+  if (!Array.isArray(data.extensions)) { process.stdout.write('nochange'); process.exit(0); }
+  const before = data.extensions.length;
+  data.extensions = data.extensions.filter(entry => !isOurs(typeof entry === 'string' ? entry : ''));
+  if (data.extensions.length === before) { process.stdout.write('nochange'); process.exit(0); }
+  fs.writeFileSync(f, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+  process.stdout.write('cleaned');
+} catch (e) { process.stderr.write(e.message); process.exit(1); }
+" "$cfg" 2>/dev/null) || result="error"
+
+    case "$result" in
+        cleaned)
+            msg "    ✅ 已清理: $short" "    ✅ Cleaned: $short" ;;
+        nochange)
+            : ;;
+        *)
+            msg "    ⚠️  跳过: $short (需手动清理)" "    ⚠️  Skipped: $short (manual cleanup needed)" ;;
+    esac
+}
+
+# ============================================================
 # CMD: uninstall
 # ============================================================
 cmd_uninstall() {
@@ -1803,6 +1845,10 @@ cmd_uninstall() {
     # Remove plugin-inject specs (OpenCode)
     msg "==> 清理 OpenCode 插件配置..." "==> Cleaning up OpenCode plugin config..."
     remove_opencode_plugin
+    echo ""
+
+    msg "==> 清理 Pi Coding Agent Extension 配置..." "==> Cleaning up Pi Coding Agent extension config..."
+    remove_pi_coding_agent_extension
     echo ""
 
     # Data directory

--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -96,6 +96,11 @@ Important fields:
 | `pluginInject` | Config paths and plugin spec. Required for plugin injection mode. |
 | `input` | Source type and source location for the collector input. |
 
+`pluginInject.configKey` can target an array field other than the default
+`plugin` / `plugins` fields (for example Pi Coding Agent uses `extensions`). Set
+`pluginInject.createIfMissing` to create the first configured JSON file when
+the agent supports an empty settings file.
+
 > When adding a `plugin-inject` agent, also register it in the uninstaller (`deploy/installer-opensource.sh` / `.ps1`) so its injected spec is removed on uninstall. Plugin-inject agents are additionally self-healed at runtime by the hook watchdog, which re-injects the spec if another tool overwrites the config.
 
 ## Emit Normalized Records Early

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -14,6 +14,7 @@ Use these IDs in installer options, `agent-control.json`, and `config.json`.
 | Codex | `codex` | Hook integration. |
 | Cursor | `cursor` | Hook integration. |
 | OpenCode | `opencode` | Plugin injection. |
+| Pi Coding Agent | `pi-coding-agent` | Pi Extension injection; captures LLM and tool lifecycle events. |
 | Qoder | `qoder` | Hook integration. |
 | Qoder CN | `qoder-cn` | Hook integration. |
 | Qoder for JetBrains | `qoder-jetbrains` | Detection-only deploy ID. Agent gating uses `qoder` in `agent-control.json`; content policy uses `qoder-idea` in `config.json`. |

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -26,6 +26,7 @@ LoongSuite Pilot runs on a developer machine and collects telemetry from support
 | Codex | Hook | Yes | Yes | Yes | Yes |
 | Cursor | Hook | Yes | Yes | Yes | Yes |
 | OpenCode | Plugin injection | Yes | Yes | Yes | Yes |
+| Pi Coding Agent | Extension injection | Yes | Yes | Yes | Yes |
 | Qoder | Hook | Yes | Yes | Yes | Yes |
 | Qoder CN | Hook | Yes | Yes | Yes | Yes |
 | Qoder for JetBrains | Detection-only | Yes | Yes | Yes | Yes |

--- a/docs/zh-CN/agent-onboarding.md
+++ b/docs/zh-CN/agent-onboarding.md
@@ -96,6 +96,10 @@ Hook 示例：
 | `pluginInject` | 配置路径和插件 spec。插件注入模式必填。 |
 | `input` | collector input 使用的数据源类型和位置。 |
 
+`pluginInject.configKey` 可指定默认 `plugin` / `plugins` 之外的数组字段，
+例如 Pi Coding Agent 使用 `extensions`。目标 Agent 支持空设置文件时，可设置
+`pluginInject.createIfMissing`，在配置不存在时自动创建第一个候选 JSON 文件。
+
 > 新增 `plugin-inject` 类型 agent 时，请同时在卸载脚本（`deploy/installer-opensource.sh` / `.ps1`）中登记，确保卸载时移除其注入的 spec。此外 plugin-inject agent 在运行时会由 hook watchdog 自愈：若配置被其它工具覆盖，会自动重新注入 spec。
 
 ## 尽早输出规范化记录

--- a/docs/zh-CN/agents.md
+++ b/docs/zh-CN/agents.md
@@ -14,6 +14,7 @@
 | Codex | `codex` | Hook 集成。 |
 | Cursor | `cursor` | Hook 集成。 |
 | OpenCode | `opencode` | 插件注入。 |
+| Pi Coding Agent | `pi-coding-agent` | 注入 Pi Extension，采集 LLM 与工具生命周期事件。 |
 | Qoder | `qoder` | Hook 集成。 |
 | Qoder CN | `qoder-cn` | Hook 集成。 |
 | Qoder for JetBrains | `qoder-jetbrains` | 部署/检测专用 ID。`agent-control.json` 中采集开关为 `qoder`；`config.json` 中内容策略为 `qoder-idea`。 |

--- a/docs/zh-CN/overview.md
+++ b/docs/zh-CN/overview.md
@@ -26,6 +26,7 @@ LoongSuite Pilot 运行在开发者本机，用于采集支持的 AI Coding Agen
 | Codex | Hook | Yes | Yes | Yes | Yes |
 | Cursor | Hook | Yes | Yes | Yes | Yes |
 | OpenCode | 插件注入 | Yes | Yes | Yes | Yes |
+| Pi Coding Agent | Extension 注入 | Yes | Yes | Yes | Yes |
 | Qoder | Hook | Yes | Yes | Yes | Yes |
 | Qoder CN | Hook | Yes | Yes | Yes | Yes |
 | Qoder for JetBrains | 自动检测 | Yes | Yes | Yes | Yes |

--- a/src/core/config-loader.ts
+++ b/src/core/config-loader.ts
@@ -337,6 +337,7 @@ function buildListenersConfig(
     'cursor-hook': { enabled: true, pollInterval: 30_000 },
     'claude-code-log': { enabled: true, pollInterval: 30_000 },
     'codex-transcript': { enabled: true, pollInterval: 30_000 },
+    'pi-coding-agent-log': { enabled: true, pollInterval: 30_000 },
   };
 
   const result = { ...defaults };

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -41,6 +41,7 @@ import { CodexTranscriptInput } from '../inputs/codex-transcript/codex-transcrip
 import { KiroCliLogInput } from '../inputs/kiro-cli-log/kiro-cli-log-input.js';
 import { KiroCliSessionInput } from '../inputs/kiro-cli-session/kiro-cli-session-input.js';
 import { OpenCodeLogInput } from '../inputs/opencode-log/opencode-log-input.js';
+import { PiCodingAgentLogInput } from '../inputs/pi-coding-agent-log/pi-coding-agent-log-input.js';
 import { QwenCodeCliLogInput } from '../inputs/qwen-code-cli-log/qwen-code-cli-log-input.js';
 import { WukongInput } from '../inputs/wukong/wukong-input.js';
 
@@ -95,6 +96,7 @@ export class Orchestrator extends EventEmitter {
     'kiro-cli-log': 'kiro-cli',
     'kiro-cli-session': 'kiro-cli',
     'opencode-log': 'opencode',
+    'pi-coding-agent-log': 'pi-coding-agent',
     'qwen-code-cli-log': 'qwen-code-cli',
     'wukong': 'wukong',
   };
@@ -436,7 +438,8 @@ export class Orchestrator extends EventEmitter {
    */
   private resolvePluginSpecPath(spec: string): string | null {
     const resolved = spec.replace(/\$PILOT_DATA/g, this.dataDir);
-    return resolved.startsWith('file://') ? resolved.slice('file://'.length) : null;
+    if (resolved.startsWith('file://')) return resolved.slice('file://'.length);
+    return path.isAbsolute(resolved) ? resolved : null;
   }
 
   private async buildFlusher(): Promise<BaseFlusher> {
@@ -1031,6 +1034,27 @@ export class Orchestrator extends EventEmitter {
             listenerCfg['opencode-log']?.enabled ?? true,
           ),
         pollIntervalMs: listenerCfg['opencode-log']?.pollInterval,
+      }),
+    );
+
+    // --- Pi Coding Agent Log (Pi extension JSONL) ---
+    const piCodingAgentLogDir = path.join(this.dataDir, 'logs', 'pi-coding-agent');
+    await ensureDir(piCodingAgentLogDir);
+    const piCodingAgentLogInput = new PiCodingAgentLogInput({
+      stateStore: this.stateStore,
+      logDir: piCodingAgentLogDir,
+    });
+    this.inputManager.registerInput(piCodingAgentLogInput);
+    entries.push(
+      this.inputManager.buildDetectionEntry(piCodingAgentLogInput, {
+        watchPaths: [piCodingAgentLogDir],
+        isAvailable: async () => directoryExists(piCodingAgentLogDir),
+        enabled: () => this.isAgentGatedEnabled(Orchestrator.LISTENER_AGENT_MAP['pi-coding-agent-log']) &&
+          this.agentControlManager.resolveEnabled(
+            'pi-coding-agent-log',
+            listenerCfg['pi-coding-agent-log']?.enabled ?? true,
+          ),
+        pollIntervalMs: listenerCfg['pi-coding-agent-log']?.pollInterval,
       }),
     );
 

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -41,7 +41,7 @@ import { CodexTranscriptInput } from '../inputs/codex-transcript/codex-transcrip
 import { KiroCliLogInput } from '../inputs/kiro-cli-log/kiro-cli-log-input.js';
 import { KiroCliSessionInput } from '../inputs/kiro-cli-session/kiro-cli-session-input.js';
 import { OpenCodeLogInput } from '../inputs/opencode-log/opencode-log-input.js';
-import { PiCodingAgentLogInput } from '../inputs/pi-coding-agent-log/pi-coding-agent-log-input.js';
+import { PiCodingAgentLogInput, ensurePiCodingAgentLogDir } from '../inputs/pi-coding-agent-log/pi-coding-agent-log-input.js';
 import { QwenCodeCliLogInput } from '../inputs/qwen-code-cli-log/qwen-code-cli-log-input.js';
 import { WukongInput } from '../inputs/wukong/wukong-input.js';
 
@@ -1039,7 +1039,7 @@ export class Orchestrator extends EventEmitter {
 
     // --- Pi Coding Agent Log (Pi extension JSONL) ---
     const piCodingAgentLogDir = path.join(this.dataDir, 'logs', 'pi-coding-agent');
-    await ensureDir(piCodingAgentLogDir);
+    await ensurePiCodingAgentLogDir(piCodingAgentLogDir);
     const piCodingAgentLogInput = new PiCodingAgentLogInput({
       stateStore: this.stateStore,
       logDir: piCodingAgentLogDir,

--- a/src/deployment/plugin-inject-strategy.ts
+++ b/src/deployment/plugin-inject-strategy.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 import type {
   AgentDefinition,
   DeployResult,
@@ -84,13 +85,13 @@ export class PluginInjectStrategy implements DeployStrategy {
     const config = def.pluginInject;
     if (!config) return true;
 
-    const configPath = await this.findConfigFile(config);
+    const configPath = await this.findConfigFile(config, false);
     if (!configPath) return true;
 
     try {
       const raw = await fs.readFile(configPath, 'utf-8');
       const json = JSON.parse(stripJsoncComments(raw));
-      const pluginKey = this.resolvePluginKey(json);
+      const pluginKey = this.resolvePluginKey(json, config);
       const plugins: unknown[] = json[pluginKey] ?? [];
       if (!Array.isArray(plugins)) return true;
 
@@ -109,7 +110,7 @@ export class PluginInjectStrategy implements DeployStrategy {
     }
 
     try {
-      const configPath = await this.findConfigFile(config);
+      const configPath = await this.findConfigFile(config, config.createIfMissing === true);
       if (!configPath) {
         return {
           success: false,
@@ -121,7 +122,7 @@ export class PluginInjectStrategy implements DeployStrategy {
 
       const raw = await fs.readFile(configPath, 'utf-8');
       const json = JSON.parse(stripJsoncComments(raw));
-      const pluginKey = this.resolvePluginKey(json);
+      const pluginKey = this.resolvePluginKey(json, config);
 
       if (!Array.isArray(json[pluginKey])) {
         json[pluginKey] = [];
@@ -165,12 +166,12 @@ export class PluginInjectStrategy implements DeployStrategy {
     if (!config) return false;
 
     try {
-      const configPath = await this.findConfigFile(config);
+      const configPath = await this.findConfigFile(config, false);
       if (!configPath) return false;
 
       const raw = await fs.readFile(configPath, 'utf-8');
       const json = JSON.parse(stripJsoncComments(raw));
-      const pluginKey = this.resolvePluginKey(json);
+      const pluginKey = this.resolvePluginKey(json, config);
 
       if (!Array.isArray(json[pluginKey])) return true;
 
@@ -197,15 +198,35 @@ export class PluginInjectStrategy implements DeployStrategy {
     }
   }
 
-  private async findConfigFile(config: PluginInjectConfig): Promise<string | null> {
+  private async findConfigFile(
+    config: PluginInjectConfig,
+    createIfMissing: boolean,
+  ): Promise<string | null> {
     for (const p of config.configPaths) {
       const resolved = resolveHome(p);
       if (await fileExists(resolved)) return resolved;
     }
+
+    if (createIfMissing && config.configPaths.length > 0) {
+      const resolved = resolveHome(config.configPaths[0]);
+      await fs.mkdir(path.dirname(resolved), { recursive: true });
+      await fs.writeFile(resolved, '{}\n', {
+        encoding: 'utf-8',
+        flag: 'wx',
+        mode: 0o600,
+      }).catch(async err => {
+        if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+      });
+      return resolved;
+    }
     return null;
   }
 
-  private resolvePluginKey(json: Record<string, unknown>): string {
+  private resolvePluginKey(
+    json: Record<string, unknown>,
+    config: PluginInjectConfig,
+  ): string {
+    if (config.configKey) return config.configKey;
     if (Array.isArray(json.plugins)) return 'plugins';
     return 'plugin';
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,7 @@ export { QoderCnTraceInput } from './inputs/qoder-cn-trace/qoder-cn-trace-input.
 export { QoderCliSessionInput } from './inputs/qoder-cli-session/qoder-cli-session-input.js';
 export { CodexTranscriptInput } from './inputs/codex-transcript/codex-transcript-input.js';
 export { CodexAbortedTurnInput } from './inputs/codex-aborted-turn/codex-aborted-turn-input.js';
+export { PiCodingAgentLogInput } from './inputs/pi-coding-agent-log/pi-coding-agent-log-input.js';
 export { BaseFlusher } from './flushers/base-flusher.js';
 export { SlsFlusher } from './flushers/sls-flusher.js';
 export { JsonlFlusher } from './flushers/jsonl-flusher.js';

--- a/src/inputs/pi-coding-agent-log/pi-coding-agent-log-input.ts
+++ b/src/inputs/pi-coding-agent-log/pi-coding-agent-log-input.ts
@@ -1,0 +1,33 @@
+import { ClientType } from '../../types/index.js';
+import type { AgentActivityEntry } from '../../types/index.js';
+import { transformHookRecord } from '../base/hook-record-transform.js';
+import { BaseHookInput, type HookInputOptions } from '../base/base-hook-input.js';
+import { directoryExists, resolveHome } from '../../utils/fs-utils.js';
+
+export class PiCodingAgentLogInput extends BaseHookInput {
+  readonly id = 'pi-coding-agent-log';
+  readonly agentType = ClientType.PiCodingAgent;
+
+  constructor(opts?: Partial<HookInputOptions> & { stateStore: HookInputOptions['stateStore'] }) {
+    super({
+      stateStore: opts!.stateStore,
+      logDir: opts?.logDir ?? resolveHome('~/.loongsuite-pilot/logs/pi-coding-agent'),
+      logPrefix: opts?.logPrefix ?? 'pi-coding-agent',
+      pollIntervalMs: opts?.pollIntervalMs ?? 30_000,
+    });
+  }
+
+  static async checkAvailability(): Promise<boolean> {
+    return directoryExists(resolveHome('~/.loongsuite-pilot/logs/pi-coding-agent'));
+  }
+
+  static getWatchPaths(): string[] {
+    return [resolveHome('~/.loongsuite-pilot/logs/pi-coding-agent')];
+  }
+
+  protected async transformRecord(
+    record: Record<string, unknown>,
+  ): Promise<AgentActivityEntry | null> {
+    return transformHookRecord(record, ClientType.PiCodingAgent, 'pi-coding-agent');
+  }
+}

--- a/src/inputs/pi-coding-agent-log/pi-coding-agent-log-input.ts
+++ b/src/inputs/pi-coding-agent-log/pi-coding-agent-log-input.ts
@@ -1,8 +1,14 @@
+import * as fs from 'node:fs/promises';
 import { ClientType } from '../../types/index.js';
 import type { AgentActivityEntry } from '../../types/index.js';
 import { transformHookRecord } from '../base/hook-record-transform.js';
 import { BaseHookInput, type HookInputOptions } from '../base/base-hook-input.js';
 import { directoryExists, resolveHome } from '../../utils/fs-utils.js';
+
+export async function ensurePiCodingAgentLogDir(logDir: string): Promise<void> {
+  await fs.mkdir(logDir, { recursive: true, mode: 0o700 });
+  if (process.platform !== 'win32') await fs.chmod(logDir, 0o700);
+}
 
 export class PiCodingAgentLogInput extends BaseHookInput {
   readonly id = 'pi-coding-agent-log';
@@ -23,6 +29,10 @@ export class PiCodingAgentLogInput extends BaseHookInput {
 
   static getWatchPaths(): string[] {
     return [resolveHome('~/.loongsuite-pilot/logs/pi-coding-agent')];
+  }
+
+  protected override async onStart(): Promise<void> {
+    await ensurePiCodingAgentLogDir(this.logDir);
   }
 
   protected async transformRecord(

--- a/src/inputs/pi-coding-agent-log/pi-coding-agent-log-input.ts
+++ b/src/inputs/pi-coding-agent-log/pi-coding-agent-log-input.ts
@@ -1,9 +1,24 @@
 import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 import { ClientType } from '../../types/index.js';
 import type { AgentActivityEntry } from '../../types/index.js';
 import { transformHookRecord } from '../base/hook-record-transform.js';
 import { BaseHookInput, type HookInputOptions } from '../base/base-hook-input.js';
 import { directoryExists, resolveHome } from '../../utils/fs-utils.js';
+
+const DEFAULT_PILOT_DATA_DIR = '~/.loongsuite-pilot';
+
+export type PiCodingAgentLogInputOptions =
+  Omit<Partial<HookInputOptions>, 'stateStore'>
+  & Pick<HookInputOptions, 'stateStore'>
+  & { dataDir?: string };
+
+export function resolvePiCodingAgentLogDir(dataDir?: string): string {
+  const resolvedDataDir = resolveHome(
+    dataDir || process.env.LOONGSUITE_PILOT_DATA_DIR || DEFAULT_PILOT_DATA_DIR,
+  );
+  return path.join(resolvedDataDir, 'logs', 'pi-coding-agent');
+}
 
 export async function ensurePiCodingAgentLogDir(logDir: string): Promise<void> {
   await fs.mkdir(logDir, { recursive: true, mode: 0o700 });
@@ -14,21 +29,24 @@ export class PiCodingAgentLogInput extends BaseHookInput {
   readonly id = 'pi-coding-agent-log';
   readonly agentType = ClientType.PiCodingAgent;
 
-  constructor(opts?: Partial<HookInputOptions> & { stateStore: HookInputOptions['stateStore'] }) {
+  constructor(opts: PiCodingAgentLogInputOptions) {
+    if (!opts?.stateStore) {
+      throw new TypeError('PiCodingAgentLogInput requires a stateStore');
+    }
     super({
-      stateStore: opts!.stateStore,
-      logDir: opts?.logDir ?? resolveHome('~/.loongsuite-pilot/logs/pi-coding-agent'),
-      logPrefix: opts?.logPrefix ?? 'pi-coding-agent',
-      pollIntervalMs: opts?.pollIntervalMs ?? 30_000,
+      stateStore: opts.stateStore,
+      logDir: opts.logDir ?? resolvePiCodingAgentLogDir(opts.dataDir),
+      logPrefix: opts.logPrefix ?? 'pi-coding-agent',
+      pollIntervalMs: opts.pollIntervalMs ?? 30_000,
     });
   }
 
-  static async checkAvailability(): Promise<boolean> {
-    return directoryExists(resolveHome('~/.loongsuite-pilot/logs/pi-coding-agent'));
+  static async checkAvailability(dataDir?: string): Promise<boolean> {
+    return directoryExists(resolvePiCodingAgentLogDir(dataDir));
   }
 
-  static getWatchPaths(): string[] {
-    return [resolveHome('~/.loongsuite-pilot/logs/pi-coding-agent')];
+  static getWatchPaths(dataDir?: string): string[] {
+    return [resolvePiCodingAgentLogDir(dataDir)];
   }
 
   protected override async onStart(): Promise<void> {

--- a/src/normalization/agent-content-policy.ts
+++ b/src/normalization/agent-content-policy.ts
@@ -11,6 +11,8 @@ const MESSAGE_CONTENT_FIELDS = new Set([
   'gen_ai.output.messages',
   'gen_ai.tool.call.arguments',
   'gen_ai.tool.call.result',
+  'gen_ai.system_instructions',
+  'gen_ai.tool.definitions',
   'input.messages',
   'input.messages_delta',
   'output.messages',

--- a/src/normalization/agent-system-map.ts
+++ b/src/normalization/agent-system-map.ts
@@ -12,6 +12,7 @@ export const AGENT_SYSTEM_MAP: Record<string, string> = {
   'cursor-hook': 'cursor',
   'qwen-code-cli': 'qwen-code',
   'opencode': 'opencode',
+  'pi-coding-agent': 'pi',
   'wukong': 'wukong',
 };
 

--- a/src/types/client-type.ts
+++ b/src/types/client-type.ts
@@ -25,6 +25,7 @@ export enum ClientType {
   CodexSession = 'codex-session',
   QoderCli = 'qoder-cli',
   CursorCli = 'cursor-cli',
+  PiCodingAgent = 'pi-coding-agent',
 
   // Hook-based tools
   ClaudeCliHook = 'claude-code',

--- a/src/types/deployment.ts
+++ b/src/types/deployment.ts
@@ -128,6 +128,10 @@ export interface PluginInjectConfig {
   pluginSpec: string;
   pluginId: string;
   replaceSpecs?: string[];
+  /** Target array field. Defaults to auto-detected `plugins` / `plugin`. */
+  configKey?: string;
+  /** Create the first config path with an empty object when none exists. */
+  createIfMissing?: boolean;
 }
 
 export interface AgentRuntimeConfig {

--- a/tests/unit/core/config-loader.test.ts
+++ b/tests/unit/core/config-loader.test.ts
@@ -226,6 +226,7 @@ describe('ConfigLoader', () => {
       expect(config.listeners['qoder-cli-session'].enabled).toBe(true);
       expect(config.listeners['cursor-hook'].enabled).toBe(true);
       expect(config.listeners['codex-transcript']).toEqual({ enabled: true, pollInterval: 30_000 });
+      expect(config.listeners['pi-coding-agent-log']).toEqual({ enabled: true, pollInterval: 30_000 });
     });
 
     it('merges file-level listener overrides', async () => {

--- a/tests/unit/core/orchestrator-plugin-inject-watchdog.test.ts
+++ b/tests/unit/core/orchestrator-plugin-inject-watchdog.test.ts
@@ -156,6 +156,26 @@ describe('Orchestrator.buildPluginInjectInterceptTargets', () => {
       expect(await target.precondition()).toBe(true);
       expect(fileExists).not.toHaveBeenCalled();
     });
+
+    it('checks absolute extension paths used by Pi Coding Agent', async () => {
+      getDefinitions.mockReturnValue([
+        pluginInjectDef({
+          id: 'pi-coding-agent',
+          pluginInject: {
+            configPaths: ['~/.pi/agent/settings.json'],
+            pluginSpec: `${DATA_DIR}/plugins/pi-coding-agent/index.mjs`,
+            pluginId: 'loongsuite-pilot-pi-coding-agent',
+            configKey: 'extensions',
+          },
+        }),
+      ]);
+      vi.mocked(fileExists).mockResolvedValue(true);
+      vi.mocked(detectAgent).mockResolvedValue(true);
+
+      const [target] = callBuild(orch);
+      expect(await target.precondition()).toBe(true);
+      expect(fileExists).toHaveBeenCalledWith(`${DATA_DIR}/plugins/pi-coding-agent/index.mjs`);
+    });
   });
 
   describe('check (healthy when spec present)', () => {

--- a/tests/unit/deploy/installer-uninstall-cleanup.test.mjs
+++ b/tests/unit/deploy/installer-uninstall-cleanup.test.mjs
@@ -65,3 +65,26 @@ describe('uninstall cleans the OpenCode plugin-inject spec', () => {
     expect(ps1).toContain('plugins/opencode/plugin.mjs');
   });
 });
+
+describe('uninstall cleans the Pi Coding Agent extension injection', () => {
+  it('sh defines and calls remove_pi_coding_agent_extension', () => {
+    expect(sh).toMatch(/remove_pi_coding_agent_extension\(\)\s*\{/);
+    const uninstall = sh.slice(sh.indexOf('cmd_uninstall()'));
+    expect(uninstall).toContain('remove_pi_coding_agent_extension');
+  });
+
+  it('ps1 defines and calls Remove-PiCodingAgentExtension', () => {
+    expect(ps1).toMatch(/function Remove-PiCodingAgentExtension\s*\{/);
+    const uninstall = ps1.slice(ps1.indexOf('function Cmd-Uninstall'));
+    expect(uninstall).toContain('Remove-PiCodingAgentExtension');
+  });
+
+  it('targets Pi settings and matches only the Pilot extension', () => {
+    expect(sh).toContain('.pi/agent/settings.json');
+    expect(ps1).toContain('.pi\\agent\\settings.json');
+    expect(sh).toContain('loongsuite-pilot-pi-coding-agent');
+    expect(sh).toContain('plugins/pi-coding-agent/index.mjs');
+    expect(ps1).toContain('loongsuite-pilot-pi-coding-agent');
+    expect(ps1).toContain('plugins/pi-coding-agent/index.mjs');
+  });
+});

--- a/tests/unit/deployment/plugin-inject-strategy.test.ts
+++ b/tests/unit/deployment/plugin-inject-strategy.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { PluginInjectStrategy } from '../../../src/deployment/plugin-inject-strategy.js';
+import type { AgentDefinition } from '../../../src/types/index.js';
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+describe('PluginInjectStrategy', () => {
+  let tmpDir: string;
+  let dataDir: string;
+  let settingsPath: string;
+  let strategy: PluginInjectStrategy;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'plugin-inject-'));
+    dataDir = path.join(tmpDir, 'pilot-data');
+    settingsPath = path.join(tmpDir, '.pi', 'agent', 'settings.json');
+    strategy = new PluginInjectStrategy(dataDir, tmpDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  function piDefinition(overrides: Partial<AgentDefinition['pluginInject']> = {}): AgentDefinition {
+    return {
+      id: 'pi-coding-agent',
+      displayName: 'Pi Coding Agent',
+      deployMode: 'plugin-inject',
+      detection: { paths: [], commands: [] },
+      pluginInject: {
+        configPaths: [settingsPath],
+        pluginSpec: '$PILOT_DATA/plugins/pi-coding-agent/index.mjs',
+        pluginId: 'loongsuite-pilot-pi-coding-agent',
+        configKey: 'extensions',
+        createIfMissing: true,
+        ...overrides,
+      },
+    };
+  }
+
+  it('injects an extension path into a configured array field', async () => {
+    await fs.mkdir(path.dirname(settingsPath), { recursive: true });
+    await fs.writeFile(settingsPath, JSON.stringify({ theme: 'dark', extensions: ['/other.mjs'] }));
+
+    const result = await strategy.deploy(piDefinition());
+
+    expect(result.success).toBe(true);
+    const settings = JSON.parse(await fs.readFile(settingsPath, 'utf8'));
+    expect(settings.theme).toBe('dark');
+    expect(settings.extensions).toEqual([
+      '/other.mjs',
+      path.join(dataDir, 'plugins', 'pi-coding-agent', 'index.mjs'),
+    ]);
+    expect(await strategy.needsDeploy(piDefinition())).toBe(false);
+  });
+
+  it('creates the first config path when createIfMissing is enabled', async () => {
+    const result = await strategy.deploy(piDefinition());
+
+    expect(result.success).toBe(true);
+    const settings = JSON.parse(await fs.readFile(settingsPath, 'utf8'));
+    expect(settings.extensions).toEqual([
+      path.join(dataDir, 'plugins', 'pi-coding-agent', 'index.mjs'),
+    ]);
+    if (process.platform !== 'win32') {
+      expect((await fs.stat(settingsPath)).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it('does not create a missing config during a read-only health check', async () => {
+    expect(await strategy.needsDeploy(piDefinition())).toBe(true);
+    await expect(fs.access(settingsPath)).rejects.toThrow();
+  });
+
+  it('does not create a missing config when createIfMissing is disabled', async () => {
+    const result = await strategy.deploy(piDefinition({ createIfMissing: false }));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('no config file found');
+    await expect(fs.access(settingsPath)).rejects.toThrow();
+  });
+
+  it('is idempotent and removes the injected extension on undeploy', async () => {
+    await strategy.deploy(piDefinition());
+    await strategy.deploy(piDefinition());
+
+    const before = JSON.parse(await fs.readFile(settingsPath, 'utf8'));
+    expect(before.extensions).toHaveLength(1);
+
+    expect(await strategy.undeploy(piDefinition())).toBe(true);
+    const after = JSON.parse(await fs.readFile(settingsPath, 'utf8'));
+    expect(after.extensions).toEqual([]);
+  });
+
+  it('keeps the existing OpenCode plugin/plugins auto-detection behavior', async () => {
+    const configPath = path.join(tmpDir, 'opencode.json');
+    await fs.writeFile(configPath, JSON.stringify({ plugins: ['existing'] }));
+    const def = piDefinition({
+      configPaths: [configPath],
+      pluginSpec: 'file://$PILOT_DATA/plugins/opencode/plugin.mjs',
+      pluginId: 'loongsuite-pilot-opencode',
+      configKey: undefined,
+      createIfMissing: false,
+    });
+
+    await strategy.deploy(def);
+
+    const config = JSON.parse(await fs.readFile(configPath, 'utf8'));
+    expect(config.plugins).toEqual([
+      'existing',
+      `file://${path.join(dataDir, 'plugins', 'opencode', 'plugin.mjs')}`,
+    ]);
+    expect(config.plugin).toBeUndefined();
+  });
+});

--- a/tests/unit/hooks/pi-coding-agent-extension.test.mjs
+++ b/tests/unit/hooks/pi-coding-agent-extension.test.mjs
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { convertEventLogToReadableSpans } from '@loongsuite/otel-util-genai';
 
 const EXTENSION_PATH = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -73,6 +74,12 @@ function readRecords() {
     .flatMap(name => fs.readFileSync(path.join(dir, name), 'utf8').trim().split('\n'))
     .filter(Boolean)
     .map(line => JSON.parse(line));
+}
+
+function spanDurationNanos(span) {
+  const start = BigInt(span.startTime[0]) * 1_000_000_000n + BigInt(span.startTime[1]);
+  const end = BigInt(span.endTime[0]) * 1_000_000_000n + BigInt(span.endTime[1]);
+  return end - start;
 }
 
 async function startTurn(runtime) {
@@ -281,6 +288,96 @@ describe('Pi Coding Agent extension', () => {
     expect(requests[1]['gen_ai.input.messages'][0].parts[0].content).toBe('second turn');
   });
 
+  it('keeps an LLM response strictly later than a request in the same millisecond', async () => {
+    const runtime = await createRuntime();
+    await startTurn(runtime);
+
+    await runtime.emit('context', { messages: [] });
+    await runtime.emit('message_end', {
+      message: {
+        role: 'assistant',
+        content: [],
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-5',
+        stopReason: 'stop',
+        timestamp: Date.now(),
+        usage: {},
+      },
+    });
+
+    const [request, response] = readRecords();
+    expect(request['event.name']).toBe('llm.request');
+    expect(response['event.name']).toBe('llm.response');
+    expect(
+      BigInt(response.time_unix_nano) - BigInt(request.time_unix_nano) >= 1_000_000n,
+    ).toBe(true);
+    expect(
+      BigInt(response.observed_time_unix_nano) >= BigInt(response.time_unix_nano),
+    ).toBe(true);
+
+    const conversion = await convertEventLogToReadableSpans([request, response]);
+    const llmSpan = conversion.spans.find(span => span.attributes['gen_ai.span.kind'] === 'LLM');
+    expect(llmSpan).toBeDefined();
+    expect(spanDurationNanos(llmSpan) >= 1_000_000n).toBe(true);
+  });
+
+  it('uses message_end receipt time as the LLM response completion time', async () => {
+    const runtime = await createRuntime();
+    await startTurn(runtime);
+    await runtime.emit('context', { messages: [] });
+
+    const providerStartedAt = Date.now();
+    vi.setSystemTime(new Date('2026-07-16T08:00:04.000Z'));
+    await runtime.emit('message_end', {
+      message: {
+        role: 'assistant',
+        content: [],
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-5',
+        stopReason: 'stop',
+        timestamp: providerStartedAt,
+        usage: {},
+      },
+    });
+
+    const [request, response] = readRecords();
+    expect(BigInt(response.time_unix_nano) - BigInt(request.time_unix_nano)).toBe(
+      4_000_000_000n,
+    );
+  });
+
+  it('emits a fallback LLM request when a response arrives without context', async () => {
+    const runtime = await createRuntime();
+    await startTurn(runtime);
+
+    await runtime.emit('message_end', {
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'done' }],
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-5',
+        stopReason: 'stop',
+        timestamp: Date.now(),
+        usage: {},
+      },
+    });
+
+    const records = readRecords();
+    expect(records.map(record => record['event.name'])).toEqual([
+      'llm.request',
+      'llm.response',
+    ]);
+    expect(
+      BigInt(records[1].time_unix_nano) - BigInt(records[0].time_unix_nano) >= 1_000_000n,
+    ).toBe(true);
+
+    const conversion = await convertEventLogToReadableSpans(records);
+    const llmSpan = conversion.spans.find(span => span.attributes['gen_ai.span.kind'] === 'LLM');
+    expect(llmSpan).toBeDefined();
+    expect(spanDurationNanos(llmSpan) >= 1_000_000n).toBe(true);
+    expect(conversion.warnings.some(warning => /orphan/i.test(warning))).toBe(false);
+  });
+
   it('records tool failures with status, error type, result, and duration', async () => {
     const runtime = await createRuntime();
     await startTurn(runtime);
@@ -327,6 +424,36 @@ describe('Pi Coding Agent extension', () => {
       'tool.result.status': 'success',
     });
     expect(result).not.toHaveProperty('gen_ai.tool.call.duration');
+  });
+
+  it('keeps a tool result strictly later than a call in the same millisecond', async () => {
+    const runtime = await createRuntime();
+    await startTurn(runtime);
+
+    await runtime.emit('tool_execution_start', {
+      toolCallId: 'call-fast',
+      toolName: 'read',
+      args: { path: 'README.md' },
+    });
+    await runtime.emit('tool_execution_end', {
+      toolCallId: 'call-fast',
+      toolName: 'read',
+      result: { content: 'ok' },
+      isError: false,
+    });
+
+    const [call, result] = readRecords();
+    expect(call['event.name']).toBe('tool.call');
+    expect(result['event.name']).toBe('tool.result');
+    expect(
+      BigInt(result.time_unix_nano) - BigInt(call.time_unix_nano) >= 1_000_000n,
+    ).toBe(true);
+    expect(result['gen_ai.tool.call.duration']).toBe(1);
+
+    const conversion = await convertEventLogToReadableSpans([call, result]);
+    const toolSpan = conversion.spans.find(span => span.attributes['gen_ai.span.kind'] === 'TOOL');
+    expect(toolSpan).toBeDefined();
+    expect(spanDurationNanos(toolSpan) >= 1_000_000n).toBe(true);
   });
 
   it('tightens an existing log directory before writing sensitive records', async () => {
@@ -475,7 +602,7 @@ describe('Pi Coding Agent extension', () => {
       },
     });
 
-    expect(readRecords()[0]).toMatchObject({
+    expect(readRecords().find(record => record['event.name'] === 'llm.response')).toMatchObject({
       'event.name': 'llm.response',
       'error.type': 'llm_error',
       'error.message': 'rate limit exceeded',

--- a/tests/unit/hooks/pi-coding-agent-extension.test.mjs
+++ b/tests/unit/hooks/pi-coding-agent-extension.test.mjs
@@ -21,6 +21,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.useRealTimers();
   if (previousDataDir === undefined) delete process.env.LOONGSUITE_PILOT_DATA_DIR;
   else process.env.LOONGSUITE_PILOT_DATA_DIR = previousDataDir;
@@ -181,6 +182,121 @@ describe('Pi Coding Agent extension', () => {
     }
   });
 
+  it('serializes tool result responses as strings without embedding image payloads', async () => {
+    const runtime = await createRuntime();
+    await startTurn(runtime);
+
+    await runtime.emit('context', {
+      messages: [
+        {
+          role: 'toolResult',
+          toolCallId: 'call-1',
+          toolName: 'read',
+          isError: false,
+          content: [{ type: 'text', text: '# README' }],
+        },
+        {
+          role: 'toolResult',
+          toolCallId: 'call-2',
+          toolName: 'image',
+          isError: false,
+          content: [
+            { type: 'text', text: 'screenshot' },
+            { type: 'image', mimeType: 'image/png', data: 'sensitive-base64-payload' },
+          ],
+        },
+      ],
+    });
+
+    const messages = readRecords()[0]['gen_ai.input.messages'];
+    expect(messages[0].parts[0].response).toBe('# README');
+    const mixedResponse = messages[1].parts[0].response;
+    expect(typeof mixedResponse).toBe('string');
+    expect(mixedResponse).toContain('screenshot');
+    expect(mixedResponse).toContain('image/png');
+    expect(mixedResponse).not.toContain('sensitive-base64-payload');
+  });
+
+  it('tightens an existing log directory before writing sensitive records', async () => {
+    if (process.platform === 'win32') return;
+
+    const logDir = path.join(tmpDir, 'logs', 'pi-coding-agent');
+    fs.mkdirSync(logDir, { recursive: true, mode: 0o755 });
+    fs.chmodSync(logDir, 0o755);
+
+    const runtime = await createRuntime();
+    await startTurn(runtime);
+    await runtime.emit('context', { messages: [] });
+
+    expect(fs.statSync(logDir).mode & 0o777).toBe(0o700);
+  });
+
+  it('creates the log directory only once across multiple event writes', async () => {
+    const mkdirSpy = vi.spyOn(fs, 'mkdirSync');
+    const runtime = await createRuntime();
+    await startTurn(runtime);
+
+    await runtime.emit('context', { messages: [] });
+    await runtime.emit('message_end', {
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'done' }],
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-5',
+        stopReason: 'stop',
+        timestamp: Date.now(),
+        usage: {},
+      },
+    });
+    await runtime.emit('tool_execution_start', {
+      toolCallId: 'call-1',
+      toolName: 'read',
+      args: { path: 'README.md' },
+    });
+    await runtime.emit('tool_execution_end', {
+      toolCallId: 'call-1',
+      toolName: 'read',
+      result: { content: 'ok' },
+      isError: false,
+    });
+
+    expect(mkdirSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('recreates the cached log directory when it is removed at runtime', async () => {
+    const runtime = await createRuntime();
+    await startTurn(runtime);
+    await runtime.emit('context', { messages: [] });
+
+    const logDir = path.join(tmpDir, 'logs', 'pi-coding-agent');
+    fs.rmSync(logDir, { recursive: true, force: true });
+    await runtime.emit('tool_execution_start', {
+      toolCallId: 'call-recovered',
+      toolName: 'read',
+      args: { path: 'README.md' },
+    });
+
+    expect(readRecords()).toEqual([
+      expect.objectContaining({
+        'event.name': 'tool.call',
+        'gen_ai.tool.call.id': 'call-recovered',
+      }),
+    ]);
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(logDir).mode & 0o777).toBe(0o700);
+    }
+  });
+
+  it('keeps fallback turn and step identifiers correlated', async () => {
+    const runtime = await createRuntime();
+    await runtime.emit('session_start', { reason: 'startup' });
+    await runtime.emit('turn_start', { turnIndex: 0, timestamp: Date.now() });
+    await runtime.emit('context', { messages: [] });
+
+    const request = readRecords()[0];
+    expect(request['gen_ai.step.id']).toBe(`${request['gen_ai.turn.id']}:s1`);
+  });
+
   it('omits sensitive message and tool payloads when content capture is disabled', async () => {
     const runtime = await createRuntime({
       agents: { 'pi-coding-agent': { captureMessageContent: false } },
@@ -195,7 +311,8 @@ describe('Pi Coding Agent extension', () => {
         content: [{ type: 'text', text: 'secret response' }],
         provider: 'openai',
         model: 'gpt-5',
-        stopReason: 'stop',
+        stopReason: 'error',
+        errorMessage: 'provider echoed secret prompt',
         timestamp: Date.now(),
         usage: {
           input: 10,
@@ -224,8 +341,33 @@ describe('Pi Coding Agent extension', () => {
     expect(records[0]).not.toHaveProperty('gen_ai.system_instructions');
     expect(records[0]).not.toHaveProperty('gen_ai.tool.definitions');
     expect(records[1]).not.toHaveProperty('gen_ai.output.messages');
+    expect(records[1]['error.type']).toBe('llm_error');
+    expect(records[1]).not.toHaveProperty('error.message');
     expect(records[2]).not.toHaveProperty('gen_ai.tool.call.arguments');
     expect(records[3]).not.toHaveProperty('gen_ai.tool.call.result');
+  });
+
+  it('keeps LLM error diagnostics when content capture is enabled', async () => {
+    const runtime = await createRuntime();
+    await startTurn(runtime);
+    await runtime.emit('message_end', {
+      message: {
+        role: 'assistant',
+        content: [],
+        provider: 'openai',
+        model: 'gpt-5',
+        stopReason: 'error',
+        errorMessage: 'rate limit exceeded',
+        timestamp: Date.now(),
+        usage: {},
+      },
+    });
+
+    expect(readRecords()[0]).toMatchObject({
+      'event.name': 'llm.response',
+      'error.type': 'llm_error',
+      'error.message': 'rate limit exceeded',
+    });
   });
 
   it('writes errors to a side log without rejecting Pi event handlers', async () => {
@@ -241,7 +383,6 @@ describe('Pi Coding Agent extension', () => {
     await expect(startTurn(runtime)).resolves.toBeUndefined();
     await expect(runtime.emit('context', { messages: [] })).resolves.toBeUndefined();
 
-    vi.restoreAllMocks();
     const errorDir = path.join(tmpDir, 'logs', 'pi-coding-agent');
     expect(fs.readdirSync(errorDir).some(name => name.includes('-error-'))).toBe(true);
   });

--- a/tests/unit/hooks/pi-coding-agent-extension.test.mjs
+++ b/tests/unit/hooks/pi-coding-agent-extension.test.mjs
@@ -82,6 +82,11 @@ function spanDurationNanos(span) {
   return end - start;
 }
 
+function spanInputMessages(span) {
+  const value = span?.attributes?.['gen_ai.input.messages'];
+  return typeof value === 'string' ? JSON.parse(value) : value;
+}
+
 async function startTurn(runtime) {
   await runtime.emit('session_start', { reason: 'startup' });
   await runtime.emit('before_agent_start', {
@@ -146,20 +151,21 @@ describe('Pi Coding Agent extension', () => {
 
     const records = readRecords();
     expect(records.map(record => record['event.name'])).toEqual([
+      'other',
       'llm.request',
       'llm.response',
       'tool.call',
       'tool.result',
     ]);
 
-    const request = records[0];
+    const request = records.find(record => record['event.name'] === 'llm.request');
     expect(request['gen_ai.session.id']).toBe('pi-session-1');
     expect(request['gen_ai.agent.type']).toBe('pi-coding-agent');
     expect(request['agent.pi-coding-agent.cwd']).toBe('/workspace/example');
     expect(request['gen_ai.input.messages'][0].parts[0].content).toBe('Inspect the repository');
     expect(request['gen_ai.tool.definitions'].map(tool => tool.name)).toEqual(['read', 'bash']);
 
-    const response = records[1];
+    const response = records.find(record => record['event.name'] === 'llm.response');
     expect(response['gen_ai.usage.input_tokens']).toBe(1_300);
     expect(response['gen_ai.usage.cache_read.input_tokens']).toBe(1_000);
     expect(response['gen_ai.usage.cache_creation.input_tokens']).toBe(200);
@@ -175,10 +181,12 @@ describe('Pi Coding Agent extension', () => {
       expect.objectContaining({ type: 'tool_call', id: 'call-1' }),
     ]));
 
-    expect(records[2]['gen_ai.tool.call.arguments']).toEqual({ path: 'README.md' });
-    expect(records[3]['tool.result.status']).toBe('success');
-    expect(records[3]['gen_ai.tool.call.duration']).toBe(250);
-    expect(records[3]['gen_ai.tool.call.result']).toEqual({
+    const toolCall = records.find(record => record['event.name'] === 'tool.call');
+    const toolResult = records.find(record => record['event.name'] === 'tool.result');
+    expect(toolCall['gen_ai.tool.call.arguments']).toEqual({ path: 'README.md' });
+    expect(toolResult['tool.result.status']).toBe('success');
+    expect(toolResult['gen_ai.tool.call.duration']).toBe(250);
+    expect(toolResult['gen_ai.tool.call.result']).toEqual({
       content: [{ type: 'text', text: '# README' }],
     });
     if (process.platform !== 'win32') {
@@ -186,6 +194,69 @@ describe('Pi Coding Agent extension', () => {
       const logFile = path.join(logDir, 'pi-coding-agent-2026-07-16.jsonl');
       expect(fs.statSync(logDir).mode & 0o777).toBe(0o700);
       expect(fs.statSync(logFile).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it('emits one turn-level input delta that populates ENTRY and AGENT spans', async () => {
+    const runtime = await createRuntime();
+    await startTurn(runtime);
+
+    const currentInput = [
+      { role: 'user', parts: [{ type: 'text', content: 'Inspect the repository' }] },
+      { role: 'user', parts: [{ type: 'text', content: 'Injected context' }] },
+    ];
+    await runtime.emit('context', {
+      messages: [
+        { role: 'user', content: 'old prompt' },
+        { role: 'assistant', content: [{ type: 'text', text: 'old response' }] },
+        { role: 'user', content: [{ type: 'text', text: 'Inspect the repository' }] },
+        {
+          role: 'custom',
+          customType: 'extension-note',
+          content: [{ type: 'text', text: 'Injected context' }],
+          display: false,
+        },
+      ],
+    });
+    // Pi can emit context more than once before one provider request. The
+    // turn-level user input must still be emitted exactly once.
+    await runtime.emit('context', {
+      messages: [{ role: 'user', content: 'duplicate snapshot' }],
+    });
+    await runtime.emit('message_end', {
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'I will inspect it.' }],
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-5',
+        stopReason: 'stop',
+        timestamp: Date.now(),
+        usage: {},
+      },
+    });
+
+    const records = readRecords();
+    const userInputRecords = records.filter(record => record['event.name'] === 'other');
+    expect(userInputRecords).toHaveLength(1);
+    expect(userInputRecords[0]['gen_ai.input.messages_delta']).toEqual(currentInput);
+    expect(userInputRecords[0]).not.toHaveProperty('gen_ai.step.id');
+    expect(userInputRecords[0]).not.toHaveProperty('gen_ai.request.model');
+
+    const previousStability = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+    const previousCapture = process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+    process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'gen_ai_latest_experimental';
+    process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = 'SPAN_ONLY';
+    try {
+      const conversion = await convertEventLogToReadableSpans(records);
+      const entry = conversion.spans.find(span => span.attributes['gen_ai.span.kind'] === 'ENTRY');
+      const agent = conversion.spans.find(span => span.attributes['gen_ai.span.kind'] === 'AGENT');
+      expect(spanInputMessages(entry)).toEqual(currentInput);
+      expect(spanInputMessages(agent)).toEqual(currentInput);
+    } finally {
+      if (previousStability === undefined) delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+      else process.env.OTEL_SEMCONV_STABILITY_OPT_IN = previousStability;
+      if (previousCapture === undefined) delete process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+      else process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = previousCapture;
     }
   });
 
@@ -215,7 +286,8 @@ describe('Pi Coding Agent extension', () => {
       ],
     });
 
-    const messages = readRecords()[0]['gen_ai.input.messages'];
+    const messages = readRecords()
+      .find(record => record['event.name'] === 'llm.request')['gen_ai.input.messages'];
     expect(messages[0].parts[0].response).toBe('# README');
     const mixedResponse = messages[1].parts[0].response;
     expect(typeof mixedResponse).toBe('string');
@@ -245,7 +317,8 @@ describe('Pi Coding Agent extension', () => {
       ],
     });
 
-    expect(readRecords()[0]['gen_ai.input.messages']).toEqual([
+    const request = readRecords().find(record => record['event.name'] === 'llm.request');
+    expect(request['gen_ai.input.messages']).toEqual([
       {
         role: 'tool',
         parts: [{
@@ -278,8 +351,15 @@ describe('Pi Coding Agent extension', () => {
       messages: [{ role: 'user', content: 'second turn' }],
     });
 
-    const requests = readRecords();
+    const records = readRecords();
+    const requests = records.filter(record => record['event.name'] === 'llm.request');
+    const userInputs = records.filter(record => record['event.name'] === 'other');
     expect(requests).toHaveLength(2);
+    expect(userInputs).toHaveLength(2);
+    expect(userInputs.map(record => record['gen_ai.input.messages_delta'][0].parts[0].content)).toEqual([
+      'first snapshot',
+      'second turn',
+    ]);
     expect(requests.map(record => record['gen_ai.step.id'])).toEqual([
       expect.stringMatching(/:s1$/),
       expect.stringMatching(/:s2$/),
@@ -305,7 +385,9 @@ describe('Pi Coding Agent extension', () => {
       },
     });
 
-    const [request, response] = readRecords();
+    const records = readRecords();
+    const request = records.find(record => record['event.name'] === 'llm.request');
+    const response = records.find(record => record['event.name'] === 'llm.response');
     expect(request['event.name']).toBe('llm.request');
     expect(response['event.name']).toBe('llm.response');
     expect(
@@ -340,7 +422,9 @@ describe('Pi Coding Agent extension', () => {
       },
     });
 
-    const [request, response] = readRecords();
+    const records = readRecords();
+    const request = records.find(record => record['event.name'] === 'llm.request');
+    const response = records.find(record => record['event.name'] === 'llm.response');
     expect(BigInt(response.time_unix_nano) - BigInt(request.time_unix_nano)).toBe(
       4_000_000_000n,
     );
@@ -364,11 +448,17 @@ describe('Pi Coding Agent extension', () => {
 
     const records = readRecords();
     expect(records.map(record => record['event.name'])).toEqual([
+      'other',
       'llm.request',
       'llm.response',
     ]);
+    expect(records[0]['gen_ai.input.messages_delta']).toEqual([
+      { role: 'user', parts: [{ type: 'text', content: 'Inspect the repository' }] },
+    ]);
+    const request = records.find(record => record['event.name'] === 'llm.request');
+    const response = records.find(record => record['event.name'] === 'llm.response');
     expect(
-      BigInt(records[1].time_unix_nano) - BigInt(records[0].time_unix_nano) >= 1_000_000n,
+      BigInt(response.time_unix_nano) - BigInt(request.time_unix_nano) >= 1_000_000n,
     ).toBe(true);
 
     const conversion = await convertEventLogToReadableSpans(records);
@@ -468,6 +558,74 @@ describe('Pi Coding Agent extension', () => {
     await runtime.emit('context', { messages: [] });
 
     expect(fs.statSync(logDir).mode & 0o777).toBe(0o700);
+  });
+
+  it('tightens an existing JSONL file before appending sensitive records', async () => {
+    if (process.platform === 'win32') return;
+
+    const logDir = path.join(tmpDir, 'logs', 'pi-coding-agent');
+    const logFile = path.join(logDir, 'pi-coding-agent-2026-07-16.jsonl');
+    fs.mkdirSync(logDir, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(logFile, '', { mode: 0o644 });
+    fs.chmodSync(logFile, 0o644);
+
+    const runtime = await createRuntime();
+    await startTurn(runtime);
+    await runtime.emit('context', { messages: [] });
+
+    expect(fs.statSync(logFile).mode & 0o777).toBe(0o600);
+  });
+
+  it('retightens a cached log path after the file is replaced at runtime', async () => {
+    if (process.platform === 'win32') return;
+
+    const runtime = await createRuntime();
+    await startTurn(runtime);
+    await runtime.emit('context', { messages: [] });
+
+    const logFile = path.join(
+      tmpDir,
+      'logs',
+      'pi-coding-agent',
+      'pi-coding-agent-2026-07-16.jsonl',
+    );
+    fs.rmSync(logFile);
+    fs.writeFileSync(logFile, '', { mode: 0o644 });
+    fs.chmodSync(logFile, 0o644);
+
+    await runtime.emit('tool_execution_start', {
+      toolCallId: 'call-after-rotation',
+      toolName: 'read',
+      args: { path: 'README.md' },
+    });
+
+    expect(fs.statSync(logFile).mode & 0o777).toBe(0o600);
+  });
+
+  it('tightens an existing error log before appending diagnostics', async () => {
+    if (process.platform === 'win32') return;
+
+    const logDir = path.join(tmpDir, 'logs', 'pi-coding-agent');
+    const errorFile = path.join(logDir, 'pi-coding-agent-error-2026-07-16.log');
+    fs.mkdirSync(logDir, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(errorFile, 'previous error\n', { mode: 0o644 });
+    fs.chmodSync(errorFile, 0o644);
+
+    const runtime = await createRuntime();
+    const originalWrite = fs.writeFileSync;
+    let failRecordWrite = true;
+    vi.spyOn(fs, 'writeFileSync').mockImplementation((file, ...args) => {
+      if (failRecordWrite) {
+        failRecordWrite = false;
+        throw new Error('disk unavailable');
+      }
+      return originalWrite(file, ...args);
+    });
+
+    await startTurn(runtime);
+    await runtime.emit('context', { messages: [] });
+
+    expect(fs.statSync(errorFile).mode & 0o777).toBe(0o600);
   });
 
   it('creates the log directory only once across multiple event writes', async () => {
@@ -576,6 +734,7 @@ describe('Pi Coding Agent extension', () => {
     });
 
     const records = readRecords();
+    expect(records.some(record => record['event.name'] === 'other')).toBe(false);
     expect(records[0]).not.toHaveProperty('gen_ai.input.messages');
     expect(records[0]).not.toHaveProperty('gen_ai.system_instructions');
     expect(records[0]).not.toHaveProperty('gen_ai.tool.definitions');
@@ -611,12 +770,12 @@ describe('Pi Coding Agent extension', () => {
 
   it('writes errors to a side log without rejecting Pi event handlers', async () => {
     const runtime = await createRuntime();
-    const originalAppend = fs.appendFileSync;
+    const originalWrite = fs.writeFileSync;
     let calls = 0;
-    vi.spyOn(fs, 'appendFileSync').mockImplementation((...args) => {
+    vi.spyOn(fs, 'writeFileSync').mockImplementation((...args) => {
       calls += 1;
       if (calls === 1) throw new Error('disk unavailable');
-      return originalAppend(...args);
+      return originalWrite(...args);
     });
 
     await expect(startTurn(runtime)).resolves.toBeUndefined();

--- a/tests/unit/hooks/pi-coding-agent-extension.test.mjs
+++ b/tests/unit/hooks/pi-coding-agent-extension.test.mjs
@@ -1,0 +1,248 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const EXTENSION_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../assets/plugins/pi-coding-agent/index.mjs',
+);
+
+let tmpDir;
+let previousDataDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-coding-agent-extension-'));
+  previousDataDir = process.env.LOONGSUITE_PILOT_DATA_DIR;
+  process.env.LOONGSUITE_PILOT_DATA_DIR = tmpDir;
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-07-16T08:00:00.000Z'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  if (previousDataDir === undefined) delete process.env.LOONGSUITE_PILOT_DATA_DIR;
+  else process.env.LOONGSUITE_PILOT_DATA_DIR = previousDataDir;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function createRuntime(config = {}) {
+  fs.writeFileSync(path.join(tmpDir, 'config.json'), JSON.stringify(config));
+  const handlers = new Map();
+  const api = {
+    on(name, handler) {
+      handlers.set(name, handler);
+    },
+    getActiveTools() {
+      return ['read', 'bash'];
+    },
+    getAllTools() {
+      return [
+        { name: 'read', description: 'Read a file', parameters: { type: 'object' } },
+        { name: 'bash', description: 'Run a command', parameters: { type: 'object' } },
+        { name: 'write', description: 'Write a file', parameters: { type: 'object' } },
+      ];
+    },
+  };
+  const mod = await import(`${pathToFileURL(EXTENSION_PATH).href}?t=${Date.now()}_${Math.random()}`);
+  mod.default(api);
+
+  const ctx = {
+    cwd: '/workspace/example',
+    model: { provider: 'anthropic', id: 'claude-sonnet-4-5' },
+    sessionManager: {
+      getSessionId: () => 'pi-session-1',
+    },
+  };
+
+  async function emit(name, event = {}) {
+    const handler = handlers.get(name);
+    expect(handler, `missing handler ${name}`).toBeDefined();
+    await handler({ type: name, ...event }, ctx);
+  }
+
+  return { emit };
+}
+
+function readRecords() {
+  const dir = path.join(tmpDir, 'logs', 'pi-coding-agent');
+  return fs.readdirSync(dir)
+    .filter(name => name.endsWith('.jsonl'))
+    .flatMap(name => fs.readFileSync(path.join(dir, name), 'utf8').trim().split('\n'))
+    .filter(Boolean)
+    .map(line => JSON.parse(line));
+}
+
+async function startTurn(runtime) {
+  await runtime.emit('session_start', { reason: 'startup' });
+  await runtime.emit('before_agent_start', {
+    prompt: 'Inspect the repository',
+    systemPrompt: 'You are a coding agent.',
+  });
+  await runtime.emit('turn_start', { turnIndex: 0, timestamp: Date.now() });
+}
+
+describe('Pi Coding Agent extension', () => {
+  it('emits canonical request, response, tool call, and tool result records', async () => {
+    const runtime = await createRuntime({ userId: 'user-1' });
+    await startTurn(runtime);
+
+    await runtime.emit('context', {
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'Inspect the repository' }] }],
+    });
+    await runtime.emit('message_end', {
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'I should inspect files.' },
+          { type: 'text', text: 'I will inspect it.' },
+          { type: 'toolCall', id: 'call-1', name: 'read', arguments: { path: 'README.md' } },
+        ],
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-5',
+        responseModel: 'claude-sonnet-4-5-20250929',
+        responseId: 'msg-response-1',
+        stopReason: 'toolUse',
+        timestamp: Date.now(),
+        usage: {
+          input: 100,
+          output: 50,
+          cacheRead: 1_000,
+          cacheWrite: 200,
+          totalTokens: 1_350,
+          cost: {
+            input: 0.001,
+            output: 0.002,
+            cacheRead: 0.003,
+            cacheWrite: 0.004,
+            total: 0.01,
+          },
+        },
+      },
+    });
+
+    vi.setSystemTime(new Date('2026-07-16T08:00:01.000Z'));
+    await runtime.emit('tool_execution_start', {
+      toolCallId: 'call-1',
+      toolName: 'read',
+      args: { path: 'README.md' },
+    });
+    vi.setSystemTime(new Date('2026-07-16T08:00:01.250Z'));
+    await runtime.emit('tool_execution_end', {
+      toolCallId: 'call-1',
+      toolName: 'read',
+      result: { content: [{ type: 'text', text: '# README' }] },
+      isError: false,
+    });
+
+    const records = readRecords();
+    expect(records.map(record => record['event.name'])).toEqual([
+      'llm.request',
+      'llm.response',
+      'tool.call',
+      'tool.result',
+    ]);
+
+    const request = records[0];
+    expect(request['gen_ai.session.id']).toBe('pi-session-1');
+    expect(request['gen_ai.agent.type']).toBe('pi-coding-agent');
+    expect(request['agent.pi-coding-agent.cwd']).toBe('/workspace/example');
+    expect(request['gen_ai.input.messages'][0].parts[0].content).toBe('Inspect the repository');
+    expect(request['gen_ai.tool.definitions'].map(tool => tool.name)).toEqual(['read', 'bash']);
+
+    const response = records[1];
+    expect(response['gen_ai.usage.input_tokens']).toBe(1_300);
+    expect(response['gen_ai.usage.cache_read.input_tokens']).toBe(1_000);
+    expect(response['gen_ai.usage.cache_creation.input_tokens']).toBe(200);
+    expect(response['gen_ai.usage.total_tokens']).toBe(1_350);
+    expect(response['gen_ai.usage.total_cost']).toBe(0.01);
+    expect(response['gen_ai.response.model']).toBe('claude-sonnet-4-5-20250929');
+    expect(response['gen_ai.response.id']).toBe('msg-response-1');
+    expect(response['gen_ai.response.finish_reasons']).toEqual(['tool_call']);
+    expect(response['gen_ai.output.messages'][0].finish_reason).toBe('tool_call');
+    expect(response['gen_ai.output.messages'][0].parts).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: 'reasoning' }),
+      expect.objectContaining({ type: 'text' }),
+      expect.objectContaining({ type: 'tool_call', id: 'call-1' }),
+    ]));
+
+    expect(records[2]['gen_ai.tool.call.arguments']).toEqual({ path: 'README.md' });
+    expect(records[3]['tool.result.status']).toBe('success');
+    expect(records[3]['gen_ai.tool.call.duration']).toBe(250);
+    expect(records[3]['gen_ai.tool.call.result']).toEqual({
+      content: [{ type: 'text', text: '# README' }],
+    });
+    if (process.platform !== 'win32') {
+      const logDir = path.join(tmpDir, 'logs', 'pi-coding-agent');
+      const logFile = path.join(logDir, 'pi-coding-agent-2026-07-16.jsonl');
+      expect(fs.statSync(logDir).mode & 0o777).toBe(0o700);
+      expect(fs.statSync(logFile).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it('omits sensitive message and tool payloads when content capture is disabled', async () => {
+    const runtime = await createRuntime({
+      agents: { 'pi-coding-agent': { captureMessageContent: false } },
+    });
+    await startTurn(runtime);
+    await runtime.emit('context', {
+      messages: [{ role: 'user', content: 'secret prompt' }],
+    });
+    await runtime.emit('message_end', {
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'secret response' }],
+        provider: 'openai',
+        model: 'gpt-5',
+        stopReason: 'stop',
+        timestamp: Date.now(),
+        usage: {
+          input: 10,
+          output: 5,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 15,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+      },
+    });
+    await runtime.emit('tool_execution_start', {
+      toolCallId: 'call-secret',
+      toolName: 'bash',
+      args: { command: 'echo secret' },
+    });
+    await runtime.emit('tool_execution_end', {
+      toolCallId: 'call-secret',
+      toolName: 'bash',
+      result: { output: 'secret' },
+      isError: false,
+    });
+
+    const records = readRecords();
+    expect(records[0]).not.toHaveProperty('gen_ai.input.messages');
+    expect(records[0]).not.toHaveProperty('gen_ai.system_instructions');
+    expect(records[0]).not.toHaveProperty('gen_ai.tool.definitions');
+    expect(records[1]).not.toHaveProperty('gen_ai.output.messages');
+    expect(records[2]).not.toHaveProperty('gen_ai.tool.call.arguments');
+    expect(records[3]).not.toHaveProperty('gen_ai.tool.call.result');
+  });
+
+  it('writes errors to a side log without rejecting Pi event handlers', async () => {
+    const runtime = await createRuntime();
+    const originalAppend = fs.appendFileSync;
+    let calls = 0;
+    vi.spyOn(fs, 'appendFileSync').mockImplementation((...args) => {
+      calls += 1;
+      if (calls === 1) throw new Error('disk unavailable');
+      return originalAppend(...args);
+    });
+
+    await expect(startTurn(runtime)).resolves.toBeUndefined();
+    await expect(runtime.emit('context', { messages: [] })).resolves.toBeUndefined();
+
+    vi.restoreAllMocks();
+    const errorDir = path.join(tmpDir, 'logs', 'pi-coding-agent');
+    expect(fs.readdirSync(errorDir).some(name => name.includes('-error-'))).toBe(true);
+  });
+});

--- a/tests/unit/hooks/pi-coding-agent-extension.test.mjs
+++ b/tests/unit/hooks/pi-coding-agent-extension.test.mjs
@@ -217,6 +217,118 @@ describe('Pi Coding Agent extension', () => {
     expect(mixedResponse).not.toContain('sensitive-base64-payload');
   });
 
+  it('converts bash execution and custom messages into canonical input messages', async () => {
+    const runtime = await createRuntime();
+    await startTurn(runtime);
+
+    await runtime.emit('context', {
+      messages: [
+        {
+          role: 'bashExecution',
+          command: 'cat missing.txt',
+          output: 'No such file or directory',
+          exitCode: 1,
+        },
+        {
+          role: 'custom',
+          customType: 'extension-note',
+          content: [{ type: 'text', text: 'Injected context' }],
+          display: false,
+        },
+      ],
+    });
+
+    expect(readRecords()[0]['gen_ai.input.messages']).toEqual([
+      {
+        role: 'tool',
+        parts: [{
+          type: 'tool_call_response',
+          id: null,
+          response: 'No such file or directory',
+          name: 'bash',
+          is_error: true,
+        }],
+      },
+      {
+        role: 'user',
+        parts: [{ type: 'text', content: 'Injected context' }],
+      },
+    ]);
+  });
+
+  it('emits at most one LLM request per step and resets on the next turn', async () => {
+    const runtime = await createRuntime();
+    await startTurn(runtime);
+
+    await runtime.emit('context', {
+      messages: [{ role: 'user', content: 'first snapshot' }],
+    });
+    await runtime.emit('context', {
+      messages: [{ role: 'user', content: 'duplicate snapshot' }],
+    });
+    await runtime.emit('turn_start', { turnIndex: 1, timestamp: Date.now() });
+    await runtime.emit('context', {
+      messages: [{ role: 'user', content: 'second turn' }],
+    });
+
+    const requests = readRecords();
+    expect(requests).toHaveLength(2);
+    expect(requests.map(record => record['gen_ai.step.id'])).toEqual([
+      expect.stringMatching(/:s1$/),
+      expect.stringMatching(/:s2$/),
+    ]);
+    expect(requests[0]['gen_ai.input.messages'][0].parts[0].content).toBe('first snapshot');
+    expect(requests[1]['gen_ai.input.messages'][0].parts[0].content).toBe('second turn');
+  });
+
+  it('records tool failures with status, error type, result, and duration', async () => {
+    const runtime = await createRuntime();
+    await startTurn(runtime);
+
+    vi.setSystemTime(new Date('2026-07-16T08:00:01.000Z'));
+    await runtime.emit('tool_execution_start', {
+      toolCallId: 'call-failed',
+      toolName: 'read',
+      args: { path: 'missing.txt' },
+    });
+    vi.setSystemTime(new Date('2026-07-16T08:00:01.400Z'));
+    await runtime.emit('tool_execution_end', {
+      toolCallId: 'call-failed',
+      toolName: 'read',
+      result: { content: 'permission denied' },
+      isError: true,
+    });
+
+    expect(readRecords()[1]).toMatchObject({
+      'event.name': 'tool.result',
+      'gen_ai.tool.call.id': 'call-failed',
+      'gen_ai.tool.call.duration': 400,
+      'gen_ai.tool.call.result': { content: 'permission denied' },
+      'tool.result.status': 'error',
+      'error.type': 'tool_error',
+    });
+  });
+
+  it('omits tool duration when no matching execution start was observed', async () => {
+    const runtime = await createRuntime();
+    await startTurn(runtime);
+
+    await runtime.emit('tool_execution_end', {
+      toolCallId: 'call-unmatched',
+      toolName: 'read',
+      result: { content: 'completed elsewhere' },
+      isError: false,
+    });
+
+    const result = readRecords()[0];
+    expect(result).toMatchObject({
+      'event.name': 'tool.result',
+      'gen_ai.tool.call.id': 'call-unmatched',
+      'tool.result.status': 'success',
+    });
+    expect(result).not.toHaveProperty('gen_ai.tool.call.duration');
+  });
+
   it('tightens an existing log directory before writing sensitive records', async () => {
     if (process.platform === 'win32') return;
 

--- a/tests/unit/inputs/pi-coding-agent-log-input.test.ts
+++ b/tests/unit/inputs/pi-coding-agent-log-input.test.ts
@@ -95,4 +95,18 @@ describe('PiCodingAgentLogInput', () => {
     await second.stop();
     expect(secondEntries).toHaveLength(0);
   });
+
+  it('tightens an existing log directory when the input starts', async () => {
+    if (process.platform === 'win32') return;
+    await fs.chmod(tmpDir, 0o755);
+
+    const input = new PiCodingAgentLogInput({
+      stateStore: stateStore as never,
+      logDir: tmpDir,
+    });
+    await input.start();
+    await input.stop();
+
+    expect((await fs.stat(tmpDir)).mode & 0o777).toBe(0o700);
+  });
 });

--- a/tests/unit/inputs/pi-coding-agent-log-input.test.ts
+++ b/tests/unit/inputs/pi-coding-agent-log-input.test.ts
@@ -10,14 +10,52 @@ import { MockStateStore } from '../../helpers/mock-state-store.js';
 describe('PiCodingAgentLogInput', () => {
   let tmpDir: string;
   let stateStore: MockStateStore;
+  let previousDataDir: string | undefined;
 
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-coding-agent-input-'));
     stateStore = new MockStateStore();
+    previousDataDir = process.env.LOONGSUITE_PILOT_DATA_DIR;
   });
 
   afterEach(async () => {
+    if (previousDataDir === undefined) delete process.env.LOONGSUITE_PILOT_DATA_DIR;
+    else process.env.LOONGSUITE_PILOT_DATA_DIR = previousDataDir;
     await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reports a clear contract error when stateStore is missing', () => {
+    expect(() => Reflect.construct(PiCodingAgentLogInput, [])).toThrow(
+      'PiCodingAgentLogInput requires a stateStore',
+    );
+  });
+
+  it('resolves standalone defaults from the Pilot data directory', async () => {
+    const dataDir = path.join(tmpDir, 'pilot-data');
+    const expectedLogDir = path.join(dataDir, 'logs', 'pi-coding-agent');
+    process.env.LOONGSUITE_PILOT_DATA_DIR = dataDir;
+    await fs.mkdir(expectedLogDir, { recursive: true });
+
+    const input = new PiCodingAgentLogInput({ stateStore: stateStore as never });
+
+    expect((input as unknown as { logDir: string }).logDir).toBe(expectedLogDir);
+    expect(PiCodingAgentLogInput.getWatchPaths()).toEqual([expectedLogDir]);
+    expect(await PiCodingAgentLogInput.checkAvailability()).toBe(true);
+  });
+
+  it('accepts an explicit dataDir for standalone construction and detection', async () => {
+    const dataDir = path.join(tmpDir, 'explicit-data');
+    const expectedLogDir = path.join(dataDir, 'logs', 'pi-coding-agent');
+    await fs.mkdir(expectedLogDir, { recursive: true });
+
+    const input = new PiCodingAgentLogInput({
+      stateStore: stateStore as never,
+      dataDir,
+    });
+
+    expect((input as unknown as { logDir: string }).logDir).toBe(expectedLogDir);
+    expect(PiCodingAgentLogInput.getWatchPaths(dataDir)).toEqual([expectedLogDir]);
+    expect(await PiCodingAgentLogInput.checkAvailability(dataDir)).toBe(true);
   });
 
   it('reads extension JSONL and normalizes canonical fields', async () => {

--- a/tests/unit/inputs/pi-coding-agent-log-input.test.ts
+++ b/tests/unit/inputs/pi-coding-agent-log-input.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { PiCodingAgentLogInput } from '../../../src/inputs/pi-coding-agent-log/pi-coding-agent-log-input.js';
+import { ClientType, CollectionMethod } from '../../../src/types/index.js';
+import type { AgentActivityEntry } from '../../../src/types/index.js';
+import { MockStateStore } from '../../helpers/mock-state-store.js';
+
+describe('PiCodingAgentLogInput', () => {
+  let tmpDir: string;
+  let stateStore: MockStateStore;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-coding-agent-input-'));
+    stateStore = new MockStateStore();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reads extension JSONL and normalizes canonical fields', async () => {
+    const today = new Date();
+    const date = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+    await fs.writeFile(path.join(tmpDir, `pi-coding-agent-${date}.jsonl`), `${JSON.stringify({
+      time_unix_nano: '1784188800000000000',
+      'event.id': 'event-1',
+      'event.name': 'llm.response',
+      'user.id': 'user-1',
+      'gen_ai.session.id': 'session-1',
+      'gen_ai.turn.id': 'turn-1',
+      'gen_ai.step.id': 'step-1',
+      'gen_ai.agent.type': 'pi-coding-agent',
+      'gen_ai.provider.name': 'anthropic',
+      'gen_ai.request.model': 'claude-sonnet-4-5',
+      'gen_ai.response.model': 'claude-sonnet-4-5',
+      'gen_ai.response.id': 'response-1',
+      'gen_ai.agent.name': 'Pi Coding Agent',
+      'gen_ai.usage.input_tokens': 100,
+      'gen_ai.usage.output_tokens': 20,
+      'agent.pi-coding-agent.cwd': '/workspace/repo',
+    })}\n`);
+
+    const input = new PiCodingAgentLogInput({
+      stateStore: stateStore as never,
+      logDir: tmpDir,
+      pollIntervalMs: 60_000,
+    });
+    const entries: AgentActivityEntry[] = [];
+    input.on('entries', batch => entries.push(...batch));
+
+    await input.start();
+    await input.stop();
+
+    expect(input.agentType).toBe(ClientType.PiCodingAgent);
+    expect(input.collectionMethod).toBe(CollectionMethod.HookJsonl);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      'event.id': 'event-1',
+      'event.name': 'llm.response',
+      'gen_ai.session.id': 'session-1',
+      'gen_ai.agent.type': 'pi-coding-agent',
+      'gen_ai.agent.name': 'Pi Coding Agent',
+      'gen_ai.response.id': 'response-1',
+      'gen_ai.provider.name': 'anthropic',
+      'gen_ai.usage.input_tokens': 100,
+      'gen_ai.usage.output_tokens': 20,
+    });
+  });
+
+  it('uses byte offsets to avoid replaying consumed records', async () => {
+    const today = new Date();
+    const date = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+    const file = path.join(tmpDir, `pi-coding-agent-${date}.jsonl`);
+    const record = {
+      'event.name': 'tool.call',
+      'gen_ai.agent.type': 'pi-coding-agent',
+      'gen_ai.session.id': 'session-1',
+      'gen_ai.tool.name': 'read',
+    };
+    await fs.writeFile(file, `${JSON.stringify(record)}\n`);
+
+    const first = new PiCodingAgentLogInput({ stateStore: stateStore as never, logDir: tmpDir });
+    const firstEntries: AgentActivityEntry[] = [];
+    first.on('entries', batch => firstEntries.push(...batch));
+    await first.start();
+    await first.stop();
+    expect(firstEntries).toHaveLength(1);
+
+    const second = new PiCodingAgentLogInput({ stateStore: stateStore as never, logDir: tmpDir });
+    const secondEntries: AgentActivityEntry[] = [];
+    second.on('entries', batch => secondEntries.push(...batch));
+    await second.start();
+    await second.stop();
+    expect(secondEntries).toHaveLength(0);
+  });
+});

--- a/tests/unit/normalization/agent-content-policy.test.ts
+++ b/tests/unit/normalization/agent-content-policy.test.ts
@@ -19,6 +19,8 @@ function makeEntry(overrides: Partial<AgentActivityEntry> = {}): AgentActivityEn
     'gen_ai.output.messages': [{ type: 'text', content: 'secret response' }],
     'gen_ai.tool.call.arguments': { command: 'cat secret.txt' },
     'gen_ai.tool.call.result': { output: 'secret output' },
+    'gen_ai.system_instructions': [{ type: 'text', content: 'secret system prompt' }],
+    'gen_ai.tool.definitions': [{ type: 'function', name: 'internal_tool' }],
     content: 'legacy secret',
     inlineDiffMessage: 'legacy diff',
     'agent.content': 'agent secret',
@@ -52,6 +54,8 @@ describe('applyAgentContentPolicy', () => {
     expect(result).not.toHaveProperty('gen_ai.output.messages');
     expect(result).not.toHaveProperty('gen_ai.tool.call.arguments');
     expect(result).not.toHaveProperty('gen_ai.tool.call.result');
+    expect(result).not.toHaveProperty('gen_ai.system_instructions');
+    expect(result).not.toHaveProperty('gen_ai.tool.definitions');
     expect(result).not.toHaveProperty('content');
     expect(result).not.toHaveProperty('inlineDiffMessage');
     expect(result).not.toHaveProperty('agent.content');

--- a/tests/unit/normalization/agent-system-map.test.ts
+++ b/tests/unit/normalization/agent-system-map.test.ts
@@ -29,6 +29,10 @@ describe('resolveAgentSystem', () => {
     expect(resolveAgentSystem('qwen-code-cli')).toBe('qwen-code');
   });
 
+  it('maps pi-coding-agent to pi', () => {
+    expect(resolveAgentSystem('pi-coding-agent')).toBe('pi');
+  });
+
   it('returns unknown for unmapped types', () => {
     expect(resolveAgentSystem('some-future-agent')).toBe('unknown');
     expect(resolveAgentSystem('')).toBe('unknown');
@@ -39,7 +43,7 @@ describe('resolveAgentSystem', () => {
       'claude-code', 'codex', 'codex-session',
       'qoder', 'qoder-idea', 'qoder-work', 'qoder-work-cn', 'qoder-cli', 'qoder-cli-hook',
       'cursor', 'cursor-hook',
-      'qwen-code-cli',
+      'qwen-code-cli', 'pi-coding-agent',
     ];
     for (const key of expectedKeys) {
       expect(AGENT_SYSTEM_MAP[key]).toBeDefined();


### PR DESCRIPTION
## Summary

- add first-class support for Pi Coding Agent using the canonical `pi-coding-agent` ID
- inject a repository-maintained Pi Extension that captures LLM request/response and tool lifecycle events
- collect and normalize the generated JSONL events through a dedicated `pi-coding-agent-log` input
- integrate deployment, watchdog repair, uninstall cleanup, content-capture policy, documentation, and agent metadata across Linux/macOS and Windows

## Implementation details

- deploys the Extension through Pi's `~/.pi/agent/settings.json` `extensions` configuration
- emits `gen_ai` attributes including request/response model, response ID, token usage, finish reasons, tool definitions, and tool results
- respects `captureMessageContent=false`, including server-side removal of message content, system instructions, and tool definitions
- uses restrictive permissions for newly created settings, log directories, and log files
- consistently reports `gen_ai.agent.type=pi-coding-agent` and `gen_ai.system=pi`

## Validation

- `npm run typecheck`
- `npm run build`
- `npm test -- --run` — 153 test files passed; 1685 tests passed, 2 skipped
- packaged and locally upgraded Pilot to `v1.1.18`; collector, updater, Extension deployment, and `pi-coding-agent-log` registration verified
- real Pi Coding Agent session verified through raw Extension JSONL and normalized Pilot output for `llm.request` and `llm.response`
