### PR TITLE
feat(trace): per-invocation span attribute passthrough

### DIFF
--- a/assets/hooks/claude-code-hook-processor.mjs
+++ b/assets/hooks/claude-code-hook-processor.mjs
@@ -57,6 +57,7 @@ import {
 import {
   agentBaseFieldPatch,
   collectResourceAttributesFromEnv,
+  parseSpanAttributesFromEnv,
 } from './shared/resource-context.mjs';
 
 const AGENT_ID = 'claude-code';
@@ -65,6 +66,9 @@ const RESOURCE_BASE_FIELD_PATCH = agentBaseFieldPatch(RESOURCE_ATTRIBUTES);
 const RESOURCE_ATTRIBUTE_FIELDS = Object.keys(RESOURCE_ATTRIBUTES).length > 0
   ? { resourceAttributes: RESOURCE_ATTRIBUTES }
   : {};
+// Caller-supplied span attributes (e.g. multica.*) stamped as top-level record
+// fields so the trace flusher can pass matching keys through to span attributes.
+const SPAN_ATTRIBUTES = parseSpanAttributesFromEnv(process.env, { agentId: AGENT_ID });
 
 // ─── utilities ───
 
@@ -443,6 +447,7 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
     'user.id': userId,
     ...(cwd ? { 'agent.claude-code.cwd': cwd } : {}),
     ...RESOURCE_ATTRIBUTE_FIELDS,
+    ...SPAN_ATTRIBUTES,
   };
 
   // 用户输入: 做法 A (EVENT_LOG_TO_TRACE_SPEC §5.1, 0.1.0-beta.3+)

--- a/assets/hooks/claude-code-hook-processor.mjs
+++ b/assets/hooks/claude-code-hook-processor.mjs
@@ -446,8 +446,10 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
     ...RESOURCE_BASE_FIELD_PATCH,
     'user.id': userId,
     ...(cwd ? { 'agent.claude-code.cwd': cwd } : {}),
-    ...RESOURCE_ATTRIBUTE_FIELDS,
+    // SPAN_ATTRIBUTES first so structural/pipeline fields (e.g. resourceAttributes)
+    // win over caller-supplied attributes; aligns with qoder's Object.assign order.
     ...SPAN_ATTRIBUTES,
+    ...RESOURCE_ATTRIBUTE_FIELDS,
   };
 
   // 用户输入: 做法 A (EVENT_LOG_TO_TRACE_SPEC §5.1, 0.1.0-beta.3+)

--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -34,6 +34,7 @@ import {
 import {
   agentBaseFieldPatch,
   collectResourceAttributesFromEnv,
+  parseSpanAttributesFromEnv,
 } from './shared/resource-context.mjs';
 
 const RESOURCE_ATTRIBUTES = collectResourceAttributesFromEnv(process.env, { agentId: 'qoder' });
@@ -41,6 +42,9 @@ const RESOURCE_BASE_FIELD_PATCH = agentBaseFieldPatch(RESOURCE_ATTRIBUTES);
 const RESOURCE_ATTRIBUTE_FIELDS = Object.keys(RESOURCE_ATTRIBUTES).length > 0
   ? { resourceAttributes: RESOURCE_ATTRIBUTES }
   : {};
+// Caller-supplied span attributes (e.g. multica.*) stamped as top-level record
+// fields so the trace flusher can pass matching keys through to span attributes.
+const SPAN_ATTRIBUTES = parseSpanAttributesFromEnv(process.env, { agentId: 'qoder' });
 
 // --- Retry lockfile (qoder-cn only) -----------------------------------------
 // QoderCN fires Stop hook multiple times per turn AND incomplete transcript
@@ -777,7 +781,7 @@ function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, turnId,
 function finalizeRecords(records, cwd) {
   for (const record of records) {
     if (cwd) record['agent.qoder.cwd'] = cwd;
-    Object.assign(record, RESOURCE_BASE_FIELD_PATCH, RESOURCE_ATTRIBUTE_FIELDS);
+    Object.assign(record, SPAN_ATTRIBUTES, RESOURCE_BASE_FIELD_PATCH, RESOURCE_ATTRIBUTE_FIELDS);
   }
   return records;
 }

--- a/assets/hooks/shared/resource-context.mjs
+++ b/assets/hooks/shared/resource-context.mjs
@@ -9,6 +9,32 @@ export const DEFAULT_RESOURCE_ENV_FIELD_MAP = {
   AGENTTEAMS_INSTANCE_ID: 'agentteams.instance.id',
 };
 
+// Env carrying caller-supplied span attributes as `key=value,key=value`. The
+// host process (e.g. multica daemon) sets this per agent invocation; the hook
+// stamps the parsed pairs onto every record as top-level fields so the trace
+// flusher can pass matching keys through to span attributes.
+const DEFAULT_SPAN_ATTRIBUTES_ENV = 'LOONGSUITE_PILOT_SPAN_ATTRIBUTES';
+
+// Prefixes reserved for converter-managed / pipeline fields. Caller-supplied
+// keys matching these are dropped so they can't clobber pipeline semantics.
+// Mirrors RESERVED_PREFIXES in src/normalization/global-attributes.ts.
+const SPAN_ATTR_RESERVED_PREFIXES = [
+  'gen_ai.',
+  'git.',
+  'workspace.',
+  'event.',
+  'trace_',
+  'user.',
+  'cost_',
+  'agent.',
+  'time_unix_nano',
+  'observed_time_unix_nano',
+];
+
+function isReservedSpanAttrKey(key) {
+  return SPAN_ATTR_RESERVED_PREFIXES.some((p) => key === p || key.startsWith(p));
+}
+
 function shouldSkipFieldName(name) {
   return SENSITIVE_FIELD_NAME_RE.test(String(name || ''));
 }
@@ -46,6 +72,47 @@ export function collectResourceAttributesFromEnv(env = process.env, opts = {}) {
   }
 
   return fields;
+}
+
+/**
+ * Parse caller-supplied span attributes from an env var (`key=value,key=value`).
+ * Returns a flat `{ field: value }` map suitable for spreading onto records as
+ * top-level fields. Reserved-prefix keys, sensitive names, over-long values, and
+ * malformed pairs are dropped. Never throws — collection must not block the host.
+ */
+export function parseSpanAttributesFromEnv(env = process.env, opts = {}) {
+  const agentId = opts.agentId || 'hook';
+  const envName = opts.envName || DEFAULT_SPAN_ATTRIBUTES_ENV;
+  const out = {};
+
+  const raw = env[envName];
+  if (typeof raw !== 'string' || raw.length === 0) return out;
+
+  for (const pair of raw.split(',')) {
+    const idx = pair.indexOf('=');
+    if (idx <= 0) continue;
+
+    const key = pair.slice(0, idx).trim();
+    const value = pair.slice(idx + 1).trim();
+    if (!key || !value) continue;
+
+    if (isReservedSpanAttrKey(key)) {
+      warnSkip(agentId, key, 'reserved prefix');
+      continue;
+    }
+    if (shouldSkipFieldName(key)) {
+      warnSkip(agentId, key, 'sensitive field name');
+      continue;
+    }
+    if (value.length > MAX_RESOURCE_FIELD_VALUE_LENGTH) {
+      warnSkip(agentId, key, 'value too long');
+      continue;
+    }
+
+    out[key] = value;
+  }
+
+  return out;
 }
 
 export function agentBaseFieldPatch(resourceAttributes = {}, opts = {}) {

--- a/assets/plugins/opencode/plugin.mjs
+++ b/assets/plugins/opencode/plugin.mjs
@@ -28,6 +28,50 @@ const MAX_SESSIONS = 100;
 const MAX_CONTENT_SIZE = 64 * 1024;
 
 // ---------------------------------------------------------------------------
+// Caller-supplied span attributes
+// ---------------------------------------------------------------------------
+// The host process (e.g. multica daemon) sets LOONGSUITE_PILOT_SPAN_ATTRIBUTES
+// as `key=value,key=value` per agent invocation. Parsed once at init and stamped
+// onto every record as top-level fields so the trace flusher can pass matching
+// keys through to span attributes. Inlined (no import) — plugins ship standalone.
+// Mirrors parseSpanAttributesFromEnv in assets/hooks/shared/resource-context.mjs.
+const SPAN_ATTR_RESERVED_PREFIXES = [
+  "gen_ai.",
+  "git.",
+  "workspace.",
+  "event.",
+  "trace_",
+  "user.",
+  "cost_",
+  "agent.",
+  "time_unix_nano",
+  "observed_time_unix_nano",
+];
+const SPAN_ATTR_MAX_VALUE_LENGTH = 512;
+const SPAN_ATTR_SENSITIVE_RE =
+  /(^|[_.-])(TOKEN|SECRET|PASSWORD|CREDENTIAL|COOKIE)([_.-]|$)|^(API_KEY|API_HEADER)$/i;
+
+function parseSpanAttributesFromEnv(env = process.env) {
+  const out = {};
+  const raw = env.LOONGSUITE_PILOT_SPAN_ATTRIBUTES;
+  if (typeof raw !== "string" || raw.length === 0) return out;
+  for (const pair of raw.split(",")) {
+    const idx = pair.indexOf("=");
+    if (idx <= 0) continue;
+    const key = pair.slice(0, idx).trim();
+    const value = pair.slice(idx + 1).trim();
+    if (!key || !value) continue;
+    if (SPAN_ATTR_RESERVED_PREFIXES.some((p) => key === p || key.startsWith(p))) continue;
+    if (SPAN_ATTR_SENSITIVE_RE.test(key)) continue;
+    if (value.length > SPAN_ATTR_MAX_VALUE_LENGTH) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+const SPAN_ATTRIBUTES = parseSpanAttributesFromEnv(process.env);
+
+// ---------------------------------------------------------------------------
 // Path helpers
 // ---------------------------------------------------------------------------
 
@@ -247,6 +291,7 @@ function buildCommonFields(sessionID, session, userId) {
     "gen_ai.agent.name": AGENT_TYPE,
     "gen_ai.agent.id": session.agentMeta?.name || undefined,
     ...(agentCwd ? { [`agent.${AGENT_TYPE}.cwd`]: agentCwd } : {}),
+    ...SPAN_ATTRIBUTES,
   };
 }
 

--- a/docs/trace-output.md
+++ b/docs/trace-output.md
@@ -304,6 +304,7 @@ Notes:
 Notes:
 - Unlike source #2 (spans only), passthrough attributes are ordinary top-level record fields, so they appear in **both** the event log (SLS / JSONL) and the trace spans — same behavior as the git fields.
 - Reserved-prefix keys (`gen_ai.`, `git.`, `workspace.`, `event.`, `trace_`, `user.`, `cost_`, `agent.`) and sensitive names (token/secret/password/…) are dropped by the hook. Use a dedicated namespace such as `multica.*`.
+- Values must not contain a comma `,` (it is the pair separator); a value is also capped at 512 chars.
 - Only keys matching a configured prefix are passed through; all other top-level fields are unaffected. Supported for agents whose records are built in-process (claude-code, qoder, opencode).
 
 ## Verify Trace Output

--- a/docs/trace-output.md
+++ b/docs/trace-output.md
@@ -84,7 +84,7 @@ Backends are **deduplicated** by normalized endpoint URL + full request headers,
 
 Shared vs. per-backend settings (spans are converted once per distinct `service.name`):
 
-- **Shared across all backends:** `resourceAttributes`, `captureMessageContent`, `resourceAttributeKeys`, `maxExportBatchBytes`, `turnIdleTimeoutMs`.
+- **Shared across all backends:** `resourceAttributes`, `captureMessageContent`, `resourceAttributeKeys`, `spanAttributePassthroughPrefixes`, `maxExportBatchBytes`, `turnIdleTimeoutMs`.
 - **Per-backend:** endpoint URL, headers, compression, and `service.name` (see below — user vs. managed backends can differ).
 
 A failing backend is isolated — it does not block the healthy backends, and its failed spans are persisted separately under `~/.loongsuite-pilot/logs/otlp-failed/<service>-<agent>__<backend-name>.jsonl`.
@@ -285,6 +285,26 @@ Notes:
 - Values are strings. File edits are picked up on the next processing cycle (bounded by the input poll interval, ~30s), not instantly.
 - Keys are written verbatim as span attribute names. **Avoid keys starting with `agent.`** and other reserved prefixes (`gen_ai.`, `git.`, `workspace.`, `event.`, `trace_`, `user.`, `cost_`) — such keys are skipped.
 - Attributes never overwrite existing span attributes (fill-only).
+
+**3. Per-invocation passthrough attributes.** The three sources above are process-global (one shared pilot daemon), so they cannot vary per agent call. To attribute individual calls (e.g. which user / issue triggered a run), the calling process sets a **per-invocation** env var on the spawned agent, and the daemon passes matching keys through onto that call's spans.
+
+- The host process sets `LOONGSUITE_PILOT_SPAN_ATTRIBUTES` (same `key=value,key=value` format) on the agent subprocess. The agent's hook/plugin parses it at startup and stamps the pairs as top-level fields on every record it emits, so each call carries its own values.
+
+  ```bash
+  # set by the launcher per agent invocation
+  export LOONGSUITE_PILOT_SPAN_ATTRIBUTES="multica.issue.id=AGE-992,multica.user.id=staff"
+  ```
+
+- `config.json` → `otlpTrace.spanAttributePassthroughPrefixes` lists the key prefixes the daemon should surface onto spans:
+
+  ```json
+  { "otlpTrace": { "spanAttributePassthroughPrefixes": ["multica."] } }
+  ```
+
+Notes:
+- Unlike source #2 (spans only), passthrough attributes are ordinary top-level record fields, so they appear in **both** the event log (SLS / JSONL) and the trace spans — same behavior as the git fields.
+- Reserved-prefix keys (`gen_ai.`, `git.`, `workspace.`, `event.`, `trace_`, `user.`, `cost_`, `agent.`) and sensitive names (token/secret/password/…) are dropped by the hook. Use a dedicated namespace such as `multica.*`.
+- Only keys matching a configured prefix are passed through; all other top-level fields are unaffected. Supported for agents whose records are built in-process (claude-code, qoder, opencode).
 
 ## Verify Trace Output
 

--- a/docs/zh-CN/trace-output.md
+++ b/docs/zh-CN/trace-output.md
@@ -84,7 +84,7 @@ Trace 导出会把**同一批**转换后的 span **同时**发往**所有**已�
 
 共享 vs 单后端设置(span 按不同 `service.name` 各转换一次):
 
-- **所有后端共享:** `resourceAttributes`、`captureMessageContent`、`resourceAttributeKeys`、`maxExportBatchBytes`、`turnIdleTimeoutMs`。
+- **所有后端共享:** `resourceAttributes`、`captureMessageContent`、`resourceAttributeKeys`、`spanAttributePassthroughPrefixes`、`maxExportBatchBytes`、`turnIdleTimeoutMs`。
 - **每后端独立:** endpoint URL、headers、compression,以及 `service.name`(见下文——用户后端与托管后端可不同)。
 
 某个后端失败会被隔离——不会阻塞健康后端,其失败 span 会单独落盘到 `~/.loongsuite-pilot/logs/otlp-failed/<service>-<agent>__<后端名>.jsonl`。
@@ -285,6 +285,26 @@ Pilot 会将 Trace 发送到 `http://localhost:3000/api/public/otel/v1/traces`�
 - 值均为字符串。文件改动会在下一个处理周期生效（受采集轮询间隔约束，约 30s），并非即时。
 - key 会原样作为 span 属性名。**请避免以 `agent.` 开头**及其它保留前缀（`gen_ai.`、`git.`、`workspace.`、`event.`、`trace_`、`user.`、`cost_`）——这类 key 会被跳过。
 - 属性为 fill-only，绝不覆盖 span 已有属性。
+
+**3. 按次调用的透传属性。** 上述三个来源都是进程级全局的（一台机器一个共享 pilot daemon），无法按每次 agent 调用区分。若要对单次调用做归因（如哪个用户 / issue 触发了本次运行），由调用方在被拉起的 agent 子进程上设置**按次**环境变量，daemon 再把匹配前缀的 key 透传到该次调用的 span 上。
+
+- 宿主进程在 agent 子进程上设置 `LOONGSUITE_PILOT_SPAN_ATTRIBUTES`（同样是 `key=value,key=value` 格式）。agent 的 hook/plugin 在启动时解析它，并把这些键值对作为顶层字段写入它产出的每条 record，因此每次调用都带上各自的值。
+
+  ```bash
+  # 由启动器在每次 agent 调用时设置
+  export LOONGSUITE_PILOT_SPAN_ATTRIBUTES="multica.issue.id=AGE-992,multica.user.id=staff"
+  ```
+
+- `config.json` → `otlpTrace.spanAttributePassthroughPrefixes` 列出 daemon 需要透传到 span 的 key 前缀：
+
+  ```json
+  { "otlpTrace": { "spanAttributePassthroughPrefixes": ["multica."] } }
+  ```
+
+说明：
+- 与来源 #2（仅 span）不同，透传属性是普通的顶层 record 字段，因此会**同时**出现在 event log（SLS / JSONL）和 trace span 上——与 git 字段行为一致。
+- 保留前缀 key（`gen_ai.`、`git.`、`workspace.`、`event.`、`trace_`、`user.`、`cost_`、`agent.`）以及敏感命名（token/secret/password/…）会被 hook 丢弃。请使用 `multica.*` 等专用命名空间。
+- 仅匹配所配置前缀的 key 会被透传，其它顶层字段不受影响。支持在进程内构建 record 的 agent（claude-code、qoder、opencode）。
 
 ## 验证 Trace 输出
 

--- a/docs/zh-CN/trace-output.md
+++ b/docs/zh-CN/trace-output.md
@@ -305,6 +305,7 @@ Pilot 会将 Trace 发送到 `http://localhost:3000/api/public/otel/v1/traces`�
 - 与来源 #2（仅 span）不同，透传属性是普通的顶层 record 字段，因此会**同时**出现在 event log（SLS / JSONL）和 trace span 上——与 git 字段行为一致。
 - 保留前缀 key（`gen_ai.`、`git.`、`workspace.`、`event.`、`trace_`、`user.`、`cost_`、`agent.`）以及敏感命名（token/secret/password/…）会被 hook 丢弃。请使用 `multica.*` 等专用命名空间。
 - 仅匹配所配置前缀的 key 会被透传，其它顶层字段不受影响。支持在进程内构建 record 的 agent（claude-code、qoder、opencode）。
+- value 不能包含逗号 `,`（逗号是键值对分隔符）；单个 value 长度上限 512 字符。
 
 ## 验证 Trace 输出
 

--- a/src/core/config-loader.ts
+++ b/src/core/config-loader.ts
@@ -133,6 +133,7 @@ export interface ConfigFile {
     captureMessageContent?: boolean;
     turnIdleTimeoutMs?: number;
     resourceAttributeKeys?: string[];
+    spanAttributePassthroughPrefixes?: string[];
   };
 
   agents?: Record<string, {
@@ -571,6 +572,7 @@ export function buildOtlpTraceConfig(config: AnalyticsConfig): OtlpTraceFlusherC
     debug: otlp?.debug ?? config.cms.debug ?? false,
     turnIdleTimeoutMs: otlp?.turnIdleTimeoutMs ?? 0,
     resourceAttributeKeys: resolveResourceAttributeKeys(otlp),
+    spanAttributePassthroughPrefixes: resolveSpanAttributePassthroughPrefixes(otlp),
     maxExportBatchBytes: otlp?.maxExportBatchBytes,
   };
 }
@@ -631,6 +633,20 @@ function resolveResourceAttributeKeys(
       .filter((key): key is string => typeof key === 'string')
       .map(key => key.trim())
       .filter(key => key.length > 0),
+  )];
+}
+
+function resolveSpanAttributePassthroughPrefixes(
+  otlp: AnalyticsConfig['otlpTrace'],
+): string[] {
+  const prefixes = Array.isArray(otlp?.spanAttributePassthroughPrefixes)
+    ? otlp.spanAttributePassthroughPrefixes
+    : [];
+  return [...new Set(
+    prefixes
+      .filter((prefix): prefix is string => typeof prefix === 'string')
+      .map(prefix => prefix.trim())
+      .filter(prefix => prefix.length > 0),
   )];
 }
 

--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -135,6 +135,7 @@ export class OtlpTraceFlusher extends BaseFlusher {
   private readonly debugDir: string;
   private readonly failedDir: string;
   private readonly resourceAttributeKeys: string[];
+  private readonly spanAttributePassthroughPrefixes: string[];
   private readonly globalAttributesProvider?: GlobalAttributesProvider;
 
   private idleTimer?: ReturnType<typeof setInterval>;
@@ -177,6 +178,9 @@ export class OtlpTraceFlusher extends BaseFlusher {
     this.resourceAttributeKeys = (cfg.resourceAttributeKeys ?? [])
       .map(key => key.trim())
       .filter(key => key.length > 0);
+    this.spanAttributePassthroughPrefixes = (cfg.spanAttributePassthroughPrefixes ?? [])
+      .map(prefix => prefix.trim())
+      .filter(prefix => prefix.length > 0);
 
     if (cfg.captureMessageContent !== false) {
       process.env.OTEL_SEMCONV_STABILITY_OPT_IN ??= 'gen_ai_latest_experimental';
@@ -423,7 +427,19 @@ export class OtlpTraceFlusher extends BaseFlusher {
         // are already on the records and only need to be listed as keys.
         const customAttrs = this.globalAttributesProvider?.resolve() ?? {};
         const customKeys = Object.keys(customAttrs);
-        const passthroughKeys = [...new Set([...DEFAULT_GIT_PASSTHROUGH_KEYS, ...customKeys])];
+        // Caller-supplied attributes (e.g. multica.*) are already stamped as
+        // top-level fields on the records by the hook/plugin; discover any key
+        // matching a configured prefix and list it so it reaches span attributes.
+        const prefixKeys = this.spanAttributePassthroughPrefixes.length === 0
+          ? []
+          : [...new Set(
+              records.flatMap(r =>
+                Object.keys(r).filter(k =>
+                  this.spanAttributePassthroughPrefixes.some(p => k.startsWith(p)),
+                ),
+              ),
+            )];
+        const passthroughKeys = [...new Set([...DEFAULT_GIT_PASSTHROUGH_KEYS, ...customKeys, ...prefixKeys])];
         const recordsForConversion = customKeys.length === 0
           ? records
           : records.map((r) => {

--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -21,6 +21,7 @@ import { normalizeAgentType } from '../utils/agent-type-normalize.js';
 import { resolveAgentSystem } from '../normalization/agent-system-map.js';
 import {
   DEFAULT_GIT_PASSTHROUGH_KEYS,
+  isReservedKey,
   type GlobalAttributesProvider,
 } from '../normalization/global-attributes.js';
 import { createLogger } from '../utils/logger.js';
@@ -435,6 +436,9 @@ export class OtlpTraceFlusher extends BaseFlusher {
           : [...new Set(
               records.flatMap(r =>
                 Object.keys(r).filter(k =>
+                  // Defense-in-depth: never surface reserved/pipeline keys even if a
+                  // misconfigured prefix (e.g. "gen_ai.") happens to match them.
+                  !isReservedKey(k) &&
                   this.spanAttributePassthroughPrefixes.some(p => k.startsWith(p)),
                 ),
               ),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,6 +49,8 @@ export interface OtlpTraceRawConfig {
   captureMessageContent?: boolean;
   turnIdleTimeoutMs?: number;
   resourceAttributeKeys?: string[];
+  /** Top-level record-key prefixes (e.g. "multica.") whose fields are passed through to span attributes. */
+  spanAttributePassthroughPrefixes?: string[];
   maxExportBatchBytes?: number;
   compression?: 'none' | 'gzip';
 }
@@ -139,6 +141,8 @@ export interface OtlpTraceFlusherConfig {
   debug?: boolean;
   turnIdleTimeoutMs?: number;
   resourceAttributeKeys?: string[];
+  /** Top-level record-key prefixes (e.g. "multica.") whose fields are passed through to span attributes. */
+  spanAttributePassthroughPrefixes?: string[];
   maxExportBatchBytes?: number;
   dataDir?: string;
 }

--- a/tests/unit/core/config-loader.test.ts
+++ b/tests/unit/core/config-loader.test.ts
@@ -786,6 +786,33 @@ describe('ConfigLoader', () => {
       expect(result!.resourceAttributeKeys).toEqual(['agentteams.worker.name', 'custom.attr']);
     });
 
+    it('buildOtlpTraceConfig defaults spanAttributePassthroughPrefixes to []', async () => {
+      mockReadJsonFile.mockResolvedValueOnce({
+        collectTrace: true,
+        otlpTrace: { endpoint: 'http://jaeger:4318' },
+      });
+
+      const config = await loadConfig();
+      const result = buildOtlpTraceConfig(config);
+
+      expect(result!.spanAttributePassthroughPrefixes).toEqual([]);
+    });
+
+    it('buildOtlpTraceConfig trims and de-dups spanAttributePassthroughPrefixes', async () => {
+      mockReadJsonFile.mockResolvedValueOnce({
+        collectTrace: true,
+        otlpTrace: {
+          endpoint: 'http://jaeger:4318',
+          spanAttributePassthroughPrefixes: ['multica.', 'multica.', ' custom. ', ' '],
+        },
+      });
+
+      const config = await loadConfig();
+      const result = buildOtlpTraceConfig(config);
+
+      expect(result!.spanAttributePassthroughPrefixes).toEqual(['multica.', 'custom.']);
+    });
+
     it('buildOtlpTraceConfig expands cms into an arms endpoint', async () => {
       mockReadJsonFile.mockResolvedValueOnce({
         collectTrace: true,

--- a/tests/unit/flushers/otlp-trace-flusher/conversion.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/conversion.test.ts
@@ -253,5 +253,21 @@ describe('OtlpTraceFlusher - conversion', () => {
       const opts = vi.mocked(convertEventLogToTrace).mock.calls.at(-1)![1] as { passthroughKeys?: string[] };
       expect(opts.passthroughKeys).not.toContain('multica.issue.id');
     });
+
+    it('never passes through reserved keys even if a misconfigured prefix matches', async () => {
+      p = new OtlpTraceFlusher({ ...makeConfig(), spanAttributePassthroughPrefixes: ['gen_ai.'] });
+
+      const entry = {
+        'event.name': 'llm.response',
+        'gen_ai.agent.type': 'claude-code',
+        'gen_ai.turn.id': 'tp3',
+        'gen_ai.response.finish_reasons': ['stop'],
+      } as unknown as AgentActivityEntry;
+
+      await p.send(entry);
+
+      const opts = vi.mocked(convertEventLogToTrace).mock.calls.at(-1)![1] as { passthroughKeys?: string[] };
+      expect(opts.passthroughKeys?.some((k) => k.startsWith('gen_ai.'))).toBe(false);
+    });
   });
 });

--- a/tests/unit/flushers/otlp-trace-flusher/conversion.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/conversion.test.ts
@@ -207,4 +207,51 @@ describe('OtlpTraceFlusher - conversion', () => {
       expect(records[0]['team']).toBe('local');
     });
   });
+
+  describe('spanAttributePassthroughPrefixes', () => {
+    let p: OtlpTraceFlusher;
+
+    afterEach(async () => {
+      await p.shutdown();
+    });
+
+    it('passes through top-level record keys matching a configured prefix', async () => {
+      p = new OtlpTraceFlusher({ ...makeConfig(), spanAttributePassthroughPrefixes: ['multica.'] });
+
+      const entry = {
+        'event.name': 'llm.response',
+        'gen_ai.agent.type': 'claude-code',
+        'gen_ai.turn.id': 'tp1',
+        'gen_ai.response.finish_reasons': ['stop'],
+        'multica.issue.id': 'AGE-992',
+        'multica.user.id': 'staff',
+        'other.key': 'ignored',
+      } as unknown as AgentActivityEntry;
+
+      await p.send(entry);
+
+      const opts = vi.mocked(convertEventLogToTrace).mock.calls.at(-1)![1] as { passthroughKeys?: string[] };
+      expect(opts.passthroughKeys).toEqual(
+        expect.arrayContaining(['multica.issue.id', 'multica.user.id', 'git.repo']),
+      );
+      expect(opts.passthroughKeys).not.toContain('other.key');
+    });
+
+    it('does not pass through any prefix key when none is configured', async () => {
+      p = new OtlpTraceFlusher(makeConfig());
+
+      const entry = {
+        'event.name': 'llm.response',
+        'gen_ai.agent.type': 'claude-code',
+        'gen_ai.turn.id': 'tp2',
+        'gen_ai.response.finish_reasons': ['stop'],
+        'multica.issue.id': 'AGE-992',
+      } as unknown as AgentActivityEntry;
+
+      await p.send(entry);
+
+      const opts = vi.mocked(convertEventLogToTrace).mock.calls.at(-1)![1] as { passthroughKeys?: string[] };
+      expect(opts.passthroughKeys).not.toContain('multica.issue.id');
+    });
+  });
 });

--- a/tests/unit/hooks/shared/resource-context.test.mjs
+++ b/tests/unit/hooks/shared/resource-context.test.mjs
@@ -1,10 +1,23 @@
 import { describe, expect, test, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import {
   agentBaseFieldPatch,
   collectResourceAttributesFromEnv,
   parseSpanAttributesFromEnv,
 } from '../../../../assets/hooks/shared/resource-context.mjs';
+
+const ROOT = path.resolve(fileURLToPath(import.meta.url), '../../../../..');
+
+/** Extract the string entries of a `NAME = [ ... ]` array literal from a source file. */
+function extractPrefixArray(relPath, constName) {
+  const src = fs.readFileSync(path.join(ROOT, relPath), 'utf8');
+  const m = new RegExp(`${constName}\\s*=\\s*\\[([\\s\\S]*?)\\]`).exec(src);
+  if (!m) throw new Error(`${constName} not found in ${relPath}`);
+  return [...m[1].matchAll(/['"]([^'"]+)['"]/g)].map((x) => x[1]).sort();
+}
 
 describe('hook resource context helper', () => {
   test('collects only default fixed non-sensitive resource marker fields', () => {
@@ -88,5 +101,20 @@ describe('parseSpanAttributesFromEnv', () => {
       { envName: 'CUSTOM_ENV' },
     );
     expect(attrs).toEqual({ 'multica.issue.id': 'AGE-1' });
+  });
+});
+
+describe('reserved-prefix list stays in sync across copies', () => {
+  // The reserved-prefix list is intentionally duplicated in three places
+  // (shared hook util, standalone opencode plugin, and the TS normalizer).
+  // This guards against silent drift between them.
+  test('shared mjs, opencode plugin, and global-attributes.ts agree', () => {
+    const canonical = extractPrefixArray('src/normalization/global-attributes.ts', 'RESERVED_PREFIXES');
+    const sharedHook = extractPrefixArray('assets/hooks/shared/resource-context.mjs', 'SPAN_ATTR_RESERVED_PREFIXES');
+    const opencode = extractPrefixArray('assets/plugins/opencode/plugin.mjs', 'SPAN_ATTR_RESERVED_PREFIXES');
+
+    expect(canonical.length).toBeGreaterThan(0);
+    expect(sharedHook).toEqual(canonical);
+    expect(opencode).toEqual(canonical);
   });
 });

--- a/tests/unit/hooks/shared/resource-context.test.mjs
+++ b/tests/unit/hooks/shared/resource-context.test.mjs
@@ -3,6 +3,7 @@ import { describe, expect, test, vi } from 'vitest';
 import {
   agentBaseFieldPatch,
   collectResourceAttributesFromEnv,
+  parseSpanAttributesFromEnv,
 } from '../../../../assets/hooks/shared/resource-context.mjs';
 
 describe('hook resource context helper', () => {
@@ -35,5 +36,57 @@ describe('hook resource context helper', () => {
     })).toEqual({
       'gen_ai.agent.name': 'worker-01',
     });
+  });
+});
+
+describe('parseSpanAttributesFromEnv', () => {
+  test('parses key=value pairs and trims', () => {
+    const attrs = parseSpanAttributesFromEnv({
+      LOONGSUITE_PILOT_SPAN_ATTRIBUTES: 'multica.issue.id=AGE-992, multica.user.id = staff ',
+    });
+    expect(attrs).toEqual({
+      'multica.issue.id': 'AGE-992',
+      'multica.user.id': 'staff',
+    });
+  });
+
+  test('returns empty for missing or empty env', () => {
+    expect(parseSpanAttributesFromEnv({})).toEqual({});
+    expect(parseSpanAttributesFromEnv({ LOONGSUITE_PILOT_SPAN_ATTRIBUTES: '' })).toEqual({});
+  });
+
+  test('drops reserved-prefix keys', () => {
+    const warn = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const attrs = parseSpanAttributesFromEnv({
+        LOONGSUITE_PILOT_SPAN_ATTRIBUTES:
+          'gen_ai.foo=x,git.repo=y,user.id=z,agent.thing=w,multica.ok=keep',
+      });
+      expect(attrs).toEqual({ 'multica.ok': 'keep' });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test('drops sensitive names, over-long values, and malformed pairs', () => {
+    const warn = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const long = 'v'.repeat(513);
+      const attrs = parseSpanAttributesFromEnv({
+        LOONGSUITE_PILOT_SPAN_ATTRIBUTES:
+          `multica.token=secret,multica.big=${long},noequalssign,=novalue,multica.ok=keep`,
+      });
+      expect(attrs).toEqual({ 'multica.ok': 'keep' });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test('honors a custom envName', () => {
+    const attrs = parseSpanAttributesFromEnv(
+      { CUSTOM_ENV: 'multica.issue.id=AGE-1' },
+      { envName: 'CUSTOM_ENV' },
+    );
+    expect(attrs).toEqual({ 'multica.issue.id': 'AGE-1' });
   });
 });


### PR DESCRIPTION
## Summary

Lets a launching process (e.g. the multica daemon) attribute **individual agent calls** — which user / issue triggered a run — onto trace spans. The existing custom-attribute sources (PR #118's `globalSpanAttributes` / `OTEL_SPAN_ATTRIBUTES` / `span-attributes.json`) all live in the single shared pilot daemon and are process-global, so they can't vary per call. This adds a per-invocation path that reuses the same mechanism as `agent.<ns>.cwd` / `git.*`.

**How it works**
1. **Hooks/plugins** parse `LOONGSUITE_PILOT_SPAN_ATTRIBUTES` (`key=value,key=value`) from the agent subprocess env and stamp the pairs as **top-level record fields** — `claude-code`, `qoder`, and `opencode`. Reserved-prefix keys (`gen_ai.` `git.` `workspace.` `event.` `trace_` `user.` `cost_` `agent.` …) and sensitive names (token/secret/…) are dropped. Shared parser: `assets/hooks/shared/resource-context.mjs#parseSpanAttributesFromEnv` (opencode plugin inlines an equivalent, since plugins ship standalone).
2. **Flusher**: new `otlpTrace.spanAttributePassthroughPrefixes` config. The OTLP trace flusher passes any top-level record key matching a configured prefix (e.g. `"multica."`) through to span attributes, exactly like `DEFAULT_GIT_PASSTHROUGH_KEYS`. Values ride the record, so they land on **both** the event log (SLS/JSONL) and spans — same behavior as `git.*`.

Because the values are stamped per-record inside the agent subprocess (which the launcher gives a per-task env), attribution is naturally per-call and per-session — no shared-daemon collapse, no file races.

## Config example

```json
{ "otlpTrace": { "spanAttributePassthroughPrefixes": ["multica."] } }
```

```bash
# set by the launcher per agent invocation
export LOONGSUITE_PILOT_SPAN_ATTRIBUTES="multica.issue.id=AGE-992,multica.user.id=staff"
```

## Notes
- `codex` uses a wakeup-marker → transcript-input record path (records built in the daemon, not the hook), so it's not wired here; left as a follow-up.
- Docs updated: `docs/trace-output.md` (+ zh-CN).

## Test plan

- [x] `npm run typecheck`
- [x] Unit: `parseSpanAttributesFromEnv` (parse / reserved-prefix drop / sensitive / over-length / custom envName); config-loader parse (default `[]`, trim/dedup); flusher passes prefix-matched record keys through to `passthroughKeys` and not others
- [x] Hermetic E2E: real opencode plugin emits `multica.*` on records (reserved keys dropped), then the **real** `@loongsuite/otel-util-genai` converter + flusher stamp them onto all 4 spans (`enter_ai_application_system`/`invoke_agent`/`react`/`chat`)
- [x] **Real E2E to ARMS**: built + ran the daemon against the machine's real CMS/xtrace endpoint, ran real `opencode` (glm-5.1) in a git repo with the env set; confirmed the collected trace's spans all carry `multica.issue.id=AGE-992` + `multica.user.id=staff` (verified via ARMS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)