### PR TITLE
fix: 限制 SLS 失败日志磁盘占用

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -83,7 +83,7 @@ Important files and directories:
 | `plugins/` | Installed plugin assets. |
 | `logs/output/` | Local normalized JSONL output. |
 | `logs/input-state.json` | Input offsets and checkpoints. |
-| `sls-failed-logs/` | SLS upload failures persisted for diagnosis. |
+| `logs/sls-failed-logs/` | Bounded SLS failure metadata for diagnosis; no failed payloads. |
 | `versions/` and `current` | Versioned runtime layout used for updates and rollback. |
 
 ## Where To Go Next

--- a/docs/sls-output.md
+++ b/docs/sls-output.md
@@ -102,11 +102,13 @@ loongsuite-pilot restart
 loongsuite-pilot status
 ```
 
-If SLS upload fails, failed batches are persisted locally:
+If an SLS upload still fails after retries, Pilot persists bounded diagnostic metadata locally:
 
 ```bash
-ls ~/.loongsuite-pilot/sls-failed-logs/
+ls ~/.loongsuite-pilot/logs/sls-failed-logs/
 ```
+
+These JSONL records contain the endpoint, error summary, batch count, and batch byte estimate. They do **not** contain the failed batch payload, message content, request headers, or credentials, so they cannot be used to replay failed uploads. Files rotate by local date and at 10 MiB; the directory is limited to 50 MiB and also follows `retention.slsFailedDays` (7 days by default).
 
 Local JSONL output can help confirm whether collection itself is working before debugging SLS delivery:
 

--- a/docs/zh-CN/overview.md
+++ b/docs/zh-CN/overview.md
@@ -83,7 +83,7 @@ Pilot 可以将同一份规范化事件流输出到多个目标：
 | `plugins/` | 已安装的插件资产。 |
 | `logs/output/` | 本地规范化 JSONL 输出。 |
 | `logs/input-state.json` | 输入源偏移和 checkpoint。 |
-| `sls-failed-logs/` | SLS 上报失败的本地持久化记录。 |
+| `logs/sls-failed-logs/` | 有容量上限的 SLS 失败诊断元数据，不包含失败 payload。 |
 | `versions/` 和 `current` | 用于升级和回滚的版本目录与指针。 |
 
 ## 下一步

--- a/docs/zh-CN/sls-output.md
+++ b/docs/zh-CN/sls-output.md
@@ -102,11 +102,13 @@ loongsuite-pilot restart
 loongsuite-pilot status
 ```
 
-如果 SLS 上传失败，失败批次会持久化到本地：
+如果 SLS 上传在重试后仍然失败，Pilot 会在本地保存有容量上限的诊断元数据：
 
 ```bash
-ls ~/.loongsuite-pilot/sls-failed-logs/
+ls ~/.loongsuite-pilot/logs/sls-failed-logs/
 ```
+
+这些 JSONL 记录只包含 endpoint、错误摘要、batch 条数和 batch 字节数估算，不包含失败 batch payload、消息正文、请求 headers 或凭证，因此不能用于重放失败数据。日志按本地日期和单文件 10MiB 轮转，目录总量限制为 50MiB，同时遵循 `retention.slsFailedDays`（默认 7 天）。
 
 调试 SLS 前，可以先通过本地 JSONL 确认采集本身是否正常：
 

--- a/scripts/lib/agent-overview.mjs
+++ b/scripts/lib/agent-overview.mjs
@@ -237,7 +237,7 @@ async function buildOverview(opts) {
     maxIndexBytesPerRefresh: opts.maxIndexBytesPerRefresh,
     maxIndexLinesPerRefresh: opts.maxIndexLinesPerRefresh,
   });
-  const failures = await aggregateFailedUploads(path.join(opts.dataDir, 'sls-failed-logs'), {
+  const failures = await aggregateFailedUploads(path.join(opts.dataDir, 'logs', 'sls-failed-logs'), {
     maxBytes: opts.failedLogMaxBytes,
   });
 
@@ -742,11 +742,17 @@ async function aggregateFailedUploads(failedDir, options) {
         timestamp,
         type: 'reporting.failure',
         severity: 'error',
-        summary: 'Upload failed and was saved locally',
+        summary: 'Upload failed; diagnostic metadata was saved locally',
         details: {
+          endpoint: row.endpoint,
           project: row.project,
           logstore: row.logstore,
-          error: row.error,
+          errorType: row.error_type,
+          errorCode: row.error_code,
+          httpStatus: row.http_status,
+          error: row.error_summary,
+          batchCount: row.batch_count,
+          batchBytes: row.batch_bytes,
           file: path.basename(filePath),
         },
       }));

--- a/src/core/legacy-sls-failed-log-cleanup-service.ts
+++ b/src/core/legacy-sls-failed-log-cleanup-service.ts
@@ -1,0 +1,291 @@
+import type { Dirent, Stats } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { createLogger } from '../utils/logger.js';
+
+const logger = createLogger('LegacySlsFailureCleanup');
+
+export const LEGACY_SLS_CLEANUP_STARTUP_DELAY_MS = 30_000;
+export const LEGACY_SLS_CLEANUP_FILE_DELAY_MS = 100;
+export const LEGACY_SLS_CLEANUP_RETRY_DELAYS_MS = [250, 1_000, 4_000] as const;
+
+export interface CleanupFileSystem {
+  lstat(filePath: string): Promise<Stats>;
+  rename(oldPath: string, newPath: string): Promise<void>;
+  readdir(directory: string): Promise<Dirent[]>;
+  unlink(filePath: string): Promise<void>;
+  rmdir(directory: string): Promise<void>;
+}
+
+const defaultFileSystem: CleanupFileSystem = {
+  lstat: filePath => fs.lstat(filePath),
+  rename: (oldPath, newPath) => fs.rename(oldPath, newPath),
+  readdir: directory => fs.readdir(directory, { withFileTypes: true }),
+  unlink: filePath => fs.unlink(filePath),
+  rmdir: directory => fs.rmdir(directory),
+};
+
+export interface LegacySlsFailedLogCleanupOptions {
+  startupDelayMs?: number;
+  fileDelayMs?: number;
+  retryDelaysMs?: readonly number[];
+  fileSystem?: CleanupFileSystem;
+  delay?: (milliseconds: number) => Promise<void>;
+}
+
+export interface LegacySlsFailedLogCleanupResult {
+  renamed: boolean;
+  deleted: number;
+  skipped: number;
+  errors: number;
+  logicalBytes: number;
+}
+
+export class LegacySlsFailedLogCleanupService {
+  private readonly legacyDir: string;
+  private readonly pendingDir: string;
+  private readonly startupDelayMs: number;
+  private readonly fileDelayMs: number;
+  private readonly retryDelaysMs: readonly number[];
+  private readonly fileSystem: CleanupFileSystem;
+  private readonly delay: (milliseconds: number) => Promise<void>;
+  private startupTimer: ReturnType<typeof setTimeout> | null = null;
+  private running: Promise<LegacySlsFailedLogCleanupResult> | null = null;
+
+  constructor(dataDir: string, options: LegacySlsFailedLogCleanupOptions = {}) {
+    this.legacyDir = path.join(dataDir, 'sls-failed-logs');
+    this.pendingDir = path.join(dataDir, 'sls-failed-logs.delete-pending');
+    this.startupDelayMs = options.startupDelayMs ?? LEGACY_SLS_CLEANUP_STARTUP_DELAY_MS;
+    this.fileDelayMs = options.fileDelayMs ?? LEGACY_SLS_CLEANUP_FILE_DELAY_MS;
+    this.retryDelaysMs = options.retryDelaysMs ?? LEGACY_SLS_CLEANUP_RETRY_DELAYS_MS;
+    this.fileSystem = options.fileSystem ?? defaultFileSystem;
+    this.delay = options.delay ?? unrefDelay;
+  }
+
+  start(): void {
+    if (this.startupTimer || this.running) return;
+    this.startupTimer = setTimeout(() => {
+      this.startupTimer = null;
+      void this.runCleanup();
+    }, this.startupDelayMs);
+    this.startupTimer.unref();
+  }
+
+  stop(): void {
+    if (!this.startupTimer) return;
+    clearTimeout(this.startupTimer);
+    this.startupTimer = null;
+  }
+
+  async runCleanup(): Promise<LegacySlsFailedLogCleanupResult> {
+    if (this.running) return this.running;
+    this.running = this.runOnce()
+      .catch(err => {
+        logger.warn('legacy SLS failure cleanup failed', { error: String(err) });
+        return emptyResult(1);
+      })
+      .finally(() => {
+        this.running = null;
+      });
+    return this.running;
+  }
+
+  private async runOnce(): Promise<LegacySlsFailedLogCleanupResult> {
+    const result = emptyResult();
+    const pendingErrors = result.errors;
+    const pendingStat = await this.safeLstat(this.pendingDir, result);
+
+    if (pendingStat) {
+      if (pendingStat.isSymbolicLink() || !pendingStat.isDirectory()) {
+        logger.warn('legacy pending path is not a regular directory; skipping', {
+          path: path.basename(this.pendingDir),
+        });
+        result.skipped++;
+        return result;
+      }
+      await this.cleanPendingDirectory(result);
+      this.logResult(result);
+      return result;
+    }
+    if (result.errors > pendingErrors) return result;
+
+    const legacyErrors = result.errors;
+    const legacyStat = await this.safeLstat(this.legacyDir, result);
+    if (result.errors > legacyErrors) return result;
+    if (!legacyStat) return result;
+    if (legacyStat.isSymbolicLink() || !legacyStat.isDirectory()) {
+      logger.warn('legacy SLS failure path is not a regular directory; skipping', {
+        path: path.basename(this.legacyDir),
+      });
+      result.skipped++;
+      return result;
+    }
+
+    const renamed = await this.retryTransient(
+      () => this.fileSystem.rename(this.legacyDir, this.pendingDir),
+      path.basename(this.legacyDir),
+      'rename',
+    );
+    if (!renamed) {
+      result.errors++;
+      return result;
+    }
+    result.renamed = true;
+
+    await this.cleanPendingDirectory(result);
+    this.logResult(result);
+    return result;
+  }
+
+  private async cleanPendingDirectory(result: LegacySlsFailedLogCleanupResult): Promise<void> {
+    let entries: Dirent[];
+    try {
+      entries = await this.fileSystem.readdir(this.pendingDir);
+    } catch (err) {
+      result.errors++;
+      logger.warn('failed to enumerate legacy SLS failure directory', {
+        error: errorCode(err),
+      });
+      return;
+    }
+
+    const candidates = entries.filter(entry => isLegacyJsonlName(entry.name));
+    for (const entry of entries) {
+      if (isLegacyJsonlName(entry.name)) continue;
+      result.skipped++;
+      logger.warn('skipping unknown legacy SLS failure entry', {
+        file: entry.name,
+        reason: entry.isDirectory() ? 'directory' : entry.isSymbolicLink() ? 'symlink' : 'name',
+      });
+    }
+
+    for (let index = 0; index < candidates.length; index++) {
+      const entry = candidates[index];
+      const fullPath = path.join(this.pendingDir, entry.name);
+      let stat: Stats;
+      try {
+        stat = await this.fileSystem.lstat(fullPath);
+      } catch (err) {
+        result.errors++;
+        logger.warn('failed to inspect legacy SLS failure file', {
+          file: entry.name,
+          error: errorCode(err),
+        });
+        continue;
+      }
+
+      if (stat.isSymbolicLink() || !stat.isFile()) {
+        result.skipped++;
+        logger.warn('skipping non-regular legacy SLS failure entry', { file: entry.name });
+        continue;
+      }
+
+      const deleted = await this.retryTransient(
+        () => this.fileSystem.unlink(fullPath),
+        entry.name,
+        'unlink',
+        stat.size,
+      );
+      if (deleted) {
+        result.deleted++;
+        result.logicalBytes += stat.size;
+      } else {
+        result.errors++;
+      }
+
+      if (index < candidates.length - 1 && this.fileDelayMs > 0) {
+        await this.delay(this.fileDelayMs);
+      }
+    }
+
+    try {
+      const remaining = await this.fileSystem.readdir(this.pendingDir);
+      if (remaining.length === 0) await this.fileSystem.rmdir(this.pendingDir);
+    } catch (err) {
+      if (errorCode(err) !== 'ENOENT') {
+        result.errors++;
+        logger.warn('failed to remove empty legacy pending directory', {
+          error: errorCode(err),
+        });
+      }
+    }
+  }
+
+  private async retryTransient(
+    operation: () => Promise<void>,
+    basename: string,
+    operationName: 'rename' | 'unlink',
+    logicalBytes?: number,
+  ): Promise<boolean> {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        await operation();
+        return true;
+      } catch (err) {
+        const code = errorCode(err);
+        const retryDelay = this.retryDelaysMs[attempt];
+        if (!isTransientFileError(code) || retryDelay === undefined) {
+          logger.warn('legacy SLS failure cleanup operation failed', {
+            operation: operationName,
+            file: basename,
+            logicalBytes,
+            error: code,
+            attempts: attempt + 1,
+          });
+          return false;
+        }
+        await this.delay(retryDelay);
+      }
+    }
+  }
+
+  private async safeLstat(
+    filePath: string,
+    result: LegacySlsFailedLogCleanupResult,
+  ): Promise<Stats | null> {
+    try {
+      return await this.fileSystem.lstat(filePath);
+    } catch (err) {
+      if (errorCode(err) !== 'ENOENT') {
+        result.errors++;
+        logger.warn('failed to inspect legacy SLS failure path', {
+          path: path.basename(filePath),
+          error: errorCode(err),
+        });
+      }
+      return null;
+    }
+  }
+
+  private logResult(result: LegacySlsFailedLogCleanupResult): void {
+    if (!result.renamed && result.deleted === 0 && result.skipped === 0 && result.errors === 0) return;
+    logger.info('legacy SLS failure cleanup complete', { ...result });
+  }
+}
+
+export function isLegacyJsonlName(name: string): boolean {
+  return !name.startsWith('.') && name.length > '.jsonl'.length && name.endsWith('.jsonl');
+}
+
+function emptyResult(errors = 0): LegacySlsFailedLogCleanupResult {
+  return { renamed: false, deleted: 0, skipped: 0, errors, logicalBytes: 0 };
+}
+
+function errorCode(error: unknown): string {
+  if (typeof error === 'object' && error !== null && 'code' in error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code) return code;
+  }
+  return String(error);
+}
+
+function isTransientFileError(code: string): boolean {
+  return code === 'EPERM' || code === 'EBUSY' || code === 'EACCES';
+}
+
+function unrefDelay(milliseconds: number): Promise<void> {
+  return new Promise(resolve => {
+    const timer = setTimeout(resolve, milliseconds);
+    timer.unref();
+  });
+}

--- a/src/core/log-retention-service.ts
+++ b/src/core/log-retention-service.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import type { LogRetentionConfig } from '../types/index.js';
 import { createLogger } from '../utils/logger.js';
+import { SLS_FAILURE_LOG_MAX_TOTAL_BYTES } from '../flushers/sls-failure-log-writer.js';
 
 const logger = createLogger('LogRetention');
 
@@ -13,6 +14,7 @@ export const OUTPUT_RETENTION_MAX_TOTAL_BYTES = 2 * 1024 * MEBIBYTE;
 export const OUTPUT_RETENTION_LARGE_FILE_THRESHOLD_BYTES = 512 * MEBIBYTE;
 export const OUTPUT_RETENTION_LARGE_FILE_DAYS = 2;
 export const OUTPUT_RETENTION_PRESSURE_MIN_KEEP_DAYS = 1;
+export const SLS_FAILURE_RETENTION_MAX_TOTAL_BYTES = SLS_FAILURE_LOG_MAX_TOTAL_BYTES;
 
 type Category = 'history' | 'errors' | 'debug' | 'output' | 'sls-failed-logs';
 
@@ -58,6 +60,7 @@ export class LogRetentionService {
       outputLargeFileThresholdBytes: OUTPUT_RETENTION_LARGE_FILE_THRESHOLD_BYTES,
       outputLargeFileDays: OUTPUT_RETENTION_LARGE_FILE_DAYS,
       outputPressureMinKeepDays: OUTPUT_RETENTION_PRESSURE_MIN_KEEP_DAYS,
+      slsFailedMaxTotalBytes: SLS_FAILURE_RETENTION_MAX_TOTAL_BYTES,
     });
 
     this.startupTimer = setTimeout(() => {
@@ -79,7 +82,7 @@ export class LogRetentionService {
   }
 
   async runCleanup(): Promise<{ deleted: number; errors: number }> {
-    const today = new Date().toISOString().slice(0, 10);
+    const today = localDateString(new Date());
     let deleted = 0;
     let errors = 0;
 
@@ -150,6 +153,9 @@ export class LogRetentionService {
     if (category === 'output') {
       return this.cleanOutputDirectory(dir, files, today);
     }
+    if (category === 'sls-failed-logs') {
+      return this.cleanSlsFailedDirectory(dir, files, today);
+    }
 
     const retentionDays = this.getRetentionDays(category);
     const cutoff = dateCutoff(retentionDays);
@@ -161,6 +167,48 @@ export class LogRetentionService {
 
       if (await this.deleteFile(path.join(dir, file))) {
         deleted++;
+      } else {
+        errors++;
+      }
+    }
+
+    return { deleted, errors };
+  }
+
+  private async cleanSlsFailedDirectory(
+    dir: string,
+    files: string[],
+    today: string,
+  ): Promise<{ deleted: number; errors: number }> {
+    let deleted = 0;
+    let errors = 0;
+    let remaining = await this.collectDatedOutputFiles(dir, files);
+
+    const cutoff = dateCutoff(this.config.slsFailedDays);
+    const expiredResult = await this.deleteDatedFiles(
+      remaining,
+      file => file.dateStr !== today && file.dateStr < cutoff,
+    );
+    deleted += expiredResult.deleted;
+    errors += expiredResult.errors;
+
+    remaining = await this.collectDatedOutputFiles(dir, await readdir(dir));
+    let totalBytes = remaining.reduce((sum, file) => sum + file.size, 0);
+    if (totalBytes <= SLS_FAILURE_RETENTION_MAX_TOTAL_BYTES) {
+      return { deleted, errors };
+    }
+
+    const activePaths = findActiveSlsFailureSegments(remaining, today);
+    const candidates = remaining
+      .filter(file => !activePaths.has(file.fullPath))
+      .sort((a, b) => a.dateStr.localeCompare(b.dateStr)
+        || a.file.localeCompare(b.file));
+
+    for (const file of candidates) {
+      if (totalBytes <= SLS_FAILURE_RETENTION_MAX_TOTAL_BYTES) break;
+      if (await this.deleteFile(file.fullPath)) {
+        deleted++;
+        totalBytes -= file.size;
       } else {
         errors++;
       }
@@ -314,7 +362,14 @@ export function extractDate(filename: string): string | null {
 function dateCutoff(retentionDays: number): string {
   const d = new Date();
   d.setDate(d.getDate() - retentionDays);
-  return d.toISOString().slice(0, 10);
+  return localDateString(d);
+}
+
+function localDateString(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }
 
 async function readdir(dir: string): Promise<string[]> {
@@ -331,4 +386,19 @@ async function safeStat(p: string) {
   } catch {
     return null;
   }
+}
+
+function findActiveSlsFailureSegments(files: DatedLogFile[], today: string): Set<string> {
+  const latestByEndpoint = new Map<string, { segment: number; path: string }>();
+  for (const file of files) {
+    if (file.dateStr !== today) continue;
+    const match = /^(.*)-(\d+)-(\d{4}-\d{2}-\d{2})\.jsonl$/.exec(file.file);
+    if (!match || match[3] !== today) continue;
+    const segment = Number(match[2]);
+    const current = latestByEndpoint.get(match[1]);
+    if (!current || segment > current.segment) {
+      latestByEndpoint.set(match[1], { segment, path: file.fullPath });
+    }
+  }
+  return new Set([...latestByEndpoint.values()].map(value => value.path));
 }

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -45,6 +45,7 @@ import { QwenCodeCliLogInput } from '../inputs/qwen-code-cli-log/qwen-code-cli-l
 import { WukongInput } from '../inputs/wukong/wukong-input.js';
 
 import { LogRetentionService } from './log-retention-service.js';
+import { LegacySlsFailedLogCleanupService } from './legacy-sls-failed-log-cleanup-service.js';
 import { HookWatchdog, type PluginCheckTarget, type InterceptCheckTarget } from './hook-watchdog.js';
 import { UpdaterWatchdog } from './updater-watchdog.js';
 import { PipelineManager } from '../pipeline/pipeline-manager.js';
@@ -107,6 +108,7 @@ export class Orchestrator extends EventEmitter {
   private stateStore!: StateStore;
   private flusher!: BaseFlusher;
   private logRetentionService!: LogRetentionService;
+  private legacySlsFailedLogCleanupService: LegacySlsFailedLogCleanupService | null = null;
   private hookWatchdog!: HookWatchdog;
   private updaterWatchdog: UpdaterWatchdog | null = null;
   private deploymentManager!: DeploymentManager;
@@ -282,6 +284,9 @@ export class Orchestrator extends EventEmitter {
     logger.info('orchestrator started', {
       inputs: detectionEntries.length,
     });
+
+    this.legacySlsFailedLogCleanupService = new LegacySlsFailedLogCleanupService(this.dataDir);
+    this.legacySlsFailedLogCleanupService.start();
   }
 
   async stop(): Promise<void> {
@@ -296,6 +301,8 @@ export class Orchestrator extends EventEmitter {
     this.updaterWatchdog?.stop();
     this.updaterWatchdog = null;
     this.hookWatchdog?.stop();
+    this.legacySlsFailedLogCleanupService?.stop();
+    this.legacySlsFailedLogCleanupService = null;
     this.logRetentionService?.stop();
     await this.localWorkerActivationService?.stop();
     await this.deploymentManager?.stopWorkers();

--- a/src/flushers/sls-failure-log-writer.ts
+++ b/src/flushers/sls-failure-log-writer.ts
@@ -1,0 +1,371 @@
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { createLogger } from '../utils/logger.js';
+import { ensureDir } from '../utils/fs-utils.js';
+
+const logger = createLogger('SlsFailureLogWriter');
+
+const MEBIBYTE = 1024 * 1024;
+
+export const SLS_FAILURE_LOG_SCHEMA_VERSION = 2;
+export const SLS_FAILURE_LOG_MAX_FILE_BYTES = 10 * MEBIBYTE;
+export const SLS_FAILURE_LOG_MAX_TOTAL_BYTES = 50 * MEBIBYTE;
+export const SLS_FAILURE_ERROR_SUMMARY_MAX_BYTES = 2 * 1024;
+
+export interface SlsFailureLogInput {
+  endpoint: string;
+  mode: string;
+  project: string;
+  logstore: string;
+  kind: string;
+  batchCount: number;
+  batchBytes: number;
+  error: unknown;
+}
+
+export interface SlsFailureLogRecord {
+  schema_version: 2;
+  ts: number;
+  endpoint: string;
+  mode: string;
+  project: string;
+  logstore: string;
+  kind: string;
+  error_type: string;
+  error_code: string;
+  http_status: number;
+  error_summary: string;
+  batch_count: number;
+  batch_bytes: number;
+}
+
+export interface SlsFailureLogWriterOptions {
+  maxFileBytes?: number;
+  maxTotalBytes?: number;
+  now?: () => Date;
+}
+
+interface FileState {
+  date: string;
+  segment: number;
+  filePath: string;
+}
+
+interface LogFileInfo {
+  file: string;
+  fullPath: string;
+  size: number;
+  mtimeMs: number;
+  group: string | null;
+  segment: number | null;
+  date: string | null;
+}
+
+const ROTATED_FILE_REGEX = /^(.*)-(\d+)-(\d{4}-\d{2}-\d{2})\.jsonl$/;
+
+export class SlsFailureLogWriter {
+  private readonly directory: string;
+  private readonly maxFileBytes: number;
+  private readonly maxTotalBytes: number;
+  private readonly now: () => Date;
+  private readonly states = new Map<string, FileState>();
+  private writeChain: Promise<void> = Promise.resolve();
+
+  constructor(directory: string, options: SlsFailureLogWriterOptions = {}) {
+    this.directory = path.resolve(directory);
+    this.maxFileBytes = options.maxFileBytes ?? SLS_FAILURE_LOG_MAX_FILE_BYTES;
+    this.maxTotalBytes = options.maxTotalBytes ?? SLS_FAILURE_LOG_MAX_TOTAL_BYTES;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async start(): Promise<void> {
+    await ensureDir(this.directory);
+  }
+
+  async write(input: SlsFailureLogInput): Promise<boolean> {
+    let written = false;
+    const operation = this.writeChain.then(async () => {
+      written = await this.writeOnce(input);
+    });
+    this.writeChain = operation.catch(() => {});
+    try {
+      await operation;
+      return written;
+    } catch (err) {
+      logger.warn('failed to persist SLS failure metadata', {
+        endpoint: input.endpoint,
+        error: String(err),
+      });
+      return false;
+    }
+  }
+
+  private async writeOnce(input: SlsFailureLogInput): Promise<boolean> {
+    await ensureDir(this.directory);
+
+    const now = this.now();
+    const record = buildSlsFailureLogRecord(input, now);
+    const line = `${JSON.stringify(record)}\n`;
+    const lineBytes = Buffer.byteLength(line);
+    const safeEndpoint = safeEndpointFilePrefix(input.endpoint);
+    const state = await this.resolveFileState(safeEndpoint, localDateString(now), lineBytes);
+
+    if (!isPathInside(this.directory, state.filePath)) {
+      logger.warn('refusing SLS failure log path outside target directory', {
+        endpoint: input.endpoint,
+      });
+      return false;
+    }
+
+    const hasCapacity = await this.ensureCapacity(lineBytes, state.filePath);
+    if (!hasCapacity) {
+      logger.warn('SLS failure metadata dropped because directory limit is exhausted', {
+        endpoint: input.endpoint,
+        maxTotalBytes: this.maxTotalBytes,
+      });
+      return false;
+    }
+
+    await fs.appendFile(state.filePath, line, 'utf8');
+    return true;
+  }
+
+  private async resolveFileState(
+    safeEndpoint: string,
+    date: string,
+    lineBytes: number,
+  ): Promise<FileState> {
+    const key = `${safeEndpoint}|${date}`;
+    let state = this.states.get(key);
+    if (!state) {
+      const segment = await this.findLatestSegment(safeEndpoint, date);
+      state = {
+        date,
+        segment,
+        filePath: this.buildFilePath(safeEndpoint, segment, date),
+      };
+    }
+
+    const stat = await safeLstat(state.filePath);
+    if (stat?.isFile() && stat.size > 0 && stat.size + lineBytes > this.maxFileBytes) {
+      state = {
+        date,
+        segment: state.segment + 1,
+        filePath: this.buildFilePath(safeEndpoint, state.segment + 1, date),
+      };
+    }
+
+    this.states.set(key, state);
+    return state;
+  }
+
+  private async findLatestSegment(safeEndpoint: string, date: string): Promise<number> {
+    let latest = 0;
+    const prefix = `${safeEndpoint}-`;
+    const suffix = `-${date}.jsonl`;
+    const entries = await safeReaddir(this.directory);
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.startsWith(prefix) || !entry.name.endsWith(suffix)) continue;
+      const segmentText = entry.name.slice(prefix.length, -suffix.length);
+      if (!/^\d+$/.test(segmentText)) continue;
+      latest = Math.max(latest, Number(segmentText));
+    }
+    return latest;
+  }
+
+  private buildFilePath(safeEndpoint: string, segment: number, date: string): string {
+    return path.join(
+      this.directory,
+      `${safeEndpoint}-${String(segment).padStart(4, '0')}-${date}.jsonl`,
+    );
+  }
+
+  private async ensureCapacity(incomingBytes: number, targetPath: string): Promise<boolean> {
+    const files = await this.collectLogFiles();
+    let totalBytes = files.reduce((sum, file) => sum + file.size, 0);
+    if (totalBytes + incomingBytes <= this.maxTotalBytes) return true;
+
+    const activePaths = findActivePaths(files, targetPath, localDateString(this.now()));
+    const candidates = files
+      .filter(file => !activePaths.has(file.fullPath))
+      .sort((a, b) => (a.date ?? '').localeCompare(b.date ?? '')
+        || a.mtimeMs - b.mtimeMs
+        || a.file.localeCompare(b.file));
+
+    for (const file of candidates) {
+      if (totalBytes + incomingBytes <= this.maxTotalBytes) break;
+      try {
+        await fs.unlink(file.fullPath);
+        totalBytes -= file.size;
+      } catch (err) {
+        logger.warn('failed to remove sealed SLS failure log segment', {
+          file: file.file,
+          error: String(err),
+        });
+      }
+    }
+
+    return totalBytes + incomingBytes <= this.maxTotalBytes;
+  }
+
+  private async collectLogFiles(): Promise<LogFileInfo[]> {
+    const result: LogFileInfo[] = [];
+    const entries = await safeReaddir(this.directory);
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.jsonl')) continue;
+      const fullPath = path.join(this.directory, entry.name);
+      const stat = await safeLstat(fullPath);
+      if (!stat?.isFile()) continue;
+      const parsed = parseRotatedFile(entry.name);
+      result.push({
+        file: entry.name,
+        fullPath,
+        size: stat.size,
+        mtimeMs: stat.mtimeMs,
+        group: parsed?.group ?? null,
+        segment: parsed?.segment ?? null,
+        date: parsed?.date ?? null,
+      });
+    }
+    return result;
+  }
+}
+
+export function buildSlsFailureLogRecord(
+  input: SlsFailureLogInput,
+  now = new Date(),
+): SlsFailureLogRecord {
+  const errorObject = asErrorObject(input.error);
+  return {
+    schema_version: SLS_FAILURE_LOG_SCHEMA_VERSION,
+    ts: now.getTime(),
+    endpoint: boundedString(input.endpoint, 256),
+    mode: boundedString(input.mode, 64),
+    project: boundedString(input.project, 256),
+    logstore: boundedString(input.logstore, 256),
+    kind: boundedString(input.kind, 128),
+    error_type: boundedString(errorObject.type, 128),
+    error_code: boundedString(errorObject.code, 128),
+    http_status: errorObject.httpStatus,
+    error_summary: truncateUtf8(redactErrorSummary(errorObject.summary), SLS_FAILURE_ERROR_SUMMARY_MAX_BYTES),
+    batch_count: boundedNonNegativeInteger(input.batchCount),
+    batch_bytes: boundedNonNegativeInteger(input.batchBytes),
+  };
+}
+
+export function safeEndpointFilePrefix(endpoint: string): string {
+  const normalized = endpoint.normalize('NFKC');
+  const base = normalized
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^[._-]+|[._-]+$/g, '')
+    .slice(0, 48) || 'endpoint';
+  const hash = createHash('sha256').update(endpoint).digest('hex').slice(0, 10);
+  return `${base}-${hash}`;
+}
+
+export function estimateStringRecordBytes(records: Record<string, string>[]): number {
+  let total = 0;
+  for (const record of records) {
+    for (const [key, value] of Object.entries(record)) {
+      total += Buffer.byteLength(key) + Buffer.byteLength(value) + 6;
+    }
+    total += 2;
+  }
+  return total;
+}
+
+function asErrorObject(error: unknown): {
+  type: string;
+  code: string;
+  httpStatus: number;
+  summary: string;
+} {
+  const value = typeof error === 'object' && error !== null
+    ? error as Record<string, unknown>
+    : null;
+  const status = Number(value?.status ?? value?.statusCode ?? 0);
+  const type = error instanceof Error
+    ? error.name || error.constructor.name
+    : typeof error;
+  const summary = error instanceof Error ? error.message : String(error ?? 'unknown error');
+  return {
+    type: type || 'Error',
+    code: typeof value?.code === 'string' ? value.code : '',
+    httpStatus: Number.isInteger(status) && status >= 100 && status <= 599 ? status : 0,
+    summary,
+  };
+}
+
+function redactErrorSummary(value: string): string {
+  return value
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [REDACTED]')
+    .replace(/\bLTAI[A-Za-z0-9]{12,}\b/g, '[REDACTED_ACCESS_KEY]')
+    .replace(
+      /((?:access[_-]?key(?:[_-]?(?:id|secret))?|api[_-]?key|authorization)\s*["']?\s*[:=]\s*["']?)[^\s,"'}]+/gi,
+      '$1[REDACTED]',
+    )
+    .replace(/(https?:\/\/)[^\s/@:]+:[^\s/@]+@/gi, '$1[REDACTED]@');
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  const bytes = Buffer.from(value, 'utf8');
+  if (bytes.length <= maxBytes) return value;
+  return bytes.subarray(0, maxBytes).toString('utf8').replace(/\uFFFD$/u, '');
+}
+
+function boundedString(value: string, maxBytes: number): string {
+  return truncateUtf8(String(value ?? ''), maxBytes);
+}
+
+function boundedNonNegativeInteger(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  return Math.min(Number.MAX_SAFE_INTEGER, Math.floor(value));
+}
+
+function localDateString(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function isPathInside(parent: string, child: string): boolean {
+  const relative = path.relative(parent, path.resolve(child));
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+function parseRotatedFile(file: string): { group: string; segment: number; date: string } | null {
+  const match = ROTATED_FILE_REGEX.exec(file);
+  if (!match) return null;
+  return { group: `${match[1]}|${match[3]}`, segment: Number(match[2]), date: match[3] };
+}
+
+function findActivePaths(files: LogFileInfo[], targetPath: string, today: string): Set<string> {
+  const latestByGroup = new Map<string, LogFileInfo>();
+  for (const file of files) {
+    if (!file.group || file.date !== today || file.segment === null) continue;
+    const current = latestByGroup.get(file.group);
+    if (!current || (current.segment ?? -1) < file.segment) latestByGroup.set(file.group, file);
+  }
+
+  const target = parseRotatedFile(path.basename(targetPath));
+  if (target?.date === today) latestByGroup.delete(target.group);
+  return new Set([...latestByGroup.values()].map(file => file.fullPath).concat(targetPath));
+}
+
+async function safeReaddir(directory: string) {
+  try {
+    return await fs.readdir(directory, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+async function safeLstat(filePath: string) {
+  try {
+    return await fs.lstat(filePath);
+  } catch {
+    return null;
+  }
+}

--- a/src/flushers/sls-flusher.ts
+++ b/src/flushers/sls-flusher.ts
@@ -8,11 +8,11 @@ import {
 import type { AgentActivityEntry, SlsFlusherConfig, SlsEndpoint } from '../types/index.js';
 import type { AlarmManager } from '../metrics/alarm-manager.js';
 import { createLogger } from '../utils/logger.js';
-import { appendLine, ensureDir } from '../utils/fs-utils.js';
 import { formatTime } from '../utils/time-utils.js';
 import { normalizeAgentType } from '../utils/agent-type-normalize.js';
 import { LOCAL_IP, buildUserAgent } from '../utils/network-utils.js';
 import * as path from 'node:path';
+import { SlsFailureLogWriter } from './sls-failure-log-writer.js';
 import {
   HttpError,
   postWebtracking,
@@ -34,6 +34,7 @@ interface QueuedLog {
   content: Record<string, string>;
   endpoint: SlsEndpoint;
   agentType?: string;
+  byteSize: number;
 }
 
 const logger = createLogger('SlsFlusher');
@@ -57,7 +58,7 @@ export class SlsFlusher extends BaseFlusher {
   private readonly config: SlsFlusherConfig;
   private readonly queue: Map<string, QueuedLog[]> = new Map();
   private flushTimer: ReturnType<typeof setInterval> | null = null;
-  private readonly failedLogDir: string;
+  private readonly failedLogWriter: SlsFailureLogWriter;
   private readonly akClients: Map<string, any> = new Map();
   private readonly endpointCounters: Map<string, EndpointCounter> = new Map();
   private alarmManager: AlarmManager | null = null;
@@ -68,7 +69,9 @@ export class SlsFlusher extends BaseFlusher {
   constructor(config: SlsFlusherConfig, dataDir: string) {
     super();
     this.config = config;
-    this.failedLogDir = path.join(dataDir, 'sls-failed-logs');
+    this.failedLogWriter = new SlsFailureLogWriter(
+      path.join(dataDir, 'logs', 'sls-failed-logs'),
+    );
     this.serviceName = config.serviceNamePrefix || '';
     this.userAgent = buildUserAgent(dataDir);
     for (const ep of config.endpoints) {
@@ -103,7 +106,7 @@ export class SlsFlusher extends BaseFlusher {
   }
 
   async start(): Promise<void> {
-    await ensureDir(this.failedLogDir);
+    await this.failedLogWriter.start();
     this.flushTimer = setInterval(
       () => void this.flush(),
       this.config.flushIntervalMs || FLUSH_INTERVAL_MS,
@@ -254,7 +257,12 @@ export class SlsFlusher extends BaseFlusher {
         { endpoint_name: endpoint.name },
       );
     }
-    await this.persistFailedLogs(endpoint, logGroup, lastErr);
+    await this.persistFailedLogs(
+      endpoint,
+      logs.length,
+      logs.reduce((sum, log) => sum + log.byteSize, 0),
+      lastErr,
+    );
   }
 
   private async flushViaWebtracking(endpoint: SlsEndpoint, logs: QueuedLog[]): Promise<void> {
@@ -368,22 +376,25 @@ export class SlsFlusher extends BaseFlusher {
         { endpoint_name: endpoint.name },
       );
     }
-    await this.persistFailedLogs(endpoint, body, lastErr);
+    await this.persistFailedLogs(endpoint, logs.length, Buffer.byteLength(raw), lastErr);
   }
 
-  private async persistFailedLogs(endpoint: SlsEndpoint, logGroup: unknown, err: unknown): Promise<void> {
-    await ensureDir(this.failedLogDir);
-    const filePath = path.join(this.failedLogDir, `${endpoint.name}.jsonl`);
-    const line = JSON.stringify({
-      ts: Date.now(),
+  private async persistFailedLogs(
+    endpoint: SlsEndpoint,
+    batchCount: number,
+    batchBytes: number,
+    err: unknown,
+  ): Promise<void> {
+    await this.failedLogWriter.write({
       endpoint: endpoint.name,
+      mode: endpoint.mode,
       project: endpoint.project,
       logstore: endpoint.logstore,
       kind: endpoint.kind,
-      logGroup,
-      error: String(err),
+      batchCount,
+      batchBytes,
+      error: err,
     });
-    await appendLine(filePath, line);
   }
 
   async shutdown(): Promise<void> {
@@ -443,12 +454,13 @@ export class SlsFlusher extends BaseFlusher {
       bucket = [];
       this.queue.set(key, bucket);
     }
-    bucket.push({ content, endpoint, agentType });
+    const byteSize = Buffer.byteLength(JSON.stringify(content));
+    bucket.push({ content, endpoint, agentType, byteSize });
 
     const counter = this.endpointCounters.get(endpoint.name);
     if (counter) {
       counter.inEntries++;
-      counter.inBytes += Buffer.byteLength(JSON.stringify(content));
+      counter.inBytes += byteSize;
       if (!counter.startTime) counter.startTime = formatTime(new Date());
     }
 

--- a/src/flushers/sls-transport.ts
+++ b/src/flushers/sls-transport.ts
@@ -1,6 +1,8 @@
 import { createLogger } from '../utils/logger.js';
-import { appendLine, ensureDir } from '../utils/fs-utils.js';
-import * as path from 'node:path';
+import {
+  SlsFailureLogWriter,
+  type SlsFailureLogInput,
+} from './sls-failure-log-writer.js';
 
 const logger = createLogger('SlsTransport');
 
@@ -33,6 +35,10 @@ export interface PostWebtrackingOptions {
   tags?: Record<string, string>;
   userAgent?: string;
 }
+
+export type PersistFailedLogContext = Omit<SlsFailureLogInput, 'endpoint' | 'error'>;
+
+const failedLogWriters = new Map<string, SlsFailureLogWriter>();
 
 export function splitForWebtracking(
   logs: Record<string, string>[],
@@ -169,19 +175,19 @@ async function postWebtrackingChunk(
 export async function persistFailedLogs(
   failedLogDir: string,
   name: string,
-  logGroup: unknown,
+  context: PersistFailedLogContext,
   err: unknown,
 ): Promise<void> {
-  await ensureDir(failedLogDir);
-  const fileName = `${name}.jsonl`;
-  const filePath = path.join(failedLogDir, fileName);
-  const line = JSON.stringify({
-    ts: Date.now(),
-    name,
-    logGroup,
-    error: String(err),
+  let writer = failedLogWriters.get(failedLogDir);
+  if (!writer) {
+    writer = new SlsFailureLogWriter(failedLogDir);
+    failedLogWriters.set(failedLogDir, writer);
+  }
+  await writer.write({
+    ...context,
+    endpoint: name,
+    error: err,
   });
-  await appendLine(filePath, line);
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/pipeline/flusher/file/file-sls-sender.ts
+++ b/src/pipeline/flusher/file/file-sls-sender.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../flushers/sls-transport.js';
 import { createLogger } from '../../../utils/logger.js';
 import { LOCAL_IP, buildUserAgent } from '../../../utils/network-utils.js';
+import { estimateStringRecordBytes } from '../../../flushers/sls-failure-log-writer.js';
 
 const logger = createLogger('FileSlsSender');
 
@@ -124,7 +125,14 @@ export class FileSlsSender {
               await persistFailedLogs(
                 this.failedLogDir,
                 this.configName,
-                { __logs__: tasks[i].batch },
+                {
+                  mode: 'webtracking',
+                  project: this.transportConfig.project,
+                  logstore: this.transportConfig.logstore,
+                  kind: this.configName,
+                  batchCount: tasks[i].batch.length,
+                  batchBytes: estimateStringRecordBytes(tasks[i].batch),
+                },
                 err,
               );
             }
@@ -181,7 +189,14 @@ export class FileSlsSender {
       await persistFailedLogs(
         this.failedLogDir,
         this.configName,
-        { __logs__: remaining },
+        {
+          mode: 'webtracking',
+          project: this.transportConfig.project,
+          logstore: this.transportConfig.logstore,
+          kind: this.configName,
+          batchCount: remaining.length,
+          batchBytes: estimateStringRecordBytes(remaining),
+        },
         new Error('shutdown drain incomplete'),
       );
     }

--- a/src/pipeline/flusher/qoder-api/qoder-api-sls-sender.ts
+++ b/src/pipeline/flusher/qoder-api/qoder-api-sls-sender.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../flushers/sls-transport.js';
 import { LOCAL_IP, buildUserAgent } from '../../../utils/network-utils.js';
 import { createLogger } from '../../../utils/logger.js';
+import { estimateStringRecordBytes } from '../../../flushers/sls-failure-log-writer.js';
 
 const logger = createLogger('QoderApiSlsSender');
 
@@ -29,7 +30,7 @@ export interface QoderApiSlsSenderOptions {
  *
  * Buffers flat-string log rows in a single array (no per-file buckets) and
  * flushes them to SLS via webtracking on a 2-second interval. On send failure
- * the batch is persisted to a local failed-log directory for later inspection.
+ * bounded diagnostic metadata is persisted to a local failed-log directory.
  */
 export class QoderApiSlsSender {
   private readonly transportConfig: SlsTransportConfig;
@@ -127,16 +128,22 @@ export class QoderApiSlsSender {
             await persistFailedLogs(
               this.failedLogDir,
               this.configName,
-              { __logs__: tasks[i].batch },
+              {
+                mode: 'webtracking',
+                project: this.transportConfig.project,
+                logstore: this.transportConfig.logstore,
+                kind: this.configName,
+                batchCount: tasks[i].batch.length,
+                batchBytes: estimateStringRecordBytes(tasks[i].batch),
+              },
               err,
             );
           }
         }
 
-        // Note: splice runs after persistFailedLogs, so if persistFailedLogs throws,
-        // successfully-sent batches remain in the buffer and will be re-sent on the
-        // next flush cycle. This is safe because event_id dedup at SLS is load-bearing
-        // for correctness — it prevents duplicate delivery, not just an optimization.
+        // Failed payloads are not retained locally. The lightweight failed-log only
+        // records bounded diagnostic metadata; event_id still protects any retry path
+        // from duplicate delivery.
         this.buffer.splice(0, sliceEnd);
         if (hasFailure) break;
 
@@ -187,7 +194,14 @@ export class QoderApiSlsSender {
       await persistFailedLogs(
         this.failedLogDir,
         this.configName,
-        { __logs__: remaining },
+        {
+          mode: 'webtracking',
+          project: this.transportConfig.project,
+          logstore: this.transportConfig.logstore,
+          kind: this.configName,
+          batchCount: remaining.length,
+          batchBytes: estimateStringRecordBytes(remaining),
+        },
         new Error('shutdown drain incomplete'),
       );
     }

--- a/src/pipeline/input/qoder-api/qoder-api-pipeline.ts
+++ b/src/pipeline/input/qoder-api/qoder-api-pipeline.ts
@@ -10,6 +10,7 @@ import { QoderApiInput } from './qoder-api-input.js';
 import { QoderApiSlsSender } from '../../flusher/qoder-api/qoder-api-sls-sender.js';
 import { createLogger, type BoundLogger } from '../../../utils/logger.js';
 import { persistFailedLogs } from '../../../flushers/sls-transport.js';
+import { estimateStringRecordBytes } from '../../../flushers/sls-failure-log-writer.js';
 
 const DEFAULT_INTERVAL_SECONDS = 300;
 const DEFAULT_BACKFILL_DAYS = 7;
@@ -160,16 +161,24 @@ export class QoderApiPipeline implements Pipeline {
         await this.input.confirmCycle();
       } else {
         // 4b. Buffer full — do NOT advance the window so data is re-collected
-        //     next cycle. Persist the dropped rows to failed-log for manual recovery.
+        //     next cycle. Persist only bounded failure metadata for diagnosis.
         this.logger.warn('sender buffer full, persisting rows to failed-log', {
           configName: this.config.configName,
           droppedRows: rows.length,
           bufferSize: this.sender.bufferSize(),
         });
+        const flusherConfig = this.config.flushers[0];
         await persistFailedLogs(
           this.failedLogDir,
           this.config.configName,
-          { __logs__: rows },
+          {
+            mode: 'webtracking',
+            project: flusherConfig.Project,
+            logstore: flusherConfig.Logstore,
+            kind: this.config.configName,
+            batchCount: rows.length,
+            batchBytes: estimateStringRecordBytes(rows),
+          },
           new Error('sender buffer full, window not advanced'),
         );
       }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -156,7 +156,7 @@ export interface SlsFlusherConfig {
 }
 
 export interface SlsEndpoint {
-  /** Unique identifier for this destination. Drives the failed-log filename `<name>.jsonl`. */
+  /** Unique identifier for this destination. Used in bounded failure-metadata filenames. */
   name: string;
   /** Per-endpoint base URL, e.g. "https://cn-hangzhou.log.aliyuncs.com". */
   endpoint: string;

--- a/tests/unit/core/legacy-sls-failed-log-cleanup-service.test.ts
+++ b/tests/unit/core/legacy-sls-failed-log-cleanup-service.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { createTempDir, cleanupTempDir } from '../../helpers/fixture-builder.js';
+import {
+  LegacySlsFailedLogCleanupService,
+  isLegacyJsonlName,
+  type CleanupFileSystem,
+} from '../../../src/core/legacy-sls-failed-log-cleanup-service.js';
+
+function realFileSystem(overrides: Partial<CleanupFileSystem> = {}): CleanupFileSystem {
+  return {
+    lstat: filePath => fs.lstat(filePath),
+    rename: (oldPath, newPath) => fs.rename(oldPath, newPath),
+    readdir: directory => fs.readdir(directory, { withFileTypes: true }),
+    unlink: filePath => fs.unlink(filePath),
+    rmdir: directory => fs.rmdir(directory),
+    ...overrides,
+  };
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  return fs.access(filePath).then(() => true, () => false);
+}
+
+describe('LegacySlsFailedLogCleanupService', () => {
+  let tmpDir: string;
+  let legacyDir: string;
+  let pendingDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTempDir('legacy-sls-cleanup-');
+    legacyDir = path.join(tmpDir, 'sls-failed-logs');
+    pendingDir = path.join(tmpDir, 'sls-failed-logs.delete-pending');
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tmpDir);
+    vi.restoreAllMocks();
+  });
+
+  it('schedules cleanup with an unref timer and stop cancels it', () => {
+    const service = new LegacySlsFailedLogCleanupService(tmpDir, { startupDelayMs: 60_000 });
+    const timerSpy = vi.spyOn(globalThis, 'setTimeout');
+    service.start();
+
+    const timer = timerSpy.mock.results[0].value as ReturnType<typeof setTimeout>;
+    expect(timer.hasRef()).toBe(false);
+    service.stop();
+  });
+
+  it('does not touch the filesystem until the startup delay has elapsed', async () => {
+    vi.useFakeTimers();
+    try {
+      const missing = Object.assign(new Error('missing'), { code: 'ENOENT' });
+      const fileSystem: CleanupFileSystem = {
+        lstat: vi.fn().mockRejectedValue(missing),
+        rename: vi.fn(),
+        readdir: vi.fn(),
+        unlink: vi.fn(),
+        rmdir: vi.fn(),
+      };
+      const service = new LegacySlsFailedLogCleanupService(tmpDir, {
+        startupDelayMs: 30_000,
+        fileSystem,
+      });
+
+      service.start();
+      expect(fileSystem.lstat).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(29_999);
+      expect(fileSystem.lstat).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(fileSystem.lstat).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('renames the legacy directory and unlinks a 10GB sparse file without parsing it', async () => {
+    await fs.mkdir(path.join(legacyDir, 'unknown-dir'), { recursive: true });
+    const largeFile = path.join(legacyDir, 'internal-sls.jsonl');
+    await fs.writeFile(largeFile, '{invalid json');
+    await fs.truncate(largeFile, 10 * 1024 * 1024 * 1024);
+    await fs.writeFile(path.join(legacyDir, 'user-sls.jsonl'), 'also invalid');
+    await fs.writeFile(path.join(legacyDir, 'README.md'), 'keep');
+
+    const delays: number[] = [];
+    const service = new LegacySlsFailedLogCleanupService(tmpDir, {
+      fileDelayMs: 100,
+      delay: async milliseconds => { delays.push(milliseconds); },
+    });
+    const result = await service.runCleanup();
+
+    expect(result.renamed).toBe(true);
+    expect(result.deleted).toBe(2);
+    expect(result.logicalBytes).toBeGreaterThanOrEqual(10 * 1024 * 1024 * 1024);
+    expect(delays).toEqual([100]);
+    expect(await exists(legacyDir)).toBe(false);
+    expect(await exists(path.join(pendingDir, 'internal-sls.jsonl'))).toBe(false);
+    expect(await exists(path.join(pendingDir, 'README.md'))).toBe(true);
+    expect(await exists(path.join(pendingDir, 'unknown-dir'))).toBe(true);
+  });
+
+  it('resumes an existing pending directory on the next startup', async () => {
+    await fs.mkdir(pendingDir, { recursive: true });
+    await fs.writeFile(path.join(pendingDir, 'remaining.jsonl'), 'not parsed');
+
+    const service = new LegacySlsFailedLogCleanupService(tmpDir, { fileDelayMs: 0 });
+    const result = await service.runCleanup();
+
+    expect(result.renamed).toBe(false);
+    expect(result.deleted).toBe(1);
+    expect(await exists(pendingDir)).toBe(false);
+  });
+
+  it('retries transient rename failures with bounded backoff', async () => {
+    await fs.mkdir(legacyDir, { recursive: true });
+    await fs.writeFile(path.join(legacyDir, 'failed.jsonl'), 'x');
+    let attempts = 0;
+    const delays: number[] = [];
+    const fileSystem = realFileSystem({
+      rename: async (oldPath, newPath) => {
+        attempts++;
+        if (attempts < 3) throw Object.assign(new Error('busy'), { code: 'EBUSY' });
+        await fs.rename(oldPath, newPath);
+      },
+    });
+
+    const result = await new LegacySlsFailedLogCleanupService(tmpDir, {
+      fileSystem,
+      fileDelayMs: 0,
+      delay: async milliseconds => { delays.push(milliseconds); },
+    }).runCleanup();
+
+    expect(attempts).toBe(3);
+    expect(delays).toEqual([250, 1_000]);
+    expect(result.deleted).toBe(1);
+  });
+
+  it('keeps a file after bounded unlink retries and continues with the next file', async () => {
+    await fs.mkdir(pendingDir, { recursive: true });
+    await fs.writeFile(path.join(pendingDir, 'busy.jsonl'), 'x');
+    await fs.writeFile(path.join(pendingDir, 'ok.jsonl'), 'y');
+    let busyAttempts = 0;
+    const fileSystem = realFileSystem({
+      unlink: async filePath => {
+        if (path.basename(filePath) === 'busy.jsonl') {
+          busyAttempts++;
+          throw Object.assign(new Error('occupied'), { code: 'EPERM' });
+        }
+        await fs.unlink(filePath);
+      },
+    });
+
+    const result = await new LegacySlsFailedLogCleanupService(tmpDir, {
+      fileSystem,
+      fileDelayMs: 0,
+      delay: async () => {},
+    }).runCleanup();
+
+    expect(busyAttempts).toBe(4);
+    expect(result.deleted).toBe(1);
+    expect(result.errors).toBe(1);
+    expect(await exists(path.join(pendingDir, 'busy.jsonl'))).toBe(true);
+    expect(await exists(path.join(pendingDir, 'ok.jsonl'))).toBe(false);
+  });
+
+  it('does not follow a symlink used as the legacy root', async () => {
+    const outsideDir = path.join(tmpDir, 'outside');
+    await fs.mkdir(outsideDir, { recursive: true });
+    await fs.writeFile(path.join(outsideDir, 'keep.jsonl'), 'keep');
+    await fs.symlink(outsideDir, legacyDir);
+
+    const result = await new LegacySlsFailedLogCleanupService(tmpDir).runCleanup();
+
+    expect(result.skipped).toBe(1);
+    expect(await exists(path.join(outsideDir, 'keep.jsonl'))).toBe(true);
+    expect((await fs.lstat(legacyDir)).isSymbolicLink()).toBe(true);
+  });
+});
+
+describe('isLegacyJsonlName', () => {
+  it('accepts only non-hidden top-level legacy JSONL names', () => {
+    expect(isLegacyJsonlName('internal-sls.jsonl')).toBe(true);
+    expect(isLegacyJsonlName('a.jsonl')).toBe(true);
+    expect(isLegacyJsonlName('.hidden.jsonl')).toBe(false);
+    expect(isLegacyJsonlName('.jsonl')).toBe(false);
+    expect(isLegacyJsonlName('notes.txt')).toBe(false);
+  });
+});

--- a/tests/unit/core/log-retention-service.test.ts
+++ b/tests/unit/core/log-retention-service.test.ts
@@ -6,6 +6,7 @@ import {
   LogRetentionService,
   OUTPUT_RETENTION_LARGE_FILE_THRESHOLD_BYTES,
   OUTPUT_RETENTION_MAX_TOTAL_BYTES,
+  SLS_FAILURE_RETENTION_MAX_TOTAL_BYTES,
   extractDate,
 } from '../../../src/core/log-retention-service.js';
 import type { LogRetentionConfig } from '../../../src/types/index.js';
@@ -199,6 +200,26 @@ describe('LogRetentionService', () => {
       const result = await service.runCleanup();
 
       expect(result.deleted).toBe(1);
+    });
+
+    it('enforces the SLS failure total limit while preserving the active segment', async () => {
+      const slsDir = path.join(tmpDir, 'logs', 'sls-failed-logs');
+      await fs.mkdir(slsDir, { recursive: true });
+      const segmentSize = Math.floor(SLS_FAILURE_RETENTION_MAX_TOTAL_BYTES / 3);
+      const sealed0 = path.join(slsDir, `activity-deadbeef00-0000-${today()}.jsonl`);
+      const sealed1 = path.join(slsDir, `activity-deadbeef00-0001-${today()}.jsonl`);
+      const active = path.join(slsDir, `activity-deadbeef00-0002-${today()}.jsonl`);
+      await writeSizedFile(sealed0, segmentSize);
+      await writeSizedFile(sealed1, segmentSize);
+      await writeSizedFile(active, segmentSize + 3);
+
+      const service = new LogRetentionService(tmpDir, makeConfig());
+      const result = await service.runCleanup();
+
+      expect(result.deleted).toBe(1);
+      expect(await fs.access(sealed0).then(() => true, () => false)).toBe(false);
+      expect(await fs.access(sealed1).then(() => true, () => false)).toBe(true);
+      expect(await fs.access(active).then(() => true, () => false)).toBe(true);
     });
 
     it('skips unrecognized subdirectories', async () => {

--- a/tests/unit/flushers/sls-failure-log-writer.test.ts
+++ b/tests/unit/flushers/sls-failure-log-writer.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { createTempDir, cleanupTempDir } from '../../helpers/fixture-builder.js';
+import {
+  SlsFailureLogWriter,
+  buildSlsFailureLogRecord,
+  estimateStringRecordBytes,
+  safeEndpointFilePrefix,
+} from '../../../src/flushers/sls-failure-log-writer.js';
+
+function failureInput(overrides: Record<string, unknown> = {}) {
+  return {
+    endpoint: 'internal-sls',
+    mode: 'webtracking',
+    project: 'test-project',
+    logstore: 'test-logstore',
+    kind: 'agentActivity',
+    batchCount: 20,
+    batchBytes: 2_048,
+    error: new Error('network timeout'),
+    ...overrides,
+  };
+}
+
+describe('SlsFailureLogWriter', () => {
+  let tmpDir: string;
+  let failedDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTempDir('sls-failure-writer-');
+    failedDir = path.join(tmpDir, 'logs', 'sls-failed-logs');
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tmpDir);
+  });
+
+  it('writes versioned metadata without batch payload or credentials', async () => {
+    const error = Object.assign(
+      new Error('Authorization: Bearer secret-token accessKeySecret=very-secret'),
+      { code: 'ETIMEDOUT', status: 503 },
+    );
+    const writer = new SlsFailureLogWriter(failedDir, {
+      now: () => new Date('2026-07-20T08:00:00+08:00'),
+    });
+
+    expect(await writer.write(failureInput({ error }))).toBe(true);
+
+    const files = await fs.readdir(failedDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/^internal-sls-[a-f0-9]{10}-0000-2026-07-20\.jsonl$/);
+    const record = JSON.parse(await fs.readFile(path.join(failedDir, files[0]), 'utf8'));
+    expect(record).toMatchObject({
+      schema_version: 2,
+      endpoint: 'internal-sls',
+      mode: 'webtracking',
+      error_type: 'Error',
+      error_code: 'ETIMEDOUT',
+      http_status: 503,
+      batch_count: 20,
+      batch_bytes: 2_048,
+    });
+    expect(record.error_summary).toContain('[REDACTED]');
+    expect(JSON.stringify(record)).not.toContain('secret-token');
+    expect(JSON.stringify(record)).not.toContain('very-secret');
+    expect(record).not.toHaveProperty('logGroup');
+    expect(record).not.toHaveProperty('__logs__');
+  });
+
+  it('uses a safe stable endpoint prefix without path traversal', () => {
+    const prefix = safeEndpointFilePrefix('../../danger/endpoint');
+    expect(prefix).not.toContain('/');
+    expect(prefix).not.toContain('..');
+    expect(prefix).toBe(safeEndpointFilePrefix('../../danger/endpoint'));
+    expect(prefix).not.toBe(safeEndpointFilePrefix('danger-endpoint'));
+  });
+
+  it('rotates by size and keeps every concurrent line valid JSON', async () => {
+    const writer = new SlsFailureLogWriter(failedDir, {
+      maxFileBytes: 650,
+      maxTotalBytes: 20_000,
+      now: () => new Date('2026-07-20T08:00:00+08:00'),
+    });
+
+    await Promise.all(Array.from({ length: 12 }, (_, index) => writer.write(
+      failureInput({ error: new Error(`failure-${index}`) }),
+    )));
+
+    const files = (await fs.readdir(failedDir)).sort();
+    expect(files.length).toBeGreaterThan(1);
+    const records = [];
+    for (const file of files) {
+      const lines = (await fs.readFile(path.join(failedDir, file), 'utf8')).trim().split('\n');
+      records.push(...lines.map(line => JSON.parse(line)));
+    }
+    expect(records).toHaveLength(12);
+    expect(records.every(record => record.schema_version === 2)).toBe(true);
+  });
+
+  it('rotates when the local date changes', async () => {
+    let now = new Date(2026, 6, 20, 23, 59, 59);
+    const writer = new SlsFailureLogWriter(failedDir, { now: () => now });
+    await writer.write(failureInput());
+    now = new Date(2026, 6, 21, 0, 0, 1);
+    await writer.write(failureInput());
+
+    const files = await fs.readdir(failedDir);
+    expect(files.some(file => file.endsWith('-2026-07-20.jsonl'))).toBe(true);
+    expect(files.some(file => file.endsWith('-2026-07-21.jsonl'))).toBe(true);
+  });
+
+  it('enforces the directory total limit by deleting sealed segments', async () => {
+    const maxTotalBytes = 1_500;
+    const writer = new SlsFailureLogWriter(failedDir, {
+      maxFileBytes: 500,
+      maxTotalBytes,
+      now: () => new Date('2026-07-20T08:00:00+08:00'),
+    });
+
+    for (let index = 0; index < 20; index++) {
+      await writer.write(failureInput({ error: new Error(`bounded-${index}`) }));
+    }
+
+    const files = await fs.readdir(failedDir);
+    const stats = await Promise.all(files.map(file => fs.lstat(path.join(failedDir, file))));
+    expect(stats.reduce((sum, stat) => sum + stat.size, 0)).toBeLessThanOrEqual(maxTotalBytes);
+    expect(files.length).toBeGreaterThan(0);
+  });
+});
+
+describe('SLS failure metadata helpers', () => {
+  it('bounds error summaries by UTF-8 bytes', () => {
+    const record = buildSlsFailureLogRecord(
+      failureInput({ error: new Error('错'.repeat(4_000)) }),
+      new Date('2026-07-20T00:00:00Z'),
+    );
+    expect(Buffer.byteLength(record.error_summary)).toBeLessThanOrEqual(2 * 1024);
+  });
+
+  it('estimates string-record bytes without serializing a batch envelope', () => {
+    expect(estimateStringRecordBytes([{ content: 'abc' }, { content: '中文' }])).toBeGreaterThan(9);
+    expect(estimateStringRecordBytes([])).toBe(0);
+  });
+});

--- a/tests/unit/flushers/sls-flusher.dual-write.test.ts
+++ b/tests/unit/flushers/sls-flusher.dual-write.test.ts
@@ -8,8 +8,7 @@ import type { SlsFlusherConfig, SlsEndpoint } from '../../../src/types/index.js'
 import { buildTestEntry } from '../../helpers/fixture-builder.js';
 
 const mockPostLogStoreLogs = vi.fn().mockResolvedValue(undefined);
-const mockAppendLine = vi.fn().mockResolvedValue(undefined);
-const mockEnsureDir = vi.fn().mockResolvedValue(undefined);
+const mockFailureWrite = vi.fn().mockResolvedValue(true);
 
 // Track each ALY client constructor call so we can assert on per-endpoint instances.
 const akClientCtorCalls: Array<{ endpoint: string; accessKeyId: string }> = [];
@@ -27,10 +26,15 @@ const fetchSpy = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async 
 vi.stubGlobal('fetch', fetchSpy);
 
 vi.mock('../../../src/utils/fs-utils.js', () => ({
-  appendLine: (...args: unknown[]) => mockAppendLine(...args),
-  ensureDir: (...args: unknown[]) => mockEnsureDir(...args),
   getTodayDateString: () => '2026-04-27',
   readInstalledVersion: () => '0.0.0-test',
+}));
+
+vi.mock('../../../src/flushers/sls-failure-log-writer.js', () => ({
+  SlsFailureLogWriter: vi.fn().mockImplementation(() => ({
+    start: vi.fn().mockResolvedValue(undefined),
+    write: mockFailureWrite,
+  })),
 }));
 
 vi.mock('../../../src/utils/logger.js', () => ({
@@ -176,15 +180,14 @@ describe('SlsFlusher dual-write — per-endpoint dispatch', () => {
     // Webtracking still went through.
     expect(fetchSpy).toHaveBeenCalledOnce();
     // Only the failing leg's batch was persisted.
-    expect(mockAppendLine).toHaveBeenCalledOnce();
-    const [filePath, line] = mockAppendLine.mock.calls[0];
-    expect(filePath).toContain('user-sls.jsonl');
-    const parsed = JSON.parse(line);
-    expect(parsed.endpoint).toBe('user-sls');
-    expect(parsed.error).toContain('quota exceeded');
+    expect(mockFailureWrite).toHaveBeenCalledOnce();
+    const metadata = mockFailureWrite.mock.calls[0][0];
+    expect(metadata.endpoint).toBe('user-sls');
+    expect(String(metadata.error)).toContain('quota exceeded');
+    expect(metadata).not.toHaveProperty('logGroup');
   });
 
-  it('per-endpoint failed-log filenames are unique even when kind matches', async () => {
+  it('persists independent metadata for endpoints that share the same kind', async () => {
     const flusher = new SlsFlusher(
       makeConfig([
         akEndpoint('user-sls', 'https://cn-shanghai.log.aliyuncs.com', 'user-proj'),
@@ -201,9 +204,8 @@ describe('SlsFlusher dual-write — per-endpoint dispatch', () => {
     await flusher.send(buildTestEntry());
     await flusher.flush();
 
-    expect(mockAppendLine).toHaveBeenCalledTimes(2);
-    const filePaths = mockAppendLine.mock.calls.map((c: unknown[]) => String(c[0]));
-    expect(filePaths.some((p: string) => p.endsWith('user-sls.jsonl'))).toBe(true);
-    expect(filePaths.some((p: string) => p.endsWith('internal-sls.jsonl'))).toBe(true);
+    expect(mockFailureWrite).toHaveBeenCalledTimes(2);
+    const endpoints = mockFailureWrite.mock.calls.map((call: unknown[]) => (call[0] as { endpoint: string }).endpoint);
+    expect(endpoints.sort()).toEqual(['internal-sls', 'user-sls']);
   });
 });

--- a/tests/unit/flushers/sls-flusher.test.ts
+++ b/tests/unit/flushers/sls-flusher.test.ts
@@ -4,8 +4,9 @@ import type { SlsFlusherConfig, SlsEndpoint } from '../../../src/types/index.js'
 import { buildTestEntry } from '../../helpers/fixture-builder.js';
 
 const mockPostLogStoreLogs = vi.fn().mockResolvedValue(undefined);
-const mockAppendLine = vi.fn().mockResolvedValue(undefined);
-const mockEnsureDir = vi.fn().mockResolvedValue(undefined);
+const mockFailureWrite = vi.fn().mockResolvedValue(true);
+const mockFailureStart = vi.fn().mockResolvedValue(undefined);
+const failureWriterDirectories: string[] = [];
 
 vi.mock('@alicloud/log', () => {
   return {
@@ -16,10 +17,18 @@ vi.mock('@alicloud/log', () => {
 });
 
 vi.mock('../../../src/utils/fs-utils.js', () => ({
-  appendLine: (...args: unknown[]) => mockAppendLine(...args),
-  ensureDir: (...args: unknown[]) => mockEnsureDir(...args),
   getTodayDateString: () => '2026-04-27',
   readInstalledVersion: () => '0.0.0-test',
+}));
+
+vi.mock('../../../src/flushers/sls-failure-log-writer.js', () => ({
+  SlsFailureLogWriter: vi.fn().mockImplementation((directory: string) => {
+    failureWriterDirectories.push(directory);
+    return {
+      start: mockFailureStart,
+      write: mockFailureWrite,
+    };
+  }),
 }));
 
 vi.mock('../../../src/utils/logger.js', () => ({
@@ -62,6 +71,7 @@ describe('SlsFlusher', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    failureWriterDirectories.length = 0;
     vi.useFakeTimers();
     flusher = new SlsFlusher(makeConfig(), '/tmp/data');
   });
@@ -174,23 +184,54 @@ describe('SlsFlusher', () => {
   });
 
   describe('failure persistence (T015)', () => {
-    it('persists failed log group to sls-failed-logs/<endpoint.name>.jsonl', async () => {
+    it('persists bounded metadata without the failed payload', async () => {
       mockPostLogStoreLogs.mockRejectedValueOnce(new Error('invalid request'));
 
       await flusher.send(buildTestEntry());
       await flusher.flush();
 
-      expect(mockAppendLine).toHaveBeenCalledOnce();
-      const [filePath, line] = mockAppendLine.mock.calls[0];
-      expect(filePath).toContain('sls-failed-logs');
-      // Filename is keyed on endpoint.name (the makeConfig fixture uses name='activity').
-      expect(filePath).toContain('activity.jsonl');
-      const parsed = JSON.parse(line);
-      expect(parsed.error).toContain('invalid request');
-      expect(parsed.project).toBe('proj-a');
-      // The kind is preserved inside the JSON payload for debugging.
-      expect(parsed.kind).toBe('agentActivity');
-      expect(parsed.endpoint).toBe('activity');
+      expect(mockFailureWrite).toHaveBeenCalledOnce();
+      const metadata = mockFailureWrite.mock.calls[0][0];
+      expect(String(metadata.error)).toContain('invalid request');
+      expect(metadata.project).toBe('proj-a');
+      expect(metadata.kind).toBe('agentActivity');
+      expect(metadata.endpoint).toBe('activity');
+      expect(metadata.mode).toBe('ak');
+      expect(metadata.batchCount).toBe(1);
+      expect(metadata.batchBytes).toBeGreaterThan(0);
+      expect(metadata).not.toHaveProperty('logGroup');
+      expect(metadata).not.toHaveProperty('__logs__');
+      expect(failureWriterDirectories).toEqual(['/tmp/data/logs/sls-failed-logs']);
+    });
+
+    it('uses the same lightweight metadata format for webtracking failures', async () => {
+      const fetchSpy = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: async () => 'invalid payload',
+      });
+      vi.stubGlobal('fetch', fetchSpy);
+      flusher = new SlsFlusher(makeConfig({
+        endpoints: [{
+          name: 'web-endpoint',
+          endpoint: 'https://cn-hangzhou.log.aliyuncs.com',
+          project: 'web-project',
+          logstore: 'web-logstore',
+          kind: 'agentActivity',
+          mode: 'webtracking',
+        }],
+      }), '/tmp/data');
+
+      await flusher.send(buildTestEntry());
+      await flusher.flush();
+
+      expect(mockFailureWrite).toHaveBeenCalledOnce();
+      const metadata = mockFailureWrite.mock.calls[0][0];
+      expect(metadata.mode).toBe('webtracking');
+      expect(metadata.batchCount).toBe(1);
+      expect(metadata.batchBytes).toBeGreaterThan(0);
+      expect(metadata).not.toHaveProperty('__logs__');
+      vi.unstubAllGlobals();
     });
   });
 

--- a/tests/unit/monitor/agent-overview.test.mjs
+++ b/tests/unit/monitor/agent-overview.test.mjs
@@ -74,7 +74,17 @@ describe('agent overview aggregation', () => {
         ],
       },
       failedLines: [
-        JSON.stringify({ ts: Date.parse('2026-05-05T04:00:03.000Z'), project: 'p', logstore: 'l', error: 'boom' }),
+        JSON.stringify({
+          schema_version: 2,
+          ts: Date.parse('2026-05-05T04:00:03.000Z'),
+          endpoint: 'activity',
+          project: 'p',
+          logstore: 'l',
+          error_type: 'Error',
+          error_summary: 'boom',
+          batch_count: 20,
+          batch_bytes: 2048,
+        }),
       ],
     });
 
@@ -377,12 +387,47 @@ describe('agent overview aggregation', () => {
       restoreEnv(savedEnv);
     }
   });
+
+  it('ignores legacy delete-pending files and skips damaged metadata lines', async () => {
+    const dataDir = await fixtureDir();
+    await writeRuntimeFiles(dataDir, {
+      failedLines: [
+        '{damaged',
+        JSON.stringify({
+          schema_version: 2,
+          ts: Date.parse('2026-05-05T04:00:03.000Z'),
+          endpoint: 'internal-sls',
+          project: 'p1',
+          logstore: 'l1',
+          error_type: 'TimeoutError',
+          error_summary: 'timeout',
+          batch_count: 2,
+          batch_bytes: 100,
+        }),
+      ],
+    });
+    const pendingDir = path.join(dataDir, 'sls-failed-logs.delete-pending');
+    await mkdir(pendingDir, { recursive: true });
+    await writeFile(
+      path.join(pendingDir, 'legacy.jsonl'),
+      JSON.stringify({ ts: Date.now(), error: 'must not count' }),
+    );
+
+    const overview = await createOverviewAggregator({
+      dataDir,
+      nowProvider: () => new Date('2026-05-05T04:01:00.000Z'),
+    }).getOverview({ force: true });
+
+    expect(overview.reporting.failedUploadsToday).toBe(1);
+    expect(JSON.stringify(overview.timeline)).toContain('internal-sls');
+    expect(JSON.stringify(overview.timeline)).not.toContain('must not count');
+  });
 });
 
 async function fixtureDir(options = {}) {
   const dataDir = await mkdtemp(path.join(tmpdir(), 'loongsuite-pilot-overview-'));
   await mkdir(path.join(dataDir, 'logs', 'output'), { recursive: true });
-  await mkdir(path.join(dataDir, 'sls-failed-logs'), { recursive: true });
+  await mkdir(path.join(dataDir, 'logs', 'sls-failed-logs'), { recursive: true });
   const config = {
     enabled: true,
     dataDir,
@@ -425,7 +470,10 @@ async function writeRuntimeFiles(dataDir, options) {
     await writeFile(path.join(dataDir, 'logs', 'output', name), lines.join('\n'));
   }
   if (options.failedLines) {
-    await writeFile(path.join(dataDir, 'sls-failed-logs', 'agentActivity.jsonl'), options.failedLines.join('\n'));
+    await writeFile(
+      path.join(dataDir, 'logs', 'sls-failed-logs', 'activity-a1b2c3d4-0000-2026-05-05.jsonl'),
+      options.failedLines.join('\n'),
+    );
   }
 }
 

--- a/tests/unit/pipeline/file-sls-sender.test.ts
+++ b/tests/unit/pipeline/file-sls-sender.test.ts
@@ -26,6 +26,7 @@ function makeSender(): FileSlsSender {
     },
     'test-config',
     '/tmp/test-failed',
+    '/tmp/test-data',
   );
 }
 
@@ -88,6 +89,16 @@ describe('FileSlsSender', () => {
     sender.enqueue(['line1'], '/tmp/test.log');
     await sender.flush();
     expect(mockPersistFailedLogs).toHaveBeenCalledTimes(1);
+    const context = mockPersistFailedLogs.mock.calls[0][2];
+    expect(context).toMatchObject({
+      mode: 'webtracking',
+      project: 'test-project',
+      logstore: 'test-logstore',
+      kind: 'test-config',
+      batchCount: 1,
+    });
+    expect(context.batchBytes).toBeGreaterThan(0);
+    expect(context).not.toHaveProperty('__logs__');
   });
 
   it('shutdown flushes remaining buffer', async () => {


### PR DESCRIPTION
## 背景

SLS 发送失败时需要保留足够的诊断信息，同时必须避免失败记录无界增长或保存原始业务内容。

## 改动

- 失败记录统一写入 `logs/sls-failed-logs/`，只保存 endpoint、错误摘要、batch 条数和字节数估算等轻量元数据。
- 不保存失败 batch payload、消息正文、请求 headers 或凭证，并对错误摘要进行脱敏和长度限制。
- 日志按本地日期和单文件 10 MiB 轮转，目录总量限制为 50 MiB。
- 日志继续遵循 `retention.slsFailedDays`，默认保留 7 天。
- 版本升级兼容处理在 Pilot 启动完成后异步运行，失败不影响采集服务启动或退出。
- 更新本地监控和中英文用户文档，文档只展示当前目录和行为。

## 验证

- `npm test`：154 个测试文件通过；1724 个用例通过，2 个跳过。
- 跨日期轮转测试在 `UTC` 和 `Asia/Shanghai` 时区下分别通过。
- `npm run typecheck`：通过。
- `git diff --check`：通过。

测试覆盖日志内容脱敏、单文件轮转、目录总量限制、跨本地日期轮转、并发写入，以及升级兼容处理的失败隔离和重启续处理。
