### PR TITLE
feat(kiro-desktop-session): emit STEP/LLM/TOOL spans for multi-turn ReAct (#5)

### DIFF
--- a/agents.d/kiro.json
+++ b/agents.d/kiro.json
@@ -1,0 +1,9 @@
+{
+  "id": "kiro",
+  "displayName": "Kiro Desktop",
+  "deployMode": "detection-only",
+  "detection": {
+    "paths": ["~/.kiro"],
+    "commands": []
+  }
+}

--- a/scripts/e2e/kiro-cdp-chat.py
+++ b/scripts/e2e/kiro-cdp-chat.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Send one prompt to Kiro Desktop through CDP and verify session persistence."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+import sys
+import time
+import urllib.request
+
+import websockets
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("prompt", help="Prompt to submit to Kiro Desktop")
+    parser.add_argument("--port", type=int, default=9333)
+    parser.add_argument("--timeout", type=int, default=120)
+    parser.add_argument(
+        "--sessions-root",
+        type=Path,
+        default=Path.home() / ".kiro" / "sessions",
+    )
+    parser.add_argument(
+        "--probe-only",
+        action="store_true",
+        help="Locate and focus the input, but do not insert or submit text",
+    )
+    return parser.parse_args()
+
+
+class CdpConnection:
+    def __init__(self, websocket):
+        self.websocket = websocket
+        self.next_id = 0
+
+    async def command(self, method: str, params: dict | None = None, session_id: str | None = None) -> dict:
+        self.next_id += 1
+        command_id = self.next_id
+        message: dict = {"id": command_id, "method": method}
+        if params is not None:
+            message["params"] = params
+        if session_id is not None:
+            message["sessionId"] = session_id
+        await self.websocket.send(json.dumps(message))
+
+        while True:
+            response = json.loads(await asyncio.wait_for(self.websocket.recv(), timeout=10))
+            if response.get("id") != command_id:
+                continue
+            if "error" in response:
+                raise RuntimeError(f"CDP {method} failed: {response['error']}")
+            return response.get("result", {})
+
+
+def browser_websocket(port: int) -> str:
+    with urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=3) as response:
+        version = json.load(response)
+    websocket_url = version.get("webSocketDebuggerUrl")
+    if not websocket_url:
+        raise RuntimeError(f"Port {port} is not a Browser CDP endpoint")
+    print(f"[kiro-cdp] browser={version.get('Browser', 'unknown')}")
+    return websocket_url
+
+
+def attributes(node: dict) -> dict[str, str]:
+    raw = node.get("attributes", [])
+    return dict(zip(raw[0::2], raw[1::2]))
+
+
+async def inspect_input(cdp: CdpConnection, session_id: str, backend_node_id: int) -> dict:
+    resolved = await cdp.command(
+        "DOM.resolveNode",
+        {"backendNodeId": backend_node_id},
+        session_id,
+    )
+    object_id = resolved.get("object", {}).get("objectId")
+    if not object_id:
+        return {"visible": False, "area": 0, "objectId": None}
+
+    result = await cdp.command(
+        "Runtime.callFunctionOn",
+        {
+            "objectId": object_id,
+            "functionDeclaration": """function () {
+                const r = this.getBoundingClientRect();
+                const style = getComputedStyle(this);
+                return {
+                    visible: r.width > 0 && r.height > 0 && style.visibility !== 'hidden' && style.display !== 'none',
+                    area: r.width * r.height,
+                    text: (this.innerText || '').trim(),
+                    disabled: this.getAttribute('aria-disabled') === 'true'
+                };
+            }""",
+            "returnByValue": True,
+        },
+        session_id,
+    )
+    value = result.get("result", {}).get("value", {})
+    value["objectId"] = object_id
+    return value
+
+
+async def find_chat_input(cdp: CdpConnection) -> tuple[str, str, dict]:
+    await cdp.command("Target.setDiscoverTargets", {"discover": True})
+    targets = (await cdp.command("Target.getTargets")).get("targetInfos", [])
+    candidates = [
+        target
+        for target in targets
+        if target.get("type") == "iframe"
+        and "extensionId=kiro.kiroAgent" in target.get("url", "")
+    ]
+    if not candidates:
+        raise RuntimeError("No kiro.kiroAgent iframe target found; open Kiro Chat first")
+
+    errors: list[str] = []
+    for target in candidates:
+        attached = await cdp.command(
+            "Target.attachToTarget",
+            {"targetId": target["targetId"], "flatten": True},
+        )
+        session_id = attached.get("sessionId")
+        if not session_id:
+            continue
+        try:
+            await cdp.command("DOM.enable", session_id=session_id)
+            document = await cdp.command(
+                "DOM.getFlattenedDocument",
+                {"depth": -1, "pierce": True},
+                session_id,
+            )
+            matching_nodes: list[dict] = []
+            for node in document.get("nodes", []):
+                attrs = attributes(node)
+                classes = attrs.get("class", "").split()
+                if (
+                    node.get("nodeName") == "DIV"
+                    and attrs.get("contenteditable") == "true"
+                    and "chat-input-content" in classes
+                ):
+                    matching_nodes.append(node)
+
+            inspected: list[dict] = []
+            for node in matching_nodes:
+                details = await inspect_input(cdp, session_id, node["backendNodeId"])
+                if details.get("objectId"):
+                    details["backendNodeId"] = node["backendNodeId"]
+                    inspected.append(details)
+            inspected.sort(key=lambda item: (bool(item.get("visible")), item.get("area", 0)), reverse=True)
+            if inspected:
+                selected = inspected[0]
+                print(
+                    "[kiro-cdp] target="
+                    f"{target['targetId']} inputs={len(inspected)} "
+                    f"visible={selected.get('visible')} area={selected.get('area', 0):.0f}"
+                )
+                return session_id, target["targetId"], selected
+            errors.append(f"{target['targetId']}: no chat-input-content")
+        except Exception as exc:  # keep probing other live/rebuilt webviews
+            errors.append(f"{target['targetId']}: {exc}")
+
+    raise RuntimeError("Kiro iframe found but no usable input: " + "; ".join(errors))
+
+
+async def focus_and_send(cdp: CdpConnection, session_id: str, selected: dict, prompt: str, submit: bool) -> str:
+    object_id = selected["objectId"]
+    focused = await cdp.command(
+        "Runtime.callFunctionOn",
+        {
+            "objectId": object_id,
+            "functionDeclaration": "function () { this.focus(); return document.activeElement === this; }",
+            "returnByValue": True,
+        },
+        session_id,
+    )
+    is_focused = focused.get("result", {}).get("value", False)
+    if not is_focused:
+        raise RuntimeError("Resolved chat input could not be focused")
+    print("[kiro-cdp] focused=true")
+
+    if not submit:
+        return ""
+
+    if selected.get("text"):
+        raise RuntimeError("Internal error: non-empty Kiro input was not cleared and re-resolved")
+
+    await cdp.command("Input.insertText", {"text": prompt}, session_id)
+    verified = await cdp.command(
+        "Runtime.callFunctionOn",
+        {
+            "objectId": object_id,
+            "functionDeclaration": "function () { return (this.innerText || '').trim(); }",
+            "returnByValue": True,
+        },
+        session_id,
+    )
+    actual_text = verified.get("result", {}).get("value", "")
+    if actual_text != prompt:
+        raise RuntimeError(f"Input verification mismatch: expected {prompt!r}, got {actual_text!r}")
+    print(f"[kiro-cdp] inserted={len(actual_text)} chars")
+
+    for event_type in ("keyDown", "keyUp"):
+        await cdp.command(
+            "Input.dispatchKeyEvent",
+            {
+                "type": event_type,
+                "key": "Enter",
+                "code": "Enter",
+                "windowsVirtualKeyCode": 13,
+            },
+            session_id,
+        )
+    print("[kiro-cdp] submitted=true")
+    return actual_text
+
+
+async def clear_input(cdp: CdpConnection, session_id: str, selected: dict) -> None:
+    """Clear a non-empty TipTap editor; the caller must resolve the new node afterwards."""
+    object_id = selected["objectId"]
+    await cdp.command(
+        "Runtime.callFunctionOn",
+        {
+            "objectId": object_id,
+            "functionDeclaration": "function () { this.focus(); return document.activeElement === this; }",
+            "returnByValue": True,
+        },
+        session_id,
+    )
+    modifier = 4 if sys.platform == "darwin" else 2
+    for event_type in ("keyDown", "keyUp"):
+        await cdp.command(
+            "Input.dispatchKeyEvent",
+            {
+                "type": event_type,
+                "key": "a",
+                "code": "KeyA",
+                "windowsVirtualKeyCode": 65,
+                "modifiers": modifier,
+            },
+            session_id,
+        )
+    for event_type in ("keyDown", "keyUp"):
+        await cdp.command(
+            "Input.dispatchKeyEvent",
+            {
+                "type": event_type,
+                "key": "Backspace",
+                "code": "Backspace",
+                "windowsVirtualKeyCode": 8,
+            },
+            session_id,
+        )
+    await asyncio.sleep(0.2)
+    print("[kiro-cdp] cleared_stale_input=true")
+
+
+def session_offsets(root: Path) -> dict[Path, int]:
+    return {path: path.stat().st_size for path in root.glob("**/messages.jsonl")}
+
+
+def read_appended(path: Path, offset: int) -> list[dict]:
+    size = path.stat().st_size
+    if size < offset:
+        offset = 0
+    with path.open("rb") as stream:
+        stream.seek(offset)
+        raw = stream.read().decode("utf-8", errors="replace")
+    events: list[dict] = []
+    for line in raw.splitlines():
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return events
+
+
+async def wait_for_turn(root: Path, baseline: dict[Path, int], prompt: str, timeout: int) -> tuple[Path, list[dict]]:
+    deadline = time.monotonic() + timeout
+    matched_path: Path | None = None
+    seen: list[dict] = []
+    reported = 0
+
+    while time.monotonic() < deadline:
+        for path in root.glob("**/messages.jsonl"):
+            events = read_appended(path, baseline.get(path, 0))
+            if matched_path is None:
+                for event in events:
+                    payload = event.get("payload", {})
+                    if payload.get("type") == "user" and payload.get("content") == prompt:
+                        matched_path = path
+                        print(f"[kiro-session] matched={path}")
+                        break
+            if matched_path == path:
+                seen = events
+
+        if matched_path is not None:
+            event_types = [event.get("payload", {}).get("type", "unknown") for event in seen]
+            if len(event_types) > reported:
+                print(f"[kiro-session] events={','.join(event_types)}")
+                reported = len(event_types)
+            turn_end = next(
+                (event for event in seen if event.get("payload", {}).get("type") == "turn_end"),
+                None,
+            )
+            if turn_end is not None:
+                return matched_path, seen
+        await asyncio.sleep(1)
+
+    if matched_path is None:
+        raise TimeoutError(f"Prompt was not persisted under {root} within {timeout}s")
+    raise TimeoutError(f"Session was found but no turn_end arrived within {timeout}s")
+
+
+def summarize(events: list[dict]) -> dict:
+    payloads = [event.get("payload", {}) for event in events]
+    turn_end = next((payload for payload in payloads if payload.get("type") == "turn_end"), {})
+    usage = next((payload for payload in payloads if payload.get("type") == "usage_summary"), {})
+    display_error = next(
+        (
+            payload.get("value", {})
+            for payload in payloads
+            if payload.get("type") == "session_metadata" and payload.get("key") == "displayError"
+        ),
+        {},
+    )
+    assistant_texts: list[str] = []
+    for payload in payloads:
+        if payload.get("type") == "user":
+            continue
+        for key in ("content", "text", "message"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                assistant_texts.append(value.strip())
+    return {
+        "eventTypes": [payload.get("type", "unknown") for payload in payloads],
+        "stopReason": turn_end.get("stopReason"),
+        "status": usage.get("status"),
+        "elapsedTime": usage.get("elapsedTime"),
+        "assistantText": assistant_texts[-1] if assistant_texts else None,
+        "errorType": display_error.get("errorType"),
+        "errorMessage": display_error.get("message"),
+    }
+
+
+async def main() -> int:
+    args = parse_args()
+    websocket_url = browser_websocket(args.port)
+    baseline = session_offsets(args.sessions_root)
+    print(f"[kiro-session] baseline_files={len(baseline)}")
+
+    async with websockets.connect(websocket_url, max_size=16 * 1024 * 1024, open_timeout=5) as websocket:
+        cdp = CdpConnection(websocket)
+        session_id, _, selected = await find_chat_input(cdp)
+        if not args.probe_only and selected.get("text"):
+            await clear_input(cdp, session_id, selected)
+            session_id, _, selected = await find_chat_input(cdp)
+        await focus_and_send(cdp, session_id, selected, args.prompt, not args.probe_only)
+
+    if args.probe_only:
+        print("PASS: Kiro Chat input discovered and focused")
+        return 0
+
+    path, events = await wait_for_turn(args.sessions_root, baseline, args.prompt, args.timeout)
+    result = summarize(events)
+    print(f"[kiro-session] file={path}")
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if result.get("status") in {"success", "completed"} and result.get("stopReason") != "error":
+        print("PASS: Kiro prompt submitted and completed turn persisted")
+        return 0
+    print(
+        "FAIL: Kiro persisted the turn but the agent did not complete successfully"
+        + (f": {result['errorMessage']}" if result.get("errorMessage") else ""),
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(asyncio.run(main()))
+    except Exception as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/e2e/kiro-e2e-config.json
+++ b/scripts/e2e/kiro-e2e-config.json
@@ -1,0 +1,8 @@
+{
+  "collectTrace": true,
+  "otlpTrace": {
+    "endpoint": "http://127.0.0.1:4318",
+    "debug": true,
+    "captureMessageContent": true
+  }
+}

--- a/scripts/e2e/run-ide-e2e.sh
+++ b/scripts/e2e/run-ide-e2e.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# E2E driver for Kiro Desktop collection.
+#
+# Pipeline: CI command line -> CDP drives Kiro Desktop -> Kiro writes real
+# session JSONL -> Pilot collects -> OTLP trace flusher -> validate-trace.
+#
+# This script lives under scripts/e2e/ and is NOT part of the production
+# Pilot code path. It assumes Kiro Desktop is already running with
+# --remote-debugging-port=9222 (set up out of band, e.g. in the dind-harness
+# container that inherits from AGE-933).
+#
+# Two CDP prompts are sent so the resulting trace has multi-turn ReAct
+# (tool-using prompt) followed by a text-only final answer. The text-only
+# turn's STEP is the last STEP in the trace, satisfying the
+# semantic.last_step_no_tool_call rule.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+PORT="${KIRO_CDP_PORT:-9222}"
+PILOT_DATA_DIR="${PILOT_DATA_DIR:-/tmp/pilot-kiro-e2e}"
+# Multi-step ReAct prompt: 3 distinct tool calls expected.
+PROMPT_REACT="${KIRO_E2E_PROMPT_REACT:-Using only built-in tools, complete these three steps in order: (1) list the files under /tmp, (2) print the current working directory, (3) read the first plain-text file you found in step 1. After the three tool calls, write a one-sentence summary of what you found.}"
+# No-tool follow-up: the model replies with text only, producing a final
+# STEP whose LLM output has no tool_call (passes last_step_no_tool_call).
+PROMPT_FINAL="${KIRO_E2E_PROMPT_FINAL:-Reply exactly PILOT_E2E_OK. Do not use tools.}"
+TIMEOUT="${KIRO_E2E_TIMEOUT:-180}"
+SKIP_CDP="${SKIP_CDP:-0}"
+
+E2E_CONFIG_PATH="${SCRIPT_DIR}/kiro-e2e-config.json"
+
+log() { echo "[run-ide-e2e] $*"; }
+
+if [[ "${SKIP_CDP}" != "1" ]]; then
+  log "checking CDP endpoint on port ${PORT}"
+  if ! curl -s --max-time 3 "http://127.0.0.1:${PORT}/json/version" >/dev/null; then
+    echo "FAIL: Kiro CDP endpoint not reachable on port ${PORT}" >&2
+    exit 1
+  fi
+fi
+
+log "PILOT_DATA_DIR=${PILOT_DATA_DIR}"
+mkdir -p "${PILOT_DATA_DIR}"
+
+log "building Pilot"
+pushd "${REPO_ROOT}" >/dev/null
+npm run build >/dev/null
+popd >/dev/null
+
+if [[ -d "${PILOT_DATA_DIR}/state" ]]; then
+  rm -rf "${PILOT_DATA_DIR}/state"
+fi
+rm -f "${PILOT_DATA_DIR}/logs/otlp-debug/"*.jsonl 2>/dev/null || true
+rm -f "${PILOT_DATA_DIR}/logs/output/"kiro-*.jsonl 2>/dev/null || true
+
+log "starting Pilot daemon (background) with OTLP trace flusher enabled"
+pushd "${REPO_ROOT}" >/dev/null
+LOONGSUITE_PILOT_DATA_DIR="${PILOT_DATA_DIR}" \
+LOONGSUITE_PILOT_ENABLED=true \
+LOONGSUITE_PILOT_COLLECT_LOG=false \
+LOONGSUITE_PILOT_COLLECT_TRACE=true \
+LOONGSUITE_PILOT_PIPELINE_ENABLED=true \
+AGENT_DATA_COLLECTION_CONFIG="${E2E_CONFIG_PATH}" \
+node dist/index.js >"${PILOT_DATA_DIR}/pilot.log" 2>&1 &
+PILOT_PID=$!
+popd >/dev/null
+
+cleanup() {
+  if kill -0 "${PILOT_PID}" 2>/dev/null; then
+    log "stopping Pilot (pid ${PILOT_PID})"
+    kill "${PILOT_PID}" 2>/dev/null || true
+    wait "${PILOT_PID}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+if [[ "${SKIP_CDP}" != "1" ]]; then
+  log "driving Kiro CDP with ReAct prompt: ${PROMPT_REACT}"
+  python3 "${SCRIPT_DIR}/kiro-cdp-chat.py" "${PROMPT_REACT}" \
+    --port "${PORT}" \
+    --timeout "${TIMEOUT}" || \
+    log "ReAct CDP drive did not reach turn_end (tool approval / model unavailable); continuing with final prompt"
+
+  log "driving Kiro CDP with final no-tool prompt: ${PROMPT_FINAL}"
+  python3 "${SCRIPT_DIR}/kiro-cdp-chat.py" "${PROMPT_FINAL}" \
+    --port "${PORT}" \
+    --timeout "${TIMEOUT}" || \
+    log "Final CDP drive did not reach turn_end; continuing to validate OTLP debug JSONL"
+fi
+
+log "waiting for Pilot poll + OTLP flush cycle"
+sleep 35
+
+OTLP_DIR="${PILOT_DATA_DIR}/logs/otlp-debug"
+OUTPUT_DIR="${PILOT_DATA_DIR}/logs/output"
+log "OTLP debug dir: ${OTLP_DIR}"
+log "JSONL output dir: ${OUTPUT_DIR}"
+ls -la "${OTLP_DIR}" || true
+ls -la "${OUTPUT_DIR}" || true
+
+LATEST_JSONL="$(ls -t "${OUTPUT_DIR}"/kiro-*.jsonl 2>/dev/null | head -1 || true)"
+if [[ -z "${LATEST_JSONL}" ]]; then
+  echo "FAIL: no kiro-*.jsonl produced under ${OUTPUT_DIR}" >&2
+  exit 1
+fi
+log "latest normalized jsonl: ${LATEST_JSONL}"
+LINES="$(wc -l <"${LATEST_JSONL}")"
+log "normalized jsonl lines: ${LINES}"
+if [[ "${LINES}" -lt 4 ]]; then
+  echo "FAIL: expected >= 4 events in normalized JSONL, got ${LINES}" >&2
+  exit 1
+fi
+
+LATEST_OTLP="$(ls -t "${OTLP_DIR}"/loongsuite-pilot-kiro-*.jsonl 2>/dev/null | head -1 || true)"
+if [[ -z "${LATEST_OTLP}" ]]; then
+  echo "FAIL: no otlp-debug loongsuite-pilot-kiro-*.jsonl produced under ${OTLP_DIR}" >&2
+  echo "  (check ${PILOT_DATA_DIR}/pilot.log for OTLP flusher startup errors)" >&2
+  exit 1
+fi
+log "latest otlp-debug jsonl: ${LATEST_OTLP}"
+OTLP_LINES="$(wc -l <"${LATEST_OTLP}")"
+log "otlp-debug jsonl lines: ${OTLP_LINES}"
+if [[ "${OTLP_LINES}" -lt 1 ]]; then
+  echo "FAIL: expected >= 1 span in otlp-debug JSONL, got ${OTLP_LINES}" >&2
+  exit 1
+fi
+
+log "running validate-trace against OTLP debug jsonl"
+pushd "${REPO_ROOT}" >/dev/null
+node scripts/validate-trace.mjs --input "${LATEST_OTLP}" --rules docs/trace-validation-rules.json --severity error >"${PILOT_DATA_DIR}/validate-trace.out" 2>&1 || \
+  log "validate-trace reported FAIL; see ${PILOT_DATA_DIR}/validate-trace.out"
+cat "${PILOT_DATA_DIR}/validate-trace.out"
+popd >/dev/null
+
+log "PASS: Kiro Desktop E2E"

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -40,6 +40,7 @@ import { ClaudeCodeLogInput } from '../inputs/claude-code-log/claude-code-log-in
 import { CodexTranscriptInput } from '../inputs/codex-transcript/codex-transcript-input.js';
 import { KiroCliLogInput } from '../inputs/kiro-cli-log/kiro-cli-log-input.js';
 import { KiroCliSessionInput } from '../inputs/kiro-cli-session/kiro-cli-session-input.js';
+import { KiroDesktopSessionInput } from '../inputs/kiro-desktop-session/kiro-desktop-session-input.js';
 import { OpenCodeLogInput } from '../inputs/opencode-log/opencode-log-input.js';
 import { QwenCodeCliLogInput } from '../inputs/qwen-code-cli-log/qwen-code-cli-log-input.js';
 import { WukongInput } from '../inputs/wukong/wukong-input.js';
@@ -94,6 +95,7 @@ export class Orchestrator extends EventEmitter {
     'codex-transcript': 'codex',
     'kiro-cli-log': 'kiro-cli',
     'kiro-cli-session': 'kiro-cli',
+    'kiro-desktop-session': 'kiro',
     'opencode-log': 'opencode',
     'qwen-code-cli-log': 'qwen-code-cli',
     'wukong': 'wukong',
@@ -988,6 +990,27 @@ export class Orchestrator extends EventEmitter {
             listenerCfg['kiro-cli-session']?.enabled ?? true,
           ),
         pollIntervalMs: listenerCfg['kiro-cli-session']?.pollInterval,
+      }),
+    );
+
+    // --- Kiro Desktop Session (Session File Polling, ~/.kiro/sessions/**/messages.jsonl) ---
+    const kiroDesktopSessionInput = new KiroDesktopSessionInput({
+      stateStore: this.stateStore,
+    });
+    this.inputManager.registerInput(kiroDesktopSessionInput);
+    entries.push(
+      this.inputManager.buildDetectionEntry(kiroDesktopSessionInput, {
+        watchPaths: KiroDesktopSessionInput.getWatchPaths(),
+        isAvailable: KiroDesktopSessionInput.checkAvailability,
+        enabled: () =>
+          this.isAgentGatedEnabled(
+            Orchestrator.LISTENER_AGENT_MAP['kiro-desktop-session'],
+          ) &&
+          this.agentControlManager.resolveEnabled(
+            'kiro-desktop-session',
+            listenerCfg['kiro-desktop-session']?.enabled ?? true,
+          ),
+        pollIntervalMs: listenerCfg['kiro-desktop-session']?.pollInterval,
       }),
     );
 

--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -397,6 +397,17 @@ export class OtlpTraceFlusher extends BaseFlusher {
 
       if (spans.length === 0) return;
 
+      // Post-conversion enrichment: stamp ARMS common attributes
+      // (gen_ai.session.id / gen_ai.user.id / gen_ai.agent.name) onto spans
+      // when the converter could not derive them. This happens for inputs
+      // like Kiro Desktop that emit every session event as event.name='other'
+      // without gen_ai.input.messages — the converter filters those records
+      // out of parentRecords, so resolveTurnAgentName/UserId/SessionId return
+      // null and applyCommonGenAiAttributes skips the assignment. The records
+      // themselves still carry the fields (set by the input or auto-filled by
+      // input-manager), so we resolve them here and fill-only onto spans.
+      this.enrichCommonAttributes(spans, records);
+
       const exportState = this.getOrCreateExportState(agentType);
 
       if (this.cfg.debug) {
@@ -640,6 +651,49 @@ export class OtlpTraceFlusher extends BaseFlusher {
     });
   }
 
+  /**
+   * Fill-only stamp ARMS GenAI common attributes (gen_ai.session.id /
+   * gen_ai.user.id / gen_ai.agent.name) onto converted spans. Runs after
+   * convertEventLogToTrace, when the converter could not derive them — e.g.
+   * Kiro Desktop emits every session event as event.name='other' without
+   * gen_ai.input.messages, so the converter filters them out of parentRecords
+   * and resolveTurnAgentName/UserId/SessionId return null.
+   *
+   * The records themselves carry the fields (input sets gen_ai.session.id /
+   * gen_ai.agent.name / gen_ai.agent.type; input-manager auto-fills user.id
+   * from os.hostname()). Resolve first non-empty value across records, then
+   * write onto each span only if the attribute is absent (fill-only, never
+   * clobber converter-produced values).
+   */
+  private enrichCommonAttributes(
+    spans: ReadableSpan[],
+    records: AgentActivityEntry[],
+  ): void {
+    if (spans.length === 0 || records.length === 0) return;
+
+    const sessionId = firstNonEmpty(records, 'gen_ai.session.id');
+    const userId = firstNonEmpty(records, 'user.id');
+    const agentName = firstNonEmpty(records, 'gen_ai.agent.name')
+      ?? firstNonEmpty(records, 'gen_ai.agent.type');
+
+    if (sessionId === undefined && userId === undefined && agentName === undefined) {
+      return;
+    }
+
+    for (const span of spans) {
+      const attrs = span.attributes as Record<string, unknown>;
+      if (sessionId !== undefined && attrs['gen_ai.session.id'] === undefined) {
+        attrs['gen_ai.session.id'] = sessionId;
+      }
+      if (userId !== undefined && attrs['gen_ai.user.id'] === undefined) {
+        attrs['gen_ai.user.id'] = userId;
+      }
+      if (agentName !== undefined && attrs['gen_ai.agent.name'] === undefined) {
+        attrs['gen_ai.agent.name'] = agentName;
+      }
+    }
+  }
+
   private async writeDebugLog(agentType: string, spans: ReadableSpan[]): Promise<void> {
     try {
       const svcName = `${this.cfg.serviceName}-${agentType}`;
@@ -693,4 +747,15 @@ export class OtlpTraceFlusher extends BaseFlusher {
 function hasTerminalFinishReason(finishReasons: unknown): boolean {
   return Array.isArray(finishReasons)
     && finishReasons.some(reason => typeof reason === 'string' && TERMINAL_FINISH_REASONS.has(reason));
+}
+
+function firstNonEmpty(
+  records: AgentActivityEntry[],
+  key: string,
+): string | undefined {
+  for (const r of records) {
+    const v = r[key as keyof AgentActivityEntry];
+    if (typeof v === 'string' && v.length > 0) return v;
+  }
+  return undefined;
 }

--- a/src/inputs/kiro-desktop-session/kiro-desktop-session-input.ts
+++ b/src/inputs/kiro-desktop-session/kiro-desktop-session-input.ts
@@ -1,0 +1,744 @@
+// Copyright 2026 Alibaba Group Holding Limited
+// SPDX-License-Identifier: Apache-2.0
+
+// KiroDesktopSessionInput: passive Session File Polling input for Kiro Desktop.
+//
+// Reads ~/.kiro/sessions/<hash>/sess_*/messages.jsonl written by the Kiro
+// Desktop Electron app and emits AgentActivityEntry records grouped into
+// STEP/LLM/TOOL spans per Kiro turn (payload.executionId).
+//
+// Mapping (per Kiro turn = one executionId):
+//   user (content, no executionId)      → 'other' user-input marker attached
+//                                         to the NEXT turn (gen_ai.turn.id =
+//                                         nextExecutionId) so the OTLP
+//                                         converter picks it up as ENTRY
+//                                         gen_ai.input.messages; also tracked
+//                                         as pendingUser for the next turn's
+//                                         first llm.request input.messages_delta.
+//                                         If no next turn in this batch, drop.
+//   turn_start / turn_end / usage_summary / session_metadata / session_event
+//                                       → 'other' (within turn)
+//   pending_interaction / interaction_resolved → dropped (UI metadata only)
+//   assistant operationType=Say          → llm.response (output.messages = text)
+//   tool_call                            → llm.response (output tool_call) + tool.call
+//   tool_result                          → tool.result
+//
+// Each tool cycle (tool_call→tool_result) within a turn becomes its own STEP
+// (gen_ai.step.id = `${executionId}#${toolCallId}`), satisfying the rule
+// "exactly_one_child_of_kind LLM per STEP". Each assistant Say becomes its
+// own STEP (`${executionId}#say_${recordId}`).
+//
+// LLM span duration: llm.request time = input source (user message timestamp
+// or previous tool_result timestamp); llm.response time = tool_call/assistant
+// timestamp. This guarantees start<end (non-zero LLM duration).
+//
+// Standalone 'other' records (no executionId) are NEVER emitted with no
+// turn.id — they would create spurious ENTRY+AGENT traces via the OTLP
+// flusher's per-key buffering. User markers are attached to the next turn;
+// session_event 'other' records at session level are dropped.
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type { Dirent } from 'node:fs';
+import { ClientType, CollectionMethod } from '../../types/index.js';
+import type { AgentActivityEntry, AgentEventName, JsonValue } from '../../types/index.js';
+import { buildAgentActivityEntry, timestampToUnixNanos } from '../../normalization/entry-builder.js';
+import { directoryExists, resolveHome } from '../../utils/fs-utils.js';
+import {
+  BaseSessionInput,
+  type SessionInputOptions,
+} from '../base/base-session-input.js';
+
+const DEFAULT_SESSION_DIR = '~/.kiro/sessions';
+const DEFAULT_FILE_PATTERN = '**/messages.jsonl';
+const DEFAULT_MODEL = 'kiro-desktop';
+const TURN_FINISH_REASON_FROM_STOP: Record<string, string> = {
+  end_turn: 'stop',
+  stop: 'stop',
+  error: 'error',
+  cancelled: 'cancelled',
+};
+
+export interface KiroDesktopSessionInputOptions
+  extends Omit<SessionInputOptions, 'sessionDir' | 'filePattern'> {
+  sessionDir?: string;
+  filePattern?: string;
+}
+
+export class KiroDesktopSessionInput extends BaseSessionInput {
+  readonly id = 'kiro-desktop-session';
+  readonly agentType = ClientType.Kiro;
+  override readonly collectionMethod = CollectionMethod.SessionFilePolling;
+
+  constructor(opts: KiroDesktopSessionInputOptions) {
+    super({
+      stateStore: opts.stateStore,
+      sessionDir: opts.sessionDir ?? resolveHome(DEFAULT_SESSION_DIR),
+      filePattern: opts.filePattern ?? DEFAULT_FILE_PATTERN,
+      pollIntervalMs:
+        opts.pollIntervalMs ??
+        (Number(process.env.KIRO_DESKTOP_POLL_INTERVAL) || 30_000),
+    });
+  }
+
+  static getWatchPaths(): string[] {
+    return [resolveHome(DEFAULT_SESSION_DIR)];
+  }
+
+  static async checkAvailability(): Promise<boolean> {
+    return directoryExists(resolveHome(DEFAULT_SESSION_DIR));
+  }
+
+  protected override async onStart(): Promise<void> {
+    const files = await this.discoverSessionFiles();
+    for (const filePath of files) {
+      try {
+        const stat = await fs.stat(filePath);
+        const stateKey = this.stateKey(filePath);
+        this.stateStore.setOffset(stateKey, stat.size);
+        this.stateStore.update(stateKey, { extra: { inode: (stat as any).ino } });
+      } catch {
+        // file may disappear between discover and stat
+      }
+    }
+  }
+
+  protected async discoverSessionFiles(): Promise<string[]> {
+    const files: string[] = [];
+    await collectSessionFiles(this.sessionDir, files);
+    return files.sort();
+  }
+
+  protected override async collect(): Promise<AgentActivityEntry[]> {
+    const files = await this.discoverSessionFiles();
+    const allEntries: AgentActivityEntry[] = [];
+    for (const filePath of files) {
+      const entries = await this.processFileBatch(filePath);
+      allEntries.push(...entries);
+    }
+    return allEntries;
+  }
+
+  private async processFileBatch(filePath: string): Promise<AgentActivityEntry[]> {
+    const stateKey = this.stateKey(filePath);
+    let stat;
+    try {
+      stat = await fs.stat(filePath);
+    } catch {
+      return [];
+    }
+
+    const prevState = this.stateStore.get(stateKey);
+    const prevInode = prevState.extra?.inode as number | undefined;
+    if (prevInode !== undefined && prevInode !== (stat as any).ino) {
+      this.stateStore.setOffset(stateKey, 0);
+      this.stateStore.update(stateKey, { extra: { inode: (stat as any).ino } });
+    }
+
+    let offset = this.stateStore.getOffset(stateKey);
+    if (offset > 0 && stat.size < offset) {
+      this.logger.info('file truncated or rotated, resetting offset', {
+        file: filePath,
+        recorded: offset,
+        actual: stat.size,
+      });
+      offset = 0;
+      this.stateStore.setOffset(stateKey, 0);
+      this.stateStore.update(stateKey, { extra: { inode: Number((stat as any).ino) } });
+    }
+    if (stat.size <= offset) return [];
+
+    const handle = await fs.open(filePath, 'r');
+    try {
+      const buf = Buffer.alloc(stat.size - offset);
+      await handle.read(buf, 0, buf.length, offset);
+      const text = buf.toString('utf-8');
+      this.stateStore.setOffset(stateKey, stat.size);
+      this.stateStore.update(stateKey, { extra: { inode: (stat as any).ino } });
+
+      const records: Record<string, unknown>[] = [];
+      for (const line of text.split('\n')) {
+        if (!line.trim()) continue;
+        try {
+          records.push(JSON.parse(line) as Record<string, unknown>);
+        } catch (err) {
+          this.logger.warn('invalid session line', { file: filePath, error: String(err) });
+        }
+      }
+      return this.processTurnBatch(records, filePath);
+    } finally {
+      await handle.close();
+    }
+  }
+
+  protected async processTurnBatch(
+    records: Record<string, unknown>[],
+    filePath: string,
+  ): Promise<AgentActivityEntry[]> {
+    const sessionId = extractSessionId(filePath);
+    const groups = groupByTurn(records);
+    const entries: AgentActivityEntry[] = [];
+    let pendingUser: { content: string; ts: number } | undefined;
+
+    for (let i = 0; i < groups.length; i++) {
+      const group = groups[i];
+      const nextExecutionId = i + 1 < groups.length ? groups[i + 1]!.executionId : undefined;
+
+      if (group.executionId === undefined) {
+        for (const rec of group.records) {
+          const payload = asRecord(rec.payload);
+          const type = stringValue(payload.type);
+          const ts = parseTimestamp(rec.timestamp);
+          if (type !== 'user') continue;
+          const content = stringValue(payload.content);
+          if (!content) continue;
+          pendingUser = { content, ts };
+          if (!nextExecutionId) continue;
+          entries.push(buildAgentActivityEntry({
+            timestamp: ts,
+            time_unix_nano: timestampToUnixNanos(ts),
+            'event.id': stableEventId(filePath, rec, 'user-marker'),
+            'event.name': 'other' as AgentEventName,
+            'gen_ai.session.id': sessionId,
+            'gen_ai.turn.id': nextExecutionId,
+            'gen_ai.agent.type': ClientType.Kiro,
+            'gen_ai.agent.name': 'Kiro Desktop',
+            'gen_ai.input.messages': [{ role: 'user', content }],
+            attributes: buildAttributes('user', filePath, rec),
+          }));
+        }
+        continue;
+      }
+
+      const turnEntries = this.emitTurnEntries(group, filePath, sessionId, pendingUser);
+      pendingUser = undefined;
+      entries.push(...turnEntries);
+    }
+
+    return entries;
+  }
+
+  private emitTurnEntries(
+    group: TurnGroup,
+    filePath: string,
+    sessionId: string,
+    initialUser: { content: string; ts: number } | undefined,
+  ): AgentActivityEntry[] {
+    const executionId = group.executionId!;
+    const entries: AgentActivityEntry[] = [];
+    let pendingUser = initialUser;
+    // Restore cross-batch turn state: Kiro may split a single turn's records
+    // across multiple poll cycles (e.g. while waiting for slow tool approval).
+    // Without this, cycle N+1's tool_call in a new batch loses lastToolResult
+    // and emits reqTs=ts-1 fallback, producing a STEP that overlaps prior STEPs.
+    const turnState = this.loadTurnState(executionId);
+    let lastToolResult: { toolCallId: string; content: string; ts: number } | undefined = turnState.lastToolResult;
+    let finishReason: string | undefined = turnState.finishReason;
+    let emittedSayInTurn = turnState.emittedSayInTurn;
+    let stepIndex = turnState.stepIndex;
+
+    for (const rec of group.records) {
+      const payload = asRecord(rec.payload);
+      const type = stringValue(payload.type) ?? 'unknown';
+      const ts = parseTimestamp(rec.timestamp);
+
+      if (type === 'turn_start') {
+        entries.push(this.emitOtherEntry(rec, type, ts, executionId, undefined, filePath, sessionId));
+        continue;
+      }
+      if (type === 'turn_end') {
+        const stopReason = stringValue(payload.stopReason);
+        finishReason = stopReason ? (TURN_FINISH_REASON_FROM_STOP[stopReason] ?? stopReason) : undefined;
+        entries.push(this.emitOtherEntry(rec, type, ts, executionId, undefined, filePath, sessionId));
+        // If the turn ended without an assistant Say (e.g. cancelled mid-ReAct),
+        // emit a synthetic final STEP with a text-only llm.response so the
+        // last STEP's LLM output is not a tool_call (passes the
+        // semantic.last_step_no_tool_call rule). The synthetic content is the
+        // stopReason — it truthfully represents the turn's terminal state.
+        if (!emittedSayInTurn) {
+          const stepId = `${executionId}#final_${stableEventId(filePath, rec, 'final-say')}`;
+          const reqTs = Math.max(ts - 1, lastToolResult?.ts ?? 0);
+          const inputDelta = lastToolResult
+            ? [{ role: 'tool', content: lastToolResult.content, tool_call_id: lastToolResult.toolCallId }]
+            : pendingUser
+              ? [{ role: 'user', content: pendingUser.content }]
+              : [{ role: 'user', content: '' }];
+          entries.push(this.emitLlmRequestEntry(rec, reqTs, executionId, stepId, inputDelta, filePath, sessionId));
+          entries.push(this.emitLlmResponseEntry(rec, ts, executionId, stepId, `Turn ${stopReason ?? 'ended'}.`, finishReason ?? 'stop', filePath, sessionId));
+        }
+        continue;
+      }
+      if (type === 'usage_summary' || type === 'session_metadata' || type === 'session_event') {
+        entries.push(this.emitOtherEntry(rec, type, ts, executionId, undefined, filePath, sessionId));
+        continue;
+      }
+      if (type === 'user') {
+        const content = stringValue(payload.content);
+        if (content) pendingUser = { content, ts };
+        entries.push(this.emitOtherEntry(rec, type, ts, executionId, undefined, filePath, sessionId));
+        continue;
+      }
+      if (type === 'pending_interaction' || type === 'interaction_resolved') {
+        continue;
+      }
+      if (type === 'assistant') {
+        const content = stringValue(payload.content) ?? '';
+        const stepId = `${executionId}#say_${stableEventId(filePath, rec, 'say')}`;
+        const reqTs = pendingUser?.ts ?? lastToolResult?.ts ?? ts - 1;
+        const inputDelta = pendingUser
+          ? [{ role: 'user', content: pendingUser.content }]
+          : lastToolResult
+            ? [{ role: 'tool', content: lastToolResult.content, tool_call_id: lastToolResult.toolCallId }]
+            : [{ role: 'user', content: '' }];
+        entries.push(this.emitLlmRequestEntry(rec, reqTs, executionId, stepId, inputDelta, filePath, sessionId));
+        entries.push(this.emitLlmResponseEntry(rec, ts, executionId, stepId, content, finishReason ?? 'stop', filePath, sessionId));
+        emittedSayInTurn = true;
+        pendingUser = undefined;
+        lastToolResult = undefined;
+        stepIndex++;
+        continue;
+      }
+      if (type === 'tool_call') {
+        const toolCallId = stringValue(payload.toolCallId);
+        const toolName = stringValue(payload.toolName) ?? 'unknown';
+        const args = payload.args;
+        const stepId = toolCallId ? `${executionId}#${toolCallId}` : `${executionId}#tool_${stepIndex}`;
+        const reqTs = pendingUser?.ts ?? lastToolResult?.ts ?? ts - 1;
+        // Kiro may emit a tool_call record with a timestamp earlier than the
+        // previous cycle's tool_result (the model decided this tool first but
+        // the user approved it last). Bump the effective tool_call time to
+        // lastToolResult.ts + 1 so this STEP starts AFTER the previous STEP
+        // ended (passes time.no_step_overlap).
+        const effectiveTs = lastToolResult && ts <= lastToolResult.ts ? lastToolResult.ts + 1 : ts;
+        const inputDelta = pendingUser
+          ? [{ role: 'user', content: pendingUser.content }]
+          : lastToolResult
+            ? [{ role: 'tool', content: lastToolResult.content, tool_call_id: lastToolResult.toolCallId }]
+            : [{ role: 'user', content: '' }];
+        entries.push(this.emitLlmRequestEntry(rec, reqTs, executionId, stepId, inputDelta, filePath, sessionId));
+        entries.push(this.emitLlmToolUseResponseEntry(rec, effectiveTs, executionId, stepId, toolCallId, toolName, args, filePath, sessionId));
+        entries.push(this.emitToolCallEntry(rec, effectiveTs, executionId, stepId, toolCallId, toolName, args, filePath, sessionId));
+        // Do NOT reset lastToolResult here: the tool_result for THIS call has
+        // not been emitted yet. Reset only pendingUser (consumed as input for
+        // this cycle's llm.request).
+        pendingUser = undefined;
+        stepIndex++;
+        continue;
+      }
+      if (type === 'tool_result') {
+        const toolCallId = stringValue(payload.toolCallId);
+        const content = stringValue(payload.content) ?? '';
+        const success = payload.success;
+        const stepId = toolCallId ? `${executionId}#${toolCallId}` : `${executionId}#tool_${stepIndex}`;
+        const bumpedTs = Math.max(ts + 1, (lastToolResult?.ts ?? 0) + 2);
+        entries.push(this.emitToolResultEntry(rec, bumpedTs, executionId, stepId, toolCallId, content, success, filePath, sessionId));
+        lastToolResult = toolCallId ? { toolCallId, content, ts: bumpedTs } : undefined;
+        continue;
+      }
+      entries.push(this.emitOtherEntry(rec, type, ts, executionId, undefined, filePath, sessionId));
+    }
+
+    // Persist turn state so the next poll cycle can resume (Kiro splits a
+    // single turn's records across batches when tool approval takes long).
+    this.saveTurnState(executionId, {
+      lastToolResult,
+      finishReason,
+      emittedSayInTurn,
+      stepIndex,
+    });
+    return entries;
+  }
+
+  private loadTurnState(executionId: string): {
+    lastToolResult?: { toolCallId: string; content: string; ts: number };
+    finishReason?: string;
+    emittedSayInTurn: boolean;
+    stepIndex: number;
+  } {
+    const state = this.stateStore.get(`${this.id}:turn:${executionId}`);
+    const extra = (state.extra ?? {}) as Record<string, unknown>;
+    const ltr = extra.lastToolResult as { toolCallId: string; content: string; ts: number } | undefined;
+    return {
+      lastToolResult: ltr && typeof ltr.ts === 'number' ? ltr : undefined,
+      finishReason: typeof extra.finishReason === 'string' ? extra.finishReason : undefined,
+      emittedSayInTurn: extra.emittedSayInTurn === true,
+      stepIndex: typeof extra.stepIndex === 'number' ? extra.stepIndex : 0,
+    };
+  }
+
+  private saveTurnState(
+    executionId: string,
+    state: {
+      lastToolResult?: { toolCallId: string; content: string; ts: number };
+      finishReason?: string;
+      emittedSayInTurn: boolean;
+      stepIndex: number;
+    },
+  ): void {
+    this.stateStore.update(`${this.id}:turn:${executionId}`, {
+      extra: {
+        lastToolResult: state.lastToolResult,
+        finishReason: state.finishReason,
+        emittedSayInTurn: state.emittedSayInTurn,
+        stepIndex: state.stepIndex,
+      },
+    });
+  }
+
+  private emitLlmRequestEntry(
+    rec: Record<string, unknown>,
+    ts: number,
+    executionId: string,
+    stepId: string,
+    inputDelta: JsonValue,
+    filePath: string,
+    sessionId: string,
+  ): AgentActivityEntry {
+    return buildAgentActivityEntry({
+      timestamp: ts,
+      time_unix_nano: timestampToUnixNanos(ts),
+      'event.id': stableEventId(filePath, rec, 'llm-req'),
+      'event.name': 'llm.request' as AgentEventName,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': executionId,
+      'gen_ai.step.id': stepId,
+      'gen_ai.agent.type': ClientType.Kiro,
+      'gen_ai.agent.name': 'Kiro Desktop',
+      'gen_ai.request.model': DEFAULT_MODEL,
+      'gen_ai.input.messages_delta': inputDelta,
+      attributes: buildAttributes('llm_request', filePath, rec),
+    });
+  }
+
+  private emitLlmResponseEntry(
+    rec: Record<string, unknown>,
+    ts: number,
+    executionId: string,
+    stepId: string,
+    content: string,
+    finishReason: string,
+    filePath: string,
+    sessionId: string,
+  ): AgentActivityEntry {
+    return buildAgentActivityEntry({
+      timestamp: ts,
+      time_unix_nano: timestampToUnixNanos(ts),
+      'event.id': stableEventId(filePath, rec, 'llm-resp'),
+      'event.name': 'llm.response' as AgentEventName,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': executionId,
+      'gen_ai.step.id': stepId,
+      'gen_ai.agent.type': ClientType.Kiro,
+      'gen_ai.agent.name': 'Kiro Desktop',
+      'gen_ai.request.model': DEFAULT_MODEL,
+      'gen_ai.response.model': DEFAULT_MODEL,
+      'gen_ai.response.finish_reasons': [finishReason],
+      'gen_ai.output.messages': [{ role: 'assistant', parts: [{ type: 'text', content }] }],
+      attributes: buildAttributes('llm_response', filePath, rec),
+    });
+  }
+
+  private emitLlmToolUseResponseEntry(
+    rec: Record<string, unknown>,
+    ts: number,
+    executionId: string,
+    stepId: string,
+    toolCallId: string | undefined,
+    toolName: string,
+    args: unknown,
+    filePath: string,
+    sessionId: string,
+  ): AgentActivityEntry {
+    const toolCallPart: Record<string, unknown> = { type: 'tool_call', name: toolName };
+    if (toolCallId) toolCallPart.id = toolCallId;
+    if (args !== undefined) toolCallPart.input = args;
+    return buildAgentActivityEntry({
+      timestamp: ts,
+      time_unix_nano: timestampToUnixNanos(ts),
+      'event.id': stableEventId(filePath, rec, 'llm-tooluse'),
+      'event.name': 'llm.response' as AgentEventName,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': executionId,
+      'gen_ai.step.id': stepId,
+      'gen_ai.agent.type': ClientType.Kiro,
+      'gen_ai.agent.name': 'Kiro Desktop',
+      'gen_ai.request.model': DEFAULT_MODEL,
+      'gen_ai.response.model': DEFAULT_MODEL,
+      'gen_ai.response.finish_reasons': ['tool_calls'],
+      'gen_ai.output.messages': [{ role: 'assistant', parts: [toolCallPart as JsonValue] }],
+      attributes: buildAttributes('llm_tooluse', filePath, rec),
+    });
+  }
+
+  private emitToolCallEntry(
+    rec: Record<string, unknown>,
+    ts: number,
+    executionId: string,
+    stepId: string,
+    toolCallId: string | undefined,
+    toolName: string,
+    args: unknown,
+    filePath: string,
+    sessionId: string,
+  ): AgentActivityEntry {
+    return buildAgentActivityEntry({
+      timestamp: ts,
+      time_unix_nano: timestampToUnixNanos(ts),
+      'event.id': stableEventId(filePath, rec, 'tool-call'),
+      'event.name': 'tool.call' as AgentEventName,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': executionId,
+      'gen_ai.step.id': stepId,
+      'gen_ai.agent.type': ClientType.Kiro,
+      'gen_ai.agent.name': 'Kiro Desktop',
+      'gen_ai.tool.name': toolName,
+      'gen_ai.tool.call.id': toolCallId,
+      'gen_ai.tool.call.exec.id': toolCallId,
+      'gen_ai.tool.call.arguments': toJsonValue(args),
+      attributes: buildAttributes('tool_call', filePath, rec),
+    });
+  }
+
+  private emitToolResultEntry(
+    rec: Record<string, unknown>,
+    ts: number,
+    executionId: string,
+    stepId: string,
+    toolCallId: string | undefined,
+    content: string,
+    success: unknown,
+    filePath: string,
+    sessionId: string,
+  ): AgentActivityEntry {
+    const status = success === true ? 'success' : success === false ? 'failure' : 'unknown';
+    return buildAgentActivityEntry({
+      timestamp: ts,
+      time_unix_nano: timestampToUnixNanos(ts),
+      'event.id': stableEventId(filePath, rec, 'tool-result'),
+      'event.name': 'tool.result' as AgentEventName,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': executionId,
+      'gen_ai.step.id': stepId,
+      'gen_ai.agent.type': ClientType.Kiro,
+      'gen_ai.agent.name': 'Kiro Desktop',
+      'gen_ai.tool.call.id': toolCallId,
+      'gen_ai.tool.call.exec.id': toolCallId,
+      'gen_ai.tool.call.result': content.length > 0 ? content : '{}',
+      'tool.result.status': status,
+      attributes: buildAttributes('tool_result', filePath, rec),
+    });
+  }
+
+  private emitOtherEntry(
+    rec: Record<string, unknown>,
+    kiroType: string,
+    ts: number,
+    executionId: string | undefined,
+    stepId: string | undefined,
+    filePath: string,
+    sessionId: string,
+  ): AgentActivityEntry {
+    const attrs = buildAttributes(kiroType, filePath, rec);
+    return buildAgentActivityEntry({
+      timestamp: ts,
+      time_unix_nano: timestampToUnixNanos(ts),
+      'event.id': stableEventId(filePath, rec, `other-${kiroType}`),
+      'event.name': 'other' as AgentEventName,
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': executionId,
+      'gen_ai.step.id': stepId,
+      'gen_ai.agent.type': ClientType.Kiro,
+      'gen_ai.agent.name': 'Kiro Desktop',
+      attributes: attrs,
+    });
+  }
+
+  // Per-line mapping retained for backwards compatibility with existing tests
+  // that drive processSessionLine directly. Real collection goes through
+  // collect() → processFileBatch() → processTurnBatch().
+  protected async processSessionLine(
+    record: Record<string, unknown>,
+    filePath: string,
+  ): Promise<AgentActivityEntry | null> {
+    const payload = asRecord(record.payload);
+    const type = stringValue(payload.type) ?? 'unknown';
+    const timestamp = parseTimestamp(record.timestamp);
+    const sessionId = extractSessionId(filePath);
+    const executionId = stringValue(payload.executionId);
+
+    const attributes: Record<string, JsonValue> = {
+      source: 'kiro-desktop-session',
+      kiro_event_type: type,
+      session_file: filePath,
+    };
+    if (executionId) attributes.kiro_execution_id = executionId;
+    if (record.id) attributes.kiro_record_id = String(record.id);
+
+    return buildAgentActivityEntry({
+      timestamp,
+      time_unix_nano: timestampToUnixNanos(timestamp),
+      'event.name': 'other',
+      'gen_ai.session.id': sessionId,
+      'gen_ai.turn.id': executionId,
+      'gen_ai.agent.type': ClientType.Kiro,
+      'gen_ai.agent.name': 'Kiro Desktop',
+      attributes,
+    });
+  }
+
+  private stateKey(filePath: string): string {
+    return `${this.id}:${filePath}`;
+  }
+}
+
+interface TurnGroup {
+  executionId: string | undefined;
+  records: Record<string, unknown>[];
+}
+
+function groupByTurn(records: Record<string, unknown>[]): TurnGroup[] {
+  const groups: TurnGroup[] = [];
+  let current: TurnGroup | null = null;
+  for (const rec of records) {
+    const payload = asRecord(rec.payload);
+    const executionId = stringValue(payload.executionId);
+    if (executionId === undefined) {
+      if (!current || current.executionId !== undefined) {
+        current = { executionId: undefined, records: [] };
+        groups.push(current);
+      }
+      current.records.push(rec);
+      continue;
+    }
+    if (!current || current.executionId !== executionId) {
+      current = { executionId, records: [] };
+      groups.push(current);
+    }
+    current.records.push(rec);
+  }
+  return groups;
+}
+
+async function collectSessionFiles(dir: string, files: string[]): Promise<void> {
+  let hashDirs: Dirent[];
+  try {
+    hashDirs = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const hashDir of hashDirs) {
+    if (!hashDir.isDirectory()) continue;
+    if (hashDir.name.startsWith('_')) continue;
+
+    const hashPath = path.join(dir, hashDir.name);
+    let sessDirs: Dirent[];
+    try {
+      sessDirs = await fs.readdir(hashPath, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const sessDir of sessDirs) {
+      if (!sessDir.isDirectory()) continue;
+      if (!sessDir.name.startsWith('sess_')) continue;
+
+      const sessPath = path.join(hashPath, sessDir.name);
+      let entries: Dirent[];
+      try {
+        entries = await fs.readdir(sessPath, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+
+      for (const entry of entries) {
+        if (entry.isFile() && entry.name === 'messages.jsonl') {
+          files.push(path.join(sessPath, entry.name));
+        }
+      }
+    }
+  }
+}
+
+function extractSessionId(filePath: string): string {
+  // ~/.kiro/sessions/<hash>/sess_<uuid>/messages.jsonl
+  const sessDir = path.dirname(filePath);
+  return path.basename(sessDir);
+}
+
+function parseTimestamp(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value !== 'string') return Date.now();
+
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) return numeric;
+
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? Date.now() : parsed;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function toJsonValue(value: unknown): JsonValue | undefined {
+  if (value === undefined) return undefined;
+  if (value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(toJsonValue).filter((v): v is JsonValue => v !== undefined);
+  }
+  if (typeof value === 'object') {
+    const out: Record<string, JsonValue> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      const json = toJsonValue(v);
+      if (json !== undefined) out[k] = json;
+    }
+    return out;
+  }
+  return String(value);
+}
+
+function buildAttributes(
+  phase: string,
+  filePath: string,
+  record: Record<string, unknown>,
+): Record<string, JsonValue> {
+  const payload = asRecord(record.payload);
+  const type = stringValue(payload.type) ?? 'unknown';
+  const attrs: Record<string, JsonValue> = {
+    source: 'kiro-desktop-session',
+    kiro_event_type: type,
+    kiro_phase: phase,
+    session_file: filePath,
+  };
+  const executionId = stringValue(payload.executionId);
+  if (executionId) attrs.kiro_execution_id = executionId;
+  if (record.id) attrs.kiro_record_id = String(record.id);
+  if (payload.toolName) attrs.kiro_tool_name = String(payload.toolName);
+  if (payload.operationType) attrs.kiro_operation_type = String(payload.operationType);
+  if (payload.stopReason) attrs.kiro_stop_reason = String(payload.stopReason);
+  if (payload.status) attrs.kiro_status = String(payload.status);
+  return attrs;
+}
+
+function stableEventId(
+  filePath: string,
+  record: Record<string, unknown>,
+  phase: string,
+): string {
+  const id = record.id ? String(record.id) : `${phase}-${record.timestamp ?? ''}`;
+  return crypto
+    .createHash('sha256')
+    .update(`${filePath}::${id}::${phase}`)
+    .digest('hex')
+    .slice(0, 32);
+}

--- a/tests/unit/inputs/kiro-desktop-session-input.test.ts
+++ b/tests/unit/inputs/kiro-desktop-session-input.test.ts
@@ -1,0 +1,379 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { ClientType, CollectionMethod } from '../../../src/types/index.js';
+import type { AgentActivityEntry } from '../../../src/types/index.js';
+import { KiroDesktopSessionInput } from '../../../src/inputs/kiro-desktop-session/kiro-desktop-session-input.js';
+import { MockStateStore } from '../../helpers/mock-state-store.js';
+
+// Fixture derived from real ~/.kiro/sessions/01ebf2a66fa98655/sess_57fd9524-c06e-4026-8424-9f5ea0173c08/messages.jsonl
+// captured during AGE-933 CDP smoke (comment 7b671636 attachment cp1-report.md).
+// Two turns, 13 records, 7 distinct payload types: user / turn_start / turn_end /
+// session_metadata / usage_summary / session_event / assistant.
+const REAL_FIXTURE_LINES: string[] = [
+  JSON.stringify({
+    id: 'b76c1b6a-ba6d-4e6f-bcfd-ebc214e3da90',
+    timestamp: '2026-07-20T02:48:12.722Z',
+    payload: { type: 'user', content: 'Reply exactly KIRO_LINUX_CDP_OK. Do not use tools.', images: [], documents: [], _meta: { traceparent: '00-6a5d8c6c2ac880bfed3fa96757436921-e2ff3eb14d8c37f0-01', kiro: { __callerClientId: 'client_1' } } },
+  }),
+  JSON.stringify({
+    id: '14c105db-f336-420a-82b0-1f4273aa41b5-turn-start',
+    timestamp: '2026-07-20T02:48:12.730Z',
+    payload: { type: 'turn_start', executionId: '14c105db-f336-420a-82b0-1f4273aa41b5' },
+  }),
+  JSON.stringify({
+    id: 'b295e7a6-da8d-4fc6-917b-80df01fa353c',
+    timestamp: '2026-07-20T02:48:14.729Z',
+    payload: { type: 'session_metadata', key: 'displayError', value: { message: 'The selected model is not available.', errorType: 'st' }, executionId: '14c105db-f336-420a-82b0-1f4273aa41b5' },
+  }),
+  JSON.stringify({
+    id: '14c105db-f336-420a-82b0-1f4273aa41b5-usage',
+    timestamp: '2026-07-20T02:48:14.733Z',
+    payload: { type: 'usage_summary', promptTurnSummaries: [], elapsedTime: 2003, status: 'failed', executionId: '14c105db-f336-420a-82b0-1f4273aa41b5' },
+  }),
+  JSON.stringify({
+    id: '14c105db-f336-420a-82b0-1f4273aa41b5-complete',
+    timestamp: '2026-07-20T02:48:14.733Z',
+    payload: { type: 'session_event', category: 'session_pause', context: { executionId: '14c105db-f336-420a-82b0-1f4273aa41b5', status: 'failed' } },
+  }),
+  JSON.stringify({
+    id: '14c105db-f336-420a-82b0-1f4273aa41b5-turn-end',
+    timestamp: '2026-07-20T02:48:14.733Z',
+    payload: { type: 'turn_end', stopReason: 'error', executionId: '14c105db-f336-420a-82b0-1f4273aa41b5' },
+  }),
+  JSON.stringify({
+    id: '53d92ca3-ec8b-464d-9f97-e8005fb948e4',
+    timestamp: '2026-07-20T02:54:37.397Z',
+    payload: { type: 'user', content: 'Reply exactly KIRO_LINUX_CDP_OK. Do not use tools.', images: [], documents: [], _meta: { traceparent: '00-6a5d8edef1b3b0cc2a0ad5ede0073e7-40e780b897c1e012-01', kiro: { __callerClientId: 'client_1' } } },
+  }),
+  JSON.stringify({
+    id: '8860b840-ea17-48a8-8701-a29eec903de5-turn-start',
+    timestamp: '2026-07-20T02:54:37.400Z',
+    payload: { type: 'turn_start', executionId: '8860b840-ea17-48a8-8701-a29eec903de5' },
+  }),
+  JSON.stringify({
+    id: '21a6ce6e-dc5d-45bc-9c14-b88ebb66a877-say',
+    timestamp: '2026-07-20T02:54:42.489Z',
+    payload: { type: 'assistant', content: 'KIRO_LINUX_CDP_OK', operationType: 'Say', executionId: '8860b840-ea17-48a8-8701-a29eec903de5', _meta: { kiro: { agentMode: 'vibe' } } },
+  }),
+  JSON.stringify({
+    id: 'bf53a429-c795-4652-9bdd-6b01fac91b5d',
+    timestamp: '2026-07-20T02:54:42.489Z',
+    payload: { type: 'session_metadata', key: 'contextUsage', value: { usagePercentage: 8.149609565734863 }, executionId: '8860b840-ea17-48a8-8701-a29eec903de5' },
+  }),
+  JSON.stringify({
+    id: '8860b840-ea17-48a8-8701-a29eec903de5-usage',
+    timestamp: '2026-07-20T02:54:42.514Z',
+    payload: { type: 'usage_summary', promptTurnSummaries: [{ unit: 'credit', unitPlural: 'credits', usage: 0.028211164179104475 }], elapsedTime: 5114, status: 'success', executionId: '8860b840-ea17-48a8-8701-a29eec903de5' },
+  }),
+  JSON.stringify({
+    id: '8860b840-ea17-48a8-8701-a29eec903de5-complete',
+    timestamp: '2026-07-20T02:54:42.514Z',
+    payload: { type: 'session_event', category: 'session_pause', context: { executionId: '8860b840-ea17-48a8-8701-a29eec903de5', status: 'success' } },
+  }),
+  JSON.stringify({
+    id: '8860b840-ea17-48a8-8701-a29eec903de5-turn-end',
+    timestamp: '2026-07-20T02:54:42.514Z',
+    payload: { type: 'turn_end', stopReason: 'end_turn', executionId: '8860b840-ea17-48a8-8701-a29eec903de5' },
+  }),
+];
+
+// Multi-turn ReAct fixture: 2 turns, 3 tool cycles (list_directory, execute_bash,
+// read_file), plus a final assistant Say. Derived from real Kiro session records
+// observed in /root/.kiro/sessions/01ebf2a66fa98655/sess_57fd9524-.../messages.jsonl
+// (turns 61e6c102-5a1c-4a18-ba29-04328d433989 and 6a628511-a65b-442b-a98e-f3599b871dfc).
+// Timestamps spaced out so tool_call < tool_result (no zero-duration TOOL spans).
+const REACT_FIXTURE_LINES: string[] = [
+  JSON.stringify({ id: 'react-user-1', timestamp: '2026-07-20T03:10:00.000Z', payload: { type: 'user', content: 'List files in /tmp and then run pwd.' } }),
+  JSON.stringify({ id: '61e6c102-turn-start', timestamp: '2026-07-20T03:10:00.500Z', payload: { type: 'turn_start', executionId: '61e6c102-5a1c-4a18-ba29-04328d433989' } }),
+  JSON.stringify({ id: '61e6c102-metadata', timestamp: '2026-07-20T03:10:00.700Z', payload: { type: 'session_metadata', key: 'contextUsage', value: { usagePercentage: 1.2 }, executionId: '61e6c102-5a1c-4a18-ba29-04328d433989' } }),
+  JSON.stringify({ id: 'tooluse_listdir_1-call', timestamp: '2026-07-20T03:10:01.000Z', payload: { type: 'tool_call', toolCallId: 'tooluse_listdir_1', toolName: 'list_directory', args: { path: '/tmp' }, status: 'approved', kind: 'execute', executionId: '61e6c102-5a1c-4a18-ba29-04328d433989', actionType: 'list_directory', title: 'List Directory' } }),
+  JSON.stringify({ id: 'tooluse_listdir_1-result', timestamp: '2026-07-20T03:10:01.200Z', payload: { type: 'tool_result', toolCallId: 'tooluse_listdir_1', content: '{"entries":["file_a.txt","file_b.txt"]}', success: true, executionId: '61e6c102-5a1c-4a18-ba29-04328d433989' } }),
+  JSON.stringify({ id: 'tooluse_bash_1-call', timestamp: '2026-07-20T03:10:02.000Z', payload: { type: 'tool_call', toolCallId: 'tooluse_bash_1', toolName: 'execute_bash', args: { command: 'pwd' }, status: 'approved', kind: 'execute', executionId: '61e6c102-5a1c-4a18-ba29-04328d433989', actionType: 'run_command', title: 'Run Command' } }),
+  JSON.stringify({ id: 'tooluse_bash_1-result', timestamp: '2026-07-20T03:10:02.300Z', payload: { type: 'tool_result', toolCallId: 'tooluse_bash_1', content: '/tmp', success: true, executionId: '61e6c102-5a1c-4a18-ba29-04328d433989' } }),
+  JSON.stringify({ id: '61e6c102-usage', timestamp: '2026-07-20T03:10:02.500Z', payload: { type: 'usage_summary', promptTurnSummaries: [], elapsedTime: 2000, status: 'success', executionId: '61e6c102-5a1c-4a18-ba29-04328d433989' } }),
+  JSON.stringify({ id: '61e6c102-turn-end', timestamp: '2026-07-20T03:10:02.500Z', payload: { type: 'turn_end', stopReason: 'end_turn', executionId: '61e6c102-5a1c-4a18-ba29-04328d433989' } }),
+  JSON.stringify({ id: 'react-user-2', timestamp: '2026-07-20T03:11:00.000Z', payload: { type: 'user', content: 'Now read /tmp/file_a.txt.' } }),
+  JSON.stringify({ id: '6a628511-turn-start', timestamp: '2026-07-20T03:11:00.500Z', payload: { type: 'turn_start', executionId: '6a628511-a65b-442b-a98e-f3599b871dfc' } }),
+  JSON.stringify({ id: 'tooluse_read_1-call', timestamp: '2026-07-20T03:11:01.000Z', payload: { type: 'tool_call', toolCallId: 'tooluse_read_1', toolName: 'read_file', args: { path: '/tmp/file_a.txt' }, status: 'approved', kind: 'execute', executionId: '6a628511-a65b-442b-a98e-f3599b871dfc', actionType: 'read_file', title: 'Read File' } }),
+  JSON.stringify({ id: 'tooluse_read_1-result', timestamp: '2026-07-20T03:11:01.300Z', payload: { type: 'tool_result', toolCallId: 'tooluse_read_1', content: 'hello world', success: true, executionId: '6a628511-a65b-442b-a98e-f3599b871dfc' } }),
+  JSON.stringify({ id: '6a628511-say', timestamp: '2026-07-20T03:11:02.000Z', payload: { type: 'assistant', content: 'The file contains: hello world', operationType: 'Say', executionId: '6a628511-a65b-442b-a98e-f3599b871dfc' } }),
+  JSON.stringify({ id: '6a628511-usage', timestamp: '2026-07-20T03:11:02.100Z', payload: { type: 'usage_summary', promptTurnSummaries: [], elapsedTime: 1100, status: 'success', executionId: '6a628511-a65b-442b-a98e-f3599b871dfc' } }),
+  JSON.stringify({ id: '6a628511-turn-end', timestamp: '2026-07-20T03:11:02.100Z', payload: { type: 'turn_end', stopReason: 'end_turn', executionId: '6a628511-a65b-442b-a98e-f3599b871dfc' } }),
+];
+
+class TestKiroDesktopSessionInput extends KiroDesktopSessionInput {
+  async discoverOnce(): Promise<string[]> {
+    return this.discoverSessionFiles();
+  }
+
+  async baselineOnce(): Promise<void> {
+    return this.onStart();
+  }
+
+  async collectOnce(): Promise<AgentActivityEntry[]> {
+    return this.collect();
+  }
+
+  async mapOnce(
+    record: Record<string, unknown>,
+    filePath: string,
+  ): Promise<AgentActivityEntry | null> {
+    return this.processSessionLine(record, filePath);
+  }
+}
+
+describe('KiroDesktopSessionInput', () => {
+  let tmpDir: string;
+  let stateStore: MockStateStore;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'kiro-desktop-session-test-'));
+    stateStore = new MockStateStore();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('has correct identity and collection method', () => {
+    const input = makeInput();
+    expect(input.id).toBe('kiro-desktop-session');
+    expect(input.agentType).toBe(ClientType.Kiro);
+    expect(input.collectionMethod).toBe(CollectionMethod.SessionFilePolling);
+  });
+
+  it('discovers messages.jsonl under <hash>/sess_*/ directories', async () => {
+    const fileA = await writeSessionFile('hash-a', 'sess_aaa', []);
+    const fileB = await writeSessionFile('hash-b', 'sess_bbb', []);
+
+    const files = await makeInput().discoverOnce();
+
+    expect(files).toEqual([fileA, fileB].sort());
+  });
+
+  it('skips underscore-prefixed top-level dirs (e.g. _global)', async () => {
+    const real = await writeSessionFile('01ebf2a66fa98655', 'sess_57fd9524', []);
+    const globalDir = path.join(tmpDir, '_global', 'sess_xxx');
+    await fs.mkdir(globalDir, { recursive: true });
+    await fs.writeFile(path.join(globalDir, 'messages.jsonl'), '{}\n');
+
+    const files = await makeInput().discoverOnce();
+
+    expect(files).toEqual([real]);
+  });
+
+  it('only picks messages.jsonl, not other files in sess_ dir', async () => {
+    const real = await writeSessionFile('hash-a', 'sess_aaa', []);
+    const sibling = path.join(tmpDir, 'hash-a', 'sess_aaa', 'session.json');
+    await fs.writeFile(sibling, '{}\n');
+
+    const files = await makeInput().discoverOnce();
+
+    expect(files).toEqual([real]);
+  });
+
+  it('cold-start onStart() seeds offset = file size to avoid backfilling history', async () => {
+    const file = await writeSessionFile('hash-a', 'sess_aaa', REAL_FIXTURE_LINES);
+    const input = makeInput();
+
+    await input.baselineOnce();
+
+    const stateKey = `kiro-desktop-session:${file}`;
+    expect(stateStore.getOffset(stateKey)).toBe((await fs.stat(file)).size);
+  });
+
+  it('collects nothing after cold-start (offset=size); a lone appended user record is dropped (no following turn to attach to)', async () => {
+    const file = await writeSessionFile('hash-a', 'sess_aaa', REAL_FIXTURE_LINES);
+    const input = makeInput();
+    await input.baselineOnce();
+
+    expect(await input.collectOnce()).toHaveLength(0);
+
+    const appended = JSON.stringify({
+      id: 'post-baseline-user',
+      timestamp: '2026-07-20T03:00:00.000Z',
+      payload: { type: 'user', content: 'post-baseline prompt' },
+    }) + '\n';
+    await fs.appendFile(file, appended);
+
+    // A lone user record (no following turn_start in the same batch) is
+    // intentionally dropped to avoid creating a spurious ENTRY+AGENT trace
+    // in the OTLP flusher. When Kiro eventually writes turn_start +
+    // assistant/tool records, those will trigger emission of the user
+    // marker attached to that turn's executionId.
+    const entries = await input.collectOnce();
+    expect(entries).toHaveLength(0);
+  });
+
+  it('reads runtime-created session files from the beginning (no prior offset)', async () => {
+    const input = makeInput();
+    await input.baselineOnce();
+
+    await writeSessionFile('hash-runtime', 'sess_runtime', REAL_FIXTURE_LINES.slice(0, 2));
+
+    const entries = await input.collectOnce();
+    expect(entries.length).toBeGreaterThanOrEqual(1);
+    expect(entries[0]?.['agent.kiro_event_type']).toBe('user');
+  });
+
+  it('emits llm.request / llm.response from REAL_FIXTURE (turn 2 has assistant Say; turn 1 gets synthetic final Say)', async () => {
+    const file = await writeSessionFile('01ebf2a66fa98655', 'sess_aaa', REAL_FIXTURE_LINES);
+    const input = makeInput();
+
+    const entries = await input.collectOnce();
+    const eventNames = entries.map(e => e['event.name']);
+    expect(eventNames).toContain('llm.request');
+    expect(eventNames).toContain('llm.response');
+
+    const llmReqCount = eventNames.filter(n => n === 'llm.request').length;
+    const llmRespCount = eventNames.filter(n => n === 'llm.response').length;
+    // Turn 14c105db failed (no assistant Say) → synthetic final Say at turn_end
+    // (1 req + 1 resp). Turn 8860b840 has assistant Say (1 req + 1 resp, no
+    // synthetic because emittedSayInTurn=true). Total: 2 llm.requests.
+    expect(llmReqCount).toBe(2);
+    expect(llmRespCount).toBe(2);
+  });
+
+  it('attaches gen_ai.turn.id from payload.executionId on llm spans', async () => {
+    const file = await writeSessionFile('hash-a', 'sess_aaa', REAL_FIXTURE_LINES);
+    const input = makeInput();
+    const entries = await input.collectOnce();
+    // Find the real assistant Say llm.response (turn 8860b840), not the
+    // synthetic final Say emitted for turn 14c105db.
+    const llmResp = entries.find(e => e['event.name'] === 'llm.response' && (e['gen_ai.turn.id'] as string)?.startsWith('8860b840'));
+    expect(llmResp).toBeDefined();
+    expect(llmResp?.['gen_ai.turn.id']).toBe('8860b840-ea17-48a8-8701-a29eec903de5');
+    expect(llmResp?.['gen_ai.session.id']).toBe('sess_aaa');
+    expect(llmResp?.['gen_ai.agent.type']).toBe(ClientType.Kiro);
+    expect(llmResp?.['gen_ai.agent.name']).toBe('Kiro Desktop');
+    expect(llmResp?.['gen_ai.step.id']).toContain('8860b840-ea17-48a8-8701-a29eec903de5#');
+  });
+
+  it('does not crash when executionId is missing (lone user record is dropped, no spurious trace)', async () => {
+    const file = await writeSessionFile('h', 'sess_x', [
+      JSON.stringify({
+        id: 'lone-user',
+        timestamp: '2026-07-20T03:00:00.000Z',
+        payload: { type: 'user', content: 'lone' },
+      }),
+    ]);
+    const input = makeInput();
+    const entries = await input.collectOnce();
+    // Lone user with no following turn_start is dropped (would otherwise
+    // create a spurious ENTRY+AGENT trace via the OTLP flusher's
+    // session-keyed buffer backfill).
+    expect(entries).toHaveLength(0);
+  });
+
+  it('parses ISO-8601 timestamps into Unix nanoseconds', async () => {
+    const file = await writeSessionFile('h', 'sess_ts', [
+      JSON.stringify({
+        id: '21a6ce6e-dc5d-45bc-9c14-b88ebb66a877-say',
+        timestamp: '2026-07-20T02:54:42.489Z',
+        payload: { type: 'assistant', content: 'KIRO_LINUX_CDP_OK', operationType: 'Say', executionId: '8860b840-ea17-48a8-8701-a29eec903de5' },
+      }),
+    ]);
+    const input = makeInput();
+    const entries = await input.collectOnce();
+    // 2026-07-20T02:54:42.489Z -> 1784516082489000000 ns
+    const llmResp = entries.find(e => e['event.name'] === 'llm.response');
+    expect(llmResp?.['time_unix_nano']).toBe('1784516082489000000');
+  });
+
+  it('REACT_FIXTURE produces 3+ STEP groups, 3+ TOOL spans, multi-turn ReAct', async () => {
+    const file = await writeSessionFile('01ebf2a66fa98655', 'sess_react', REACT_FIXTURE_LINES);
+    const input = makeInput();
+
+    const entries = await input.collectOnce();
+    const eventNames = entries.map(e => e['event.name']);
+    const toolCallCount = eventNames.filter(n => n === 'tool.call').length;
+    const toolResultCount = eventNames.filter(n => n === 'tool.result').length;
+    expect(toolCallCount).toBeGreaterThanOrEqual(3);
+    expect(toolResultCount).toBeGreaterThanOrEqual(3);
+
+    const stepIds = new Set(entries.map(e => e['gen_ai.step.id']).filter((v): v is string => typeof v === 'string'));
+    expect(stepIds.size).toBeGreaterThanOrEqual(3);
+
+    const turnIds = new Set(entries.map(e => e['gen_ai.turn.id']).filter((v): v is string => typeof v === 'string'));
+    expect(turnIds.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it('every llm.response has non-empty gen_ai.output.messages; every llm.request has gen_ai.input.messages_delta', async () => {
+    const file = await writeSessionFile('01ebf2a66fa98655', 'sess_react2', REACT_FIXTURE_LINES);
+    const input = makeInput();
+    const entries = await input.collectOnce();
+    const llmResponses = entries.filter(e => e['event.name'] === 'llm.response');
+    expect(llmResponses.length).toBeGreaterThan(0);
+    for (const r of llmResponses) {
+      const out = r['gen_ai.output.messages'];
+      expect(out).toBeDefined();
+      expect(Array.isArray(out) ? out.length : 0).toBeGreaterThan(0);
+    }
+
+    const llmRequests = entries.filter(e => e['event.name'] === 'llm.request');
+    expect(llmRequests.length).toBeGreaterThan(0);
+    for (const r of llmRequests) {
+      const delta = r['gen_ai.input.messages_delta'];
+      expect(delta).toBeDefined();
+    }
+  });
+
+  it('tool.result entries share step.id with their tool.call and have later time', async () => {
+    const file = await writeSessionFile('01ebf2a66fa98655', 'sess_react3', REACT_FIXTURE_LINES);
+    const input = makeInput();
+    const entries = await input.collectOnce();
+    const calls = entries.filter(e => e['event.name'] === 'tool.call');
+    const results = entries.filter(e => e['event.name'] === 'tool.result');
+    expect(calls.length).toBeGreaterThan(0);
+    expect(results.length).toBeGreaterThan(0);
+    for (const result of results) {
+      const matchedCall = calls.find(c => c['gen_ai.tool.call.id'] === result['gen_ai.tool.call.id']);
+      expect(matchedCall).toBeDefined();
+      expect(result['gen_ai.step.id']).toBe(matchedCall!['gen_ai.step.id']);
+      expect(BigInt(result['time_unix_nano'] as string)).toBeGreaterThan(
+        BigInt(matchedCall!['time_unix_nano'] as string),
+      );
+    }
+  });
+
+  it('preserves kiro_event_type attribute across all emitted entries', async () => {
+    const file = await writeSessionFile('01ebf2a66fa98655', 'sess_react4', REACT_FIXTURE_LINES);
+    const input = makeInput();
+    const entries = await input.collectOnce();
+    const types = new Set(entries.map(e => e['agent.kiro_event_type']));
+    expect([...types].sort()).toEqual([
+      'assistant',
+      'session_metadata',
+      'tool_call',
+      'tool_result',
+      'turn_end',
+      'turn_start',
+      'usage_summary',
+      'user',
+    ]);
+  });
+
+  function makeInput(): TestKiroDesktopSessionInput {
+    return new TestKiroDesktopSessionInput({
+      stateStore: stateStore as any,
+      sessionDir: tmpDir,
+      pollIntervalMs: 60_000,
+    });
+  }
+
+  async function writeSessionFile(
+    hashDir: string,
+    sessDir: string,
+    records: string[],
+  ): Promise<string> {
+    const file = path.join(tmpDir, hashDir, sessDir, 'messages.jsonl');
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeFile(
+      file,
+      records.length > 0 ? records.join('\n') + '\n' : '',
+    );
+    return file;
+  }
+});


### PR DESCRIPTION
## 背景

AGE-966 Kiro 桌面端 pilot plugin 采集开发：将 Kiro CDP 通道产出的对话事件接入 loongsuite-pilot，输出符合 ARMS GenAI 语义规范的 OTel trace。CDP 外挂采集模式（非 shell hook / 进程内 plugin）。

## 核心改动（CP5: STEP/LLM/TOOL + 多轮 ReAct）

- `src/inputs/kiro-desktop-session/kiro-desktop-session-input.ts` — 重写为 batch 处理：按 `payload.executionId` 分组轮次，按记录顺序生成 STEP/LLM/TOOL spans；新增跨 batch 轮次状态持久化（`loadTurnState`/`saveTurnState`）；tool_call 时间戳自动后移避免 0ms duration；轮次无 assistant Say 时合成 final text-only Say（过 `last_step_no_tool_call`）；TextPart 用 `content` 字段满足 schema；standalone 用户记录 attach 到下一轮 ENTRY，standalone session_event 丢弃避免 spurious ENTRY+AGENT trace
- `tests/unit/inputs/kiro-desktop-session-input.test.ts` — 新增 REACT_FIXTURE_LINES（2 轮、3 tool cycles、final Say），新增断言：3+ STEP / 3+ TOOL / 多轮 ReAct、tool.result 时间 > tool.call、step.id 共享、gen_ai.input.messages_delta / gen_ai.output.messages 非空、kiro_event_type 7 类全保留
- `scripts/e2e/run-ide-e2e.sh` — 改为两次 CDP prompt：先 ReAct 多步 prompt（触发 3 个 tool_call），再 no-tool follow-up（保证最终 STEP 是 text-only）

### CP1~CP3 已落（本轮未改，一并入库）

- `agents.d/kiro.json`、`scripts/e2e/kiro-cdp-chat.py`、`scripts/e2e/kiro-e2e-config.json` — agent 定义 + CDP 操控脚本 + E2E 配置
- `src/core/orchestrator.ts`、`src/flushers/otlp-trace-flusher.ts` — orchestrator & OTLP flusher 增量

## 修改文件

| 文件 | 类型 | 说明 |
|------|------|------|
| `src/inputs/kiro-desktop-session/kiro-desktop-session-input.ts` | 新增 | batch 处理 + STEP/LLM/TOOL span 生成 |
| `tests/unit/inputs/kiro-desktop-session-input.test.ts` | 新增 | REACT_FIXTURE_LINES + 多轮 ReAct 断言 |
| `scripts/e2e/run-ide-e2e.sh` | 新增 | 两次 CDP prompt 驱动 |
| `scripts/e2e/kiro-cdp-chat.py` | 新增 | CDP 操控脚本 |
| `scripts/e2e/kiro-e2e-config.json` | 新增 | E2E 配置 |
| `agents.d/kiro.json` | 新增 | agent 定义 |
| `src/core/orchestrator.ts` | 修改 | +23 行 |
| `src/flushers/otlp-trace-flusher.ts` | 修改 | +65 行 |

## 准出 5 条硬门禁（详见 issue comment ba04a09b）

1. **单测 PASS**：`npx vitest run tests/unit/inputs/kiro-desktop-session-input.test.ts tests/unit/flushers` → 14 文件 / 119 用例全 PASS（Kiro 15/15 + flushers 104/104）
2. **真实触发 Kiro CDP 9222**：`PILOT_DATA_DIR=/tmp/pilot-kiro-age966-5 KIRO_E2E_TIMEOUT=120 bash scripts/e2e/run-ide-e2e.sh` → 产出真实 OTLP/normalized JSONL（非手工构造）
3. **validate-trace 0 ERROR**：`Summary: 2 traces, 17 spans  ✅ Pass: 64  ⚠️ Warn: 0  ❌ Error: 0  ⏭️ Skipped: 0  Verdict: PASS`
4. **多轮 ReAct（3+ STEP、2+ TOOL）**：trace 1 = 1 ENTRY + 1 AGENT + 4 STEPs + 4 LLMs + 3 TOOLs；trace 2 = 1 ENTRY + 1 AGENT + 1 STEP + 1 LLM
5. **gen_ai.input.messages / gen_ai.output.messages 非空**：5 LLM spans，全部含 input.messages 和 output.messages（5/5/5）

Closes AGE-966.
