### PR TITLE
feat(cursor): detect skill usage from transcript post-assembly

### DIFF
--- a/assets/hooks/cursor-hook-processor.mjs
+++ b/assets/hooks/cursor-hook-processor.mjs
@@ -10,6 +10,7 @@
  * Raw capture is behind LOONGSUITE_CURSOR_RAW_TRACE=1 env flag.
  */
 
+import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -104,6 +105,80 @@ function compactJournal(allEvents, consumedConversationIds) {
     if (pendingTurnConvIds.has(ev.conversation_id)) remaining.push(ev);
   }
   rewriteJournal(remaining, allEvents);
+}
+
+function injectSkillRecords(records, skills, promptEvent) {
+  // Find first LLM span (llm.request or llm.response) to annotate with skill name
+  const firstLlmIdx = records.findIndex(r =>
+    r['event.name'] === 'llm.request' || r['event.name'] === 'llm.response'
+  );
+
+  if (firstLlmIdx < 0) return; // no LLM span found
+
+  // Append Read tool_use entries to the first LLM span's output messages
+  const llmRecord = records[firstLlmIdx];
+  const outputMsgs = Array.isArray(llmRecord['gen_ai.output.messages'])
+    ? llmRecord['gen_ai.output.messages']
+    : [];
+
+  let assistantMsg = outputMsgs.find(m => m.role === 'assistant');
+  if (!assistantMsg) {
+    assistantMsg = { role: 'assistant', parts: [] };
+    outputMsgs.push(assistantMsg);
+  }
+  if (!Array.isArray(assistantMsg.parts)) assistantMsg.parts = [];
+
+  for (const skill of skills) {
+    assistantMsg.parts.push({
+      type: 'tool_use',
+      name: 'Read',
+      tool_use_id: crypto.randomUUID(),
+      input: { path: skill.skillPath },
+    });
+  }
+  llmRecord['gen_ai.output.messages'] = outputMsgs;
+
+  // Create tool.call + tool.result record pairs for each skill read
+  const insertRecords = [];
+  for (const skill of skills) {
+    const toolCallId = crypto.randomUUID();
+    const baseFields = {
+      time_unix_nano: String(BigInt(records[firstLlmIdx].time_unix_nano) + 1000000n),
+      observed_time_unix_nano: String(BigInt(records[firstLlmIdx].observed_time_unix_nano) + 1000000n),
+      trace_id: records[firstLlmIdx].trace_id,
+      'gen_ai.session.id': records[firstLlmIdx]['gen_ai.session.id'],
+      'gen_ai.turn.id': records[firstLlmIdx]['gen_ai.turn.id'],
+      'gen_ai.step.id': records[firstLlmIdx]['gen_ai.step.id'] || 'step_1',
+      'gen_ai.agent.type': records[firstLlmIdx]['gen_ai.agent.type'],
+      'user.id': records[firstLlmIdx]['user.id'],
+    };
+
+    // tool.call
+    insertRecords.push({
+      ...baseFields,
+      'event.id': crypto.randomUUID(),
+      'event.name': 'tool.call',
+      'gen_ai.tool.name': 'Read',
+      'gen_ai.tool.call.id': toolCallId,
+      'gen_ai.tool.call.arguments': JSON.stringify({ path: skill.skillPath }),
+      'gen_ai.skill.name': skill.skillName,
+      'agent.cursor.skill_detection_source': 'transcript_post_assembly',
+    });
+
+    // tool.result
+    insertRecords.push({
+      ...baseFields,
+      'event.id': crypto.randomUUID(),
+      'event.name': 'tool.result',
+      'gen_ai.tool.name': 'Read',
+      'gen_ai.tool.call.id': toolCallId,
+      'gen_ai.skill.name': skill.skillName,
+      'agent.cursor.skill_detection_source': 'transcript_post_assembly',
+    });
+  }
+
+  // Insert after the first LLM span
+  records.splice(firstLlmIdx + 1, 0, ...insertRecords);
 }
 
 async function main() {
@@ -256,6 +331,21 @@ async function main() {
         records = result.records;
         consumedConversationIds = result.consumedConversationIds;
       }
+
+      // ─── Post-assembly: Skill Usage Detection from Transcript ───
+      try {
+        const transcriptPathForSkill = internalEvent.transcript_path;
+        const promptForSkill = allEvents.find(e =>
+          e.hook_event === 'beforeSubmitPrompt' && e.conversation_id === convId
+        );
+        if (transcriptPathForSkill && promptForSkill?.prompt && records.length > 0) {
+          const { detectSkillFromTranscript } = await import('./cursor/skill-detector.mjs');
+          const detectedSkills = detectSkillFromTranscript(transcriptPathForSkill, promptForSkill.prompt);
+          if (detectedSkills && detectedSkills.length > 0) {
+            injectSkillRecords(records, detectedSkills, promptForSkill);
+          }
+        }
+      } catch { /* best-effort skill detection — never block output */ }
 
       if (records.length > 0) {
         const day = localDateString(now);

--- a/assets/hooks/cursor-hook-processor.mjs
+++ b/assets/hooks/cursor-hook-processor.mjs
@@ -107,16 +107,22 @@ function compactJournal(allEvents, consumedConversationIds) {
   rewriteJournal(remaining, allEvents);
 }
 
-function injectSkillRecords(records, skills, promptEvent) {
-  // Find first LLM span (llm.request or llm.response) to annotate with skill name
-  const firstLlmIdx = records.findIndex(r =>
-    r['event.name'] === 'llm.request' || r['event.name'] === 'llm.response'
-  );
+function injectSkillRecords(records, skills) {
+  // Skill-to-step alignment is best-effort: attach detected reads to the first
+  // assembled LLM response. Cursor's assemblers synthesize a response even for
+  // thought-only and implicit tool steps, so never attach output to a request.
+  const targetLlmIdx = records.findIndex(r => r['event.name'] === 'llm.response');
+  if (targetLlmIdx < 0) return;
 
-  if (firstLlmIdx < 0) return; // no LLM span found
+  // Generate each call ID once so the LLM output, tool.call, and tool.result
+  // records all describe the same synthetic tool invocation.
+  const skillEntries = skills.map(skill => ({
+    skill,
+    toolCallId: crypto.randomUUID(),
+  }));
 
-  // Append Read tool_use entries to the first LLM span's output messages
-  const llmRecord = records[firstLlmIdx];
+  // Append canonical Read tool_call entries to the first LLM response.
+  const llmRecord = records[targetLlmIdx];
   const outputMsgs = Array.isArray(llmRecord['gen_ai.output.messages'])
     ? llmRecord['gen_ai.output.messages']
     : [];
@@ -128,39 +134,45 @@ function injectSkillRecords(records, skills, promptEvent) {
   }
   if (!Array.isArray(assistantMsg.parts)) assistantMsg.parts = [];
 
-  for (const skill of skills) {
+  for (const { skill, toolCallId } of skillEntries) {
     assistantMsg.parts.push({
-      type: 'tool_use',
+      type: 'tool_call',
+      id: toolCallId,
       name: 'Read',
-      tool_use_id: crypto.randomUUID(),
-      input: { path: skill.skillPath },
+      arguments: { path: skill.skillPath },
     });
   }
   llmRecord['gen_ai.output.messages'] = outputMsgs;
 
   // Create tool.call + tool.result record pairs for each skill read
   const insertRecords = [];
-  for (const skill of skills) {
-    const toolCallId = crypto.randomUUID();
+  const baseTime = BigInt(llmRecord.time_unix_nano);
+  const baseObservedTime = BigInt(
+    llmRecord.observed_time_unix_nano ?? llmRecord.time_unix_nano
+  );
+  for (let index = 0; index < skillEntries.length; index++) {
+    const { skill, toolCallId } = skillEntries[index];
+    const callOffset = BigInt(index * 2 + 1);
+    const resultOffset = callOffset + 1n;
     const baseFields = {
-      time_unix_nano: String(BigInt(records[firstLlmIdx].time_unix_nano) + 1000000n),
-      observed_time_unix_nano: String(BigInt(records[firstLlmIdx].observed_time_unix_nano) + 1000000n),
-      trace_id: records[firstLlmIdx].trace_id,
-      'gen_ai.session.id': records[firstLlmIdx]['gen_ai.session.id'],
-      'gen_ai.turn.id': records[firstLlmIdx]['gen_ai.turn.id'],
-      'gen_ai.step.id': records[firstLlmIdx]['gen_ai.step.id'] || 'step_1',
-      'gen_ai.agent.type': records[firstLlmIdx]['gen_ai.agent.type'],
-      'user.id': records[firstLlmIdx]['user.id'],
+      trace_id: llmRecord.trace_id,
+      'gen_ai.session.id': llmRecord['gen_ai.session.id'],
+      'gen_ai.turn.id': llmRecord['gen_ai.turn.id'],
+      'gen_ai.step.id': llmRecord['gen_ai.step.id'] || 'step_1',
+      'gen_ai.agent.type': llmRecord['gen_ai.agent.type'],
+      'user.id': llmRecord['user.id'],
     };
 
     // tool.call
     insertRecords.push({
       ...baseFields,
+      time_unix_nano: String(baseTime + callOffset),
+      observed_time_unix_nano: String(baseObservedTime + callOffset),
       'event.id': crypto.randomUUID(),
       'event.name': 'tool.call',
       'gen_ai.tool.name': 'Read',
       'gen_ai.tool.call.id': toolCallId,
-      'gen_ai.tool.call.arguments': JSON.stringify({ path: skill.skillPath }),
+      'gen_ai.tool.call.arguments': { path: skill.skillPath },
       'gen_ai.skill.name': skill.skillName,
       'agent.cursor.skill_detection_source': 'transcript_post_assembly',
     });
@@ -168,6 +180,8 @@ function injectSkillRecords(records, skills, promptEvent) {
     // tool.result
     insertRecords.push({
       ...baseFields,
+      time_unix_nano: String(baseTime + resultOffset),
+      observed_time_unix_nano: String(baseObservedTime + resultOffset),
       'event.id': crypto.randomUUID(),
       'event.name': 'tool.result',
       'gen_ai.tool.name': 'Read',
@@ -177,8 +191,8 @@ function injectSkillRecords(records, skills, promptEvent) {
     });
   }
 
-  // Insert after the first LLM span
-  records.splice(firstLlmIdx + 1, 0, ...insertRecords);
+  // Insert after the first LLM response.
+  records.splice(targetLlmIdx + 1, 0, ...insertRecords);
 }
 
 async function main() {
@@ -342,7 +356,7 @@ async function main() {
           const { detectSkillFromTranscript } = await import('./cursor/skill-detector.mjs');
           const detectedSkills = detectSkillFromTranscript(transcriptPathForSkill, promptForSkill.prompt);
           if (detectedSkills && detectedSkills.length > 0) {
-            injectSkillRecords(records, detectedSkills, promptForSkill);
+            injectSkillRecords(records, detectedSkills);
           }
         }
       } catch { /* best-effort skill detection — never block output */ }

--- a/assets/hooks/cursor-hook-processor.mjs
+++ b/assets/hooks/cursor-hook-processor.mjs
@@ -430,3 +430,5 @@ main().catch(async err => {
   });
   writeEmptyResponse();
 });
+
+export { injectSkillRecords };

--- a/assets/hooks/cursor-hook-processor.mjs
+++ b/assets/hooks/cursor-hook-processor.mjs
@@ -319,6 +319,7 @@ async function main() {
       const runtimeConfig = loadHookRuntimeConfig(dataDir);
       let records;
       let consumedConversationIds;
+      let assembledFromTranscript = false;
 
       // On Windows: use transcript as source of truth for text content.
       // This bypasses GB18030 codepage corruption of hook payload text.
@@ -331,6 +332,7 @@ async function main() {
         if (transcriptRecords && transcriptRecords.length > 0) {
           records = transcriptRecords;
           consumedConversationIds = new Set([convId]);
+          assembledFromTranscript = true;
         }
       }
 
@@ -355,7 +357,9 @@ async function main() {
         if (transcriptPathForSkill && promptForSkill?.prompt && records.length > 0) {
           const { detectSkillFromTranscript } = await import('./cursor/skill-detector.mjs');
           const detectedSkills = detectSkillFromTranscript(transcriptPathForSkill, promptForSkill.prompt);
-          if (detectedSkills && detectedSkills.length > 0) {
+          // The Windows transcript assembler already materializes transcript
+          // tool_use entries. Only compensate paths assembled from hook events.
+          if (detectedSkills && detectedSkills.length > 0 && !assembledFromTranscript) {
             injectSkillRecords(records, detectedSkills);
           }
         }

--- a/assets/hooks/cursor-hook-processor.mjs
+++ b/assets/hooks/cursor-hook-processor.mjs
@@ -14,7 +14,9 @@ import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import {
+  applyHookContentPolicy,
   hashJson,
   loadHookRuntimeConfig,
   sanitizeObject,
@@ -107,7 +109,11 @@ function compactJournal(allEvents, consumedConversationIds) {
   rewriteJournal(remaining, allEvents);
 }
 
-function injectSkillRecords(records, skills) {
+function applyPolicy(record, runtimeConfig) {
+  return sanitizeObject(applyHookContentPolicy(record, runtimeConfig)) || {};
+}
+
+function injectSkillRecords(records, skills, runtimeConfig = {}) {
   // Skill-to-step alignment is best-effort: attach detected reads to the first
   // assembled LLM response. Cursor's assemblers synthesize a response even for
   // thought-only and implicit tool steps, so never attach output to a request.
@@ -143,6 +149,7 @@ function injectSkillRecords(records, skills) {
     });
   }
   llmRecord['gen_ai.output.messages'] = outputMsgs;
+  records[targetLlmIdx] = applyPolicy(llmRecord, runtimeConfig);
 
   // Create tool.call + tool.result record pairs for each skill read
   const insertRecords = [];
@@ -164,7 +171,7 @@ function injectSkillRecords(records, skills) {
     };
 
     // tool.call
-    insertRecords.push({
+    insertRecords.push(applyPolicy({
       ...baseFields,
       time_unix_nano: String(baseTime + callOffset),
       observed_time_unix_nano: String(baseObservedTime + callOffset),
@@ -175,10 +182,10 @@ function injectSkillRecords(records, skills) {
       'gen_ai.tool.call.arguments': { path: skill.skillPath },
       'gen_ai.skill.name': skill.skillName,
       'agent.cursor.skill_detection_source': 'transcript_post_assembly',
-    });
+    }, runtimeConfig));
 
     // tool.result
-    insertRecords.push({
+    insertRecords.push(applyPolicy({
       ...baseFields,
       time_unix_nano: String(baseTime + resultOffset),
       observed_time_unix_nano: String(baseObservedTime + resultOffset),
@@ -188,7 +195,7 @@ function injectSkillRecords(records, skills) {
       'gen_ai.tool.call.id': toolCallId,
       'gen_ai.skill.name': skill.skillName,
       'agent.cursor.skill_detection_source': 'transcript_post_assembly',
-    });
+    }, runtimeConfig));
   }
 
   // Insert after the first LLM response.
@@ -360,7 +367,7 @@ async function main() {
           // The Windows transcript assembler already materializes transcript
           // tool_use entries. Only compensate paths assembled from hook events.
           if (detectedSkills && detectedSkills.length > 0 && !assembledFromTranscript) {
-            injectSkillRecords(records, detectedSkills);
+            injectSkillRecords(records, detectedSkills, runtimeConfig);
           }
         }
       } catch { /* best-effort skill detection — never block output */ }
@@ -422,13 +429,18 @@ async function main() {
   writeEmptyResponse();
 }
 
-main().catch(async err => {
-  await appendErrorJsonl(resolveDataDir(), new Date(), {
-    stage: 'runtime',
-    'error.type': 'unhandled_exception',
-    'error.message': err instanceof Error ? err.message : String(err),
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+) {
+  main().catch(async err => {
+    await appendErrorJsonl(resolveDataDir(), new Date(), {
+      stage: 'runtime',
+      'error.type': 'unhandled_exception',
+      'error.message': err instanceof Error ? err.message : String(err),
+    });
+    writeEmptyResponse();
   });
-  writeEmptyResponse();
-});
+}
 
 export { injectSkillRecords };

--- a/assets/hooks/cursor/skill-detector.mjs
+++ b/assets/hooks/cursor/skill-detector.mjs
@@ -1,0 +1,99 @@
+/**
+ * skill-detector.mjs — Detect skill usage from Cursor transcript post-assembly.
+ *
+ * Strategy: After assembly completes, scan the transcript to find Read tool_use
+ * entries targeting ~/.cursor/skills/<name>/SKILL.md paths within the matched turn.
+ */
+
+import fs from 'node:fs';
+
+// Path pattern: /.cursor/skills/<skill-name>/SKILL.md (case-insensitive)
+const SKILL_PATH_RE = /[/\\]\.cursor[/\\]skills[/\\]([\w-]+)[/\\]SKILL\.md/i;
+
+/**
+ * Detect skill usage from transcript for a specific turn.
+ *
+ * @param {string} transcriptPath - Path to the transcript JSONL file
+ * @param {string} userPrompt - The user prompt text to match the correct turn
+ * @returns {{ skillName: string, skillPath: string }[] | null}
+ */
+export function detectSkillFromTranscript(transcriptPath, userPrompt) {
+  if (!transcriptPath || !userPrompt) return null;
+
+  let content;
+  try {
+    content = fs.readFileSync(transcriptPath, 'utf-8');
+  } catch (_e) {
+    return null; // transcript file not accessible
+  }
+
+  const lines = content.trim().split('\n').filter(Boolean);
+  const entries = [];
+  for (const line of lines) {
+    try { entries.push(JSON.parse(line)); } catch (_e) { /* skip malformed */ }
+  }
+
+  if (entries.length === 0) return null;
+
+  // Step 1: Find the user message that matches our prompt
+  // The user prompt in transcript is wrapped in <user_query> tags and may have <timestamp>
+  // Match strategy: normalize both sides and check inclusion
+  const normalizedPrompt = normalizeForMatch(userPrompt);
+
+  let matchedTurnStart = -1;
+  for (let i = 0; i < entries.length; i++) {
+    const e = entries[i];
+    if (e.role !== 'user') continue;
+    const userText = extractUserText(e);
+    if (userText && normalizeForMatch(userText).includes(normalizedPrompt)) {
+      matchedTurnStart = i;
+    }
+  }
+
+  if (matchedTurnStart < 0) return null;
+
+  // Step 2: Scan assistant messages after matched user message until next turn_ended or next user message
+  const skills = [];
+  for (let i = matchedTurnStart + 1; i < entries.length; i++) {
+    const e = entries[i];
+    if (e.type === 'turn_ended' || e.role === 'user') break;
+
+    if (e.role === 'assistant' && e.message?.content) {
+      for (const block of e.message.content) {
+        if (block.type === 'tool_use' && (block.name === 'Read' || block.name === 'ReadFile')) {
+          const filePath = block.input?.path || '';
+          const match = filePath.match(SKILL_PATH_RE);
+          if (match) {
+            skills.push({
+              skillName: match[1],
+              skillPath: filePath,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  return skills.length > 0 ? skills : null;
+}
+
+/**
+ * Extract plain text from a user message entry.
+ */
+function extractUserText(entry) {
+  const content = entry.message?.content;
+  if (!Array.isArray(content)) return '';
+  const textParts = content.filter(b => b.type === 'text');
+  return textParts.map(b => b.text || '').join('\n');
+}
+
+/**
+ * Normalize text for fuzzy matching: strip tags, collapse whitespace, lowercase.
+ */
+function normalizeForMatch(text) {
+  return text
+    .replace(/<[^>]+>/g, '') // strip XML/HTML tags
+    .replace(/\s+/g, ' ')    // collapse whitespace
+    .trim()
+    .toLowerCase();
+}

--- a/tests/unit/hooks/cursor/inject-skill-records.test.mjs
+++ b/tests/unit/hooks/cursor/inject-skill-records.test.mjs
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest';
+import { injectSkillRecords } from '../../../../assets/hooks/cursor-hook-processor.mjs';
+
+/**
+ * Helper: create a minimal llm.response record.
+ */
+function makeLlmResponse(overrides = {}) {
+  return {
+    trace_id: 'trace-001',
+    'gen_ai.session.id': 'session-001',
+    'gen_ai.turn.id': 'turn-001',
+    'gen_ai.step.id': 'step_1',
+    'gen_ai.agent.type': 'cursor',
+    'user.id': 'user-001',
+    'event.id': 'evt-resp-001',
+    'event.name': 'llm.response',
+    time_unix_nano: '1700000000000000000',
+    observed_time_unix_nano: '1700000000000000100',
+    'gen_ai.output.messages': [
+      { role: 'assistant', parts: [{ type: 'text', text: 'Hello' }] },
+    ],
+    ...overrides,
+  };
+}
+
+/**
+ * Helper: create a minimal llm.request record.
+ */
+function makeLlmRequest(overrides = {}) {
+  return {
+    trace_id: 'trace-001',
+    'event.id': 'evt-req-001',
+    'event.name': 'llm.request',
+    time_unix_nano: '1700000000000000000',
+    ...overrides,
+  };
+}
+
+function makeSkill(name = 'my-skill', skillPath = '/Users/test/.cursor/skills/my-skill/SKILL.md') {
+  return { skillName: name, skillPath };
+}
+
+describe('injectSkillRecords', () => {
+  it('should inject tool_call part into llm.response output.messages', () => {
+    const records = [makeLlmResponse()];
+    const skills = [makeSkill()];
+
+    injectSkillRecords(records, skills);
+
+    const llm = records[0];
+    const assistantMsg = llm['gen_ai.output.messages'].find(m => m.role === 'assistant');
+    const toolCallParts = assistantMsg.parts.filter(p => p.type === 'tool_call');
+    expect(toolCallParts).toHaveLength(1);
+    expect(toolCallParts[0]).toMatchObject({
+      type: 'tool_call',
+      name: 'Read',
+      arguments: { path: '/Users/test/.cursor/skills/my-skill/SKILL.md' },
+    });
+    expect(toolCallParts[0].id).toBeDefined();
+  });
+
+  it('should insert tool.call and tool.result records after llm.response', () => {
+    const records = [makeLlmResponse()];
+    const skills = [makeSkill()];
+
+    injectSkillRecords(records, skills);
+
+    expect(records).toHaveLength(3);
+    const toolCall = records[1];
+    const toolResult = records[2];
+
+    expect(toolCall['event.name']).toBe('tool.call');
+    expect(toolCall['gen_ai.tool.name']).toBe('Read');
+    expect(toolCall['gen_ai.tool.call.arguments']).toEqual({ path: '/Users/test/.cursor/skills/my-skill/SKILL.md' });
+    expect(toolCall['gen_ai.skill.name']).toBe('my-skill');
+    expect(toolCall['agent.cursor.skill_detection_source']).toBe('transcript_post_assembly');
+
+    expect(toolResult['event.name']).toBe('tool.result');
+    expect(toolResult['gen_ai.tool.name']).toBe('Read');
+    expect(toolResult['gen_ai.skill.name']).toBe('my-skill');
+    expect(toolResult['agent.cursor.skill_detection_source']).toBe('transcript_post_assembly');
+  });
+
+  it('should share the same toolCallId across output.messages, tool.call, and tool.result', () => {
+    const records = [makeLlmResponse()];
+    const skills = [makeSkill()];
+
+    injectSkillRecords(records, skills);
+
+    const llm = records[0];
+    const assistantMsg = llm['gen_ai.output.messages'].find(m => m.role === 'assistant');
+    const toolCallPart = assistantMsg.parts.find(p => p.type === 'tool_call');
+    const toolCallRecord = records[1];
+    const toolResultRecord = records[2];
+
+    expect(toolCallPart.id).toBe(toolCallRecord['gen_ai.tool.call.id']);
+    expect(toolCallRecord['gen_ai.tool.call.id']).toBe(toolResultRecord['gen_ai.tool.call.id']);
+  });
+
+  it('should assign strictly increasing timestamps relative to llm.response', () => {
+    const baseTime = '1700000000000000000';
+    const records = [makeLlmResponse({ time_unix_nano: baseTime })];
+    const skills = [makeSkill()];
+
+    injectSkillRecords(records, skills);
+
+    const toolCall = records[1];
+    const toolResult = records[2];
+
+    expect(toolCall.time_unix_nano).toBe(String(BigInt(baseTime) + 1n));
+    expect(toolResult.time_unix_nano).toBe(String(BigInt(baseTime) + 2n));
+    expect(BigInt(toolCall.time_unix_nano)).toBeGreaterThan(BigInt(baseTime));
+    expect(BigInt(toolResult.time_unix_nano)).toBeGreaterThan(BigInt(toolCall.time_unix_nano));
+  });
+
+  it('should handle multiple skills with correct timestamps and paired IDs', () => {
+    const records = [makeLlmResponse()];
+    const skills = [makeSkill('skill-a', '/path/a/SKILL.md'), makeSkill('skill-b', '/path/b/SKILL.md')];
+
+    injectSkillRecords(records, skills);
+
+    // 1 original + 4 inserted = 5
+    expect(records).toHaveLength(5);
+
+    const baseTime = BigInt('1700000000000000000');
+    const call1 = records[1];
+    const result1 = records[2];
+    const call2 = records[3];
+    const result2 = records[4];
+
+    // Verify timestamps: +1, +2, +3, +4
+    expect(call1.time_unix_nano).toBe(String(baseTime + 1n));
+    expect(result1.time_unix_nano).toBe(String(baseTime + 2n));
+    expect(call2.time_unix_nano).toBe(String(baseTime + 3n));
+    expect(result2.time_unix_nano).toBe(String(baseTime + 4n));
+
+    // Verify paired IDs
+    expect(call1['gen_ai.tool.call.id']).toBe(result1['gen_ai.tool.call.id']);
+    expect(call2['gen_ai.tool.call.id']).toBe(result2['gen_ai.tool.call.id']);
+    expect(call1['gen_ai.tool.call.id']).not.toBe(call2['gen_ai.tool.call.id']);
+
+    // Verify skill names
+    expect(call1['gen_ai.skill.name']).toBe('skill-a');
+    expect(call2['gen_ai.skill.name']).toBe('skill-b');
+  });
+
+  it('should not modify records when no llm.response exists', () => {
+    const records = [makeLlmRequest()];
+    const skills = [makeSkill()];
+
+    injectSkillRecords(records, skills);
+
+    expect(records).toHaveLength(1);
+    expect(records[0]['event.name']).toBe('llm.request');
+  });
+
+  it('should handle empty records array without error', () => {
+    const records = [];
+    const skills = [makeSkill()];
+
+    expect(() => injectSkillRecords(records, skills)).not.toThrow();
+    expect(records).toHaveLength(0);
+  });
+
+  it('should append tool_call parts without overwriting existing output.messages', () => {
+    const existingParts = [
+      { type: 'text', text: 'existing response' },
+      { type: 'tool_call', id: 'existing-id', name: 'Write', arguments: { path: '/tmp/x' } },
+    ];
+    const records = [
+      makeLlmResponse({
+        'gen_ai.output.messages': [
+          { role: 'assistant', parts: [...existingParts] },
+        ],
+      }),
+    ];
+    const skills = [makeSkill()];
+
+    injectSkillRecords(records, skills);
+
+    const llm = records[0];
+    const assistantMsg = llm['gen_ai.output.messages'].find(m => m.role === 'assistant');
+    // Original parts are preserved
+    expect(assistantMsg.parts[0]).toEqual(existingParts[0]);
+    expect(assistantMsg.parts[1]).toEqual(existingParts[1]);
+    // New tool_call appended at end
+    expect(assistantMsg.parts).toHaveLength(3);
+    expect(assistantMsg.parts[2].type).toBe('tool_call');
+    expect(assistantMsg.parts[2].name).toBe('Read');
+  });
+
+  it('should use time_unix_nano for observed_time_unix_nano fallback when missing', () => {
+    const baseTime = '1700000000000000000';
+    const records = [
+      makeLlmResponse({
+        time_unix_nano: baseTime,
+        observed_time_unix_nano: undefined,
+      }),
+    ];
+    const skills = [makeSkill()];
+
+    injectSkillRecords(records, skills);
+
+    const toolCall = records[1];
+    const toolResult = records[2];
+
+    // When observed_time_unix_nano is missing, fallback to time_unix_nano
+    expect(toolCall.observed_time_unix_nano).toBe(String(BigInt(baseTime) + 1n));
+    expect(toolResult.observed_time_unix_nano).toBe(String(BigInt(baseTime) + 2n));
+  });
+});

--- a/tests/unit/hooks/cursor/inject-skill-records.test.mjs
+++ b/tests/unit/hooks/cursor/inject-skill-records.test.mjs
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { injectSkillRecords } from '../../../../assets/hooks/cursor-hook-processor.mjs';
+
+const PROCESSOR_URL = new URL('../../../../assets/hooks/cursor-hook-processor.mjs', import.meta.url);
 
 /**
  * Helper: create a minimal llm.response record.
@@ -207,5 +211,53 @@ describe('injectSkillRecords', () => {
     // When observed_time_unix_nano is missing, fallback to time_unix_nano
     expect(toolCall.observed_time_unix_nano).toBe(String(BigInt(baseTime) + 1n));
     expect(toolResult.observed_time_unix_nano).toBe(String(BigInt(baseTime) + 2n));
+  });
+
+  it('should apply captureMessageContent=false to injected response and tool records', () => {
+    const skillPath = '/Users/alice/.cursor/skills/private-skill/SKILL.md';
+    const records = [makeLlmResponse()];
+    const runtimeConfig = {
+      agents: {
+        cursor: { captureMessageContent: false },
+      },
+    };
+
+    injectSkillRecords(
+      records,
+      [makeSkill('private-skill', skillPath)],
+      runtimeConfig,
+    );
+
+    expect(records[0]['gen_ai.output.messages']).toBeUndefined();
+    expect(records[1]['gen_ai.tool.call.arguments']).toBeUndefined();
+    expect(records[1]['gen_ai.skill.name']).toBe('private-skill');
+    expect(records[2]['gen_ai.skill.name']).toBe('private-skill');
+    expect(JSON.stringify(records)).not.toContain(skillPath);
+  });
+
+  it('should not execute main when imported', () => {
+    const imported = spawnSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '--eval',
+        `await import(${JSON.stringify(PROCESSOR_URL.href)})`,
+      ],
+      { encoding: 'utf-8' },
+    );
+
+    expect(imported.status).toBe(0);
+    expect(imported.stdout).toBe('');
+  });
+
+  it('should still execute main when invoked directly', () => {
+    const invoked = spawnSync(
+      process.execPath,
+      [fileURLToPath(PROCESSOR_URL)],
+      { input: '', encoding: 'utf-8' },
+    );
+
+    expect(invoked.status).toBe(0);
+    expect(invoked.stdout).toBe('{}\n');
   });
 });

--- a/tests/unit/hooks/cursor/skill-detector.test.mjs
+++ b/tests/unit/hooks/cursor/skill-detector.test.mjs
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { detectSkillFromTranscript } from '../../../../assets/hooks/cursor/skill-detector.mjs';
+
+function createTempTranscript(lines) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-detector-test-'));
+  const filePath = path.join(dir, 'transcript.jsonl');
+  const content = lines.map(l => JSON.stringify(l)).join('\n');
+  fs.writeFileSync(filePath, content, 'utf-8');
+  return { dir, filePath };
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe('detectSkillFromTranscript', () => {
+  let tempDir;
+  let transcriptPath;
+
+  afterEach(() => {
+    if (tempDir) {
+      cleanup(tempDir);
+      tempDir = null;
+    }
+  });
+
+  it('should detect skill usage when transcript contains Read SKILL.md', () => {
+    const lines = [
+      { role: 'user', message: { content: [{ type: 'text', text: '<timestamp>Tuesday, Jul 21, 2026, 1:35 PM (UTC+8)</timestamp>\n<user_query>\n使用 leetcode-solver，解决 leetcode 120\n</user_query>' }] } },
+      { role: 'assistant', message: { content: [
+        { type: 'text', text: 'I will read the skill file first.' },
+        { type: 'tool_use', name: 'Read', input: { path: '/Users/yunshen/.cursor/skills/leetcode-solver/SKILL.md' } },
+      ] } },
+      { type: 'turn_ended' },
+    ];
+
+    ({ dir: tempDir, filePath: transcriptPath } = createTempTranscript(lines));
+
+    const result = detectSkillFromTranscript(transcriptPath, '使用 leetcode-solver，解决 leetcode 120');
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result[0].skillName).toBe('leetcode-solver');
+    expect(result[0].skillPath).toBe('/Users/yunshen/.cursor/skills/leetcode-solver/SKILL.md');
+  });
+
+  it('should return null when transcript has no skill reads', () => {
+    const lines = [
+      { role: 'user', message: { content: [{ type: 'text', text: '<user_query>\nfix the bug\n</user_query>' }] } },
+      { role: 'assistant', message: { content: [
+        { type: 'text', text: 'Let me look at the code.' },
+        { type: 'tool_use', name: 'Read', input: { path: '/Users/yunshen/project/src/main.ts' } },
+      ] } },
+      { type: 'turn_ended' },
+    ];
+
+    ({ dir: tempDir, filePath: transcriptPath } = createTempTranscript(lines));
+
+    const result = detectSkillFromTranscript(transcriptPath, 'fix the bug');
+    expect(result).toBeNull();
+  });
+
+  it('should match the correct turn among multiple turns', () => {
+    const lines = [
+      // Turn 1
+      { role: 'user', message: { content: [{ type: 'text', text: '<user_query>\nfirst turn prompt\n</user_query>' }] } },
+      { role: 'assistant', message: { content: [
+        { type: 'text', text: 'Done with first turn.' },
+      ] } },
+      { type: 'turn_ended' },
+      // Turn 2 — with skill usage
+      { role: 'user', message: { content: [{ type: 'text', text: '<user_query>\nuse my-skill to do something\n</user_query>' }] } },
+      { role: 'assistant', message: { content: [
+        { type: 'tool_use', name: 'Read', input: { path: '/home/user/.cursor/skills/my-skill/SKILL.md' } },
+        { type: 'text', text: 'Skill loaded.' },
+      ] } },
+      { type: 'turn_ended' },
+    ];
+
+    ({ dir: tempDir, filePath: transcriptPath } = createTempTranscript(lines));
+
+    const result = detectSkillFromTranscript(transcriptPath, 'use my-skill to do something');
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result[0].skillName).toBe('my-skill');
+  });
+
+  it('should match user prompt containing Chinese characters', () => {
+    const lines = [
+      { role: 'user', message: { content: [{ type: 'text', text: '<timestamp>2026-07-21</timestamp>\n<user_query>\n请使用代码审查技能检查代码\n</user_query>' }] } },
+      { role: 'assistant', message: { content: [
+        { type: 'tool_use', name: 'ReadFile', input: { path: 'C:\\Users\\test\\.cursor\\skills\\code-review\\SKILL.md' } },
+      ] } },
+      { type: 'turn_ended' },
+    ];
+
+    ({ dir: tempDir, filePath: transcriptPath } = createTempTranscript(lines));
+
+    const result = detectSkillFromTranscript(transcriptPath, '请使用代码审查技能检查代码');
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result[0].skillName).toBe('code-review');
+    expect(result[0].skillPath).toBe('C:\\Users\\test\\.cursor\\skills\\code-review\\SKILL.md');
+  });
+
+  it('should return null when path is not under .cursor/skills/', () => {
+    const lines = [
+      { role: 'user', message: { content: [{ type: 'text', text: '<user_query>\nread some file\n</user_query>' }] } },
+      { role: 'assistant', message: { content: [
+        { type: 'tool_use', name: 'Read', input: { path: '/Users/test/projects/skills/my-skill/SKILL.md' } },
+      ] } },
+      { type: 'turn_ended' },
+    ];
+
+    ({ dir: tempDir, filePath: transcriptPath } = createTempTranscript(lines));
+
+    const result = detectSkillFromTranscript(transcriptPath, 'read some file');
+    expect(result).toBeNull();
+  });
+
+  it('should return null when transcriptPath is empty or null', () => {
+    expect(detectSkillFromTranscript(null, 'some prompt')).toBeNull();
+    expect(detectSkillFromTranscript('', 'some prompt')).toBeNull();
+  });
+
+  it('should return null when userPrompt is empty or null', () => {
+    const lines = [
+      { role: 'user', message: { content: [{ type: 'text', text: 'hello' }] } },
+    ];
+    ({ dir: tempDir, filePath: transcriptPath } = createTempTranscript(lines));
+
+    expect(detectSkillFromTranscript(transcriptPath, null)).toBeNull();
+    expect(detectSkillFromTranscript(transcriptPath, '')).toBeNull();
+  });
+
+  it('should return null when transcript file does not exist', () => {
+    const result = detectSkillFromTranscript('/nonexistent/path/transcript.jsonl', 'hello');
+    expect(result).toBeNull();
+  });
+
+  it('should detect multiple skills in a single turn', () => {
+    const lines = [
+      { role: 'user', message: { content: [{ type: 'text', text: '<user_query>\nuse both skills\n</user_query>' }] } },
+      { role: 'assistant', message: { content: [
+        { type: 'tool_use', name: 'Read', input: { path: '/Users/test/.cursor/skills/skill-a/SKILL.md' } },
+        { type: 'tool_use', name: 'Read', input: { path: '/Users/test/.cursor/skills/skill-b/SKILL.md' } },
+      ] } },
+      { type: 'turn_ended' },
+    ];
+
+    ({ dir: tempDir, filePath: transcriptPath } = createTempTranscript(lines));
+
+    const result = detectSkillFromTranscript(transcriptPath, 'use both skills');
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(2);
+    expect(result[0].skillName).toBe('skill-a');
+    expect(result[1].skillName).toBe('skill-b');
+  });
+
+  it('should stop scanning at turn_ended boundary', () => {
+    const lines = [
+      { role: 'user', message: { content: [{ type: 'text', text: '<user_query>\nfirst turn\n</user_query>' }] } },
+      { role: 'assistant', message: { content: [{ type: 'text', text: 'ok' }] } },
+      { type: 'turn_ended' },
+      // Next turn has skill usage but should not be included
+      { role: 'user', message: { content: [{ type: 'text', text: '<user_query>\nsecond turn\n</user_query>' }] } },
+      { role: 'assistant', message: { content: [
+        { type: 'tool_use', name: 'Read', input: { path: '/Users/test/.cursor/skills/some-skill/SKILL.md' } },
+      ] } },
+      { type: 'turn_ended' },
+    ];
+
+    ({ dir: tempDir, filePath: transcriptPath } = createTempTranscript(lines));
+
+    const result = detectSkillFromTranscript(transcriptPath, 'first turn');
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

When Cursor Agent uses a skill (reads `~/.cursor/skills/<name>/SKILL.md`), the `preToolUse` hook doesn't fire for this Read operation (Cursor IDE limitation). This PR adds a degraded detection strategy: after assembly completes, scan the transcript to detect skill reads and inject corresponding trace records.

## Changes

- **New**: `assets/hooks/cursor/skill-detector.mjs` — Transcript post-processing detector
  - Matches user prompt text to locate the correct turn in transcript
  - Scans assistant tool_use entries for `.cursor/skills/<name>/SKILL.md` path pattern
  - Returns detected skill name and path

- **Modified**: `assets/hooks/cursor-hook-processor.mjs`
  - Added `injectSkillRecords()` function: appends Read tool_use to LLM output messages, inserts paired `tool.call` + `tool.result` records with BigInt timestamp offset (+1ms) for ordering
  - Post-assembly skill detection block in STOP handler (try-catch wrapped, best-effort)

- **New**: `tests/unit/hooks/cursor/skill-detector.test.mjs` — 10 test cases

## Verification

- All 388 existing hook tests pass (0 regression)
- Manual E2E: skill detection confirmed working with real Cursor trace
- Syntax check: `node --check` passes on both files

## Known Limitations

- Only covers Cursor IDE path (STOP handler); CLI deferred-stop path not yet covered
- Skill detection is best-effort — if transcript is inaccessible or prompt doesn't match, silently skips
- Step placement: currently injects at first LLM span; accurate step matching (by tool sequence alignment) is a future improvement