### PR TITLE
fix(qoder): prevent cold-start trace replay

### DIFF
--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -17,7 +17,7 @@ import {
   parseArgs,
   parseStdinPayload,
   logDebug,
-  getLineRange,
+  getLineRangeInfo,
   getTranscriptLineCount,
   readTranscriptLines,
   appendRowsToHistory,
@@ -185,7 +185,7 @@ async function main() {
     // qoder-cn only: serialize concurrent retries on the same transcript.
     // We wait the HOOK_RETRY_DELAY first (so all queued Stop hooks have
     // already advanced the offset via updateLineRecord), then acquire the
-    // lock. The losers see currentCount==lastCount in getLineRange and exit.
+    // lock. The losers see currentCount==lastCount in getLineRangeInfo and exit.
     const retryDelay = parseInt(process.env.HOOK_RETRY_DELAY || '0', 10);
     if (retryDelay > 0) {
       await new Promise(r => setTimeout(r, retryDelay));
@@ -198,11 +198,12 @@ async function main() {
       }
     }
     try {
-      const range = getLineRange(agentId, transcriptPath, sessionId);
+      const range = getLineRangeInfo(agentId, transcriptPath, sessionId);
       if (!range) return;
       await processTranscript(
         agentId, logPrefix, transcriptPath, sessionId,
-        range[0], range[1], runtimeConfig, cwd, { delayApplied: true },
+        range.startLine, range.endLine, runtimeConfig, cwd,
+        { delayApplied: true, rangeReason: range.reason },
       );
     } finally {
       if (agentId === 'qoder-cn') releaseRetryLock(transcriptPath);
@@ -224,11 +225,11 @@ async function main() {
 
   const runtimeConfig = loadHookRuntimeConfig(path.join(HOOKS_DIR, '..'));
 
-  const range = getLineRange(agentId, transcriptPath, sessionId);
+  const range = getLineRangeInfo(agentId, transcriptPath, sessionId);
   if (!range) return;
 
-  const [startLine] = range;
-  const endLine = range[1];
+  const startLine = range.startLine;
+  const endLine = range.endLine;
   const lines = readTranscriptLines(transcriptPath, startLine, endLine);
   logDebug(agentId, `Read ${lines.length} lines (range: ${startLine}-${endLine})`);
   if (!lines.length) {
@@ -273,19 +274,25 @@ async function main() {
       return;
     }
     try {
-      await processTranscript(agentId, logPrefix, transcriptPath, sessionId, startLine, endLine, runtimeConfig, cwd);
+      await processTranscript(
+        agentId, logPrefix, transcriptPath, sessionId, startLine, endLine,
+        runtimeConfig, cwd, { rangeReason: range.reason },
+      );
     } finally {
       releaseRetryLock(transcriptPath);
     }
     return;
   }
 
-  await processTranscript(agentId, logPrefix, transcriptPath, sessionId, startLine, endLine, runtimeConfig, cwd);
+  await processTranscript(
+    agentId, logPrefix, transcriptPath, sessionId, startLine, endLine,
+    runtimeConfig, cwd, { rangeReason: range.reason },
+  );
 }
 
 // NOTE: Retry subprocess won't race with normal hook because non-interactive mode (--print)
 // only fires Stop once per session (process exits after hook returns). The offset check in
-// getLineRange prevents double-processing if another hook invocation somehow occurs.
+// getLineRangeInfo prevents double-processing if another hook invocation somehow occurs.
 function spawnDelayedRetry(agentId, transcriptPath, sessionId, logPrefix, cwd) {
   const nodebin = process.argv[0];
   const script = fileURLToPath(import.meta.url);
@@ -407,7 +414,21 @@ async function processTranscript(agentId, logPrefix, transcriptPath, sessionId, 
   // Each real user prompt starts a new turn. Tool results stay attached to the
   // preceding turn. This ensures each turn gets its own user input instead of
   // inheriting the first prompt of the whole transcript segment.
-  const turnSegments = splitContentEventsIntoTurns(contentEvents);
+  const allTurnSegments = splitContentEventsIntoTurns(contentEvents);
+  const rangeReason = opts?.rangeReason || 'incremental';
+  // Cursor recovery always reads the full transcript to re-establish a safe
+  // checkpoint, but only the latest logical turn is new. QoderCN also rebuilds
+  // from line 0 on every completed Stop so its full ReAct chain is available;
+  // it must therefore emit only the latest logical turn even with a valid
+  // incremental cursor.
+  const turnSegments = selectTurnSegmentsForCollection(allTurnSegments, rangeReason, agentId);
+  const keepLatestTurnOnly = turnSegments.length < allTurnSegments.length;
+  if (keepLatestTurnOnly && allTurnSegments.length > turnSegments.length) {
+    const recoverySource = agentId === 'qoder-cn' && rangeReason === 'incremental'
+      ? 'QoderCN full reparse'
+      : `cursor recovery (${rangeReason})`;
+    logDebug(agentId, `${recoverySource}: skipped ${allTurnSegments.length - turnSegments.length} historical turn(s), kept latest turn`);
+  }
   logDebug(agentId, `Split transcript segment into ${turnSegments.length} turn(s)`);
 
   // --- Phase 4: Build events per turn ---
@@ -428,6 +449,14 @@ async function processTranscript(agentId, logPrefix, transcriptPath, sessionId, 
     logDebug(agentId, `Turn ${turnIdx + 1}: produced ${turnRecords.length} events, turn_id=${turnId}`);
   }
 
+  const cursorMode = rangeReason === 'incremental' ? 'incremental' : 'bootstrap';
+  const cursorBatchId = crypto.randomUUID();
+  for (const record of records) {
+    record['agent.transcript.cursor_mode'] = cursorMode;
+    record['agent.transcript.cursor_reason'] = rangeReason;
+    record['agent.transcript.cursor_batch_id'] = cursorBatchId;
+  }
+
   // --- Phase 5: Write to history ---
   const rowsToAppend = records.map(r => JSON.stringify(r));
   const success = appendRowsToHistory(agentId, logPrefix, rowsToAppend);
@@ -435,6 +464,16 @@ async function processTranscript(agentId, logPrefix, transcriptPath, sessionId, 
     logDebug(agentId, `Appended ${rowsToAppend.length} rows`);
     updateLineRecord(agentId, transcriptPath, sessionId, endLine);
   }
+}
+
+export function selectTurnSegmentsForCollection(turnSegments, rangeReason, agentId) {
+  // QoderCN intentionally reparses the complete transcript on every Stop to
+  // rebuild its ReAct chain. Other variants only do that during cursor
+  // recovery. In both cases, only the latest logical turn may be emitted.
+  if (rangeReason !== 'incremental' || agentId === 'qoder-cn') {
+    return turnSegments.slice(-1);
+  }
+  return turnSegments;
 }
 
 // --- LLM Boundary Detection --------------------------------------------------

--- a/assets/hooks/qoderwork-hook-processor.mjs
+++ b/assets/hooks/qoderwork-hook-processor.mjs
@@ -19,7 +19,7 @@ import {
   parseArgs,
   parseStdinPayload,
   logDebug,
-  getLineRange,
+  getLineRangeInfo,
   readTranscriptLines,
   appendRowsToHistory,
   updateLineRecord,
@@ -44,10 +44,10 @@ async function main() {
   const cwd = resolveQoderWorkProjectDir(rawCwd, agentId);
   const runtimeConfig = loadHookRuntimeConfig(path.join(HOOKS_DIR, '..'));
 
-  const range = getLineRange(agentId, transcriptPath, sessionId);
+  const range = getLineRangeInfo(agentId, transcriptPath, sessionId);
   if (!range) return;
 
-  const [startLine, endLine] = range;
+  const { startLine, endLine, reason: rangeReason } = range;
   const lines = readTranscriptLines(transcriptPath, startLine, endLine);
   logDebug(agentId, `Read ${lines.length} lines from ${transcriptPath} (range: ${startLine}-${endLine})`);
   if (!lines.length) {
@@ -64,7 +64,9 @@ async function main() {
     return;
   }
 
-  const records = processTranscript(parsed, sessionId, agentId, runtimeConfig, cwd);
+  const records = processTranscript(parsed, sessionId, agentId, runtimeConfig, cwd, {
+    rangeReason,
+  });
   logDebug(agentId, `Produced ${records.length} events`);
 
   const rowsToAppend = records.filter(Boolean).map(r => JSON.stringify(r));
@@ -75,7 +77,7 @@ async function main() {
   }
 }
 
-function processTranscript(parsed, sessionId, agentId, runtimeConfig, cwd) {
+function processTranscript(parsed, sessionId, agentId, runtimeConfig, cwd, opts = {}) {
   const observedTs = timestampToUnixNanos(Date.now());
   const records = [];
 
@@ -103,19 +105,35 @@ function processTranscript(parsed, sessionId, agentId, runtimeConfig, cwd) {
 
   if (!contentRows.length) return records;
 
-  // Determine user info from first row
-  const firstRow = contentRows[0];
+  // Split into turns: each user message (non tool_result) starts a new turn
+  const allTurns = splitIntoTurns(contentRows);
+  const rangeReason = opts.rangeReason || 'incremental';
+  const isBootstrap = rangeReason !== 'incremental';
+  const turns = isBootstrap ? allTurns.slice(-1) : allTurns;
+  if (isBootstrap && allTurns.length > turns.length) {
+    logDebug(agentId, `Cursor recovery (${rangeReason}): skipped ${allTurns.length - turns.length} historical turn(s), kept latest turn`);
+  }
+
+  // Bootstrap recovery may discard earlier turns, so metadata must come from
+  // the selected turn rather than the beginning of the full transcript.
+  const firstRow = turns[0]?.[0] || contentRows[0];
   const userId = resolveUserId(firstRow, runtimeConfig);
   const providerName = inferProviderName({ 'gen_ai.agent.type': agentId });
   const version = getStringValue(firstRow, 'version') || '';
-
-  // Split into turns: each user message (non tool_result) starts a new turn
-  const turns = splitIntoTurns(contentRows);
 
   for (const turn of turns) {
     const turnId = getTurnIdForRows(turn);
     const turnRecords = buildTurnEvents(turn, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, cwd, agentId);
     records.push(...turnRecords);
+  }
+
+  const cursorMode = isBootstrap ? 'bootstrap' : 'incremental';
+  const cursorBatchId = crypto.randomUUID();
+  for (const record of records) {
+    if (!record) continue;
+    record['agent.transcript.cursor_mode'] = cursorMode;
+    record['agent.transcript.cursor_reason'] = rangeReason;
+    record['agent.transcript.cursor_batch_id'] = cursorBatchId;
   }
 
   return records;

--- a/assets/hooks/shared/hook-processor-base.mjs
+++ b/assets/hooks/shared/hook-processor-base.mjs
@@ -15,9 +15,10 @@ import {
 
 const ENABLE_LOGGING = true;
 export const HOOKS_DIR = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+export const LOONGSUITE_PILOT_DATA_DIR = process.env.LOONGSUITE_PILOT_DATA_DIR
+  || path.join(os.homedir(), '.loongsuite-pilot');
 export const LOONGSUITE_PILOT_LOGS_BASE_DIR = (() => {
-  const configured = process.env.LOONGSUITE_PILOT_DATA_DIR;
-  return path.join(configured || path.join(os.homedir(), '.loongsuite-pilot'), 'logs');
+  return path.join(LOONGSUITE_PILOT_DATA_DIR, 'logs');
 })();
 
 // --- CLI argument parsing ---------------------------------------------------
@@ -71,26 +72,46 @@ export function logDebug(agentId, message) {
 // --- Line record persistence (per agent-id) ---------------------------------
 
 function lineRecordFile(agentId) {
+  return path.join(LOONGSUITE_PILOT_DATA_DIR, 'state', 'hooks', `${agentId}-line-records.json`);
+}
+
+function legacyLineRecordFile(agentId) {
   return path.join(HOOKS_DIR, `.line_records.${agentId}.json`);
 }
 
 export function loadLineRecords(agentId) {
   try {
     const f = lineRecordFile(agentId);
-    if (!fs.existsSync(f)) return {};
-    return JSON.parse(fs.readFileSync(f, 'utf-8'));
+    if (fs.existsSync(f)) return JSON.parse(fs.readFileSync(f, 'utf-8'));
+
+    // Before v1.0 the cursor lived beside the deployed hook scripts. That
+    // directory can be replaced during deployment, so migrate it lazily into
+    // the persistent data directory while old installations still have it.
+    const legacy = legacyLineRecordFile(agentId);
+    if (!fs.existsSync(legacy)) return {};
+    const records = JSON.parse(fs.readFileSync(legacy, 'utf-8'));
+    if (saveLineRecords(agentId, records)) {
+      try { fs.unlinkSync(legacy); } catch { /* best-effort migration cleanup */ }
+    }
+    return records;
   } catch {
     return {};
   }
 }
 
 export function saveLineRecords(agentId, records) {
+  let tmp = '';
   try {
     const f = lineRecordFile(agentId);
     fs.mkdirSync(path.dirname(f), { recursive: true });
-    fs.writeFileSync(f, JSON.stringify(records, null, 2), 'utf-8');
+    tmp = `${f}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(records, null, 2), 'utf-8');
+    fs.renameSync(tmp, f);
     return true;
   } catch {
+    if (tmp) {
+      try { fs.unlinkSync(tmp); } catch { /* best-effort temp cleanup */ }
+    }
     return false;
   }
 }
@@ -125,17 +146,21 @@ export function getTranscriptLineCount(transcriptPath) {
   }
 }
 
-export function getLineRange(agentId, transcriptPath, sessionId) {
+export function getLineRangeInfo(agentId, transcriptPath, sessionId) {
   const records = loadLineRecords(agentId);
   const record = records[transcriptPath] || {};
-  let lastCount = record.last_line_count || 0;
+  const hasRecordedOffset = Number.isFinite(record.last_line_count)
+    && record.last_line_count >= 0;
+  let lastCount = hasRecordedOffset ? record.last_line_count : 0;
   const recordedSession = record.session_id || '';
+  let reason = hasRecordedOffset ? 'incremental' : 'missing-cursor';
 
   const currentCount = getTranscriptLineCount(transcriptPath);
 
   if (recordedSession && recordedSession !== sessionId) {
     logDebug(agentId, `Session changed: ${recordedSession} -> ${sessionId}, reset to 0`);
     lastCount = 0;
+    reason = 'session-changed';
   }
   if (currentCount === 0) {
     logDebug(agentId, 'Transcript is empty');
@@ -148,10 +173,20 @@ export function getLineRange(agentId, transcriptPath, sessionId) {
   if (currentCount < lastCount) {
     logDebug(agentId, `File truncated (${lastCount} -> ${currentCount}), sending all`);
     lastCount = 0;
+    reason = 'truncated';
   }
 
-  logDebug(agentId, `Range: ${lastCount} -> ${currentCount}`);
-  return [lastCount, currentCount];
+  logDebug(agentId, `Range: ${lastCount} -> ${currentCount} (${reason})`);
+  return { startLine: lastCount, endLine: currentCount, reason };
+}
+
+/**
+ * Backward-compatible tuple API used by hook processors that do not need to
+ * distinguish a normal incremental read from cursor recovery.
+ */
+export function getLineRange(agentId, transcriptPath, sessionId) {
+  const info = getLineRangeInfo(agentId, transcriptPath, sessionId);
+  return info ? [info.startLine, info.endLine] : null;
 }
 
 export function readTranscriptLines(transcriptPath, startLine, endLine) {

--- a/assets/hooks/shared/hook-processor-base.mjs
+++ b/assets/hooks/shared/hook-processor-base.mjs
@@ -308,8 +308,9 @@ export function getLineRangeInfo(agentId, transcriptPath, sessionId) {
 }
 
 /**
- * Backward-compatible tuple API used by hook processors that do not need to
- * distinguish a normal incremental read from cursor recovery.
+ * Compatibility API for a transient mixed-version deployment: the shared
+ * module may be replaced before an older deployed processor that still imports
+ * the tuple form. Current in-tree processors use getLineRangeInfo().
  */
 export function getLineRange(agentId, transcriptPath, sessionId) {
   const info = getLineRangeInfo(agentId, transcriptPath, sessionId);

--- a/assets/hooks/shared/hook-processor-base.mjs
+++ b/assets/hooks/shared/hook-processor-base.mjs
@@ -7,6 +7,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import crypto from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import {
   buildQoderHookRecord,
@@ -69,44 +70,43 @@ export function logDebug(agentId, message) {
   } catch { /* best-effort */ }
 }
 
-// --- Line record persistence (per agent-id) ---------------------------------
+// --- Line record persistence (per agent-id and session) ---------------------
 
-function lineRecordFile(agentId) {
+function aggregateLineRecordFile(agentId) {
   return path.join(LOONGSUITE_PILOT_DATA_DIR, 'state', 'hooks', `${agentId}-line-records.json`);
 }
 
-function legacyLineRecordFile(agentId) {
+function deployedLegacyLineRecordFile(agentId) {
   return path.join(HOOKS_DIR, `.line_records.${agentId}.json`);
 }
 
-export function loadLineRecords(agentId) {
-  try {
-    const f = lineRecordFile(agentId);
-    if (fs.existsSync(f)) return JSON.parse(fs.readFileSync(f, 'utf-8'));
+function sessionLineRecordDir(agentId) {
+  return path.join(LOONGSUITE_PILOT_DATA_DIR, 'state', 'hooks', `${agentId}-line-records`);
+}
 
-    // Before v1.0 the cursor lived beside the deployed hook scripts. That
-    // directory can be replaced during deployment, so migrate it lazily into
-    // the persistent data directory while old installations still have it.
-    const legacy = legacyLineRecordFile(agentId);
-    if (!fs.existsSync(legacy)) return {};
-    const records = JSON.parse(fs.readFileSync(legacy, 'utf-8'));
-    if (saveLineRecords(agentId, records)) {
-      try { fs.unlinkSync(legacy); } catch { /* best-effort migration cleanup */ }
-    }
-    return records;
+function sessionLineRecordFile(agentId, sessionId) {
+  const sessionHash = crypto.createHash('sha256').update(sessionId).digest('hex');
+  return path.join(sessionLineRecordDir(agentId), `${sessionHash}.json`);
+}
+
+function readJsonObject(file) {
+  try {
+    if (!fs.existsSync(file)) return null;
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
   } catch {
-    return {};
+    return null;
   }
 }
 
-export function saveLineRecords(agentId, records) {
+function saveSessionLineRecord(agentId, sessionId, record) {
+  const file = sessionLineRecordFile(agentId, sessionId);
   let tmp = '';
   try {
-    const f = lineRecordFile(agentId);
-    fs.mkdirSync(path.dirname(f), { recursive: true });
-    tmp = `${f}.${process.pid}.${Date.now()}.tmp`;
-    fs.writeFileSync(tmp, JSON.stringify(records, null, 2), 'utf-8');
-    fs.renameSync(tmp, f);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(record, null, 2), 'utf-8');
+    fs.renameSync(tmp, file);
     return true;
   } catch {
     if (tmp) {
@@ -116,14 +116,66 @@ export function saveLineRecords(agentId, records) {
   }
 }
 
+function migrateAggregateLineRecords(agentId) {
+  const sources = [
+    aggregateLineRecordFile(agentId),
+    deployedLegacyLineRecordFile(agentId),
+  ];
+
+  for (const source of sources) {
+    const records = readJsonObject(source);
+    if (!records) continue;
+
+    let migratedAll = true;
+    for (const [transcriptPath, value] of Object.entries(records)) {
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        migratedAll = false;
+        continue;
+      }
+      const sessionId = typeof value.session_id === 'string' ? value.session_id : '';
+      if (!sessionId) {
+        migratedAll = false;
+        continue;
+      }
+
+      const target = sessionLineRecordFile(agentId, sessionId);
+      if (fs.existsSync(target)) continue;
+      const migrated = saveSessionLineRecord(agentId, sessionId, {
+        ...value,
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+      });
+      if (!migrated) migratedAll = false;
+    }
+
+    if (migratedAll) {
+      try { fs.unlinkSync(source); } catch { /* best-effort migration cleanup */ }
+    }
+  }
+}
+
+export function loadLineRecord(agentId, sessionId) {
+  if (!sessionId) return {};
+  const file = sessionLineRecordFile(agentId, sessionId);
+  const persisted = readJsonObject(file);
+  if (persisted) return persisted;
+
+  // Older releases stored every transcript in one per-agent JSON object,
+  // either in the persistent state directory or beside the deployed hooks.
+  // Split those maps lazily into independent session files so concurrent Stop
+  // hooks for different sessions never overwrite each other's cursor.
+  migrateAggregateLineRecords(agentId);
+  return readJsonObject(file) || {};
+}
+
 export function updateLineRecord(agentId, transcriptPath, sessionId, endLine) {
-  const records = loadLineRecords(agentId);
-  records[transcriptPath] = {
+  const record = {
     session_id: sessionId,
+    transcript_path: transcriptPath,
     last_line_count: endLine,
     updated_at: new Date().toISOString().replace('T', ' ').replace(/\.\d+Z$/, ''),
   };
-  const ok = saveLineRecords(agentId, records);
+  const ok = saveSessionLineRecord(agentId, sessionId, record);
   if (ok) logDebug(agentId, `Updated record: ${transcriptPath} -> ${endLine} lines`);
   else logDebug(agentId, 'Warning: Failed to save line records');
   return ok;
@@ -147,12 +199,12 @@ export function getTranscriptLineCount(transcriptPath) {
 }
 
 export function getLineRangeInfo(agentId, transcriptPath, sessionId) {
-  const records = loadLineRecords(agentId);
-  const record = records[transcriptPath] || {};
+  const record = loadLineRecord(agentId, sessionId);
   const hasRecordedOffset = Number.isFinite(record.last_line_count)
     && record.last_line_count >= 0;
   let lastCount = hasRecordedOffset ? record.last_line_count : 0;
   const recordedSession = record.session_id || '';
+  const recordedTranscript = record.transcript_path || '';
   let reason = hasRecordedOffset ? 'incremental' : 'missing-cursor';
 
   const currentCount = getTranscriptLineCount(transcriptPath);
@@ -161,6 +213,11 @@ export function getLineRangeInfo(agentId, transcriptPath, sessionId) {
     logDebug(agentId, `Session changed: ${recordedSession} -> ${sessionId}, reset to 0`);
     lastCount = 0;
     reason = 'session-changed';
+  }
+  if (recordedTranscript && recordedTranscript !== transcriptPath) {
+    logDebug(agentId, `Transcript changed for session ${sessionId}, reset to 0`);
+    lastCount = 0;
+    reason = 'transcript-changed';
   }
   if (currentCount === 0) {
     logDebug(agentId, 'Transcript is empty');

--- a/assets/hooks/shared/hook-processor-base.mjs
+++ b/assets/hooks/shared/hook-processor-base.mjs
@@ -99,13 +99,12 @@ function readJsonObject(file) {
   }
 }
 
-function saveSessionLineRecord(agentId, sessionId, record) {
-  const file = sessionLineRecordFile(agentId, sessionId);
+function saveJsonObject(file, value) {
   let tmp = '';
   try {
     fs.mkdirSync(path.dirname(file), { recursive: true });
     tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
-    fs.writeFileSync(tmp, JSON.stringify(record, null, 2), 'utf-8');
+    fs.writeFileSync(tmp, JSON.stringify(value, null, 2), 'utf-8');
     fs.renameSync(tmp, file);
     return true;
   } catch {
@@ -116,7 +115,11 @@ function saveSessionLineRecord(agentId, sessionId, record) {
   }
 }
 
-function migrateAggregateLineRecords(agentId) {
+function saveSessionLineRecord(agentId, sessionId, record) {
+  return saveJsonObject(sessionLineRecordFile(agentId, sessionId), record);
+}
+
+function reconcileAggregateLineRecord(agentId, requestedSessionId) {
   const sources = [
     aggregateLineRecordFile(agentId),
     deployedLegacyLineRecordFile(agentId),
@@ -126,45 +129,104 @@ function migrateAggregateLineRecords(agentId) {
     const records = readJsonObject(source);
     if (!records) continue;
 
-    let migratedAll = true;
     for (const [transcriptPath, value] of Object.entries(records)) {
-      if (!value || typeof value !== 'object' || Array.isArray(value)) {
-        migratedAll = false;
-        continue;
-      }
+      if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
       const sessionId = typeof value.session_id === 'string' ? value.session_id : '';
-      if (!sessionId) {
-        migratedAll = false;
-        continue;
-      }
+      if (!sessionId || sessionId !== requestedSessionId) continue;
 
       const target = sessionLineRecordFile(agentId, sessionId);
-      if (fs.existsSync(target)) continue;
-      const migrated = saveSessionLineRecord(agentId, sessionId, {
+      const existing = readJsonObject(target);
+      const candidate = {
         ...value,
         session_id: sessionId,
         transcript_path: transcriptPath,
-      });
-      if (!migrated) migratedAll = false;
-    }
-
-    if (migratedAll) {
-      try { fs.unlinkSync(source); } catch { /* best-effort migration cleanup */ }
+      };
+      if (!existing || isLineRecordNewer(candidate, existing)) {
+        saveSessionLineRecord(agentId, sessionId, candidate);
+      }
     }
   }
+}
+
+function isLineRecordNewer(candidate, existing) {
+  if (candidate.transcript_path === existing.transcript_path) {
+    // Cursor progress for one transcript is monotonic. An older implementation
+    // may write a later timestamp with a stale line count after a concurrent
+    // read-modify-write, but that must never rewind the per-session primary.
+    return Number(candidate.last_line_count) > Number(existing.last_line_count);
+  }
+
+  const candidateUpdated = typeof candidate.updated_at === 'string' ? candidate.updated_at : '';
+  const existingUpdated = typeof existing.updated_at === 'string' ? existing.updated_at : '';
+  return Boolean(candidateUpdated)
+    && (!existingUpdated || candidateUpdated > existingUpdated);
+}
+
+const LOCK_WAIT_ARRAY = new Int32Array(new SharedArrayBuffer(4));
+
+function updateAggregateShadow(file, transcriptPath, record) {
+  const lockFile = `${file}.lock`;
+  const deadline = Date.now() + 1_000;
+  let acquired = false;
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    while (!acquired) {
+      try {
+        const fd = fs.openSync(lockFile, 'wx');
+        fs.closeSync(fd);
+        acquired = true;
+      } catch (err) {
+        if (err?.code !== 'EEXIST') return false;
+        try {
+          const stat = fs.statSync(lockFile);
+          if (Date.now() - stat.mtimeMs > 30_000) {
+            fs.unlinkSync(lockFile);
+            continue;
+          }
+        } catch { /* retry acquisition */ }
+        if (Date.now() >= deadline) return false;
+        Atomics.wait(LOCK_WAIT_ARRAY, 0, 0, 10);
+      }
+    }
+
+    const records = readJsonObject(file) || {};
+    const existing = records[transcriptPath];
+    if (existing?.session_id === record.session_id
+      && Number(existing.last_line_count) > Number(record.last_line_count)) {
+      return true;
+    }
+    records[transcriptPath] = {
+      session_id: record.session_id,
+      last_line_count: record.last_line_count,
+      updated_at: record.updated_at,
+    };
+    return saveJsonObject(file, records);
+  } finally {
+    if (acquired) {
+      try { fs.unlinkSync(lockFile); } catch { /* best-effort lock cleanup */ }
+    }
+  }
+}
+
+function rollbackShadowFiles(agentId) {
+  const files = [aggregateLineRecordFile(agentId)];
+  const deployedHooksDir = path.join(LOONGSUITE_PILOT_DATA_DIR, 'hooks');
+  if (path.resolve(HOOKS_DIR) === path.resolve(deployedHooksDir)) {
+    files.push(deployedLegacyLineRecordFile(agentId));
+  }
+  return files;
 }
 
 export function loadLineRecord(agentId, sessionId) {
   if (!sessionId) return {};
   const file = sessionLineRecordFile(agentId, sessionId);
-  const persisted = readJsonObject(file);
-  if (persisted) return persisted;
 
   // Older releases stored every transcript in one per-agent JSON object,
   // either in the persistent state directory or beside the deployed hooks.
-  // Split those maps lazily into independent session files so concurrent Stop
-  // hooks for different sessions never overwrite each other's cursor.
-  migrateAggregateLineRecords(agentId);
+  // Reconcile the requested session lazily. The aggregate files remain as
+  // locked rollback shadows, so a forward upgrade after an old-version rollback
+  // can recover any cursor advances made while that version was active.
+  reconcileAggregateLineRecord(agentId, sessionId);
   return readJsonObject(file) || {};
 }
 
@@ -176,8 +238,16 @@ export function updateLineRecord(agentId, transcriptPath, sessionId, endLine) {
     updated_at: new Date().toISOString().replace('T', ' ').replace(/\.\d+Z$/, ''),
   };
   const ok = saveSessionLineRecord(agentId, sessionId, record);
-  if (ok) logDebug(agentId, `Updated record: ${transcriptPath} -> ${endLine} lines`);
-  else logDebug(agentId, 'Warning: Failed to save line records');
+  if (ok) {
+    logDebug(agentId, `Updated record: ${transcriptPath} -> ${endLine} lines`);
+    for (const shadow of rollbackShadowFiles(agentId)) {
+      if (!updateAggregateShadow(shadow, transcriptPath, record)) {
+        logDebug(agentId, `Warning: Failed to update rollback cursor shadow ${shadow}`);
+      }
+    }
+  } else {
+    logDebug(agentId, 'Warning: Failed to save line records');
+  }
   return ok;
 }
 

--- a/assets/skills/loongsuite-pilot-ops/references/qoder-diagnostics.md
+++ b/assets/skills/loongsuite-pilot-ops/references/qoder-diagnostics.md
@@ -124,7 +124,7 @@ tail -2 ~/.loongsuite-pilot/logs/qoder/history/qoder-$(date -u +%Y-%m-%d).jsonl 
 processor 的增量状态保存在：
 
 ```bash
-cat ~/.loongsuite-pilot/hooks/.line_records.qoder.json
+cat ~/.loongsuite-pilot/state/hooks/qoder-line-records.json
 # 每个 transcript_path → { session_id, last_line_count, updated_at }
 ```
 
@@ -335,7 +335,7 @@ ls -la "${XDG_CONFIG_HOME:-$HOME/.config}/Qoder"
 | `~/.qoder/logs/sessions/<cwd>/<session>/segments/*.jsonl` | Qoder CLI 原生 transcript + token 事件（`qoder-trace` / `qoder-cli-session` 读取） |
 | `~/.loongsuite-pilot/hooks/qoder-loongsuite-pilot-hook.sh` | Qoder Hook shell 入口 |
 | `~/.loongsuite-pilot/hooks/qoder-hook-processor.mjs` | Qoder 专用 transcript forwarder（从 stdin 拿 transcript_path，增量 append 到 history） |
-| `~/.loongsuite-pilot/hooks/.line_records.qoder.json` | processor 的增量行记录状态 |
+| `~/.loongsuite-pilot/state/hooks/qoder-line-records.json` | processor 的增量行记录状态（持久目录，部署升级不会覆盖） |
 | `~/.loongsuite-pilot/logs/qoder/history/qoder-YYYY-MM-DD.jsonl` | transcript 转发后的 history（`qoder-trace` / `qoder-cli-hook` 读取） |
 | `~/.loongsuite-pilot/logs/qoder/debug/qoder-debug-*.log` | processor 调试日志 |
 | `~/Library/Application Support/Qoder/SharedClientCache/cache/db/local.db` | Qoder IDE SQLite token 数据源 |

--- a/assets/skills/loongsuite-pilot-ops/references/qoder-diagnostics.md
+++ b/assets/skills/loongsuite-pilot-ops/references/qoder-diagnostics.md
@@ -129,6 +129,9 @@ cat ~/.loongsuite-pilot/state/hooks/qoder-line-records/*.json
 # 每个文件对应一个 session，内容含 session_id、transcript_path、last_line_count、updated_at
 ```
 
+同目录下的 `qoder-line-records.json` 是加锁维护的旧版本回滚兼容影子；当前版本以
+`qoder-line-records/*.json` 为主状态。
+
 若 history 为空但 sessions 有数据：
 - hook 从未被触发 → 检查第 2.A.1 的 settings.json
 - hook 被触发但 transcript_path 或 session_id 缺失 → 看 debug 日志：
@@ -337,6 +340,7 @@ ls -la "${XDG_CONFIG_HOME:-$HOME/.config}/Qoder"
 | `~/.loongsuite-pilot/hooks/qoder-loongsuite-pilot-hook.sh` | Qoder Hook shell 入口 |
 | `~/.loongsuite-pilot/hooks/qoder-hook-processor.mjs` | Qoder 专用 transcript forwarder（从 stdin 拿 transcript_path，增量 append 到 history） |
 | `~/.loongsuite-pilot/state/hooks/qoder-line-records/*.json` | processor 的 per-session 增量行记录状态（持久目录，部署升级不会覆盖） |
+| `~/.loongsuite-pilot/state/hooks/qoder-line-records.json` | 旧版本回滚兼容影子（加锁更新，非当前主状态） |
 | `~/.loongsuite-pilot/logs/qoder/history/qoder-YYYY-MM-DD.jsonl` | transcript 转发后的 history（`qoder-trace` / `qoder-cli-hook` 读取） |
 | `~/.loongsuite-pilot/logs/qoder/debug/qoder-debug-*.log` | processor 调试日志 |
 | `~/Library/Application Support/Qoder/SharedClientCache/cache/db/local.db` | Qoder IDE SQLite token 数据源 |

--- a/assets/skills/loongsuite-pilot-ops/references/qoder-diagnostics.md
+++ b/assets/skills/loongsuite-pilot-ops/references/qoder-diagnostics.md
@@ -124,8 +124,9 @@ tail -2 ~/.loongsuite-pilot/logs/qoder/history/qoder-$(date -u +%Y-%m-%d).jsonl 
 processor 的增量状态保存在：
 
 ```bash
-cat ~/.loongsuite-pilot/state/hooks/qoder-line-records.json
-# 每个 transcript_path → { session_id, last_line_count, updated_at }
+ls -la ~/.loongsuite-pilot/state/hooks/qoder-line-records/
+cat ~/.loongsuite-pilot/state/hooks/qoder-line-records/*.json
+# 每个文件对应一个 session，内容含 session_id、transcript_path、last_line_count、updated_at
 ```
 
 若 history 为空但 sessions 有数据：
@@ -335,7 +336,7 @@ ls -la "${XDG_CONFIG_HOME:-$HOME/.config}/Qoder"
 | `~/.qoder/logs/sessions/<cwd>/<session>/segments/*.jsonl` | Qoder CLI 原生 transcript + token 事件（`qoder-trace` / `qoder-cli-session` 读取） |
 | `~/.loongsuite-pilot/hooks/qoder-loongsuite-pilot-hook.sh` | Qoder Hook shell 入口 |
 | `~/.loongsuite-pilot/hooks/qoder-hook-processor.mjs` | Qoder 专用 transcript forwarder（从 stdin 拿 transcript_path，增量 append 到 history） |
-| `~/.loongsuite-pilot/state/hooks/qoder-line-records.json` | processor 的增量行记录状态（持久目录，部署升级不会覆盖） |
+| `~/.loongsuite-pilot/state/hooks/qoder-line-records/*.json` | processor 的 per-session 增量行记录状态（持久目录，部署升级不会覆盖） |
 | `~/.loongsuite-pilot/logs/qoder/history/qoder-YYYY-MM-DD.jsonl` | transcript 转发后的 history（`qoder-trace` / `qoder-cli-hook` 读取） |
 | `~/.loongsuite-pilot/logs/qoder/debug/qoder-debug-*.log` | processor 调试日志 |
 | `~/Library/Application Support/Qoder/SharedClientCache/cache/db/local.db` | Qoder IDE SQLite token 数据源 |

--- a/assets/skills/loongsuite-pilot-ops/references/qoder-work-cn-diagnostics.md
+++ b/assets/skills/loongsuite-pilot-ops/references/qoder-work-cn-diagnostics.md
@@ -217,6 +217,7 @@ ls -la ~/.loongsuite-pilot/logs/output/ | grep qoder-work-cn
 | `~/.loongsuite-pilot/hooks/qoderworkcn-loongsuite-pilot-hook.sh` | Qoder Work CN 专用 shell 入口 |
 | `~/.loongsuite-pilot/hooks/qoderwork-hook-processor.mjs` | 共享 transcript forwarder |
 | `~/.loongsuite-pilot/state/hooks/qoder-work-cn-line-records/*.json` | processor 的 per-session 增量行记录状态（持久目录，部署升级不会覆盖） |
+| `~/.loongsuite-pilot/state/hooks/qoder-work-cn-line-records.json` | 旧版本回滚兼容影子（加锁更新，非当前主状态） |
 | `~/.loongsuite-pilot/logs/qoder-work-cn/history/qoder-work-cn-YYYY-MM-DD.jsonl` | Hook 转发后的 history |
 | `~/Library/Application Support/QoderWork CN/logs/` | SDK log tail 数据源（macOS） |
 | `~/Library/Application Support/QoderWork CN/data/agents.db` | SQLite fallback 数据源（macOS） |

--- a/assets/skills/loongsuite-pilot-ops/references/qoder-work-cn-diagnostics.md
+++ b/assets/skills/loongsuite-pilot-ops/references/qoder-work-cn-diagnostics.md
@@ -216,7 +216,7 @@ ls -la ~/.loongsuite-pilot/logs/output/ | grep qoder-work-cn
 | `~/.qoderworkcn/settings.json` | Qoder Work CN 的 Stop hook 注册（nested 格式） |
 | `~/.loongsuite-pilot/hooks/qoderworkcn-loongsuite-pilot-hook.sh` | Qoder Work CN 专用 shell 入口 |
 | `~/.loongsuite-pilot/hooks/qoderwork-hook-processor.mjs` | 共享 transcript forwarder |
-| `~/.loongsuite-pilot/hooks/.line_records.qoder-work-cn.json` | processor 的 per-transcript 增量行记录状态 |
+| `~/.loongsuite-pilot/state/hooks/qoder-work-cn-line-records/*.json` | processor 的 per-session 增量行记录状态（持久目录，部署升级不会覆盖） |
 | `~/.loongsuite-pilot/logs/qoder-work-cn/history/qoder-work-cn-YYYY-MM-DD.jsonl` | Hook 转发后的 history |
 | `~/Library/Application Support/QoderWork CN/logs/` | SDK log tail 数据源（macOS） |
 | `~/Library/Application Support/QoderWork CN/data/agents.db` | SQLite fallback 数据源（macOS） |

--- a/assets/skills/loongsuite-pilot-ops/references/qoderwork-diagnostics.md
+++ b/assets/skills/loongsuite-pilot-ops/references/qoderwork-diagnostics.md
@@ -141,6 +141,9 @@ cat ~/.loongsuite-pilot/state/hooks/qoder-work-line-records/*.json
 # 每个文件对应一个 session，内容含 session_id、transcript_path、last_line_count、updated_at
 ```
 
+同目录下的 `qoder-work-line-records.json` 是加锁维护的旧版本回滚兼容影子；当前版本以
+`qoder-work-line-records/*.json` 为主状态，排障时不要把两者混为同一个游标文件。
+
 若 history 目录**不存在**或**完全为空**：
 
 - 用户在 hook 注入之后**从未触发过 Stop**（没结束过对话）→ 让用户在 Qoder Work
@@ -358,6 +361,7 @@ env | grep LOONGSUITE_PILOT
 | `~/.loongsuite-pilot/hooks/qoderwork-loongsuite-pilot-hook.sh` | Qoder Work 专用的 shell 入口（pilot 维护） |
 | `~/.loongsuite-pilot/hooks/qoderwork-hook-processor.mjs` | Qoder Work 专用 transcript forwarder（从 stdin 拿 `transcript_path`，增量 append 到 history） |
 | `~/.loongsuite-pilot/state/hooks/qoder-work-line-records/*.json` | processor 的 per-session 增量行记录状态（持久目录） |
+| `~/.loongsuite-pilot/state/hooks/qoder-work-line-records.json` | 旧版本回滚兼容影子（加锁更新，非当前主状态） |
 | `~/.loongsuite-pilot/logs/qoder-work/history/qoder-work-YYYY-MM-DD.jsonl` | transcript 转发后的 history（`qoder-work-trace` 默认读取；trace 关闭时 `qoder-work-hook` fallback 读取） |
 | `~/.loongsuite-pilot/logs/qoder-work/debug/qoder-work-debug-*.log` | processor 调试日志 |
 | `~/.loongsuite-pilot/logs/qoder-work/errors/qoder-work-error-*.log` | processor 错误日志（fail-open，不阻塞 Qoder Work） |

--- a/assets/skills/loongsuite-pilot-ops/references/qoderwork-diagnostics.md
+++ b/assets/skills/loongsuite-pilot-ops/references/qoderwork-diagnostics.md
@@ -39,7 +39,7 @@ Qoder Work
 | Hook 注册 | `~/.qoderwork/settings.json` 的 `hooks.Stop`（nested 格式） | pilot 启动时检测到 `~/.qoderwork/` 存在自动注入 |
 | Hook 脚本 | `~/.loongsuite-pilot/hooks/qoderwork-loongsuite-pilot-hook.sh` | pilot 安装/升级时拷贝 |
 | Hook processor | `~/.loongsuite-pilot/hooks/qoderwork-hook-processor.mjs` | pilot 安装/升级时拷贝 |
-| Processor 游标 | `~/.loongsuite-pilot/hooks/.line_records.qoder-work.json` | processor 每次成功 append 后更新 |
+| Processor 游标 | `~/.loongsuite-pilot/state/hooks/qoder-work-line-records.json` | processor 每次成功 append 后更新；部署升级不会覆盖 |
 | History JSONL | `~/.loongsuite-pilot/logs/qoder-work/history/qoder-work-YYYY-MM-DD.jsonl` | processor 增量 append，`qoder-work-trace` 默认读取 |
 | Session segments | `~/.qoderwork/logs/sessions/` | Qoder Work 应用自身写入，`qoder-work-trace` 用于 token/timing enrichment |
 | SDK log | Qoder Work 应用 logs 目录 | Qoder Work 应用自身写入，trace 关闭时 `qoder-work-log` fallback 才单独启动 |
@@ -136,7 +136,7 @@ tail -2 ~/.loongsuite-pilot/logs/qoder-work/history/qoder-work-$(date -u +%Y-%m-
 processor 的增量状态保存在：
 
 ```bash
-cat ~/.loongsuite-pilot/hooks/.line_records.qoder-work.json
+cat ~/.loongsuite-pilot/state/hooks/qoder-work-line-records.json
 # 每个 transcript_path → { session_id, last_line_count, updated_at }
 ```
 
@@ -356,7 +356,7 @@ env | grep LOONGSUITE_PILOT
 | `~/.qoderwork/settings.json` | Qoder Work 的 hook 注册（`hooks.Stop`，nested 格式） |
 | `~/.loongsuite-pilot/hooks/qoderwork-loongsuite-pilot-hook.sh` | Qoder Work 专用的 shell 入口（pilot 维护） |
 | `~/.loongsuite-pilot/hooks/qoderwork-hook-processor.mjs` | Qoder Work 专用 transcript forwarder（从 stdin 拿 `transcript_path`，增量 append 到 history） |
-| `~/.loongsuite-pilot/hooks/.line_records.qoder-work.json` | processor 的 per-transcript 增量行记录状态 |
+| `~/.loongsuite-pilot/state/hooks/qoder-work-line-records.json` | processor 的 per-transcript 增量行记录状态（持久目录） |
 | `~/.loongsuite-pilot/logs/qoder-work/history/qoder-work-YYYY-MM-DD.jsonl` | transcript 转发后的 history（`qoder-work-trace` 默认读取；trace 关闭时 `qoder-work-hook` fallback 读取） |
 | `~/.loongsuite-pilot/logs/qoder-work/debug/qoder-work-debug-*.log` | processor 调试日志 |
 | `~/.loongsuite-pilot/logs/qoder-work/errors/qoder-work-error-*.log` | processor 错误日志（fail-open，不阻塞 Qoder Work） |

--- a/assets/skills/loongsuite-pilot-ops/references/qoderwork-diagnostics.md
+++ b/assets/skills/loongsuite-pilot-ops/references/qoderwork-diagnostics.md
@@ -39,7 +39,7 @@ Qoder Work
 | Hook 注册 | `~/.qoderwork/settings.json` 的 `hooks.Stop`（nested 格式） | pilot 启动时检测到 `~/.qoderwork/` 存在自动注入 |
 | Hook 脚本 | `~/.loongsuite-pilot/hooks/qoderwork-loongsuite-pilot-hook.sh` | pilot 安装/升级时拷贝 |
 | Hook processor | `~/.loongsuite-pilot/hooks/qoderwork-hook-processor.mjs` | pilot 安装/升级时拷贝 |
-| Processor 游标 | `~/.loongsuite-pilot/state/hooks/qoder-work-line-records.json` | processor 每次成功 append 后更新；部署升级不会覆盖 |
+| Processor 游标 | `~/.loongsuite-pilot/state/hooks/qoder-work-line-records/*.json` | 每个 session 一个状态文件；processor 成功 append 后更新，部署升级不会覆盖 |
 | History JSONL | `~/.loongsuite-pilot/logs/qoder-work/history/qoder-work-YYYY-MM-DD.jsonl` | processor 增量 append，`qoder-work-trace` 默认读取 |
 | Session segments | `~/.qoderwork/logs/sessions/` | Qoder Work 应用自身写入，`qoder-work-trace` 用于 token/timing enrichment |
 | SDK log | Qoder Work 应用 logs 目录 | Qoder Work 应用自身写入，trace 关闭时 `qoder-work-log` fallback 才单独启动 |
@@ -136,8 +136,9 @@ tail -2 ~/.loongsuite-pilot/logs/qoder-work/history/qoder-work-$(date -u +%Y-%m-
 processor 的增量状态保存在：
 
 ```bash
-cat ~/.loongsuite-pilot/state/hooks/qoder-work-line-records.json
-# 每个 transcript_path → { session_id, last_line_count, updated_at }
+ls -la ~/.loongsuite-pilot/state/hooks/qoder-work-line-records/
+cat ~/.loongsuite-pilot/state/hooks/qoder-work-line-records/*.json
+# 每个文件对应一个 session，内容含 session_id、transcript_path、last_line_count、updated_at
 ```
 
 若 history 目录**不存在**或**完全为空**：
@@ -356,7 +357,7 @@ env | grep LOONGSUITE_PILOT
 | `~/.qoderwork/settings.json` | Qoder Work 的 hook 注册（`hooks.Stop`，nested 格式） |
 | `~/.loongsuite-pilot/hooks/qoderwork-loongsuite-pilot-hook.sh` | Qoder Work 专用的 shell 入口（pilot 维护） |
 | `~/.loongsuite-pilot/hooks/qoderwork-hook-processor.mjs` | Qoder Work 专用 transcript forwarder（从 stdin 拿 `transcript_path`，增量 append 到 history） |
-| `~/.loongsuite-pilot/state/hooks/qoder-work-line-records.json` | processor 的 per-transcript 增量行记录状态（持久目录） |
+| `~/.loongsuite-pilot/state/hooks/qoder-work-line-records/*.json` | processor 的 per-session 增量行记录状态（持久目录） |
 | `~/.loongsuite-pilot/logs/qoder-work/history/qoder-work-YYYY-MM-DD.jsonl` | transcript 转发后的 history（`qoder-work-trace` 默认读取；trace 关闭时 `qoder-work-hook` fallback 读取） |
 | `~/.loongsuite-pilot/logs/qoder-work/debug/qoder-work-debug-*.log` | processor 调试日志 |
 | `~/.loongsuite-pilot/logs/qoder-work/errors/qoder-work-error-*.log` | processor 错误日志（fail-open，不阻塞 Qoder Work） |

--- a/src/inputs/base/bootstrap-turn-filter.ts
+++ b/src/inputs/base/bootstrap-turn-filter.ts
@@ -1,0 +1,38 @@
+import type { AgentActivityEntry } from '../../types/index.js';
+
+/**
+ * Keep only the latest logical turn from each hook cursor-recovery batch.
+ *
+ * The hook processor normally performs this reduction before writing JSONL.
+ * This is a second, batch-scoped safety boundary in the Trace Input so a later
+ * old session cannot replay history merely because the input's global file
+ * offset was already initialized by an earlier session.
+ */
+export function filterBootstrapHistoryTurns(
+  entries: AgentActivityEntry[],
+): AgentActivityEntry[] {
+  const latestTurnByBatch = new Map<string, string>();
+
+  for (const entry of entries) {
+    if (entry['agent.transcript.cursor_mode'] !== 'bootstrap') continue;
+    const batchId = nonEmptyString(entry['agent.transcript.cursor_batch_id']);
+    const turnId = nonEmptyString(entry['gen_ai.turn.id']);
+    if (batchId && turnId) latestTurnByBatch.set(batchId, turnId);
+  }
+
+  if (latestTurnByBatch.size === 0) return entries;
+
+  return entries.filter(entry => {
+    if (entry['agent.transcript.cursor_mode'] !== 'bootstrap') return true;
+    const batchId = nonEmptyString(entry['agent.transcript.cursor_batch_id']);
+    const turnId = nonEmptyString(entry['gen_ai.turn.id']);
+    // Fail open for mixed-version or malformed records. Without both fields we
+    // cannot safely distinguish separate transcript invocations.
+    if (!batchId || !turnId) return true;
+    return latestTurnByBatch.get(batchId) === turnId;
+  });
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}

--- a/src/inputs/base/hook-history-checkpoint.ts
+++ b/src/inputs/base/hook-history-checkpoint.ts
@@ -1,0 +1,58 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type { InputState } from '../../types/index.js';
+import { getTodayDateString } from '../../utils/fs-utils.js';
+
+export interface HookHistoryStartupCheckpoint {
+  state: InputState;
+  skippedExistingBytes: number;
+}
+
+/**
+ * Establish a deterministic consumer boundary before the first collection.
+ *
+ * A missing checkpoint plus an existing history file is ambiguous: the file
+ * may contain records dispatched before state loss as well as records written
+ * while the collector was down. Guessing a logical turn is not a safe recovery
+ * rule, so the no-replay policy baselines the existing bytes and reports the
+ * skipped size to the caller for diagnostics. If the file does not exist yet,
+ * persisting offset 0 ensures every batch created after startup is consumed.
+ */
+export async function createHookHistoryStartupCheckpoint(
+  current: InputState,
+  logDir: string,
+  logPrefix: string,
+): Promise<HookHistoryStartupCheckpoint | null> {
+  if (hasUsableCheckpoint(current)) return null;
+
+  const logFileName = `${logPrefix}-${getTodayDateString()}.jsonl`;
+  const logFile = path.join(logDir, logFileName);
+  let existingBytes = 0;
+  try {
+    existingBytes = (await fs.stat(logFile)).size;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    // The hook creates the daily file lazily. Offset 0 is the important part:
+    // it marks initialization now, before multiple sessions can append batches.
+  }
+
+  return {
+    state: {
+      ...current,
+      lastFile: logFileName,
+      lastOffset: existingBytes,
+      extra: {
+        ...(current.extra ?? {}),
+        hookHistoryInitialized: true,
+      },
+    },
+    skippedExistingBytes: existingBytes,
+  };
+}
+
+function hasUsableCheckpoint(state: InputState): boolean {
+  return typeof state.lastFile === 'string'
+    && state.lastFile.length > 0
+    && Number.isFinite(state.lastOffset)
+    && (state.lastOffset ?? -1) >= 0;
+}

--- a/src/inputs/qoder-cn-trace/qoder-cn-trace-input.ts
+++ b/src/inputs/qoder-cn-trace/qoder-cn-trace-input.ts
@@ -6,6 +6,7 @@ import { BaseInput, type InputOptions } from '../base/base-input.js';
 import { resolveHome, directoryExists, ensureDir } from '../../utils/fs-utils.js';
 import { getTodayDateString } from '../../utils/fs-utils.js';
 import { buildCanonicalHookEntry } from '../base/canonical-hook-record.js';
+import { filterBootstrapHistoryTurns } from '../base/bootstrap-turn-filter.js';
 import { enrichCanonicalEntryWithGit } from '../../normalization/enrich-git-context.js';
 import { readSqliteTokensForSession } from './sqlite-token-reader.js';
 import { enrichIdeTurn, injectTraceId } from '../qoder-trace/token-enricher.js';
@@ -223,7 +224,7 @@ export class QoderCnTraceInput extends BaseInput {
       await handle.close();
     }
 
-    return entries;
+    return filterBootstrapHistoryTurns(entries);
   }
 
   // ─── Record transformation ──────────────────────────────────────────────────
@@ -438,5 +439,4 @@ function expandContainerTimes(entries: AgentActivityEntry[]): void {
     }
   }
 }
-
 

--- a/src/inputs/qoder-cn-trace/qoder-cn-trace-input.ts
+++ b/src/inputs/qoder-cn-trace/qoder-cn-trace-input.ts
@@ -7,6 +7,7 @@ import { resolveHome, directoryExists, ensureDir } from '../../utils/fs-utils.js
 import { getTodayDateString } from '../../utils/fs-utils.js';
 import { buildCanonicalHookEntry } from '../base/canonical-hook-record.js';
 import { filterBootstrapHistoryTurns } from '../base/bootstrap-turn-filter.js';
+import { createHookHistoryStartupCheckpoint } from '../base/hook-history-checkpoint.js';
 import { enrichCanonicalEntryWithGit } from '../../normalization/enrich-git-context.js';
 import { readSqliteTokensForSession } from './sqlite-token-reader.js';
 import { enrichIdeTurn, injectTraceId } from '../qoder-trace/token-enricher.js';
@@ -55,6 +56,20 @@ export class QoderCnTraceInput extends BaseInput {
 
   protected override async onStart(): Promise<void> {
     await ensureDir(this.logDir);
+    const checkpoint = await createHookHistoryStartupCheckpoint(
+      this.getState(),
+      this.logDir,
+      this.logPrefix,
+    );
+    if (!checkpoint) return;
+    this.setState(checkpoint.state);
+    if (checkpoint.skippedExistingBytes > 0) {
+      this.logger.warn('history checkpoint missing, baselining existing file without replay', {
+        skippedBytes: checkpoint.skippedExistingBytes,
+      });
+    } else {
+      this.logger.info('history checkpoint initialized before first hook record');
+    }
   }
 
   protected async collect(): Promise<AgentActivityEntry[]> {
@@ -439,4 +454,3 @@ function expandContainerTimes(entries: AgentActivityEntry[]): void {
     }
   }
 }
-

--- a/src/inputs/qoder-trace/qoder-trace-input.ts
+++ b/src/inputs/qoder-trace/qoder-trace-input.ts
@@ -6,6 +6,7 @@ import { BaseInput, type InputOptions } from '../base/base-input.js';
 import { resolveHome, directoryExists, ensureDir } from '../../utils/fs-utils.js';
 import { getTodayDateString } from '../../utils/fs-utils.js';
 import { buildCanonicalHookEntry } from '../base/canonical-hook-record.js';
+import { filterBootstrapHistoryTurns } from '../base/bootstrap-turn-filter.js';
 import { enrichCanonicalEntryWithGit } from '../../normalization/enrich-git-context.js';
 import { readSegmentTokensForSession } from './segment-token-reader.js';
 import { readSqliteTokensForSession, isIdeaDbPath } from './sqlite-token-reader.js';
@@ -153,6 +154,8 @@ export class QoderTraceInput extends BaseInput {
     } finally {
       await handle.close();
     }
+
+    entries = filterBootstrapHistoryTurns(entries);
 
     // On cold start with multiple turns already in the file, only report the last turn
     // to avoid replaying full history after a redeployment wipes the state store.

--- a/src/inputs/qoder-trace/qoder-trace-input.ts
+++ b/src/inputs/qoder-trace/qoder-trace-input.ts
@@ -7,6 +7,7 @@ import { resolveHome, directoryExists, ensureDir } from '../../utils/fs-utils.js
 import { getTodayDateString } from '../../utils/fs-utils.js';
 import { buildCanonicalHookEntry } from '../base/canonical-hook-record.js';
 import { filterBootstrapHistoryTurns } from '../base/bootstrap-turn-filter.js';
+import { createHookHistoryStartupCheckpoint } from '../base/hook-history-checkpoint.js';
 import { enrichCanonicalEntryWithGit } from '../../normalization/enrich-git-context.js';
 import { readSegmentTokensForSession } from './segment-token-reader.js';
 import { readSqliteTokensForSession, isIdeaDbPath } from './sqlite-token-reader.js';
@@ -50,6 +51,20 @@ export class QoderTraceInput extends BaseInput {
 
   protected override async onStart(): Promise<void> {
     await ensureDir(this.logDir);
+    const checkpoint = await createHookHistoryStartupCheckpoint(
+      this.getState(),
+      this.logDir,
+      this.logPrefix,
+    );
+    if (!checkpoint) return;
+    this.setState(checkpoint.state);
+    if (checkpoint.skippedExistingBytes > 0) {
+      this.logger.warn('history checkpoint missing, baselining existing file without replay', {
+        skippedBytes: checkpoint.skippedExistingBytes,
+      });
+    } else {
+      this.logger.info('history checkpoint initialized before first hook record');
+    }
   }
 
   protected async collect(): Promise<AgentActivityEntry[]> {
@@ -119,9 +134,6 @@ export class QoderTraceInput extends BaseInput {
     }
 
     const state = this.getState();
-    // Cold start: no prior state at all (e.g. after redeployment wiped input-state.json).
-    // Day rollover: state.lastFile exists but differs from today's file (normal new-day transition).
-    const isColdStart = !state.lastFile;
     let offset = state.lastFile === logFileName ? (state.lastOffset ?? 0) : 0;
 
     if (offset > 0 && stat.size < offset) {
@@ -156,18 +168,6 @@ export class QoderTraceInput extends BaseInput {
     }
 
     entries = filterBootstrapHistoryTurns(entries);
-
-    // On cold start with multiple turns already in the file, only report the last turn
-    // to avoid replaying full history after a redeployment wipes the state store.
-    if (isColdStart && entries.length > 0) {
-      const turnIds = new Set(entries.map(e => (e['gen_ai.turn.id'] as string) || 'unknown'));
-      if (turnIds.size > 1) {
-        const lastTurnId = entries[entries.length - 1]['gen_ai.turn.id'] as string || 'unknown';
-        const skipped = turnIds.size - 1;
-        this.logger.info('cold start detected, skipping historical turns', { skipped, totalTurns: turnIds.size, keepTurnId: lastTurnId });
-        entries = entries.filter(e => ((e['gen_ai.turn.id'] as string) || 'unknown') === lastTurnId);
-      }
-    }
 
     return entries;
   }

--- a/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
+++ b/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
@@ -6,6 +6,7 @@ import { createInterface } from 'node:readline';
 import { ClientType, CollectionMethod } from '../../types/index.js';
 import type { AgentActivityEntry } from '../../types/index.js';
 import { BaseInput, type InputOptions } from '../base/base-input.js';
+import { filterBootstrapHistoryTurns } from '../base/bootstrap-turn-filter.js';
 import { enrichCanonicalEntryWithGit } from '../../normalization/enrich-git-context.js';
 import { resolveHome, directoryExists, ensureDir } from '../../utils/fs-utils.js';
 import { getTodayDateString } from '../../utils/fs-utils.js';
@@ -98,11 +99,13 @@ export class QoderWorkTraceInput extends BaseInput {
       const { entries: rawEntries, isFirstRun, turnCount } = await this.readHookJsonl();
       if (rawEntries.length === 0) return [];
 
+      const bootstrapFilteredEntries = filterBootstrapHistoryTurns(rawEntries);
+
       // A fresh collector must not replay a whole pre-existing daily hook log.
-      const allTurnGroups = this.groupByTurn(rawEntries);
+      const allTurnGroups = this.groupByTurn(bootstrapFilteredEntries);
       const entries = isFirstRun
         ? [...allTurnGroups.values()].at(-1) ?? []
-        : rawEntries;
+        : bootstrapFilteredEntries;
       if (isFirstRun) {
         const state = this.getState();
         const extra = state.extra && typeof state.extra === 'object'

--- a/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
+++ b/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
@@ -1,12 +1,11 @@
 import * as crypto from 'node:crypto';
-import { createReadStream } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { createInterface } from 'node:readline';
 import { ClientType, CollectionMethod } from '../../types/index.js';
 import type { AgentActivityEntry } from '../../types/index.js';
 import { BaseInput, type InputOptions } from '../base/base-input.js';
 import { filterBootstrapHistoryTurns } from '../base/bootstrap-turn-filter.js';
+import { createHookHistoryStartupCheckpoint } from '../base/hook-history-checkpoint.js';
 import { enrichCanonicalEntryWithGit } from '../../normalization/enrich-git-context.js';
 import { resolveHome, directoryExists, ensureDir } from '../../utils/fs-utils.js';
 import { getTodayDateString } from '../../utils/fs-utils.js';
@@ -87,6 +86,20 @@ export class QoderWorkTraceInput extends BaseInput {
 
   protected override async onStart(): Promise<void> {
     await ensureDir(this.logDir);
+    const checkpoint = await createHookHistoryStartupCheckpoint(
+      this.getState(),
+      this.logDir,
+      this.logPrefix,
+    );
+    if (!checkpoint) return;
+    this.setState(checkpoint.state);
+    if (checkpoint.skippedExistingBytes > 0) {
+      this.logger.warn('history checkpoint missing, baselining existing file without replay', {
+        skippedBytes: checkpoint.skippedExistingBytes,
+      });
+    } else {
+      this.logger.info('history checkpoint initialized before first hook record');
+    }
   }
 
   protected async collect(): Promise<AgentActivityEntry[]> {
@@ -96,25 +109,10 @@ export class QoderWorkTraceInput extends BaseInput {
       await this.readSdkTokenState();
 
       // 1. Hook JSONL — primary source of structure.
-      const { entries: rawEntries, isFirstRun, turnCount } = await this.readHookJsonl();
+      const rawEntries = await this.readHookJsonl();
       if (rawEntries.length === 0) return [];
 
-      const bootstrapFilteredEntries = filterBootstrapHistoryTurns(rawEntries);
-
-      // A fresh collector must not replay a whole pre-existing daily hook log.
-      const allTurnGroups = this.groupByTurn(bootstrapFilteredEntries);
-      const entries = isFirstRun
-        ? [...allTurnGroups.values()].at(-1) ?? []
-        : bootstrapFilteredEntries;
-      if (isFirstRun) {
-        const state = this.getState();
-        const extra = state.extra && typeof state.extra === 'object'
-          ? state.extra as Record<string, unknown>
-          : {};
-        this.setState({
-          extra: { ...extra, qoderWorkTurnCount: turnCount ?? allTurnGroups.size },
-        });
-      }
+      const entries = filterBootstrapHistoryTurns(rawEntries);
 
       // 2. Discover the (sessionId, cwd) pairs we have entries for, then read
       //    fresh segments for each. Lazily — sessions absent from hook batch
@@ -151,7 +149,7 @@ export class QoderWorkTraceInput extends BaseInput {
 
   // ─── Hook JSONL reading ────────────────────────────────────────────────────
 
-  private async readHookJsonl(): Promise<HookJsonlBatch> {
+  private async readHookJsonl(): Promise<AgentActivityEntry[]> {
     const today = getTodayDateString();
     const logFileName = `${this.logPrefix}-${today}.jsonl`;
     const logFile = path.join(this.logDir, logFileName);
@@ -160,7 +158,7 @@ export class QoderWorkTraceInput extends BaseInput {
     try {
       stat = await fs.stat(logFile);
     } catch {
-      return { entries: [], isFirstRun: false };
+      return [];
     }
 
     const state = this.getState();
@@ -170,16 +168,7 @@ export class QoderWorkTraceInput extends BaseInput {
       this.logger.info('file truncated, resetting offset', { file: logFile });
       offset = 0;
     }
-    if (stat.size <= offset) return { entries: [], isFirstRun: false };
-
-    const hasFirstRunMarker = state.extra
-      && typeof state.extra === 'object'
-      && Object.hasOwn(state.extra, 'qoderWorkTurnCount');
-    const isFirstRun = offset === 0 && !hasFirstRunMarker;
-
-    if (isFirstRun) {
-      return this.readFirstRunHookBaseline(logFile, logFileName, stat.size);
-    }
+    if (stat.size <= offset) return [];
 
     const handle = await fs.open(logFile, 'r');
     const entries: AgentActivityEntry[] = [];
@@ -209,41 +198,7 @@ export class QoderWorkTraceInput extends BaseInput {
       await handle.close();
     }
 
-    return { entries, isFirstRun };
-  }
-
-  private async readFirstRunHookBaseline(
-    logFile: string,
-    logFileName: string,
-    fileSize: number,
-  ): Promise<HookJsonlBatch> {
-    let latestTurnId: string | undefined;
-    let latestTurnEntries: AgentActivityEntry[] = [];
-    let turnCount = 0;
-    const reader = createInterface({
-      input: createReadStream(logFile, { encoding: 'utf-8' }),
-      crlfDelay: Infinity,
-    });
-
-    for await (const line of reader) {
-      if (!line.trim()) continue;
-      try {
-        const record = JSON.parse(line) as AgentActivityEntry;
-        if (!record['event.name']) continue;
-        const turnId = String(record['gen_ai.turn.id'] ?? 'unknown');
-        if (turnId !== latestTurnId) {
-          latestTurnId = turnId;
-          latestTurnEntries = [];
-          turnCount++;
-        }
-        latestTurnEntries.push(record);
-      } catch {
-        this.logger.warn('invalid JSONL line');
-      }
-    }
-
-    this.setState({ lastFile: logFileName, lastOffset: fileSize });
-    return { entries: latestTurnEntries, isFirstRun: true, turnCount };
+    return entries;
   }
 
   // ─── Segments reading ──────────────────────────────────────────────────────
@@ -882,12 +837,6 @@ export interface QoderWorkTraceInputOptions extends InputOptions {
   segmentsRoot?: string;
   sdkLogDir?: string;
   interceptFile?: string;
-}
-
-interface HookJsonlBatch {
-  entries: AgentActivityEntry[];
-  isFirstRun: boolean;
-  turnCount?: number;
 }
 
 interface SegmentEvent {

--- a/tests/integration/hook-jsonl-flow.test.ts
+++ b/tests/integration/hook-jsonl-flow.test.ts
@@ -676,7 +676,7 @@ describe('Hook JSONL integration flow', () => {
 
     const transcriptPath = path.join(tmpDir, 'multi-turn-transcript.jsonl');
     await fs.writeFile(transcriptPath, [
-      // Turn 1: hello
+      // Turn 1: first hook invocation establishes the per-transcript cursor.
       JSON.stringify({
         type: 'user',
         timestamp: '2026-06-18T08:00:00.000Z',
@@ -689,7 +689,25 @@ describe('Hook JSONL integration flow', () => {
         sessionId: 'sess-multi',
         message: { role: 'assistant', content: [{ type: 'text', text: 'Hi there.' }] },
       }),
-      // Turn 2: leetcode
+      JSON.stringify({
+        type: 'last-prompt',
+        sessionId: 'sess-multi',
+        lastPrompt: 'hello',
+      }),
+    ].join('\n') + '\n');
+
+    const firstResult = runQoderHook(hookScript, JSON.stringify({
+      hook_event_name: 'Stop',
+      transcript_path: transcriptPath,
+      session_id: 'sess-multi',
+    }), {
+      LOONGSUITE_PILOT_DATA_DIR: dataDir,
+    });
+    expect(firstResult.status).toBe(0);
+
+    // Turn 2 arrives after a valid cursor exists, so the processor must retain
+    // normal incremental multi-turn behavior rather than treating it as replay.
+    await fs.appendFile(transcriptPath, [
       JSON.stringify({
         type: 'user',
         timestamp: '2026-06-18T08:01:00.000Z',
@@ -714,14 +732,14 @@ describe('Hook JSONL integration flow', () => {
       }),
     ].join('\n') + '\n');
 
-    const result = runQoderHook(hookScript, JSON.stringify({
+    const secondResult = runQoderHook(hookScript, JSON.stringify({
       hook_event_name: 'Stop',
       transcript_path: transcriptPath,
       session_id: 'sess-multi',
     }), {
       LOONGSUITE_PILOT_DATA_DIR: dataDir,
     });
-    expect(result.status).toBe(0);
+    expect(secondResult.status).toBe(0);
 
     const historyFile = path.join(dataDir, 'logs', 'qoder', 'history', `qoder-${getTodayDateString()}.jsonl`);
     const records = (await fs.readFile(historyFile, 'utf-8')).trim().split('\n').map(line => JSON.parse(line));

--- a/tests/integration/hook-jsonl-flow.test.ts
+++ b/tests/integration/hook-jsonl-flow.test.ts
@@ -469,7 +469,7 @@ describe('Hook JSONL integration flow', () => {
     ]);
   });
 
-  it('QoderTraceInput cold start: only reports last turn when state is empty', async () => {
+  it('QoderTraceInput missing checkpoint: baselines existing history and reads later appends', async () => {
     const logDir = path.join(tmpDir, 'logs-cold');
     await fs.mkdir(logDir, { recursive: true });
 
@@ -520,7 +520,7 @@ describe('Hook JSONL integration flow', () => {
         time_unix_nano: '1780000011000000000',
         observed_time_unix_nano: '1780000011000000000',
       }),
-      // Turn 3 (latest — should be reported)
+      // Turn 3 (also historical — must not be guessed as the only new turn)
       JSON.stringify({
         'event.name': 'other',
         'event.id': 'e-5',
@@ -560,9 +560,9 @@ describe('Hook JSONL integration flow', () => {
     await input.start();
     await input.stop();
 
-    // Only the last turn should be reported
-    expect(allEntries.length).toBe(2);
-    expect(allEntries.every(e => e['gen_ai.turn.id'] === 'turn-latest')).toBe(true);
+    // Existing bytes are an ambiguous recovery case. The no-replay policy
+    // baselines the complete file instead of guessing one global latest turn.
+    expect(allEntries).toHaveLength(0);
 
     // Offset should be at end of file
     await freshStore.save();
@@ -570,7 +570,32 @@ describe('Hook JSONL integration flow', () => {
     expect(state.lastOffset).toBe((await fs.stat(logFile)).size);
     expect(state.lastFile).toBe(`qoder-${today}.jsonl`);
 
-    // Subsequent run should not re-emit anything
+    const afterBaseline = [
+      JSON.stringify({
+        'event.name': 'llm.request',
+        'event.id': 'e-new-request',
+        'gen_ai.turn.id': 'turn-after-baseline',
+        'gen_ai.session.id': 'sess-new',
+        'gen_ai.agent.type': 'qoder-cli',
+        'gen_ai.step.id': 'turn-after-baseline:s1',
+        time_unix_nano: '1780000030000000000',
+        observed_time_unix_nano: '1780000030000000000',
+      }),
+      JSON.stringify({
+        'event.name': 'llm.response',
+        'event.id': 'e-new-response',
+        'gen_ai.turn.id': 'turn-after-baseline',
+        'gen_ai.session.id': 'sess-new',
+        'gen_ai.agent.type': 'qoder-cli',
+        'gen_ai.step.id': 'turn-after-baseline:s1',
+        time_unix_nano: '1780000031000000000',
+        observed_time_unix_nano: '1780000031000000000',
+      }),
+    ];
+    await fs.appendFile(logFile, afterBaseline.join('\n') + '\n');
+
+    // A later run resumes from the deterministic boundary and consumes all new
+    // records, rather than applying another process-global cold-start filter.
     const input2 = new QoderTraceInput({
       stateStore: freshStore as any,
       logDir,
@@ -580,7 +605,10 @@ describe('Hook JSONL integration flow', () => {
     input2.on('entries', (e: AgentActivityEntry[]) => newEntries.push(...e));
     await input2.start();
     await input2.stop();
-    expect(newEntries).toHaveLength(0);
+    expect(newEntries.map(entry => entry['event.id'])).toEqual([
+      'e-new-request',
+      'e-new-response',
+    ]);
   });
 
   it('KiroCliLogInput cold start: only reports last turn when state is empty', async () => {

--- a/tests/unit/hooks/hook-processor-line-records.test.mjs
+++ b/tests/unit/hooks/hook-processor-line-records.test.mjs
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { spawn } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BASE_MODULE = pathToFileURL(
+  path.resolve(__dirname, '../../../assets/hooks/shared/hook-processor-base.mjs'),
+).href;
+
+let dataDir;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hook-line-records-'));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+function runWorker(source, extraEnv = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ['--input-type=module', '--eval', source], {
+      env: {
+        ...process.env,
+        LOONGSUITE_PILOT_DATA_DIR: dataDir,
+        ...extraEnv,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf-8');
+    child.stderr.setEncoding('utf-8');
+    child.stdout.on('data', chunk => { stdout += chunk; });
+    child.stderr.on('data', chunk => { stderr += chunk; });
+    child.on('error', reject);
+    child.on('close', code => {
+      if (code === 0) resolve(stdout);
+      else reject(new Error(`worker exited ${code}: ${stderr}`));
+    });
+  });
+}
+
+describe('hook processor per-session line records', () => {
+  it('persists concurrent sessions in independent files', async () => {
+    const worker = `
+      import { updateLineRecord } from ${JSON.stringify(BASE_MODULE)};
+      const record = JSON.parse(process.env.TEST_LINE_RECORD);
+      if (!updateLineRecord('qoder-work', record.transcriptPath, record.sessionId, record.endLine)) {
+        process.exit(1);
+      }
+    `;
+    const expected = Array.from({ length: 4 }, (_, index) => ({
+      sessionId: `session-${index}`,
+      transcriptPath: path.join(dataDir, `transcript-${index}.jsonl`),
+      endLine: 100 + index,
+    }));
+
+    await Promise.all(expected.map(record => runWorker(worker, {
+      TEST_LINE_RECORD: JSON.stringify(record),
+    })));
+
+    const cursorDir = path.join(dataDir, 'state', 'hooks', 'qoder-work-line-records');
+    const files = fs.readdirSync(cursorDir).filter(file => file.endsWith('.json'));
+    expect(files).toHaveLength(expected.length);
+
+    const persisted = files.map(file =>
+      JSON.parse(fs.readFileSync(path.join(cursorDir, file), 'utf-8'))
+    );
+    expect(new Set(persisted.map(record => record.session_id))).toEqual(
+      new Set(expected.map(record => record.sessionId)),
+    );
+    for (const record of expected) {
+      expect(persisted).toContainEqual(expect.objectContaining({
+        session_id: record.sessionId,
+        transcript_path: record.transcriptPath,
+        last_line_count: record.endLine,
+      }));
+    }
+  }, 30_000);
+
+  it('lazily splits the previous aggregate state into session files', async () => {
+    const stateDir = path.join(dataDir, 'state', 'hooks');
+    fs.mkdirSync(stateDir, { recursive: true });
+    const aggregateFile = path.join(stateDir, 'qoder-work-line-records.json');
+    fs.writeFileSync(aggregateFile, JSON.stringify({
+      '/tmp/transcript-a.jsonl': {
+        session_id: 'session-a',
+        last_line_count: 10,
+        updated_at: '2026-07-22 10:00:00',
+      },
+      '/tmp/transcript-b.jsonl': {
+        session_id: 'session-b',
+        last_line_count: 20,
+        updated_at: '2026-07-22 10:01:00',
+      },
+    }));
+
+    const worker = `
+      import { loadLineRecord } from ${JSON.stringify(BASE_MODULE)};
+      process.stdout.write(JSON.stringify([
+        loadLineRecord('qoder-work', 'session-a'),
+        loadLineRecord('qoder-work', 'session-b'),
+      ]));
+    `;
+    const stdout = await runWorker(worker);
+    const records = JSON.parse(stdout);
+
+    expect(records).toEqual([
+      expect.objectContaining({
+        session_id: 'session-a',
+        transcript_path: '/tmp/transcript-a.jsonl',
+        last_line_count: 10,
+      }),
+      expect.objectContaining({
+        session_id: 'session-b',
+        transcript_path: '/tmp/transcript-b.jsonl',
+        last_line_count: 20,
+      }),
+    ]);
+    expect(fs.existsSync(aggregateFile)).toBe(false);
+    expect(
+      fs.readdirSync(path.join(stateDir, 'qoder-work-line-records'))
+        .filter(file => file.endsWith('.json')),
+    ).toHaveLength(2);
+  });
+});

--- a/tests/unit/hooks/hook-processor-line-records.test.mjs
+++ b/tests/unit/hooks/hook-processor-line-records.test.mjs
@@ -80,6 +80,14 @@ describe('hook processor per-session line records', () => {
         last_line_count: record.endLine,
       }));
     }
+    const rollbackShadow = JSON.parse(fs.readFileSync(
+      path.join(dataDir, 'state', 'hooks', 'qoder-work-line-records.json'),
+      'utf-8',
+    ));
+    expect(Object.keys(rollbackShadow)).toHaveLength(expected.length);
+    expect(fs.existsSync(
+      path.join(dataDir, 'state', 'hooks', 'qoder-work-line-records.json.lock'),
+    )).toBe(false);
   }, 30_000);
 
   it('lazily splits the previous aggregate state into session files', async () => {
@@ -121,10 +129,59 @@ describe('hook processor per-session line records', () => {
         last_line_count: 20,
       }),
     ]);
-    expect(fs.existsSync(aggregateFile)).toBe(false);
+    // Keep the aggregate as a locked compatibility shadow so the immediately
+    // previous Pilot version can still resume if an upgrade is rolled back.
+    expect(fs.existsSync(aggregateFile)).toBe(true);
     expect(
       fs.readdirSync(path.join(stateDir, 'qoder-work-line-records'))
         .filter(file => file.endsWith('.json')),
     ).toHaveLength(2);
+  });
+
+  it('reconciles cursor advances written by an old version during rollback', async () => {
+    const stateDir = path.join(dataDir, 'state', 'hooks');
+    fs.mkdirSync(stateDir, { recursive: true });
+    const aggregateFile = path.join(stateDir, 'qoder-work-line-records.json');
+    const transcriptPath = '/tmp/transcript-rollback.jsonl';
+    fs.writeFileSync(aggregateFile, JSON.stringify({
+      [transcriptPath]: {
+        session_id: 'session-rollback',
+        last_line_count: 10,
+        updated_at: '2026-07-22 10:00:00',
+      },
+    }));
+
+    const worker = `
+      import { loadLineRecord } from ${JSON.stringify(BASE_MODULE)};
+      process.stdout.write(JSON.stringify(loadLineRecord('qoder-work', 'session-rollback')));
+    `;
+    expect(JSON.parse(await runWorker(worker))).toMatchObject({ last_line_count: 10 });
+
+    // Simulate the previous version running after rollback and advancing its
+    // aggregate cursor format, which does not know about per-session files.
+    fs.writeFileSync(aggregateFile, JSON.stringify({
+      [transcriptPath]: {
+        session_id: 'session-rollback',
+        last_line_count: 30,
+        updated_at: '2026-07-22 10:05:00',
+      },
+    }));
+
+    expect(JSON.parse(await runWorker(worker))).toMatchObject({
+      session_id: 'session-rollback',
+      transcript_path: transcriptPath,
+      last_line_count: 30,
+    });
+
+    // A stale old-version writer can finish later and carry a newer timestamp.
+    // The forward version must still keep line progress monotonic.
+    fs.writeFileSync(aggregateFile, JSON.stringify({
+      [transcriptPath]: {
+        session_id: 'session-rollback',
+        last_line_count: 20,
+        updated_at: '2026-07-22 10:10:00',
+      },
+    }));
+    expect(JSON.parse(await runWorker(worker))).toMatchObject({ last_line_count: 30 });
   });
 });

--- a/tests/unit/hooks/qoder-hook-processor-cold-start.test.mjs
+++ b/tests/unit/hooks/qoder-hook-processor-cold-start.test.mjs
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROCESSOR = path.resolve(__dirname, '../../../assets/hooks/qoder-hook-processor.mjs');
+
+let dataDir;
+let transcriptPath;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qoder-hook-cold-start-'));
+  transcriptPath = path.join(dataDir, 'transcript.jsonl');
+});
+
+afterEach(() => {
+  try { fs.rmSync(dataDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+function turnRows(index, prompt) {
+  const second = String(10 + index * 2).padStart(2, '0');
+  return [
+    {
+      type: 'user',
+      uuid: `user-${index}`,
+      timestamp: `2026-07-20T10:00:${second}.000Z`,
+      sessionId: 'session-old',
+      entrypoint: 'cli',
+      message: { role: 'user', content: prompt },
+    },
+    {
+      type: 'assistant',
+      uuid: `assistant-${index}`,
+      timestamp: `2026-07-20T10:00:${second}.500Z`,
+      sessionId: 'session-old',
+      message: {
+        role: 'assistant',
+        id: `message-${index}`,
+        content: [{ type: 'text', text: `answer ${index}` }],
+        stop_reason: 'end_turn',
+      },
+    },
+  ];
+}
+
+function lastPrompt(index) {
+  return { type: 'last-prompt', sessionId: 'session-old', lastPrompt: `prompt ${index}` };
+}
+
+function runProcessor() {
+  return spawnSync('node', [PROCESSOR, '--agent-id', 'qoder', '--log-prefix', 'qoder'], {
+    input: JSON.stringify({
+      session_id: 'session-old',
+      transcript_path: transcriptPath,
+      cwd: '/tmp/qoder-project',
+    }),
+    env: { ...process.env, LOONGSUITE_PILOT_DATA_DIR: dataDir },
+    encoding: 'utf-8',
+    timeout: 30_000,
+  });
+}
+
+function readHistory() {
+  const historyDir = path.join(dataDir, 'logs', 'qoder', 'history');
+  if (!fs.existsSync(historyDir)) return [];
+  return fs.readdirSync(historyDir)
+    .filter(file => file.endsWith('.jsonl'))
+    .flatMap(file => fs.readFileSync(path.join(historyDir, file), 'utf-8').split('\n'))
+    .filter(Boolean)
+    .map(line => JSON.parse(line));
+}
+
+function userBoundaryPrompts(records) {
+  return records
+    .filter(record => record['event.name'] === 'other' && record['agent.qoder.raw_type'] === 'user')
+    .map(record => record['gen_ai.input.messages_delta']?.[0]?.parts?.[0]?.content);
+}
+
+describe('qoder-hook-processor cold-start recovery', () => {
+  it('does not replay old turns when each old session first appears after redeployment', () => {
+    fs.writeFileSync(transcriptPath, [
+      ...turnRows(1, 'historical prompt 1'),
+      ...turnRows(2, 'historical prompt 2'),
+      lastPrompt(2),
+    ].map(row => JSON.stringify(row)).join('\n') + '\n');
+
+    const first = runProcessor();
+    expect(first.status).toBe(0);
+    const bootstrapRecords = readHistory();
+    expect(userBoundaryPrompts(bootstrapRecords)).toEqual(['historical prompt 2']);
+    expect(new Set(bootstrapRecords.map(r => r['agent.transcript.cursor_mode']))).toEqual(
+      new Set(['bootstrap']),
+    );
+    expect(new Set(bootstrapRecords.map(r => r['agent.transcript.cursor_reason']))).toEqual(
+      new Set(['missing-cursor']),
+    );
+
+    const cursorFile = path.join(dataDir, 'state', 'hooks', 'qoder-line-records.json');
+    expect(fs.existsSync(cursorFile)).toBe(true);
+
+    const before = bootstrapRecords.length;
+    fs.appendFileSync(transcriptPath, [
+      ...turnRows(3, 'new prompt 3'),
+      lastPrompt(3),
+    ].map(row => JSON.stringify(row)).join('\n') + '\n');
+
+    const second = runProcessor();
+    expect(second.status).toBe(0);
+    const incrementalRecords = readHistory().slice(before);
+    expect(userBoundaryPrompts(incrementalRecords)).toEqual(['new prompt 3']);
+    expect(new Set(incrementalRecords.map(r => r['agent.transcript.cursor_mode']))).toEqual(
+      new Set(['incremental']),
+    );
+
+    // A different pre-existing transcript may be opened much later, after the
+    // global Trace Input offset is already active. It must get its own recovery
+    // decision instead of inheriting the first transcript's initialized state.
+    const beforeSecondSession = readHistory().length;
+    transcriptPath = path.join(dataDir, 'second-old-transcript.jsonl');
+    fs.writeFileSync(transcriptPath, [
+      ...turnRows(4, 'second session historical prompt 4'),
+      ...turnRows(5, 'second session historical prompt 5'),
+      lastPrompt(5),
+    ].map(row => JSON.stringify(row)).join('\n') + '\n');
+
+    const third = runProcessor();
+    expect(third.status).toBe(0);
+    const secondSessionRecords = readHistory().slice(beforeSecondSession);
+    expect(userBoundaryPrompts(secondSessionRecords)).toEqual([
+      'second session historical prompt 5',
+    ]);
+    expect(new Set(secondSessionRecords.map(r => r['agent.transcript.cursor_mode']))).toEqual(
+      new Set(['bootstrap']),
+    );
+  });
+});

--- a/tests/unit/hooks/qoder-hook-processor-cold-start.test.mjs
+++ b/tests/unit/hooks/qoder-hook-processor-cold-start.test.mjs
@@ -50,10 +50,10 @@ function lastPrompt(index) {
   return { type: 'last-prompt', sessionId: 'session-old', lastPrompt: `prompt ${index}` };
 }
 
-function runProcessor() {
+function runProcessor(sessionId = 'session-old') {
   return spawnSync('node', [PROCESSOR, '--agent-id', 'qoder', '--log-prefix', 'qoder'], {
     input: JSON.stringify({
-      session_id: 'session-old',
+      session_id: sessionId,
       transcript_path: transcriptPath,
       cwd: '/tmp/qoder-project',
     }),
@@ -98,8 +98,8 @@ describe('qoder-hook-processor cold-start recovery', () => {
       new Set(['missing-cursor']),
     );
 
-    const cursorFile = path.join(dataDir, 'state', 'hooks', 'qoder-line-records.json');
-    expect(fs.existsSync(cursorFile)).toBe(true);
+    const cursorDir = path.join(dataDir, 'state', 'hooks', 'qoder-line-records');
+    expect(fs.readdirSync(cursorDir).filter(file => file.endsWith('.json'))).toHaveLength(1);
 
     const before = bootstrapRecords.length;
     fs.appendFileSync(transcriptPath, [
@@ -126,7 +126,7 @@ describe('qoder-hook-processor cold-start recovery', () => {
       lastPrompt(5),
     ].map(row => JSON.stringify(row)).join('\n') + '\n');
 
-    const third = runProcessor();
+    const third = runProcessor('session-second-old');
     expect(third.status).toBe(0);
     const secondSessionRecords = readHistory().slice(beforeSecondSession);
     expect(userBoundaryPrompts(secondSessionRecords)).toEqual([
@@ -134,6 +134,14 @@ describe('qoder-hook-processor cold-start recovery', () => {
     ]);
     expect(new Set(secondSessionRecords.map(r => r['agent.transcript.cursor_mode']))).toEqual(
       new Set(['bootstrap']),
+    );
+    const cursorFiles = fs.readdirSync(cursorDir).filter(file => file.endsWith('.json'));
+    expect(cursorFiles).toHaveLength(2);
+    const persistedSessionIds = cursorFiles.map(file =>
+      JSON.parse(fs.readFileSync(path.join(cursorDir, file), 'utf-8')).session_id
+    );
+    expect(new Set(persistedSessionIds)).toEqual(
+      new Set(['session-old', 'session-second-old']),
     );
   });
 });

--- a/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
+++ b/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
@@ -7,6 +7,7 @@ import {
   readRetryLock,
   releaseRetryLock,
   retryLockPath,
+  selectTurnSegmentsForCollection,
   tryAcquireRetryLock,
 } from '../../../assets/hooks/qoder-hook-processor.mjs';
 
@@ -106,5 +107,28 @@ describe('isRetryLockStale', () => {
 
   it('returns true for fresh lock with dead pid', () => {
     expect(isRetryLockStale({ pid: 999999, startedAt: Date.now() })).toBe(true);
+  });
+});
+
+describe('selectTurnSegmentsForCollection', () => {
+  const turns = [['turn-1'], ['turn-2'], ['turn-3']];
+
+  it('keeps all normal Qoder incremental turns', () => {
+    expect(selectTurnSegmentsForCollection(turns, 'incremental', 'qoder')).toEqual(turns);
+  });
+
+  it('keeps only the latest turn when any Qoder-family cursor is recovered', () => {
+    expect(selectTurnSegmentsForCollection(turns, 'missing-cursor', 'qoder')).toEqual([
+      ['turn-3'],
+    ]);
+    expect(selectTurnSegmentsForCollection(turns, 'truncated', 'qoder-cn')).toEqual([
+      ['turn-3'],
+    ]);
+  });
+
+  it('keeps only the latest QoderCN turn after its intentional full reparse', () => {
+    expect(selectTurnSegmentsForCollection(turns, 'incremental', 'qoder-cn')).toEqual([
+      ['turn-3'],
+    ]);
   });
 });

--- a/tests/unit/hooks/qoderwork/hook-processor.test.mjs
+++ b/tests/unit/hooks/qoderwork/hook-processor.test.mjs
@@ -10,7 +10,6 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROCESSOR = path.resolve(__dirname, '../../../../assets/hooks/qoderwork-hook-processor.mjs');
 const AGENT_ID = 'qoder-work-test';
 const LOG_PREFIX = 'qoder-work';
-const LINE_RECORD = path.resolve(__dirname, '../../../../assets/hooks/.line_records.qoder-work-test.json');
 
 let DATA_DIR;
 let TRANSCRIPT;
@@ -18,12 +17,10 @@ let TRANSCRIPT;
 beforeEach(() => {
   DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'qoderwork-hook-test-'));
   TRANSCRIPT = path.join(DATA_DIR, 'transcript.jsonl');
-  try { fs.rmSync(LINE_RECORD, { force: true }); } catch {}
 });
 
 afterEach(() => {
   try { fs.rmSync(DATA_DIR, { recursive: true, force: true }); } catch {}
-  try { fs.rmSync(LINE_RECORD, { force: true }); } catch {}
 });
 
 function writeTranscript(records) {
@@ -39,7 +36,7 @@ function runHook(sessionId) {
     }),
     env: { ...process.env, LOONGSUITE_PILOT_DATA_DIR: DATA_DIR },
     encoding: 'utf-8',
-    timeout: 10_000,
+    timeout: 30_000,
   });
 }
 
@@ -92,6 +89,84 @@ function baseRows(userContent) {
     },
   ];
 }
+
+function turnRows(index, text) {
+  const second = String(50 + index * 2).padStart(2, '0');
+  return [
+    {
+      type: 'user',
+      uuid: `user-${index}`,
+      promptId: `prompt-${index}`,
+      timestamp: `2026-06-18T01:35:${second}.477Z`,
+      message: { role: 'user', content: [{ type: 'text', text }] },
+      sessionId: 'sess-recovery',
+      userType: 'external',
+      isSidechain: false,
+    },
+    {
+      type: 'assistant',
+      uuid: `assistant-${index}`,
+      parentUuid: `user-${index}`,
+      timestamp: `2026-06-18T01:35:${second}.977Z`,
+      message: {
+        role: 'assistant',
+        id: `msg-${index}`,
+        content: [{ type: 'text', text: `answer ${index}` }],
+        stop_reason: 'end_turn',
+      },
+      sessionId: 'sess-recovery',
+      isSidechain: false,
+    },
+  ];
+}
+
+describe('qoderwork-hook-processor cursor recovery', () => {
+  test('bootstraps only the latest old turn, persists cursor outside hooks, then resumes incrementally', () => {
+    writeTranscript([
+      ...turnRows(1, 'historical prompt 1'),
+      ...turnRows(2, 'historical prompt 2'),
+    ]);
+
+    const first = runHook('sess-recovery');
+    expect(first.status).toBe(0);
+
+    const bootstrapRecords = readJsonlRecords();
+    expect(inputContents(bootstrapRecords)).toEqual(['historical prompt 2']);
+    expect(new Set(bootstrapRecords.map(r => r['agent.transcript.cursor_mode']))).toEqual(
+      new Set(['bootstrap']),
+    );
+    expect(new Set(bootstrapRecords.map(r => r['agent.transcript.cursor_reason']))).toEqual(
+      new Set(['missing-cursor']),
+    );
+    expect(new Set(bootstrapRecords.map(r => r['agent.transcript.cursor_batch_id'])).size).toBe(1);
+
+    const persistentCursor = path.join(
+      DATA_DIR,
+      'state',
+      'hooks',
+      `${AGENT_ID}-line-records.json`,
+    );
+    expect(fs.existsSync(persistentCursor)).toBe(true);
+
+    const before = bootstrapRecords.length;
+    fs.appendFileSync(
+      TRANSCRIPT,
+      turnRows(3, 'new prompt 3').map(row => JSON.stringify(row)).join('\n') + '\n',
+      'utf-8',
+    );
+    const second = runHook('sess-recovery');
+    expect(second.status).toBe(0);
+
+    const incrementalRecords = readJsonlRecords().slice(before);
+    expect(inputContents(incrementalRecords)).toEqual(['new prompt 3']);
+    expect(new Set(incrementalRecords.map(r => r['agent.transcript.cursor_mode']))).toEqual(
+      new Set(['incremental']),
+    );
+    expect(new Set(incrementalRecords.map(r => r['agent.transcript.cursor_reason']))).toEqual(
+      new Set(['incremental']),
+    );
+  });
+});
 
 describe('qoderwork-hook-processor user prompt extraction', () => {
   test('emits per-step input deltas that the converter accumulates', async () => {

--- a/tests/unit/hooks/qoderwork/hook-processor.test.mjs
+++ b/tests/unit/hooks/qoderwork/hook-processor.test.mjs
@@ -140,13 +140,21 @@ describe('qoderwork-hook-processor cursor recovery', () => {
     );
     expect(new Set(bootstrapRecords.map(r => r['agent.transcript.cursor_batch_id'])).size).toBe(1);
 
-    const persistentCursor = path.join(
+    const persistentCursorDir = path.join(
       DATA_DIR,
       'state',
       'hooks',
-      `${AGENT_ID}-line-records.json`,
+      `${AGENT_ID}-line-records`,
     );
-    expect(fs.existsSync(persistentCursor)).toBe(true);
+    const cursorFiles = fs.readdirSync(persistentCursorDir).filter(file => file.endsWith('.json'));
+    expect(cursorFiles).toHaveLength(1);
+    const persistentCursor = JSON.parse(
+      fs.readFileSync(path.join(persistentCursorDir, cursorFiles[0]), 'utf-8'),
+    );
+    expect(persistentCursor).toMatchObject({
+      session_id: 'sess-recovery',
+      transcript_path: TRANSCRIPT,
+    });
 
     const before = bootstrapRecords.length;
     fs.appendFileSync(

--- a/tests/unit/inputs/bootstrap-turn-filter.test.ts
+++ b/tests/unit/inputs/bootstrap-turn-filter.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { filterBootstrapHistoryTurns } from '../../../src/inputs/base/bootstrap-turn-filter.js';
+import type { AgentActivityEntry } from '../../../src/types/index.js';
+
+function entry(
+  id: string,
+  turnId: string,
+  mode: 'bootstrap' | 'incremental',
+  batchId?: string,
+): AgentActivityEntry {
+  return {
+    'event.id': id,
+    'event.name': 'llm.response',
+    'gen_ai.agent.type': 'qoder',
+    'gen_ai.turn.id': turnId,
+    'agent.transcript.cursor_mode': mode,
+    ...(batchId ? { 'agent.transcript.cursor_batch_id': batchId } : {}),
+  } as AgentActivityEntry;
+}
+
+describe('filterBootstrapHistoryTurns', () => {
+  it('keeps only the latest turn in each bootstrap batch', () => {
+    const entries = [
+      entry('old-request', 'turn-old', 'bootstrap', 'batch-a'),
+      entry('old-response', 'turn-old', 'bootstrap', 'batch-a'),
+      entry('latest-request', 'turn-latest', 'bootstrap', 'batch-a'),
+      entry('latest-response', 'turn-latest', 'bootstrap', 'batch-a'),
+    ];
+
+    expect(filterBootstrapHistoryTurns(entries).map(e => e['event.id'])).toEqual([
+      'latest-request',
+      'latest-response',
+    ]);
+  });
+
+  it('scopes recovery independently per transcript invocation batch', () => {
+    const entries = [
+      entry('a-old', 'a-old-turn', 'bootstrap', 'batch-a'),
+      entry('a-latest', 'a-latest-turn', 'bootstrap', 'batch-a'),
+      entry('b-old', 'b-old-turn', 'bootstrap', 'batch-b'),
+      entry('b-latest', 'b-latest-turn', 'bootstrap', 'batch-b'),
+      entry('normal', 'normal-turn', 'incremental', 'batch-c'),
+    ];
+
+    expect(filterBootstrapHistoryTurns(entries).map(e => e['event.id'])).toEqual([
+      'a-latest',
+      'b-latest',
+      'normal',
+    ]);
+  });
+
+  it('fails open when a mixed-version record has no batch id', () => {
+    const entries = [
+      entry('legacy-old', 'legacy-old-turn', 'bootstrap'),
+      entry('legacy-new', 'legacy-new-turn', 'bootstrap'),
+    ];
+
+    expect(filterBootstrapHistoryTurns(entries)).toEqual(entries);
+  });
+});

--- a/tests/unit/inputs/qoder-cn-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-cn-trace-input.test.ts
@@ -38,6 +38,12 @@ beforeEach(async () => {
   await createSchema(dbPath);
 
   stateStore = new MockStateStore();
+  // Most tests exercise ordinary incremental collection. Seed the byte cursor
+  // explicitly so they do not accidentally depend on cold-start semantics.
+  stateStore.set('qoder-cn-trace', {
+    lastFile: `qoder-cn-${getTodayDateString()}.jsonl`,
+    lastOffset: 0,
+  });
 });
 
 afterEach(async () => {
@@ -45,6 +51,53 @@ afterEach(async () => {
 });
 
 describe('QoderCnTraceInput.collect (session-level enrich)', () => {
+  it('baselines existing incremental history when the input checkpoint is missing', async () => {
+    const oldEntries = [
+      buildEntry({ event: 'llm.response', turn: 'historical-turn-1', step: 'historical-turn-1:s1', session: '', ts: 1_780_000_000_000 }),
+      buildEntry({ event: 'llm.response', turn: 'historical-turn-2', step: 'historical-turn-2:s1', session: '', ts: 1_780_000_001_000 }),
+    ];
+    for (const entry of oldEntries) {
+      entry['agent.transcript.cursor_mode'] = 'incremental';
+    }
+    await writeHookJsonl(logDir, oldEntries);
+
+    // Reproduce a redeploy/state-loss boundary while the daily history remains.
+    stateStore = new MockStateStore();
+    const input = new QoderCnTraceInput({
+      stateStore: stateStore as any,
+      logDir,
+      pollIntervalMs: 60_000,
+    });
+    const collected: AgentActivityEntry[] = [];
+    input.on('entries', (batch: AgentActivityEntry[]) => collected.push(...batch));
+
+    await input.start();
+    expect(collected).toEqual([]);
+
+    const logFileName = `qoder-cn-${getTodayDateString()}.jsonl`;
+    const logFile = path.join(logDir, logFileName);
+    const baselineSize = (await fs.stat(logFile)).size;
+    expect(stateStore.get('qoder-cn-trace')).toMatchObject({
+      lastFile: logFileName,
+      lastOffset: baselineSize,
+      extra: { hookHistoryInitialized: true },
+    });
+
+    const nextEntry = buildEntry({
+      event: 'llm.response',
+      turn: 'turn-after-baseline',
+      step: 'turn-after-baseline:s1',
+      session: '',
+      ts: 1_780_000_002_000,
+    });
+    nextEntry['agent.transcript.cursor_mode'] = 'incremental';
+    await fs.appendFile(logFile, `${JSON.stringify(nextEntry)}\n`, 'utf-8');
+
+    const appended = await (input as any).collect() as AgentActivityEntry[];
+    await input.stop();
+    expect(appended.map(entry => entry['gen_ai.turn.id'])).toEqual(['turn-after-baseline']);
+  });
+
   it('aggregates multiple turns in the same session into one enrich pass', async () => {
     // SQLite has 2 assistant rows (one per LLM call); hook JSONL has 2 turns
     // referencing those calls. With session-level aggregation matchIdeTurnsBySqliteOrder

--- a/tests/unit/inputs/qoder-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-trace-input.test.ts
@@ -503,6 +503,53 @@ describe('QoderTraceInput token-enricher', () => {
 });
 
 describe('QoderTraceInput bootstrap history filtering', () => {
+  it('consumes every session batch created after startup with an empty history', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'qoder-trace-empty-start-'));
+    try {
+      const logFileName = `qoder-${getTodayDateString()}.jsonl`;
+      const logFile = path.join(tmpDir, logFileName);
+      const record = (id: string, turnId: string, batchId: string) => ({
+        'event.id': id,
+        'event.name': 'llm.response',
+        'gen_ai.agent.type': 'qoder',
+        'gen_ai.session.id': batchId,
+        'gen_ai.turn.id': turnId,
+        'agent.transcript.cursor_mode': 'bootstrap',
+        'agent.transcript.cursor_batch_id': batchId,
+        time_unix_nano: '1780000000000000000',
+      });
+      const stateStore = new MockStateStore();
+      const input = new QoderTraceInput({
+        stateStore: stateStore as any,
+        logDir: tmpDir,
+        pollIntervalMs: 60_000,
+      });
+
+      await input.start();
+      expect(stateStore.get('qoder-trace')).toMatchObject({
+        lastFile: logFileName,
+        lastOffset: 0,
+        extra: { hookHistoryInitialized: true },
+      });
+
+      await fs.writeFile(logFile, [
+        record('session-a-old', 'session-a-old-turn', 'session-a-batch'),
+        record('session-a-latest', 'session-a-latest-turn', 'session-a-batch'),
+        record('session-b-old', 'session-b-old-turn', 'session-b-batch'),
+        record('session-b-latest', 'session-b-latest-turn', 'session-b-batch'),
+      ].map(entry => JSON.stringify(entry)).join('\n') + '\n');
+
+      const entries = await (input as any).collect() as AgentActivityEntry[];
+      await input.stop();
+      expect(entries.map(entry => entry['event.id'])).toEqual([
+        'session-a-latest',
+        'session-b-latest',
+      ]);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it('protects every later old-session batch after the global file state is initialized', async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'qoder-trace-bootstrap-'));
     try {

--- a/tests/unit/inputs/qoder-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-trace-input.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { enrichCliTurn, enrichIdeTurn, injectTraceId } from '../../../src/inputs/qoder-trace/token-enricher.js';
+import { QoderTraceInput } from '../../../src/inputs/qoder-trace/qoder-trace-input.js';
 import type { AgentActivityEntry } from '../../../src/types/index.js';
 import type { SegmentTokenData } from '../../../src/inputs/qoder-trace/segment-token-reader.js';
 import type { SqliteTokenData } from '../../../src/inputs/qoder-trace/sqlite-token-reader.js';
+import { getTodayDateString } from '../../../src/utils/fs-utils.js';
+import { MockStateStore } from '../../helpers/mock-state-store.js';
 
 function makeEntry(overrides: Partial<AgentActivityEntry> = {}): AgentActivityEntry {
   return {
@@ -493,5 +499,51 @@ describe('QoderTraceInput token-enricher', () => {
     it('does nothing for empty array', () => {
       expect(() => injectTraceId([])).not.toThrow();
     });
+  });
+});
+
+describe('QoderTraceInput bootstrap history filtering', () => {
+  it('protects every later old-session batch after the global file state is initialized', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'qoder-trace-bootstrap-'));
+    try {
+      const logFileName = `qoder-${getTodayDateString()}.jsonl`;
+      const logFile = path.join(tmpDir, logFileName);
+      const record = (id: string, turnId: string, batchId: string) => ({
+        'event.id': id,
+        'event.name': 'llm.response',
+        'gen_ai.agent.type': 'qoder',
+        'gen_ai.turn.id': turnId,
+        'agent.transcript.cursor_mode': 'bootstrap',
+        'agent.transcript.cursor_batch_id': batchId,
+        time_unix_nano: '1780000000000000000',
+      });
+      await fs.writeFile(logFile, [
+        record('session-a-old', 'session-a-old-turn', 'session-a-batch'),
+        record('session-a-latest', 'session-a-latest-turn', 'session-a-batch'),
+        record('session-b-old', 'session-b-old-turn', 'session-b-batch'),
+        record('session-b-latest', 'session-b-latest-turn', 'session-b-batch'),
+      ].map(entry => JSON.stringify(entry)).join('\n') + '\n');
+
+      const stateStore = new MockStateStore();
+      // lastFile proves the process-level cold start already occurred before
+      // these old sessions first appeared.
+      stateStore.set('qoder-trace', { lastFile: logFileName, lastOffset: 0 });
+      const input = new QoderTraceInput({
+        stateStore: stateStore as any,
+        logDir: tmpDir,
+        pollIntervalMs: 60_000,
+      });
+      const entries: AgentActivityEntry[] = [];
+      input.on('entries', batch => entries.push(...batch));
+      await input.start();
+      await input.stop();
+
+      expect(entries.map(entry => entry['event.id'])).toEqual([
+        'session-a-latest',
+        'session-b-latest',
+      ]);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/unit/inputs/qoder-work-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-work-trace-input.test.ts
@@ -33,7 +33,17 @@ describe('QoderWorkTraceInput', () => {
     await fs.rm(tmpRoot, { recursive: true, force: true });
   });
 
-  function makeInput(opts: { interceptFile?: string } = {}) {
+  function makeInput(opts: { interceptFile?: string; initializeHistory?: boolean } = {}) {
+    if (opts.initializeHistory !== false) {
+      const current = stateStore.get('qoder-work-trace');
+      if (!current.lastFile) {
+        stateStore.set('qoder-work-trace', {
+          ...current,
+          lastFile: todayFileName(),
+          lastOffset: 0,
+        });
+      }
+    }
     return new QoderWorkTraceInput({
       stateStore: stateStore as any,
       logDir: hookLogDir,
@@ -159,7 +169,7 @@ describe('QoderWorkTraceInput', () => {
     await input.stop();
   });
 
-  it('on first run emits only the last historical turn and checkpoints the whole file', async () => {
+  it('baselines an existing history when the checkpoint is missing, then reads new appends', async () => {
     const hookFile = path.join(hookLogDir, todayFileName());
     const oldRequest = buildHookEntry({
       'event.id': 'old-request',
@@ -188,15 +198,14 @@ describe('QoderWorkTraceInput', () => {
       .join('\n') + '\n';
     await fs.writeFile(hookFile, initialText);
 
-    const input = makeInput();
+    const input = makeInput({ initializeHistory: false });
     const initialEntries = await startAndCollect(input);
 
-    expect(initialEntries.map(entry => entry['event.id'])).toEqual([
-      'latest-request',
-      'latest-response',
-    ]);
+    expect(initialEntries).toEqual([]);
     expect(stateStore.get('qoder-work-trace').lastOffset).toBe(Buffer.byteLength(initialText));
-    expect(stateStore.get('qoder-work-trace').extra).toMatchObject({ qoderWorkTurnCount: 2 });
+    expect(stateStore.get('qoder-work-trace').extra).toMatchObject({
+      hookHistoryInitialized: true,
+    });
 
     const nextResponse = buildHookEntry({
       'event.id': 'next-response',
@@ -211,24 +220,30 @@ describe('QoderWorkTraceInput', () => {
     expect(nextEntries.map(entry => entry['event.id'])).toEqual(['next-response']);
   });
 
-  it('on first run emits the only turn', async () => {
+  it('initializes offset zero before a lazily-created history and consumes its first turn', async () => {
     const hookFile = path.join(hookLogDir, todayFileName());
     const onlyEntry = buildHookEntry({
       'event.id': 'only-response',
       'gen_ai.turn.id': 'turn-only',
       'gen_ai.step.id': 'turn-only:s1',
     });
-    await fs.writeFile(hookFile, JSON.stringify(onlyEntry) + '\n');
+    const input = makeInput({ initializeHistory: false });
+    const initialEntries = await startAndCollect(input);
+    expect(initialEntries).toEqual([]);
+    expect(stateStore.get('qoder-work-trace')).toMatchObject({
+      lastFile: todayFileName(),
+      lastOffset: 0,
+      extra: { hookHistoryInitialized: true },
+    });
 
-    const input = makeInput();
-    const entries = await startAndCollect(input);
+    await fs.writeFile(hookFile, JSON.stringify(onlyEntry) + '\n');
+    const entries = await triggerCycle(input);
     await input.stop();
 
     expect(entries.map(entry => entry['event.id'])).toEqual(['only-response']);
-    expect(stateStore.get('qoder-work-trace').extra).toMatchObject({ qoderWorkTurnCount: 1 });
   });
 
-  it('filters every later bootstrap batch independently after input state is initialized', async () => {
+  it('reports every bootstrap session written before the first poll after empty startup', async () => {
     const hookFile = path.join(hookLogDir, todayFileName());
     const bootstrap = (id: string, turnId: string, batchId: string) => buildHookEntry({
       'event.id': id,
@@ -250,13 +265,10 @@ describe('QoderWorkTraceInput', () => {
         'agent.transcript.cursor_batch_id': 'normal-batch',
       } as Partial<AgentActivityEntry>),
     ];
+    const input = makeInput({ initializeHistory: false });
+    expect(await startAndCollect(input)).toEqual([]);
     await fs.writeFile(hookFile, records.map(record => JSON.stringify(record)).join('\n') + '\n');
-    // Simulate a running collector whose global history-file bootstrap already
-    // happened before these two old sessions were opened.
-    stateStore.set('qoder-work-trace', { extra: { qoderWorkTurnCount: 1 } });
-
-    const input = makeInput();
-    const entries = await startAndCollect(input);
+    const entries = await triggerCycle(input);
     await input.stop();
 
     expect(entries.map(entry => entry['event.id'])).toEqual([
@@ -266,7 +278,7 @@ describe('QoderWorkTraceInput', () => {
     ]);
   });
 
-  it('streams a large first-run history and exports only its last turn', async () => {
+  it('baselines a large existing history without loading or replaying it', async () => {
     const hookFile = path.join(hookLogDir, todayFileName());
     const oldEntry = {
       ...buildHookEntry({ 'event.id': 'large-old', 'gen_ai.turn.id': 'turn-old' }),
@@ -276,11 +288,11 @@ describe('QoderWorkTraceInput', () => {
     const text = `${JSON.stringify(oldEntry)}\n${JSON.stringify(latestEntry)}\n`;
     await fs.writeFile(hookFile, text);
 
-    const input = makeInput();
+    const input = makeInput({ initializeHistory: false });
     const entries = await startAndCollect(input);
     await input.stop();
 
-    expect(entries.map(entry => entry['event.id'])).toEqual(['large-latest']);
+    expect(entries).toEqual([]);
     expect(stateStore.get('qoder-work-trace').lastOffset).toBe(Buffer.byteLength(text));
   });
 
@@ -359,8 +371,6 @@ describe('QoderWorkTraceInput', () => {
     const e2 = buildHookEntry({ 'event.id': 'e2', 'gen_ai.turn.id': 'turn-A' });
     const e3 = buildHookEntry({ 'event.id': 'e3', 'gen_ai.turn.id': 'turn-B' });
     await fs.writeFile(hookFile, [JSON.stringify(e1), JSON.stringify(e2), JSON.stringify(e3)].join('\n') + '\n');
-    stateStore.set('qoder-work-trace', { extra: { qoderWorkTurnCount: 1 } });
-
     const input = makeInput();
     const entries = await startAndCollect(input);
     await input.stop();

--- a/tests/unit/inputs/qoder-work-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-work-trace-input.test.ts
@@ -228,6 +228,44 @@ describe('QoderWorkTraceInput', () => {
     expect(stateStore.get('qoder-work-trace').extra).toMatchObject({ qoderWorkTurnCount: 1 });
   });
 
+  it('filters every later bootstrap batch independently after input state is initialized', async () => {
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const bootstrap = (id: string, turnId: string, batchId: string) => buildHookEntry({
+      'event.id': id,
+      'gen_ai.turn.id': turnId,
+      'gen_ai.step.id': `${turnId}:s1`,
+      'agent.transcript.cursor_mode': 'bootstrap',
+      'agent.transcript.cursor_batch_id': batchId,
+    } as Partial<AgentActivityEntry>);
+    const records = [
+      bootstrap('session-a-old', 'session-a-turn-old', 'session-a-bootstrap'),
+      bootstrap('session-a-latest', 'session-a-turn-latest', 'session-a-bootstrap'),
+      bootstrap('session-b-old', 'session-b-turn-old', 'session-b-bootstrap'),
+      bootstrap('session-b-latest', 'session-b-turn-latest', 'session-b-bootstrap'),
+      buildHookEntry({
+        'event.id': 'normal-incremental',
+        'gen_ai.turn.id': 'normal-turn',
+        'gen_ai.step.id': 'normal-turn:s1',
+        'agent.transcript.cursor_mode': 'incremental',
+        'agent.transcript.cursor_batch_id': 'normal-batch',
+      } as Partial<AgentActivityEntry>),
+    ];
+    await fs.writeFile(hookFile, records.map(record => JSON.stringify(record)).join('\n') + '\n');
+    // Simulate a running collector whose global history-file bootstrap already
+    // happened before these two old sessions were opened.
+    stateStore.set('qoder-work-trace', { extra: { qoderWorkTurnCount: 1 } });
+
+    const input = makeInput();
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    expect(entries.map(entry => entry['event.id'])).toEqual([
+      'session-a-latest',
+      'session-b-latest',
+      'normal-incremental',
+    ]);
+  });
+
   it('streams a large first-run history and exports only its last turn', async () => {
     const hookFile = path.join(hookLogDir, todayFileName());
     const oldEntry = {


### PR DESCRIPTION
## Summary

- persist Qoder-family hook cursors as independent per-session files so concurrent Stop hooks cannot overwrite another session
- keep a locked aggregate cursor shadow for immediate-version rollback compatibility and reconcile it without allowing line offsets to move backward
- replace Qoder/QoderWork Input’s global first-poll “keep the last turn” heuristic with a deterministic startup checkpoint
- apply the same startup checkpoint to Qoder CN so missing `input-state.json` cannot replay a daily history made of steady-state `incremental` records
- when history is absent, initialize offset 0 before Hook batches arrive; when state is missing but history already exists, baseline EOF instead of replaying or guessing a global turn
- keep batch-scoped bootstrap filtering, so every old session first opened after startup contributes its own latest logical turn
- correct Qoder Work CN cursor diagnostics and document primary versus rollback-shadow state

## Validation

- 93 targeted Qoder/QoderWork/Qoder CN/shared Hook tests passed
- regression covers Qoder CN state loss with an existing daily history containing only `cursor_mode=incremental`: history is not emitted, EOF is checkpointed, and a later append is consumed
- regression covers two sessions appending bootstrap batches before the first Input poll; both sessions are emitted
- regression covers four concurrent session cursor writers, old-version rollback reconciliation, and monotonic cursor recovery
- manual redeploy verification before the final Input correction confirmed the Hook processor independently reduced three old QoderWork sessions to their latest turn
- local `npm run typecheck` is blocked by an existing workspace dependency mismatch: installed `@loongsuite/otel-util-genai` beta.8 versus package-lock beta.9; CI installs the locked dependency

## Follow-up

- stale-lock cleanup for the best-effort aggregate rollback shadow has a cross-process TOCTOU window; the per-session primary cursor is unaffected, and lock hardening can be handled separately