### PR TITLE
fix(qoderwork): load host app's own worker runtime, never a foreign one

### DIFF
--- a/assets/hooks/qoderwork-runtime-wrapper.mjs
+++ b/assets/hooks/qoderwork-runtime-wrapper.mjs
@@ -1,108 +1,170 @@
-// QoderWork worker runtime wrapper — intercepts token data via JSON.parse hook.
-// Loaded via: QODER_WORKER_RUNTIME_PATH=<this-file>
+// QoderWork-family worker runtime wrapper — transparent, app-agnostic shim.
 //
-// QoderWork runs its agent SDK in a Node.js worker_thread (not Bun), so the
-// qodercli BUN_OPTIONS --preload trick does not apply. The SDK honors
-// QODER_WORKER_RUNTIME_PATH as the worker entry, so we wrap it: install a
-// JSON.parse/JSON.stringify hook, then `await import()` the real runtime.
+// Loaded via the SHARED env var QODER_WORKER_RUNTIME_PATH. The ENTIRE
+// @qoder-ai/qoder-agent-sdk family honours this variable (QoderWork,
+// QwenWorkCN, QoderWork CN, ...), and on macOS we set it with `launchctl
+// setenv`, which is GLOBAL to the launchd user domain. Consequences:
+//   • Every GUI app inherits the variable, but only apps that actually run the
+//     @qoder-ai SDK ever load this file as their worker entry.
+//   • Therefore this wrapper CAN be the worker entry of ANY sibling app, not
+//     just QoderWork. It MUST NOT assume which app loaded it.
 //
-// Writes to: ~/.loongsuite-pilot/logs/qoderwork-intercept.jsonl
-// The captured `id` (chatcmpl-xxx) matches the hook processor's
-// gen_ai.response.id (derived from transcript message.id), enabling direct
-// token matching in qoder-work-trace-input without a transcript mapping module.
+// Design priority (do NOT weaken): NEVER break the host app. We only ever hand
+// control to the *host app's OWN* bundled runtime, located dynamically from the
+// running process. There is intentionally NO hardcoded/app-specific fallback:
+// loading a foreign runtime (e.g. QoderWork's runtime inside QwenWorkCN) is
+// exactly what corrupts the app. If we cannot locate the host app's own runtime
+// with certainty, we install nothing and load nothing — token interception is
+// sacrificed, the app is never handed a wrong runtime.
+//
+// On the success path only, token/system-prompt records are appended to
+// ~/.loongsuite-pilot/logs/qoderwork-intercept.jsonl.
 
 import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
 const require = createRequire(import.meta.url);
 const fs = require('node:fs');
 const path = require('node:path');
 
 const INTERCEPT_DIR = path.join(process.env.HOME || '/tmp', '.loongsuite-pilot', 'logs');
 const INTERCEPT_FILE = path.join(INTERCEPT_DIR, 'qoderwork-intercept.jsonl');
+const ERROR_LOG = path.join(INTERCEPT_DIR, 'qoderwork-wrapper-error.log');
 const MIN_SYSTEM_PROMPT_LENGTH = 100;
-
-try { fs.mkdirSync(INTERCEPT_DIR, { recursive: true }); } catch {}
 
 const origParse = JSON.parse;
 const origStringify = JSON.stringify;
 let lastId = null;
 let systemPromptCaptured = false;
 
-// Global override of JSON.parse to intercept SSE-parsed token usage.
-JSON.parse = function (text, reviver) {
-  const result = origParse.call(JSON, text, reviver);
+function logDiag(msg) {
   try {
-    if (result && typeof result === "object"
-        && result.usage && result.choices !== undefined
-        && result.id !== lastId) {
-      lastId = result.id;
-      const u = result.usage;
-      const rec = {
-        type: "token",
-        ts: Date.now(),
-        id: result.id,  // chatcmpl-xxx, matches transcript message.id
-        model: result.model || "",
-        prompt_tokens: u.prompt_tokens || 0,
-        cached_tokens: (u.prompt_tokens_details && u.prompt_tokens_details.cached_tokens) || 0,
-        completion_tokens: u.completion_tokens || 0,
-        reasoning_tokens: (u.completion_tokens_details && u.completion_tokens_details.reasoning_tokens) || 0,
-        total_tokens: u.total_tokens || 0,
-      };
-      // Token records are ~200 bytes, well under PIPE_BUF — atomic on POSIX.
-      fs.appendFileSync(INTERCEPT_FILE, origStringify.call(JSON, rec) + "\n");
-    }
+    fs.mkdirSync(INTERCEPT_DIR, { recursive: true });
+    fs.appendFileSync(ERROR_LOG, `[${new Date().toISOString()}] ${msg}\n`);
   } catch {}
-  return result;
-};
-
-// Global override of JSON.stringify to capture system prompt before request encryption.
-// Each process captures at most once (systemPromptCaptured flag).
-JSON.stringify = function (value, replacer, space) {
-  try {
-    if (!systemPromptCaptured && value && typeof value === "object"
-        && value.messages && Array.isArray(value.messages)) {
-      const sys = value.messages.find(m => m.role === "system");
-      if (sys && typeof sys.content === "string" && sys.content.length > MIN_SYSTEM_PROMPT_LENGTH) {
-        systemPromptCaptured = true;
-        const rec = { type: "system_prompt", ts: Date.now(), content: sys.content };
-        fs.appendFileSync(INTERCEPT_FILE, origStringify.call(JSON, rec) + "\n");
-      }
-    }
-  } catch {}
-  return origStringify.call(JSON, value, replacer, space);
-};
-
-// Discover and load the real QoderWork runtime. Cover both the system-wide
-// install (`/Applications/...`) and the per-user install (`~/Applications/...`),
-// each with obfuscated (`.obf.mjs`) and non-obfuscated (`.mjs`) variants.
-const SDK_REL_BASE = 'Contents/Resources/app.asar.unpacked/node_modules/@qoder-ai/qoder-agent-sdk/dist/_worker';
-const RUNTIME_CANDIDATES = [
-  `/Applications/QoderWork.app/${SDK_REL_BASE}/qoder-worker-runtime.obf.mjs`,
-  `/Applications/QoderWork.app/${SDK_REL_BASE}/qoder-worker-runtime.mjs`,
-  path.join(process.env.HOME || '', `Applications/QoderWork.app/${SDK_REL_BASE}/qoder-worker-runtime.obf.mjs`),
-  path.join(process.env.HOME || '', `Applications/QoderWork.app/${SDK_REL_BASE}/qoder-worker-runtime.mjs`),
-];
-
-let loaded = false;
-let lastErr = null;
-for (const candidate of RUNTIME_CANDIDATES) {
-  try {
-    if (fs.existsSync(candidate)) {
-      await import(candidate);
-      loaded = true;
-      break;
-    }
-  } catch (e) { lastErr = e; }
 }
 
-if (!loaded) {
-  // Log a diagnostic but do NOT throw. Throwing at module level crashes the
-  // worker_thread entirely, which would also prevent the QoderWork SDK from
-  // falling back to its ProcessTransport. By returning silently we let the SDK
-  // detect "no runtime registered" and degrade on its own — token interception
-  // is lost (acceptable) but normal agent operation is not disrupted.
+// Install the JSON.parse / JSON.stringify interception hooks. Only ever called
+// right before we import the host app's own runtime, so a worker that fails to
+// self-locate is left completely untouched.
+function installInterceptHooks() {
+  try { fs.mkdirSync(INTERCEPT_DIR, { recursive: true }); } catch {}
+
+  // Intercept SSE-parsed token usage.
+  JSON.parse = function (text, reviver) {
+    const result = origParse.call(JSON, text, reviver);
+    try {
+      if (result && typeof result === "object"
+          && result.usage && result.choices !== undefined
+          && result.id !== lastId) {
+        lastId = result.id;
+        const u = result.usage;
+        const rec = {
+          type: "token",
+          ts: Date.now(),
+          id: result.id,  // chatcmpl-xxx, matches transcript message.id
+          model: result.model || "",
+          prompt_tokens: u.prompt_tokens || 0,
+          cached_tokens: (u.prompt_tokens_details && u.prompt_tokens_details.cached_tokens) || 0,
+          completion_tokens: u.completion_tokens || 0,
+          reasoning_tokens: (u.completion_tokens_details && u.completion_tokens_details.reasoning_tokens) || 0,
+          total_tokens: u.total_tokens || 0,
+        };
+        // Token records are ~200 bytes, well under PIPE_BUF — atomic on POSIX.
+        fs.appendFileSync(INTERCEPT_FILE, origStringify.call(JSON, rec) + "\n");
+      }
+    } catch {}
+    return result;
+  };
+
+  // Capture system prompt before request encryption. Each process captures once.
+  JSON.stringify = function (value, replacer, space) {
+    try {
+      if (!systemPromptCaptured && value && typeof value === "object"
+          && value.messages && Array.isArray(value.messages)) {
+        const sys = value.messages.find(m => m.role === "system");
+        if (sys && typeof sys.content === "string" && sys.content.length > MIN_SYSTEM_PROMPT_LENGTH) {
+          systemPromptCaptured = true;
+          const rec = { type: "system_prompt", ts: Date.now(), content: sys.content };
+          fs.appendFileSync(INTERCEPT_FILE, origStringify.call(JSON, rec) + "\n");
+        }
+      }
+    } catch {}
+    return origStringify.call(JSON, value, replacer, space);
+  };
+}
+
+// The SDK worker runtime always lives at this fixed path relative to an app's
+// Resources dir. It bundles native deps (sharp / node-pty / keytar), so it must
+// be asar-UNPACKED and is guaranteed to exist on disk for a shipped app.
+const SDK_WORKER_REL = path.join(
+  'app.asar.unpacked', 'node_modules', '@qoder-ai', 'qoder-agent-sdk', 'dist', '_worker',
+);
+const RUNTIME_NAMES = ['qoder-worker-runtime.obf.mjs', 'qoder-worker-runtime.mjs'];
+
+// Resource roots derived purely from the running process, so they resolve to
+// WHICHEVER app is hosting this worker — no app name is ever hardcoded.
+function candidateResourceRoots() {
+  const roots = [];
+
+  // (1) Enclosing .app bundle from the executable path. In an Electron worker
+  // thread process.execPath is the host app's own binary, e.g.
+  //   /Applications/QwenWorkCN.app/Contents/MacOS/QwenWorkCN
+  // Match the FIRST ".app" (non-greedy) so a nested "*Helper.app" cannot shadow
+  // the outer bundle. This is a hard macOS bundle-layout guarantee.
+  const exec = process.execPath || '';
+  const m = /^(.*?\.app)(?:\/|$)/.exec(exec);
+  if (m) roots.push(path.join(m[1], 'Contents', 'Resources'));
+
+  // (2) Electron's resourcesPath, when present, is <App>/Contents/Resources.
+  if (process.resourcesPath) roots.push(process.resourcesPath);
+
+  return roots;
+}
+
+// Locate the host app's OWN worker runtime. Returns an absolute path or null.
+function findHostAppRuntime() {
+  let selfPath = '';
+  try { selfPath = fs.realpathSync(fileURLToPath(import.meta.url)); } catch {}
+
+  const seen = new Set();
+  for (const root of candidateResourceRoots()) {
+    for (const name of RUNTIME_NAMES) {
+      const cand = path.join(root, SDK_WORKER_REL, name);
+      if (seen.has(cand)) continue;
+      seen.add(cand);
+      try {
+        if (!fs.existsSync(cand)) continue;
+        const real = fs.realpathSync(cand);
+        if (real === selfPath) continue; // anti-recursion: never import ourselves
+        return real;
+      } catch {}
+    }
+  }
+  return null;
+}
+
+const hostRuntime = findHostAppRuntime();
+
+if (hostRuntime) {
+  // Certain we will hand control to the host app's OWN runtime. Install
+  // interception, then load it. The app behaves exactly as if unhooked, plus we
+  // capture token usage.
+  installInterceptHooks();
   try {
-    fs.appendFileSync(path.join(INTERCEPT_DIR, 'qoderwork-wrapper-error.log'),
-      `[${new Date().toISOString()}] real runtime not found in candidates: ${RUNTIME_CANDIDATES.join(', ')}\n` +
-      (lastErr ? `last error: ${lastErr.message}\n` : ''));
-  } catch {}
+    await import(hostRuntime);
+  } catch (e) {
+    // The app's own runtime failed to load — the app would have hit this even
+    // without us. Do not throw (module-level throw crashes the worker_thread and
+    // blocks the SDK's own transport fallback) and do not try any other runtime.
+    logDiag(`host runtime import failed: ${hostRuntime} :: ${e && e.message}`);
+  }
+} else {
+  // Could not locate the host app's own runtime. Per design priority we refuse
+  // to load any guessed/foreign runtime (that is what broke QwenWorkCN). Install
+  // nothing, load nothing: token interception is lost, the app is never handed a
+  // wrong runtime. The SDK detects the empty worker entry and degrades on its own.
+  logDiag(
+    'host app runtime not found — skipping intercept to avoid loading a foreign runtime '
+    + `(execPath=${process.execPath || ''}, resourcesPath=${process.resourcesPath || ''})`,
+  );
 }


### PR DESCRIPTION
## Background

Token interception for QoderWork is injected by setting `QODER_WORKER_RUNTIME_PATH` to `qoderwork-runtime-wrapper.mjs`. On macOS this is done with `launchctl setenv`, which sets the variable in the **launchd user domain — global to every GUI app**. The entire `@qoder-ai/qoder-agent-sdk` family (QoderWork, QwenWorkCN, QoderWork CN, …) honours the *same* variable name and uses it as its worker entry.

## The bug

The old wrapper hardcoded `QoderWork.app` in `RUNTIME_CANDIDATES`. So when a **sibling** app (e.g. QwenWorkCN) starts its worker, it inherits the global env, loads our wrapper, and the wrapper imports **QoderWork's** runtime into the sibling's worker — a cross-version / cross-site (`global` vs `cn`) mismatch that breaks the sibling app (the reported "千问办公挂掉 / two CLIs get confused").

Verified on a machine with both apps installed:
- `launchctl getenv QODER_WORKER_RUNTIME_PATH` → the wrapper (and the var even leaks into unrelated Electron apps like Cursor/Wukong).
- QwenWorkCN bundles its own `qoder-worker-runtime.obf.mjs` (v1.0.46 / `cn`) and reads the same env var; QoderWork's is v1.0.41 / `global` (different md5).

## The fix

Make the wrapper a transparent, **app-agnostic** shim:
- Locate the **host app's own** runtime purely from the running process — the first `.app` in `process.execPath`, then `process.resourcesPath` — resolving to whichever app is hosting the worker. No app name is hardcoded.
- Install the JSON.parse/stringify interception only right before importing that runtime.
- **Remove the hardcoded candidates entirely.** If the host app's own runtime cannot be located with certainty, install nothing and load nothing.

Design priority: **never break the host app.** Losing token interception is acceptable; loading a foreign runtime is not.

`workerData.qoderWorkerRuntime.runtimeRoot` / `QODER_WORKER_RUNTIME_ASSET_ROOT` are intentionally not used — the SDK materialises the wrapper, so those point at the materialised wrapper copy, not the app.

## Test plan

- [x] Static resolution validated against real bundles: QwenWorkCN main binary, QwenWorkCN nested `*Helper.app`, QoderWork main binary → each resolves to its OWN runtime; nested Helper correctly falls back to the outer bundle; plain `node` (no clue) → not found → safe no-op.
- [x] `node --check` passes.
- [x] Live: after deploying, QoderWork ran a worker and token collection still works end-to-end (fresh intercept record → `gen_ai.usage` in the final output), with no `qoderwork-wrapper-error.log` entries — confirming self-location works in the real Electron worker thread.
- [ ] QwenWorkCN end-to-end once its beta allows a conversation (root cause is structurally removed regardless).

## How to verify locally (before release)

No need to wait for a release — this can be grey-tested by hand on any machine that can open QwenWorkCN:

1. Replace the **live** wrapper (the one the env points at), not the packaged copy:
   `~/.loongsuite-pilot/hooks/qoderwork-runtime-wrapper.mjs`
2. Confirm the env is actually pointing at it: `launchctl getenv QODER_WORKER_RUNTIME_PATH` should print that path. (It is normally set because QoderWork.app is installed; if empty, the app never loads the wrapper and there is nothing to test.)
3. **Fully quit** QwenWorkCN (Cmd+Q, not just close the window) and reopen it, then have a real conversation. The worker only reads the env / loads its runtime at startup; a content change is re-materialised by the SDK, so there is no stale-cache concern.
4. Pass criteria: QwenWorkCN works normally **and** `~/.loongsuite-pilot/logs/qoderwork-wrapper-error.log` gets no new `host app runtime not found` / `host runtime import failed` lines for QwenWorkCN.

This is the same procedure already confirmed for QoderWork above, just exercised from QwenWorkCN.

## How the fix reaches users (after release)

Once merged and released, the fix propagates through the normal install/update path — with one caveat:

- Both the installer (`deploy/installer-opensource.sh` → `scripts/postinstall.js`) and the auto-updater (`src/updater/updater.ts` runs the staged `postinstall.js`) copy `assets/hooks/` → `~/.loongsuite-pilot/hooks/` via `fs.cpSync(..., { recursive: true })`. Node's `cpSync` overwrites by default, so the live `qoderwork-runtime-wrapper.mjs` is replaced with the new version (no "skip if exists").
- The env path (`~/.loongsuite-pilot/hooks/qoderwork-runtime-wrapper.mjs`) is stable, so it keeps pointing at the now-updated file, and the SDK re-materialises on the content change.
- **Caveat:** reinstalling/updating pilot does **not** restart the GUI apps, and a worker only picks up the new wrapper when its host app starts. So the effective statement is: *reinstall or auto-update **+** fully quit & reopen the affected app → fixed.* Already-running workers are not hot-patched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)