### PR TITLE
fix(intercept): guard rc wrapper against user aliases and respect agent selection

### DIFF
--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -855,7 +855,8 @@ _sed_inplace() {
 }
 
 inject_qodercli_token_intercept() {
-    if ! echo "$SELECTED_AGENTS" | grep -q 'qoder'; then return 0; fi
+    # Not selected: clean up any stale block from a prior install, then bail.
+    if ! echo "$SELECTED_AGENTS" | grep -q 'qoder'; then remove_qodercli_token_intercept; return 0; fi
     if ! command -v qodercli >/dev/null 2>&1; then return 0; fi
 
     local intercept_script="$DATA_DIR/hooks/qodercli-token-intercept.mjs"
@@ -874,10 +875,18 @@ inject_qodercli_token_intercept() {
         [ -s "$file" ] && [ "$(tail -c1 "$file" | wc -l)" -eq 0 ] && echo "" >> "$file"
         # Double-quoted heredoc so $DATA_DIR expands at install time, honoring
         # --data-dir overrides. $@ is escaped to defer expansion to runtime.
+        # The `if ! alias ... eval '...'` shape guards against clobbering a
+        # user's own qodercli alias/function AND avoids a parse error: a bare
+        # qodercli() token would fail to parse under an active alias (interactive
+        # shells expand aliases at parse time, before the guard runs), so the
+        # definition is deferred behind eval. Keep byte-identical to the
+        # watchdog's blockFn (src/core/hook-watchdog.ts).
         cat >> "$file" << INTERCEPTBLOCK
 
 # loongsuite-pilot BEGIN qodercli-intercept
-qodercli() { BUN_OPTIONS="--preload=$DATA_DIR/hooks/qodercli-token-intercept.mjs" command qodercli "\$@"; }
+if ! alias qodercli >/dev/null 2>&1 && ! typeset -f qodercli >/dev/null 2>&1; then
+  eval 'qodercli() { BUN_OPTIONS="--preload=$DATA_DIR/hooks/qodercli-token-intercept.mjs" command qodercli "\$@"; }'
+fi
 # loongsuite-pilot END qodercli-intercept
 INTERCEPTBLOCK
         msg "    ✅ 已写入 $file (请执行 source $file 或打开新终端)" \
@@ -889,6 +898,18 @@ INTERCEPTBLOCK
         */bash) _inject_to_rc "$HOME/.bashrc" ;;
         *)      _inject_to_rc "$HOME/.bashrc" ;;
     esac
+
+    # If the user already defines their own `qodercli`, our guard skipped the
+    # wrapper (to avoid clobbering it), so collection won't run. Tell them how
+    # to opt in, since there is otherwise no signal explaining the silence.
+    if _rc_user_override_present qodercli \
+        'loongsuite-pilot BEGIN qodercli-intercept' \
+        'loongsuite-pilot END qodercli-intercept'; then
+        msg "    ⚠️  检测到你已自定义 qodercli(alias/function)，为避免覆盖，采集未启用。" \
+            "    ⚠️  Detected your own 'qodercli' (alias/function); collection is disabled to avoid clobbering it."
+        msg "        如需启用采集，请在你的 qodercli 定义中加入： BUN_OPTIONS=\"--preload=$DATA_DIR/hooks/qodercli-token-intercept.mjs\"" \
+            "        To enable collection, add to your qodercli definition: BUN_OPTIONS=\"--preload=$DATA_DIR/hooks/qodercli-token-intercept.mjs\""
+    fi
     echo ""
 }
 
@@ -914,7 +935,8 @@ remove_qodercli_token_intercept() {
 # ============================================================
 inject_qoderwork_runtime_wrapper() {
     if [ "$(uname)" != "Darwin" ]; then return 0; fi
-    if ! echo "$SELECTED_AGENTS" | grep -q 'qoder-work'; then return 0; fi
+    # Not selected: clean up any stale env/plist from a prior install, then bail.
+    if ! echo "$SELECTED_AGENTS" | grep -q 'qoder-work'; then remove_qoderwork_runtime_wrapper; return 0; fi
     # Cover system-wide (/Applications) and per-user (~/Applications) installs;
     # the wrapper's RUNTIME_CANDIDATES handles both locations symmetrically.
     if [ ! -d "/Applications/QoderWork.app" ] && [ ! -d "$HOME/Applications/QoderWork.app" ]; then return 0; fi
@@ -1007,8 +1029,29 @@ remove_qoderwork_runtime_wrapper() {
 # The wrapper prepends our preload but preserves any existing BUN_OPTIONS
 # the user (or qodercli wrapper, or launchd setenv) may have set.
 # ============================================================
+# Detect a user-defined <cli> alias/function OUTSIDE our managed block.
+#   $1=cli name  $2=BEGIN marker substring  $3=END marker substring
+# Returns 0 (true) when found. Our injected wrapper's `if ! alias ...` guard
+# intentionally skips such users to avoid clobbering their setup — which means
+# collection is silently off for them. This lets the installer surface a
+# one-time, actionable hint at install time (rc is sourced too often to warn on
+# every shell). Heuristic: scans common rc files with our block stripped; misses
+# aliases defined in files those rc's source.
+_rc_user_override_present() {
+    local cli="$1" begin="$2" end="$3" file
+    for file in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.profile"; do
+        [ -f "$file" ] || continue
+        if sed "/$begin/,/$end/d" "$file" 2>/dev/null \
+           | grep -Eq "^[[:space:]]*(alias[[:space:]]+$cli=|(function[[:space:]]+)?$cli[[:space:]]*\(\)|function[[:space:]]+$cli([[:space:]]|\{|\$))"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 inject_claude_code_fetch_intercept() {
-    if ! echo "$SELECTED_AGENTS" | grep -q 'claude-code'; then return 0; fi
+    # Not selected: clean up any stale block from a prior install, then bail.
+    if ! echo "$SELECTED_AGENTS" | grep -q 'claude-code'; then remove_claude_code_fetch_intercept; return 0; fi
     if ! command -v claude >/dev/null 2>&1; then return 0; fi
 
     local intercept_script="$DATA_DIR/hooks/claude-code-fetch-intercept.mjs"
@@ -1028,10 +1071,18 @@ inject_claude_code_fetch_intercept() {
         # Double-quoted heredoc so $DATA_DIR expands at install time, honoring
         # --data-dir overrides. Other refs (${BUN_OPTIONS}, $@) are escaped to
         # defer expansion until the wrapper actually runs in the user's shell.
+        # The `if ! alias ... eval '...'` shape guards against clobbering a
+        # user's own claude alias/function (e.g. a proxy+flags alias) AND avoids
+        # a parse error: a bare claude() token would fail to parse under an
+        # active alias (interactive shells expand aliases at parse time, before
+        # the guard runs), so the definition is deferred behind eval. Keep
+        # byte-identical to the watchdog's blockFn (src/core/hook-watchdog.ts).
         cat >> "$file" << INTERCEPTBLOCK
 
 # loongsuite-pilot BEGIN claude-code-intercept
-claude() { BUN_OPTIONS="--preload=$DATA_DIR/hooks/claude-code-fetch-intercept.mjs \${BUN_OPTIONS}" command claude "\$@"; }
+if ! alias claude >/dev/null 2>&1 && ! typeset -f claude >/dev/null 2>&1; then
+  eval 'claude() { BUN_OPTIONS="--preload=$DATA_DIR/hooks/claude-code-fetch-intercept.mjs \${BUN_OPTIONS}" command claude "\$@"; }'
+fi
 # loongsuite-pilot END claude-code-intercept
 INTERCEPTBLOCK
         msg "    ✅ 已写入 $file (请执行 source $file 或打开新终端)" \
@@ -1043,6 +1094,18 @@ INTERCEPTBLOCK
         */bash) _inject_to_rc "$HOME/.bashrc" ;;
         *)      _inject_to_rc "$HOME/.bashrc" ;;
     esac
+
+    # If the user already defines their own `claude`, our guard skipped the
+    # wrapper (to avoid clobbering it), so collection won't run. Tell them how
+    # to opt in, since there is otherwise no signal explaining the silence.
+    if _rc_user_override_present claude \
+        'loongsuite-pilot BEGIN claude-code-intercept' \
+        'loongsuite-pilot END claude-code-intercept'; then
+        msg "    ⚠️  检测到你已自定义 claude(alias/function)，为避免覆盖，采集未启用。" \
+            "    ⚠️  Detected your own 'claude' (alias/function); collection is disabled to avoid clobbering it."
+        msg "        如需启用采集，请在你的 claude 定义中加入： BUN_OPTIONS=\"--preload=$DATA_DIR/hooks/claude-code-fetch-intercept.mjs \${BUN_OPTIONS}\"" \
+            "        To enable collection, add to your claude definition: BUN_OPTIONS=\"--preload=$DATA_DIR/hooks/claude-code-fetch-intercept.mjs \${BUN_OPTIONS}\""
+    fi
     echo ""
 }
 

--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -871,7 +871,15 @@ inject_qodercli_token_intercept() {
             msg "    ⚠️  $file 不可写，跳过" "    ⚠️  $file is not writable, skipping"
             return 0
         fi
-        if grep -q 'loongsuite-pilot BEGIN qodercli-intercept' "$file" 2>/dev/null; then return 0; fi
+        # Migrate-or-skip: our block may already be present. If it is the current
+        # guard shape (signature line present) we're done; otherwise it is an
+        # older released bare-function block sharing the same marker — remove it
+        # so the new guarded block below replaces it (the old bare block
+        # parse-errors under a user alias, which is exactly what we're fixing).
+        if grep -q 'loongsuite-pilot BEGIN qodercli-intercept' "$file" 2>/dev/null; then
+            if grep -qF 'if ! alias qodercli >/dev/null 2>&1' "$file"; then return 0; fi
+            _sed_inplace '/# loongsuite-pilot BEGIN qodercli-intercept/,/# loongsuite-pilot END qodercli-intercept/d' "$file"
+        fi
         [ -s "$file" ] && [ "$(tail -c1 "$file" | wc -l)" -eq 0 ] && echo "" >> "$file"
         # Double-quoted heredoc so $DATA_DIR expands at install time, honoring
         # --data-dir overrides. $@ is escaped to defer expansion to runtime.
@@ -1066,7 +1074,15 @@ inject_claude_code_fetch_intercept() {
             msg "    ⚠️  $file 不可写，跳过" "    ⚠️  $file is not writable, skipping"
             return 0
         fi
-        if grep -q 'loongsuite-pilot BEGIN claude-code-intercept' "$file" 2>/dev/null; then return 0; fi
+        # Migrate-or-skip: our block may already be present. If it is the current
+        # guard shape (signature line present) we're done; otherwise it is an
+        # older released bare-function block sharing the same marker — remove it
+        # so the new guarded block below replaces it (the old bare block
+        # parse-errors under a user alias, which is exactly what we're fixing).
+        if grep -q 'loongsuite-pilot BEGIN claude-code-intercept' "$file" 2>/dev/null; then
+            if grep -qF 'if ! alias claude >/dev/null 2>&1' "$file"; then return 0; fi
+            _sed_inplace '/# loongsuite-pilot BEGIN claude-code-intercept/,/# loongsuite-pilot END claude-code-intercept/d' "$file"
+        fi
         [ -s "$file" ] && [ "$(tail -c1 "$file" | wc -l)" -eq 0 ] && echo "" >> "$file"
         # Double-quoted heredoc so $DATA_DIR expands at install time, honoring
         # --data-dir overrides. Other refs (${BUN_OPTIONS}, $@) are escaped to

--- a/src/core/hook-watchdog.ts
+++ b/src/core/hook-watchdog.ts
@@ -36,11 +36,36 @@ export interface InterceptCheckTarget {
   precondition: () => Promise<boolean>;
   /**
    * Whether the owning agent is enabled by the user's selection
-   * (config.agents[<id>].enabled). When this returns false the target is
-   * skipped entirely — no check, no repair — so a deselected agent's intercept
-   * is never (re)injected. Omitted → treated as enabled (backward compatible).
+   * (config.agents[<id>].enabled). When this returns false the target is not
+   * (re)injected — instead cleanup() runs (if provided) so the intercept is
+   * removed rather than merely left in place. Omitted → treated as enabled
+   * (backward compatible).
    */
   enabled?: () => boolean | Promise<boolean>;
+  /**
+   * Idempotent removal of an already-installed intercept, invoked when
+   * enabled() is false. Lets "config disable" actually stop collection (not
+   * just stop self-healing) — otherwise a wrapper written on a prior run would
+   * keep intercepting for an agent the user has since turned off. Omitted →
+   * disabled targets are simply skipped.
+   */
+  cleanup?: () => Promise<void>;
+}
+
+/**
+ * Remove a marker-delimited block (inclusive of the BEGIN/END marker lines)
+ * from rc-file content. Any line containing `begin` starts the cut and any
+ * line containing `end` ends it; non-block lines are preserved verbatim.
+ */
+export function stripMarkerBlock(content: string, begin: string, end: string): string {
+  const out: string[] = [];
+  let inBlock = false;
+  for (const line of content.split('\n')) {
+    if (!inBlock && line.includes(begin)) { inBlock = true; continue; }
+    if (inBlock && line.includes(end)) { inBlock = false; continue; }
+    if (!inBlock) out.push(line);
+  }
+  return out.join('\n');
 }
 
 export interface CheckResult {
@@ -327,11 +352,22 @@ export class HookWatchdog {
 
     for (const target of this.interceptTargets) {
       try {
-        // User-selection gate: skip disabled agents before any check/repair, so
-        // a deselected agent's intercept is never (re)injected and does not
-        // consume the repair cooldown / daily-limit budget.
+        // User-selection gate, checked before any check/repair so a disabled
+        // agent never (re)injects and does not consume the cooldown / daily
+        // budget. When disabled we also run cleanup() (idempotent) so an
+        // intercept written on a prior run is removed — "config disable" stops
+        // collection, not just self-healing.
         if (target.enabled && !(await target.enabled())) {
-          logger.debug('intercept-watchdog.disabled', { id: target.id });
+          if (target.cleanup) {
+            try {
+              await target.cleanup();
+              logger.info('intercept-watchdog.disabled-cleanup', { id: target.id });
+            } catch (err) {
+              logger.warn('intercept-watchdog.cleanup-failed', { id: target.id, error: String(err) });
+            }
+          } else {
+            logger.debug('intercept-watchdog.disabled', { id: target.id });
+          }
           summary.skipped++;
           continue;
         }
@@ -433,11 +469,19 @@ export class HookWatchdog {
    *
    * Exposed as a pure, static seam so tests can render the exact block for any
    * path without touching HOME/fs (see hook-watchdog-intercept-shell.test.ts).
+   *
+   * `signature` is a substring unique to the CURRENT block shape (the guard
+   * line). check()/repair() use it — not just `marker` — to detect and migrate
+   * an older block that shares the same marker (e.g. the released bare
+   * `<cli>() {...}` form). Keep it byte-identical to the installer's grep.
+   * `endMarker` bounds the block for removal/migration.
    */
   static interceptRcBlockDefs(): Array<{
     id: string;
     agentId: string;
     marker: string;
+    endMarker: string;
+    signature: string;
     scriptName: string;
     blockFn: (scriptPath: string) => string;
   }> {
@@ -446,6 +490,8 @@ export class HookWatchdog {
         id: 'qodercli-rc',
         agentId: 'qoder',
         marker: 'loongsuite-pilot BEGIN qodercli-intercept',
+        endMarker: 'loongsuite-pilot END qodercli-intercept',
+        signature: 'if ! alias qodercli >/dev/null 2>&1',
         scriptName: 'qodercli-token-intercept.mjs',
         blockFn: (p) => [
           '',
@@ -460,6 +506,8 @@ export class HookWatchdog {
         id: 'claude-code-rc',
         agentId: 'claude-code',
         marker: 'loongsuite-pilot BEGIN claude-code-intercept',
+        endMarker: 'loongsuite-pilot END claude-code-intercept',
+        signature: 'if ! alias claude >/dev/null 2>&1',
         scriptName: 'claude-code-fetch-intercept.mjs',
         blockFn: (p) => [
           '',
@@ -536,6 +584,22 @@ export class HookWatchdog {
           await execFileAsync('launchctl', ['unload', plistPath]).catch(() => {});
           await execFileAsync('launchctl', ['load', plistPath]).catch(() => {});
         },
+        cleanup: async () => {
+          // Mirror installer remove_qoderwork_runtime_wrapper: drop the env only
+          // if it still points at our wrapper, and remove the LaunchAgent plist.
+          try {
+            const { stdout } = await execFileAsync('launchctl', ['getenv', 'QODER_WORKER_RUNTIME_PATH']);
+            if (stdout.trim() === wrapperPath) {
+              await execFileAsync('launchctl', ['unsetenv', 'QODER_WORKER_RUNTIME_PATH']).catch(() => {});
+            }
+          } catch {
+            // getenv fails when unset — nothing to drop.
+          }
+          if (await fileExists(plistPath)) {
+            await execFileAsync('launchctl', ['unload', plistPath]).catch(() => {});
+            await fs.rm(plistPath, { force: true }).catch(() => {});
+          }
+        },
       });
     }
 
@@ -565,27 +629,47 @@ export class HookWatchdog {
           return fileExists(scriptPath);
         },
         check: async () => {
-          // Check ALL common rc files — marker must exist in at least one.
+          // Health is keyed on block CONTENT, not just the marker: an older
+          // released block shares the same marker but lacks `signature`, and
+          // must be migrated. A stale block anywhere → unhealthy (repair).
+          let anyCurrent = false;
+          let anyRcExists = false;
           for (const rcPath of rcPaths) {
-            try {
-              const content = await fs.readFile(rcPath, 'utf-8');
-              if (content.includes(rc.marker)) return true;
-            } catch {
-              // file doesn't exist, check next
+            if (!await fileExists(rcPath)) continue;
+            anyRcExists = true;
+            const content = await fs.readFile(rcPath, 'utf-8');
+            if (content.includes(rc.marker)) {
+              if (content.includes(rc.signature)) anyCurrent = true;
+              else return false; // marker present but old shape → migrate
             }
           }
-          // Not found in any existing rc file. If no rc files exist at all,
-          // there's nothing we can repair into, so treat as healthy.
-          const anyRcExists = (await Promise.all(rcPaths.map(p => fileExists(p)))).some(Boolean);
+          if (anyCurrent) return true;
+          // No block present anywhere. If no rc files exist, nothing to repair
+          // into → healthy; otherwise repair() will append.
           return !anyRcExists;
         },
         repair: async () => {
-          // Append to ALL existing rc files that don't already have the marker.
           for (const rcPath of rcPaths) {
             if (!await fileExists(rcPath)) continue; // never create rc files
             const content = await fs.readFile(rcPath, 'utf-8');
-            if (content.includes(rc.marker)) continue; // already present
-            await fs.appendFile(rcPath, rc.blockFn(scriptPath) + '\n');
+            if (content.includes(rc.marker)) {
+              if (content.includes(rc.signature)) continue; // already current
+              // Stale block: strip the old marker region, then append fresh.
+              const stripped = stripMarkerBlock(content, rc.marker, rc.endMarker).replace(/\n+$/, '\n');
+              await fs.writeFile(rcPath, stripped + rc.blockFn(scriptPath) + '\n');
+            } else {
+              await fs.appendFile(rcPath, rc.blockFn(scriptPath) + '\n');
+            }
+          }
+        },
+        cleanup: async () => {
+          // Disabled agent: remove our block from every rc file (idempotent).
+          for (const rcPath of rcPaths) {
+            if (!await fileExists(rcPath)) continue;
+            const content = await fs.readFile(rcPath, 'utf-8');
+            if (!content.includes(rc.marker)) continue;
+            const stripped = stripMarkerBlock(content, rc.marker, rc.endMarker).replace(/\n{3,}$/, '\n\n');
+            await fs.writeFile(rcPath, stripped);
           }
         },
       });

--- a/src/core/hook-watchdog.ts
+++ b/src/core/hook-watchdog.ts
@@ -524,6 +524,10 @@ export class HookWatchdog {
   static defaultInterceptTargets(
     dataDir: string,
     isAgentEnabled: (agentId: string) => boolean = () => true,
+    // rcPaths is injectable so tests can exercise the real check()/repair()/
+    // cleanup() closures against a temp dir instead of the developer's real rc
+    // files. Production omits it and uses ~/.zshrc + ~/.bashrc.
+    rcPathsOverride?: string[],
   ): InterceptCheckTarget[] {
     const targets: InterceptCheckTarget[] = [];
     const home = os.homedir();
@@ -607,7 +611,7 @@ export class HookWatchdog {
     // Check BOTH .zshrc and .bashrc regardless of daemon's $SHELL — the
     // daemon is launchd-started and its $SHELL may not match the user's
     // interactive shell. Installer's remove function also scans all rc files.
-    const rcPaths = [
+    const rcPaths = rcPathsOverride ?? [
       path.join(home, '.zshrc'),
       path.join(home, '.bashrc'),
     ];

--- a/src/core/hook-watchdog.ts
+++ b/src/core/hook-watchdog.ts
@@ -34,6 +34,13 @@ export interface InterceptCheckTarget {
   check: () => Promise<boolean>;
   repair: () => Promise<void>;
   precondition: () => Promise<boolean>;
+  /**
+   * Whether the owning agent is enabled by the user's selection
+   * (config.agents[<id>].enabled). When this returns false the target is
+   * skipped entirely — no check, no repair — so a deselected agent's intercept
+   * is never (re)injected. Omitted → treated as enabled (backward compatible).
+   */
+  enabled?: () => boolean | Promise<boolean>;
 }
 
 export interface CheckResult {
@@ -320,6 +327,15 @@ export class HookWatchdog {
 
     for (const target of this.interceptTargets) {
       try {
+        // User-selection gate: skip disabled agents before any check/repair, so
+        // a deselected agent's intercept is never (re)injected and does not
+        // consume the repair cooldown / daily-limit budget.
+        if (target.enabled && !(await target.enabled())) {
+          logger.debug('intercept-watchdog.disabled', { id: target.id });
+          summary.skipped++;
+          continue;
+        }
+
         const preOk = await target.precondition();
         if (!preOk) {
           logger.debug('intercept-watchdog.skipped', { id: target.id, reason: 'precondition' });
@@ -404,7 +420,63 @@ export class HookWatchdog {
     ];
   }
 
-  static defaultInterceptTargets(dataDir: string): InterceptCheckTarget[] {
+  /**
+   * Shell-rc intercept block definitions (qodercli + claude-code).
+   *
+   * blockFn must stay byte-identical to the block written by the installer
+   * (deploy/installer-opensource.sh inject_*), so the marker-based idempotency
+   * checks agree. The `if ! alias ... eval '...'` shape guards against
+   * clobbering a user's own alias/function AND avoids a parse error: a bare
+   * `<cli>()` token would fail to parse under an active alias because
+   * interactive shells expand aliases at parse time (before the guard runs), so
+   * the definition is deferred behind eval.
+   *
+   * Exposed as a pure, static seam so tests can render the exact block for any
+   * path without touching HOME/fs (see hook-watchdog-intercept-shell.test.ts).
+   */
+  static interceptRcBlockDefs(): Array<{
+    id: string;
+    agentId: string;
+    marker: string;
+    scriptName: string;
+    blockFn: (scriptPath: string) => string;
+  }> {
+    return [
+      {
+        id: 'qodercli-rc',
+        agentId: 'qoder',
+        marker: 'loongsuite-pilot BEGIN qodercli-intercept',
+        scriptName: 'qodercli-token-intercept.mjs',
+        blockFn: (p) => [
+          '',
+          '# loongsuite-pilot BEGIN qodercli-intercept',
+          'if ! alias qodercli >/dev/null 2>&1 && ! typeset -f qodercli >/dev/null 2>&1; then',
+          `  eval 'qodercli() { BUN_OPTIONS="--preload=${p}" command qodercli "$@"; }'`,
+          'fi',
+          '# loongsuite-pilot END qodercli-intercept',
+        ].join('\n'),
+      },
+      {
+        id: 'claude-code-rc',
+        agentId: 'claude-code',
+        marker: 'loongsuite-pilot BEGIN claude-code-intercept',
+        scriptName: 'claude-code-fetch-intercept.mjs',
+        blockFn: (p) => [
+          '',
+          '# loongsuite-pilot BEGIN claude-code-intercept',
+          'if ! alias claude >/dev/null 2>&1 && ! typeset -f claude >/dev/null 2>&1; then',
+          `  eval 'claude() { BUN_OPTIONS="--preload=${p} \${BUN_OPTIONS}" command claude "$@"; }'`,
+          'fi',
+          '# loongsuite-pilot END claude-code-intercept',
+        ].join('\n'),
+      },
+    ];
+  }
+
+  static defaultInterceptTargets(
+    dataDir: string,
+    isAgentEnabled: (agentId: string) => boolean = () => true,
+  ): InterceptCheckTarget[] {
     const targets: InterceptCheckTarget[] = [];
     const home = os.homedir();
 
@@ -416,6 +488,7 @@ export class HookWatchdog {
 
       targets.push({
         id: 'qoderwork-env',
+        enabled: () => isAgentEnabled('qoder-work'),
         precondition: async () => {
           if (!await fileExists(wrapperPath)) return false;
           const sysApp = await directoryExists('/Applications/QoderWork.app');
@@ -475,41 +548,12 @@ export class HookWatchdog {
       path.join(home, '.bashrc'),
     ];
 
-    const rcTargets: Array<{
-      id: string;
-      marker: string;
-      scriptName: string;
-      blockFn: (scriptPath: string) => string;
-    }> = [
-      {
-        id: 'qodercli-rc',
-        marker: 'loongsuite-pilot BEGIN qodercli-intercept',
-        scriptName: 'qodercli-token-intercept.mjs',
-        blockFn: (p) => [
-          '',
-          '# loongsuite-pilot BEGIN qodercli-intercept',
-          `qodercli() { BUN_OPTIONS="--preload=${p}" command qodercli "$@"; }`,
-          '# loongsuite-pilot END qodercli-intercept',
-        ].join('\n'),
-      },
-      {
-        id: 'claude-code-rc',
-        marker: 'loongsuite-pilot BEGIN claude-code-intercept',
-        scriptName: 'claude-code-fetch-intercept.mjs',
-        blockFn: (p) => [
-          '',
-          '# loongsuite-pilot BEGIN claude-code-intercept',
-          `claude() { BUN_OPTIONS="--preload=${p} \${BUN_OPTIONS}" command claude "$@"; }`,
-          '# loongsuite-pilot END claude-code-intercept',
-        ].join('\n'),
-      },
-    ];
-
-    for (const rc of rcTargets) {
+    for (const rc of HookWatchdog.interceptRcBlockDefs()) {
       const scriptPath = path.join(dataDir, 'hooks', rc.scriptName);
 
       targets.push({
         id: rc.id,
+        enabled: () => isAgentEnabled(rc.agentId),
         precondition: async () => {
           // Only check if the hook script was deployed by the installer.
           // We intentionally do NOT run `which <cli>` — the daemon process

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -235,7 +235,7 @@ export class Orchestrator extends EventEmitter {
       ...this.buildHookWatchdogTargets(),
     ];
     const interceptTargets = [
-      ...HookWatchdog.defaultInterceptTargets(this.dataDir),
+      ...HookWatchdog.defaultInterceptTargets(this.dataDir, (id) => this.isAgentGatedEnabled(id)),
       ...this.buildPluginInjectInterceptTargets(),
     ];
     this.hookWatchdog = new HookWatchdog(this.config.hookWatchdog, hookWatchdogTargets, interceptTargets);
@@ -434,6 +434,7 @@ export class Orchestrator extends EventEmitter {
 
       targets.push({
         id: `plugin-inject:${def.id}`,
+        enabled: () => this.isAgentGatedEnabled(def.id),
         precondition: async () => {
           // Only self-heal when the plugin asset is actually deployed AND the
           // agent is present. Otherwise repair would inject a spec pointing at

--- a/tests/unit/core/hook-watchdog-intercept-shell.test.ts
+++ b/tests/unit/core/hook-watchdog-intercept-shell.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { HookWatchdog } from '../../../src/core/hook-watchdog.js';
+
+// Real-shell regression guard for the rc intercept block.
+//
+// Unlike hook-watchdog-intercept.test.ts (which mocks node:child_process and
+// only asserts the block text), this file does NOT mock child_process: it
+// renders the ACTUAL block the watchdog/installer write — via the pure
+// HookWatchdog.interceptRcBlockDefs() seam — and sources it in bash AND zsh to
+// prove the block is parse-safe under an active user alias (the reported bug)
+// and does not clobber the user's own alias/function.
+//
+// Using the pure seam (not repair()) avoids touching HOME/fs — important
+// because under vitest os.homedir() ignores a runtime process.env.HOME change,
+// which would otherwise risk writing into the developer's real rc files.
+
+function shellAvailable(sh: string): boolean {
+  try {
+    execFileSync(sh, ['-c', 'exit 0'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function blockFor(id: string): string {
+  const def = HookWatchdog.interceptRcBlockDefs().find(d => d.id === id);
+  if (!def) throw new Error(`no rc block def for ${id}`);
+  return def.blockFn(`/tmp/pilot-hooks/${def.scriptName}`);
+}
+
+function sourceInBash(script: string): string {
+  // shopt -s expand_aliases makes non-interactive bash expand aliases, matching
+  // the interactive rc-sourcing behavior where the parse-time collision occurs.
+  return execFileSync('bash', ['-c', `shopt -s expand_aliases\n${script}`], { encoding: 'utf-8' });
+}
+
+function sourceInZsh(script: string): string {
+  return execFileSync('zsh', ['-c', script], { encoding: 'utf-8' });
+}
+
+const CLAUDE_ALIAS =
+  "alias claude='all_proxy=http://127.0.0.1:7899 /usr/local/bin/claude --dangerously-skip-permissions'";
+// Fake `command` so we can observe what the wrapper would forward, with no real CLI.
+const PROBE = 'command() { echo "WRAP_RAN BUN_OPTIONS=$BUN_OPTIONS args=[$*]"; }';
+
+const HAS_BASH = shellAvailable('bash');
+const HAS_ZSH = shellAvailable('zsh');
+
+describe('rc intercept block sources safely in real shells', () => {
+  describe.skipIf(!HAS_BASH)('bash', () => {
+    it('sources cleanly under an active claude alias and does not clobber it', () => {
+      const block = blockFor('claude-code-rc');
+      const out = sourceInBash(`${CLAUDE_ALIAS}\n${block}\necho SRC_OK\nalias claude`);
+      expect(out).toContain('SRC_OK'); // no syntax error → reached echo
+      expect(out).toContain('dangerously-skip-permissions'); // user alias preserved
+      expect(out).not.toContain('WRAP_RAN'); // our wrapper did not shadow the alias
+    });
+
+    it('defines the wrapper and composes BUN_OPTIONS when no alias exists', () => {
+      const block = blockFor('claude-code-rc');
+      const out = sourceInBash(
+        `export BUN_OPTIONS='--preload=/user/own.mjs'\n${block}\n${PROBE}\nclaude hello`,
+      );
+      expect(out).toContain('WRAP_RAN');
+      expect(out).toContain('claude-code-fetch-intercept.mjs'); // our preload injected
+      expect(out).toContain('/user/own.mjs'); // user's existing BUN_OPTIONS preserved
+      expect(out).toContain('args=[claude hello]'); // `command claude "$@"` forwards args
+    });
+
+    it('does not clobber a user-defined claude function', () => {
+      const block = blockFor('claude-code-rc');
+      const out = sourceInBash(`claude() { echo USER_FN; }\n${block}\nclaude`);
+      expect(out).toContain('USER_FN');
+    });
+
+    it('is idempotent across a double source', () => {
+      const block = blockFor('claude-code-rc');
+      const out = sourceInBash(`${block}\n${block}\n${PROBE}\nclaude x\necho DONE`);
+      expect(out).toContain('DONE');
+      expect(out).toContain('WRAP_RAN');
+    });
+  });
+
+  describe.skipIf(!HAS_ZSH)('zsh', () => {
+    it('sources cleanly under an active claude alias and does not clobber it', () => {
+      const block = blockFor('claude-code-rc');
+      const out = sourceInZsh(`${CLAUDE_ALIAS}\n${block}\necho SRC_OK\nwhich claude`);
+      expect(out).toContain('SRC_OK');
+      expect(out).toContain('dangerously-skip-permissions');
+      expect(out).not.toContain('WRAP_RAN');
+    });
+
+    it('defines the wrapper and composes BUN_OPTIONS when no alias exists', () => {
+      const block = blockFor('claude-code-rc');
+      const out = sourceInZsh(
+        `export BUN_OPTIONS='--preload=/user/own.mjs'\n${block}\n${PROBE}\nclaude hello`,
+      );
+      expect(out).toContain('WRAP_RAN');
+      expect(out).toContain('/user/own.mjs');
+      expect(out).toContain('args=[claude hello]');
+    });
+  });
+
+  describe.skipIf(!HAS_BASH)('qodercli block (bash)', () => {
+    it('sources cleanly under an active qodercli alias and preserves it', () => {
+      const block = blockFor('qodercli-rc');
+      const out = sourceInBash(
+        `alias qodercli='qodercli --foo'\n${block}\necho SRC_OK\nalias qodercli`,
+      );
+      expect(out).toContain('SRC_OK');
+      expect(out).toContain('qodercli --foo'); // user alias preserved
+    });
+  });
+});

--- a/tests/unit/core/hook-watchdog-intercept-shell.test.ts
+++ b/tests/unit/core/hook-watchdog-intercept-shell.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { HookWatchdog } from '../../../src/core/hook-watchdog.js';
+import { HookWatchdog, stripMarkerBlock } from '../../../src/core/hook-watchdog.js';
 
 // Real-shell regression guard for the rc intercept block.
 //
@@ -111,6 +111,45 @@ describe('rc intercept block sources safely in real shells', () => {
       );
       expect(out).toContain('SRC_OK');
       expect(out).toContain('qodercli --foo'); // user alias preserved
+    });
+  });
+
+  // The reported bug's real-world path: a user who installed an OLD release
+  // already has a bare `claude() {...}` block (same marker) in their rc AND a
+  // claude alias — so their rc parse-errors today. Simulate repair()'s
+  // migration (stripMarkerBlock + append current block) and prove the result
+  // sources cleanly, with the old bare block gone.
+  describe.skipIf(!HAS_BASH)('migration of an old bare-function block (bash)', () => {
+    const def = HookWatchdog.interceptRcBlockDefs().find(d => d.id === 'claude-code-rc')!;
+    const OLD_BARE_BLOCK = [
+      '# loongsuite-pilot BEGIN claude-code-intercept',
+      'claude() { BUN_OPTIONS="--preload=/old/path ${BUN_OPTIONS}" command claude "$@"; }',
+      '# loongsuite-pilot END claude-code-intercept',
+    ].join('\n');
+
+    it('old bare block under an alias fails to source (documents the bug)', () => {
+      let errored = false;
+      try {
+        sourceInBash(`${CLAUDE_ALIAS}\n${OLD_BARE_BLOCK}\necho SHOULD_NOT_REACH`);
+      } catch {
+        errored = true; // non-zero exit → parse error
+      }
+      expect(errored).toBe(true);
+    });
+
+    it('after migration the rc sources cleanly and the bare block is gone', () => {
+      const rc = `${CLAUDE_ALIAS}\n\n${OLD_BARE_BLOCK}\n`;
+      // What repair() does for a stale block:
+      const migrated =
+        stripMarkerBlock(rc, def.marker, def.endMarker).replace(/\n+$/, '\n') +
+        def.blockFn('/tmp/pilot-hooks/claude-code-fetch-intercept.mjs') + '\n';
+
+      expect(migrated).not.toMatch(/^claude\(\) \{/m); // old bare block removed
+      expect(migrated).toContain(def.signature);       // new guarded block present
+
+      const out = sourceInBash(`${migrated}\necho SRC_OK\nalias claude`);
+      expect(out).toContain('SRC_OK');                 // no syntax error
+      expect(out).toContain('dangerously-skip-permissions'); // user alias preserved
     });
   });
 });

--- a/tests/unit/core/hook-watchdog-intercept.test.ts
+++ b/tests/unit/core/hook-watchdog-intercept.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   HookWatchdog,
+  stripMarkerBlock,
   type InterceptCheckTarget,
 } from '../../../src/core/hook-watchdog.js';
 import type { HookWatchdogConfig } from '../../../src/types/index.js';
@@ -182,6 +183,41 @@ describe('HookWatchdog intercept targets', () => {
     expect(result.repaired).toBe(1);
   });
 
+  it('runs cleanup() (not check/repair) when disabled', async () => {
+    const cleanup = vi.fn<[], Promise<void>>().mockResolvedValue(undefined);
+    const target = makeTarget({
+      enabled: vi.fn<[], boolean>().mockReturnValue(false),
+      cleanup,
+      check: vi.fn().mockResolvedValue(false),
+    });
+    const wd = new HookWatchdog(defaultConfig, [], [target]);
+    const result = await wd.runCheck();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(target.precondition).not.toHaveBeenCalled();
+    expect(target.check).not.toHaveBeenCalled();
+    expect(target.repair).not.toHaveBeenCalled();
+    expect(result.skipped).toBe(1);
+  });
+
+  it('does not crash when cleanup() throws while disabled', async () => {
+    const target = makeTarget({
+      enabled: vi.fn<[], boolean>().mockReturnValue(false),
+      cleanup: vi.fn<[], Promise<void>>().mockRejectedValue(new Error('rc read-only')),
+    });
+    const wd = new HookWatchdog(defaultConfig, [], [target]);
+    const result = await wd.runCheck();
+    expect(result.skipped).toBe(1);
+  });
+
+  it('skips cleanly when disabled and no cleanup() is provided', async () => {
+    const target = makeTarget({ enabled: vi.fn<[], boolean>().mockReturnValue(false) });
+    const wd = new HookWatchdog(defaultConfig, [], [target]);
+    const result = await wd.runCheck();
+    expect(target.check).not.toHaveBeenCalled();
+    expect(result.skipped).toBe(1);
+  });
+
   it('does not interfere with plugin check targets', async () => {
     // Plugin target with repairFn
     const pluginRepair = vi.fn().mockResolvedValue(true);
@@ -288,6 +324,66 @@ describe('intercept rc block is parse-safe and non-clobbering', () => {
     } finally {
       process.env.HOME = prevHome;
       fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('stripMarkerBlock', () => {
+  const BEGIN = 'loongsuite-pilot BEGIN claude-code-intercept';
+  const END = 'loongsuite-pilot END claude-code-intercept';
+
+  it('removes the marker-delimited block inclusive of the marker lines', () => {
+    const content = [
+      'export PATH=/x:$PATH',
+      '# loongsuite-pilot BEGIN claude-code-intercept',
+      'claude() { echo old; }',
+      '# loongsuite-pilot END claude-code-intercept',
+      'alias ll=ls',
+    ].join('\n');
+    const out = stripMarkerBlock(content, BEGIN, END);
+    expect(out).not.toContain('claude() { echo old; }');
+    expect(out).not.toContain(BEGIN);
+    expect(out).not.toContain(END);
+    expect(out).toContain('export PATH=/x:$PATH');
+    expect(out).toContain('alias ll=ls');
+  });
+
+  it('is a no-op when the markers are absent', () => {
+    const content = 'export A=1\nalias ll=ls\n';
+    expect(stripMarkerBlock(content, BEGIN, END)).toBe(content);
+  });
+
+  it('handles a multi-line (new-shape) block', () => {
+    const content = [
+      'before',
+      '# loongsuite-pilot BEGIN claude-code-intercept',
+      'if ! alias claude >/dev/null 2>&1 && ! typeset -f claude >/dev/null 2>&1; then',
+      "  eval 'claude() { :; }'",
+      'fi',
+      '# loongsuite-pilot END claude-code-intercept',
+      'after',
+    ].join('\n');
+    const out = stripMarkerBlock(content, BEGIN, END);
+    expect(out.split('\n')).toEqual(['before', 'after']);
+  });
+});
+
+describe('interceptRcBlockDefs migration metadata', () => {
+  it('exposes signature + endMarker matching the block body', () => {
+    for (const def of HookWatchdog.interceptRcBlockDefs()) {
+      const block = def.blockFn(`/tmp/hooks/${def.scriptName}`);
+      expect(block).toContain(def.marker);       // BEGIN marker present
+      expect(block).toContain(def.endMarker);    // END marker present
+      expect(block).toContain(def.signature);    // guard signature present
+      // signature must be the guard line, which the old bare block never had
+      expect(def.signature).toMatch(/^if ! alias \S+ >\/dev\/null 2>&1$/);
+    }
+  });
+
+  it('exposes cleanup() on every default intercept target', () => {
+    const targets = HookWatchdog.defaultInterceptTargets('/tmp/test-pilot');
+    for (const t of targets) {
+      expect(typeof t.cleanup).toBe('function');
     }
   });
 });

--- a/tests/unit/core/hook-watchdog-intercept.test.ts
+++ b/tests/unit/core/hook-watchdog-intercept.test.ts
@@ -154,6 +154,34 @@ describe('HookWatchdog intercept targets', () => {
     expect(target.repair).toHaveBeenCalledTimes(4); // counter reset, new repair allowed
   });
 
+  it('skips target entirely when enabled() returns false (before precondition)', async () => {
+    const target = makeTarget({
+      enabled: vi.fn<[], boolean>().mockReturnValue(false),
+      check: vi.fn().mockResolvedValue(false), // would repair if reached
+    });
+    const wd = new HookWatchdog(defaultConfig, [], [target]);
+    const result = await wd.runCheck();
+
+    expect(target.enabled).toHaveBeenCalled();
+    expect(target.precondition).not.toHaveBeenCalled();
+    expect(target.check).not.toHaveBeenCalled();
+    expect(target.repair).not.toHaveBeenCalled();
+    expect(result.skipped).toBe(1);
+  });
+
+  it('proceeds normally when enabled() returns true', async () => {
+    const target = makeTarget({
+      enabled: vi.fn<[], boolean>().mockReturnValue(true),
+      check: vi.fn().mockResolvedValue(false),
+    });
+    const wd = new HookWatchdog(defaultConfig, [], [target]);
+    const result = await wd.runCheck();
+
+    expect(target.enabled).toHaveBeenCalled();
+    expect(target.repair).toHaveBeenCalledTimes(1);
+    expect(result.repaired).toBe(1);
+  });
+
   it('does not interfere with plugin check targets', async () => {
     // Plugin target with repairFn
     const pluginRepair = vi.fn().mockResolvedValue(true);
@@ -191,6 +219,75 @@ describe('HookWatchdog.defaultInterceptTargets', () => {
     expect(ids).toContain('claude-code-rc');
     if (process.platform === 'darwin') {
       expect(ids).toContain('qoderwork-env');
+    }
+  });
+
+  it('defaults every target to enabled when no gate is passed', () => {
+    const targets = HookWatchdog.defaultInterceptTargets('/tmp/test-pilot');
+    for (const t of targets) {
+      // enabled is optional; when present it must report true under the default gate
+      expect(t.enabled?.() ?? true).toBe(true);
+    }
+  });
+
+  it('wires the isAgentEnabled gate to the right agent id per target', () => {
+    const disabled = new Set(['claude-code', 'qoder', 'qoder-work']);
+    const targets = HookWatchdog.defaultInterceptTargets(
+      '/tmp/test-pilot',
+      (id) => !disabled.has(id),
+    );
+    const byId = Object.fromEntries(targets.map(t => [t.id, t]));
+
+    expect(byId['claude-code-rc'].enabled?.()).toBe(false); // → claude-code
+    expect(byId['qodercli-rc'].enabled?.()).toBe(false);    // → qoder
+    if (process.platform === 'darwin') {
+      expect(byId['qoderwork-env'].enabled?.()).toBe(false); // → qoder-work
+    }
+  });
+});
+
+describe('intercept rc block is parse-safe and non-clobbering', () => {
+  // Render the rc block the way repair() would, into a temp rc file, without
+  // touching the real HOME. defaultInterceptTargets(dataDir) uses os.homedir()
+  // for rcPaths, which is awkward to stub across the ESM boundary; instead we
+  // point HOME at a temp dir up-front and assert the block via a fresh
+  // fs-backed write driven by the same rcTargets definitions the watchdog uses.
+  const fs = require('node:fs') as typeof import('node:fs');
+  const path = require('node:path') as typeof import('node:path');
+
+  it('claude-code-rc / qodercli-rc repair writes a guarded, eval-deferred block', async () => {
+    const tmpHome = fs.mkdtempSync(path.join(require('node:os').tmpdir(), 'pilot-rc-'));
+    const prevHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+    try {
+      fs.mkdirSync(path.join(tmpHome, 'hooks'), { recursive: true });
+      fs.writeFileSync(path.join(tmpHome, 'hooks', 'claude-code-fetch-intercept.mjs'), '// stub\n');
+      fs.writeFileSync(path.join(tmpHome, 'hooks', 'qodercli-token-intercept.mjs'), '// stub\n');
+      fs.writeFileSync(path.join(tmpHome, '.zshrc'), '# pre-existing\n');
+
+      const targets = HookWatchdog.defaultInterceptTargets(tmpHome);
+      const homeMatches = require('node:os').homedir() === tmpHome;
+      // Only meaningful when os.homedir() honors HOME (POSIX). Skip on platforms
+      // where it doesn't, rather than risk writing to the real rc.
+      if (!homeMatches) return;
+
+      for (const id of ['claude-code-rc', 'qodercli-rc']) {
+        const target = targets.find(t => t.id === id)!;
+        if (await target.check()) continue; // marker somehow already present
+        await target.repair();
+      }
+      const rc = fs.readFileSync(path.join(tmpHome, '.zshrc'), 'utf-8');
+
+      expect(rc).toContain('if ! alias claude >/dev/null 2>&1 && ! typeset -f claude >/dev/null 2>&1; then');
+      expect(rc).toContain(`eval 'claude() { BUN_OPTIONS="--preload=`);
+      expect(rc).toContain('${BUN_OPTIONS}'); // preserve user's existing BUN_OPTIONS at call time
+      expect(rc).not.toMatch(/^\s*claude\(\)/m); // no bare, unguarded def token
+      expect(rc).toContain('if ! alias qodercli >/dev/null 2>&1 && ! typeset -f qodercli >/dev/null 2>&1; then');
+      expect(rc).toContain(`eval 'qodercli() { BUN_OPTIONS="--preload=`);
+      expect(rc).not.toMatch(/^\s*qodercli\(\)/m);
+    } finally {
+      process.env.HOME = prevHome;
+      fs.rmSync(tmpHome, { recursive: true, force: true });
     }
   });
 });

--- a/tests/unit/core/hook-watchdog-intercept.test.ts
+++ b/tests/unit/core/hook-watchdog-intercept.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   HookWatchdog,
   stripMarkerBlock,
@@ -282,49 +282,114 @@ describe('HookWatchdog.defaultInterceptTargets', () => {
   });
 });
 
-describe('intercept rc block is parse-safe and non-clobbering', () => {
-  // Render the rc block the way repair() would, into a temp rc file, without
-  // touching the real HOME. defaultInterceptTargets(dataDir) uses os.homedir()
-  // for rcPaths, which is awkward to stub across the ESM boundary; instead we
-  // point HOME at a temp dir up-front and assert the block via a fresh
-  // fs-backed write driven by the same rcTargets definitions the watchdog uses.
+describe('intercept rc target check/repair/cleanup against a temp rc (real closures)', () => {
+  // rcPaths is injected (3rd arg) so these exercise the ACTUAL closures the
+  // daemon runs — reading/writing real files in a temp dir, no HOME stubbing.
   const fs = require('node:fs') as typeof import('node:fs');
+  const os = require('node:os') as typeof import('node:os');
   const path = require('node:path') as typeof import('node:path');
 
-  it('claude-code-rc / qodercli-rc repair writes a guarded, eval-deferred block', async () => {
-    const tmpHome = fs.mkdtempSync(path.join(require('node:os').tmpdir(), 'pilot-rc-'));
-    const prevHome = process.env.HOME;
-    process.env.HOME = tmpHome;
-    try {
-      fs.mkdirSync(path.join(tmpHome, 'hooks'), { recursive: true });
-      fs.writeFileSync(path.join(tmpHome, 'hooks', 'claude-code-fetch-intercept.mjs'), '// stub\n');
-      fs.writeFileSync(path.join(tmpHome, 'hooks', 'qodercli-token-intercept.mjs'), '// stub\n');
-      fs.writeFileSync(path.join(tmpHome, '.zshrc'), '# pre-existing\n');
+  const SCRIPT = 'claude-code-fetch-intercept.mjs';
+  const SIG = 'if ! alias claude >/dev/null 2>&1';
+  const OLD_BARE_BLOCK = [
+    '# loongsuite-pilot BEGIN claude-code-intercept',
+    'claude() { BUN_OPTIONS="--preload=/old ${BUN_OPTIONS}" command claude "$@"; }',
+    '# loongsuite-pilot END claude-code-intercept',
+  ].join('\n');
 
-      const targets = HookWatchdog.defaultInterceptTargets(tmpHome);
-      const homeMatches = require('node:os').homedir() === tmpHome;
-      // Only meaningful when os.homedir() honors HOME (POSIX). Skip on platforms
-      // where it doesn't, rather than risk writing to the real rc.
-      if (!homeMatches) return;
+  let tmp: string;
+  let zshrc: string;
+  let bashrc: string;
 
-      for (const id of ['claude-code-rc', 'qodercli-rc']) {
-        const target = targets.find(t => t.id === id)!;
-        if (await target.check()) continue; // marker somehow already present
-        await target.repair();
-      }
-      const rc = fs.readFileSync(path.join(tmpHome, '.zshrc'), 'utf-8');
+  function claudeTarget(enabled = true) {
+    const isEnabled = (id: string) => (id === 'claude-code' ? enabled : true);
+    return HookWatchdog
+      .defaultInterceptTargets(tmp, isEnabled, [zshrc, bashrc])
+      .find(t => t.id === 'claude-code-rc')!;
+  }
 
-      expect(rc).toContain('if ! alias claude >/dev/null 2>&1 && ! typeset -f claude >/dev/null 2>&1; then');
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pilot-rc-real-'));
+    fs.mkdirSync(path.join(tmp, 'hooks'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, 'hooks', SCRIPT), '// stub\n');
+    zshrc = path.join(tmp, '.zshrc');
+    bashrc = path.join(tmp, '.bashrc');
+  });
+
+  afterEach(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+  it('repair() appends a guarded, eval-deferred block when none exists', async () => {
+    fs.writeFileSync(zshrc, '# pre-existing\n');
+    fs.writeFileSync(bashrc, '# pre-existing\n');
+    const t = claudeTarget();
+    expect(await t.check()).toBe(false); // no block yet → needs repair
+    await t.repair();
+
+    for (const rcFile of [zshrc, bashrc]) {
+      const rc = fs.readFileSync(rcFile, 'utf-8');
+      expect(rc).toContain(SIG);
       expect(rc).toContain(`eval 'claude() { BUN_OPTIONS="--preload=`);
-      expect(rc).toContain('${BUN_OPTIONS}'); // preserve user's existing BUN_OPTIONS at call time
-      expect(rc).not.toMatch(/^\s*claude\(\)/m); // no bare, unguarded def token
-      expect(rc).toContain('if ! alias qodercli >/dev/null 2>&1 && ! typeset -f qodercli >/dev/null 2>&1; then');
-      expect(rc).toContain(`eval 'qodercli() { BUN_OPTIONS="--preload=`);
-      expect(rc).not.toMatch(/^\s*qodercli\(\)/m);
-    } finally {
-      process.env.HOME = prevHome;
-      fs.rmSync(tmpHome, { recursive: true, force: true });
+      expect(rc).toContain('${BUN_OPTIONS}');
+      expect(rc).not.toMatch(/^\s*claude\(\)/m); // no bare def token
     }
+    expect(await t.check()).toBe(true); // healthy after repair
+  });
+
+  it('check() flags an OLD bare block as stale and repair() migrates it', async () => {
+    fs.writeFileSync(zshrc, `# top\n\n${OLD_BARE_BLOCK}\n`);
+    const t = claudeTarget();
+    expect(await t.check()).toBe(false); // marker present but old shape → stale
+
+    await t.repair();
+    const rc = fs.readFileSync(zshrc, 'utf-8');
+    expect(rc).not.toContain('claude() { BUN_OPTIONS="--preload=/old'); // old bare gone
+    expect(rc).not.toMatch(/^\s*claude\(\)/m);
+    expect(rc).toContain(SIG);                       // migrated to guarded block
+    expect(rc.match(/BEGIN claude-code-intercept/g)!.length).toBe(1); // exactly one block
+    expect(rc).toContain('# top');                   // surrounding content preserved
+    expect(await t.check()).toBe(true);
+  });
+
+  it('repair() is idempotent — current block is not duplicated', async () => {
+    fs.writeFileSync(zshrc, '');
+    const t = claudeTarget();
+    await t.repair();
+    await t.repair();
+    const rc = fs.readFileSync(zshrc, 'utf-8');
+    expect(rc.match(/BEGIN claude-code-intercept/g)!.length).toBe(1);
+  });
+
+  it('cleanup() removes our block (disabled agent) and leaves other content', async () => {
+    fs.writeFileSync(zshrc, '# keep-me\n');
+    const enabled = claudeTarget(true);
+    await enabled.repair(); // install first
+    expect(fs.readFileSync(zshrc, 'utf-8')).toContain(SIG);
+
+    const disabled = claudeTarget(false);
+    await disabled.cleanup!();
+    const rc = fs.readFileSync(zshrc, 'utf-8');
+    expect(rc).not.toContain('loongsuite-pilot BEGIN claude-code-intercept');
+    expect(rc).not.toContain(SIG);
+    expect(rc).toContain('# keep-me'); // unrelated content untouched
+  });
+
+  it('cleanup() also removes an OLD bare block', async () => {
+    fs.writeFileSync(zshrc, `# keep\n${OLD_BARE_BLOCK}\n`);
+    await claudeTarget(false).cleanup!();
+    const rc = fs.readFileSync(zshrc, 'utf-8');
+    expect(rc).not.toContain('loongsuite-pilot BEGIN claude-code-intercept');
+    expect(rc).toContain('# keep');
+  });
+
+  it('disabled target: runCheck() runs cleanup() and does not re-inject', async () => {
+    fs.writeFileSync(zshrc, '');
+    await claudeTarget(true).repair(); // block present
+    expect(fs.readFileSync(zshrc, 'utf-8')).toContain(SIG);
+
+    const wd = new HookWatchdog(defaultConfig, [], [claudeTarget(false)]);
+    const result = await wd.runCheck();
+    expect(result.skipped).toBe(1);
+    expect(fs.readFileSync(zshrc, 'utf-8')).not.toContain(SIG); // cleaned, not re-injected
   });
 });
 


### PR DESCRIPTION
## Summary

The shell-rc fetch/token intercept wrapper (`claude()` / `qodercli()` in `~/.zshrc`/`.bashrc`) broke users who already define their own `claude`/`qodercli` alias:

- A bare `claude() {...}` token **parse-errors** under an active alias — interactive shells expand aliases at parse time, before any runtime guard runs, so sourcing the rc file fails on every new shell.
- Even when it parsed, `command claude` **shadowed the user's alias**, silently dropping their proxy / `--dangerously-skip-permissions` flags.
- The hook-watchdog **re-injected** the wrapper regardless of whether the agent was selected at install time (installer respected `--agents`, watchdog did not).

## Changes

- **Parse-safe, non-clobbering block**: rc block now uses
  ```sh
  if ! alias claude >/dev/null 2>&1 && ! typeset -f claude >/dev/null 2>&1; then
    eval 'claude() { BUN_OPTIONS="--preload=<path> ${BUN_OPTIONS}" command claude "$@"; }'
  fi
  ```
  The guard skips users who define their own alias/function (no clobber); `eval` defers parsing the definition so it never parse-errors under an active alias. Applied to both the installer and the watchdog `blockFn` (kept byte-identical).
- **Respect agent selection**: added optional `InterceptCheckTarget.enabled()`; the watchdog skips disabled agents before check/repair. `defaultInterceptTargets` takes an `isAgentEnabled` gate (id→agent map: `claude-code-rc`→`claude-code`, `qodercli-rc`→`qoder`, `qoderwork-env`→`qoder-work`); orchestrator wires `isAgentGatedEnabled` and also gates plugin-inject intercept targets. A deselected agent's intercept is no longer re-injected.
- **Cleanup on deselect**: installer removes any stale rc block when an agent is deselected on reinstall.
- **One-time hint**: installer detects a user-defined `claude`/`qodercli` and prints how to opt in to collection (rc is sourced too often to warn on every shell).
- **Testability**: extracted rc block defs into a pure `HookWatchdog.interceptRcBlockDefs()` seam.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `bash -n deploy/installer-opensource.sh`
- [x] Watchdog unit tests (intercept gate, id mapping, block shape): 16/16
- [x] New real bash+zsh sourcing regression test (`hook-watchdog-intercept-shell.test.ts`): sources the actual block under an active alias → no syntax error, alias preserved, wrapper composes `BUN_OPTIONS` when no alias; 7/7
- [x] Manual bash+zsh smoke across alias / function / no-override / idempotent-double-source scenarios: 20/20

🤖 Generated with [Claude Code](https://claude.com/claude-code)