### PR TITLE
docs: add Kiro CLI to supported agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Pilot is designed to answer practical questions:
 | Claude Code   | Hook                      | Yes          | Yes        | Yes         | Yes                       |
 | Codex         | Hook                      | Yes          | Yes        | Yes         | Yes                       |
 | Cursor        | Hook                      | Yes          | Yes        | Yes         | Yes                       |
+| Kiro CLI      | Hook / session polling    | Yes          | Yes        | No          | Yes                       |
 | OpenCode      | Plugin injection          | Yes          | Yes        | Yes         | Yes                       |
 | Qoder         | Hook                      | Yes          | Yes        | Yes         | Yes                       |
 | Qoder CN      | Hook                      | Yes          | Yes        | Yes         | Yes                       |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -42,6 +42,7 @@ Pilot 主要帮助回答这些问题：
 | Claude Code | Hook | Yes | Yes | Yes | Yes |
 | Codex | Hook | Yes | Yes | Yes | Yes |
 | Cursor | Hook | Yes | Yes | Yes | Yes |
+| Kiro CLI | Hook / session 轮询 | Yes | Yes | No | Yes |
 | OpenCode | 插件注入 | Yes | Yes | Yes | Yes |
 | Qoder | Hook | Yes | Yes | Yes | Yes |
 | Qoder CN | Hook | Yes | Yes | Yes | Yes |

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -13,6 +13,7 @@ Use these IDs in installer options, `agent-control.json`, and `config.json`.
 | Claude Code | `claude-code` | Hook integration. |
 | Codex | `codex` | Hook integration. |
 | Cursor | `cursor` | Hook integration. |
+| Kiro CLI | `kiro-cli` | Hook integration with delayed local SQLite/session collection. Token usage is not exposed by the source. |
 | OpenCode | `opencode` | Plugin injection. |
 | Qoder | `qoder` | Hook integration. |
 | Qoder CN | `qoder-cn` | Hook integration. |

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -25,6 +25,7 @@ LoongSuite Pilot runs on a developer machine and collects telemetry from support
 | Claude Code | Hook | Yes | Yes | Yes | Yes |
 | Codex | Hook | Yes | Yes | Yes | Yes |
 | Cursor | Hook | Yes | Yes | Yes | Yes |
+| Kiro CLI | Hook / local session polling | Yes | Yes | No | Yes |
 | OpenCode | Plugin injection | Yes | Yes | Yes | Yes |
 | Qoder | Hook | Yes | Yes | Yes | Yes |
 | Qoder CN | Hook | Yes | Yes | Yes | Yes |

--- a/docs/zh-CN/agents.md
+++ b/docs/zh-CN/agents.md
@@ -13,6 +13,7 @@
 | Claude Code | `claude-code` | Hook 集成。 |
 | Codex | `codex` | Hook 集成。 |
 | Cursor | `cursor` | Hook 集成。 |
+| Kiro CLI | `kiro-cli` | Hook 集成，并延迟采集本地 SQLite/session 数据；源端暂不提供 Token 用量。 |
 | OpenCode | `opencode` | 插件注入。 |
 | Qoder | `qoder` | Hook 集成。 |
 | Qoder CN | `qoder-cn` | Hook 集成。 |

--- a/docs/zh-CN/overview.md
+++ b/docs/zh-CN/overview.md
@@ -25,6 +25,7 @@ LoongSuite Pilot 运行在开发者本机，用于采集支持的 AI Coding Agen
 | Claude Code | Hook | Yes | Yes | Yes | Yes |
 | Codex | Hook | Yes | Yes | Yes | Yes |
 | Cursor | Hook | Yes | Yes | Yes | Yes |
+| Kiro CLI | Hook / 本地 session 轮询 | Yes | Yes | No | Yes |
 | OpenCode | 插件注入 | Yes | Yes | Yes | Yes |
 | Qoder | Hook | Yes | Yes | Yes | Yes |
 | Qoder CN | Hook | Yes | Yes | Yes | Yes |


### PR DESCRIPTION
## Summary

- add Kiro CLI to the supported-agent tables
- document the public `kiro-cli` agent ID and collection path
- keep English and Chinese documentation aligned
- mark token usage as unavailable because the current source does not expose it

## Testing

- `git diff --check`