### PR TITLE
feat(metrics): refresh userId at runtime so self-monitoring status matches logs

### DIFF
--- a/src/core/config-loader.ts
+++ b/src/core/config-loader.ts
@@ -1,4 +1,5 @@
 import * as os from 'node:os';
+import * as fs from 'node:fs';
 import type {
   AgentsConfig,
   AnalyticsConfig,
@@ -195,6 +196,87 @@ function envInt(key: string, fallback: number): number {
 }
 
 /**
+ * Single source of truth for userId precedence:
+ *   env LOONGSUITE_PILOT_USER_ID > config.userId > config['user.id'] > hostname.
+ * Shared by loadConfig() (startup) and createUserIdProvider() (runtime refresh)
+ * so the two never diverge. Empty/whitespace-only values are treated as unset
+ * (fall through to hostname), consistent with the hooks' `||` resolution — this
+ * prevents self-monitoring status from reporting an empty user_id while the
+ * collected logs fall back to hostname.
+ */
+function resolveUserId(file: Pick<ConfigFile, 'userId' | 'user.id'> | null | undefined): string {
+  const candidates = [env('LOONGSUITE_PILOT_USER_ID'), file?.userId, file?.['user.id']];
+  for (const c of candidates) {
+    const trimmed = c?.trim();
+    if (trimmed) return trimmed;
+  }
+  return os.hostname();
+}
+
+/**
+ * How often createUserIdProvider() re-resolves userId from config.json. userId is
+ * otherwise a process-startup snapshot; refreshing lets an operator correct a
+ * wrong/missing userId (so self-monitoring status matches the collected logs)
+ * without a service restart. 24h keeps filesystem reads negligible while bounding staleness.
+ */
+export const USER_ID_REFRESH_INTERVAL_MS = 86_400_000; // 24h
+
+export interface UserIdProviderOptions {
+  /** Value resolved at startup; used until the first refresh and as fallback on read errors. */
+  initialUserId: string;
+  /** Config file path (defaults to AGENT_DATA_COLLECTION_CONFIG or ~/.loongsuite-pilot/config.json). */
+  configPath?: string;
+  /** Refresh interval in ms (default 24h). */
+  refreshIntervalMs?: number;
+  /** Injectable clock for tests. */
+  now?: () => number;
+  /** Injectable file reader for tests. */
+  readFile?: (filePath: string) => string;
+}
+
+/**
+ * Returns a getter that re-resolves userId at most once per refresh interval
+ * (default 24h), mirroring loadConfig()'s precedence. Only the config file can
+ * change during a process lifetime, so a periodic re-read is enough.
+ */
+export function createUserIdProvider(opts: UserIdProviderOptions): () => string {
+  const configPath = resolveHome(opts.configPath ?? env('AGENT_DATA_COLLECTION_CONFIG') ?? DEFAULT_CONFIG_PATH);
+  const refreshIntervalMs = opts.refreshIntervalMs ?? USER_ID_REFRESH_INTERVAL_MS;
+  const now = opts.now ?? Date.now;
+  const readFile = opts.readFile ?? ((p: string) => fs.readFileSync(p, 'utf-8'));
+
+  let cached = opts.initialUserId;
+  let hasRefreshed = false;
+  let lastRefreshAt = 0;
+
+  function resolve(): string {
+    let file: ConfigFile;
+    try {
+      file = JSON.parse(readFile(configPath)) as ConfigFile;
+    } catch {
+      // Missing or corrupt config: keep the last known good value rather than
+      // regressing to hostname on a transient read error.
+      return cached;
+    }
+    return resolveUserId(file);
+  }
+
+  return (): string => {
+    const t = now();
+    if (!hasRefreshed || t - lastRefreshAt >= refreshIntervalMs) {
+      const next = resolve();
+      if (next !== cached) {
+        logger.info('userId refreshed from config', { previous: cached, current: next });
+      }
+      cached = next;
+      hasRefreshed = true;
+      lastRefreshAt = t;
+    }
+    return cached;
+  };
+}
+
+/**
  * Load configuration with three priority layers:
  *   1. Environment variables (highest)
  *   2. Config file (~/.loongsuite-pilot/config.json or AGENT_DATA_COLLECTION_CONFIG)
@@ -217,7 +299,7 @@ export async function loadConfig(): Promise<AnalyticsConfig> {
   const innerDataConfigPath = resolveHome(`${dataDir}/configs/inner/data_config.json`);
   const innerDataConfig = await readJsonFile<InnerDataConfig>(innerDataConfigPath);
 
-  const userId = env('LOONGSUITE_PILOT_USER_ID') ?? file?.userId ?? file?.['user.id'] ?? os.hostname();
+  const userId = resolveUserId(file);
 
   const serviceNamePrefix = env('LOONGSUITE_PILOT_SERVICE_NAME_PREFIX') ?? file?.serviceNamePrefix ?? 'loongsuite-pilot';
 

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -20,7 +20,7 @@ import { SlsFlusher } from '../flushers/sls-flusher.js';
 import { JsonlFlusher } from '../flushers/jsonl-flusher.js';
 import { HttpFlusher } from '../flushers/http-flusher.js';
 import { MultiFlusher } from '../flushers/multi-flusher.js';
-import { buildOtlpTraceConfig } from './config-loader.js';
+import { buildOtlpTraceConfig, createUserIdProvider } from './config-loader.js';
 
 // Concrete inputs
 import { QoderSqliteInput } from '../inputs/qoder-sqlite/qoder-sqlite-input.js';
@@ -164,7 +164,11 @@ export class Orchestrator extends EventEmitter {
 
     // 4. Build InputManager & AlarmManager
     const version = readInstalledVersion(this.dataDir);
-    this.alarmManager = new AlarmManager({ ip: resolveLocalIp(), version, userId: this.config.userId });
+    // Refreshable userId source: re-reads config.json (24h) so an operator can
+    // correct a wrong/missing userId without restarting the service. Shared by
+    // alarms and metrics so self-monitoring output stays consistent.
+    const userIdProvider = createUserIdProvider({ initialUserId: this.config.userId });
+    this.alarmManager = new AlarmManager({ ip: resolveLocalIp(), version, userIdProvider });
 
     this.inputManager = new InputManager();
     this.inputManager.setFlusher(this.flusher);
@@ -272,6 +276,7 @@ export class Orchestrator extends EventEmitter {
       dataDir: this.dataDir,
       version,
       userId: this.config.userId,
+      userIdProvider,
       canaryPolicy: this.config.autoUpdate?.canaryPolicy ?? '',
       getSnapshot: () => this.buildDataflowSnapshot(),
       alarmManager: this.alarmManager,

--- a/src/metrics/alarm-manager.ts
+++ b/src/metrics/alarm-manager.ts
@@ -49,12 +49,14 @@ export class AlarmManager {
   private readonly alarms: Map<string, AlarmItem> = new Map();
   private readonly ip: string;
   private readonly version: string;
-  private readonly userId: string;
+  private readonly userIdProvider: () => string;
 
-  constructor(opts: { ip: string; version: string; userId: string }) {
+  constructor(opts: { ip: string; version: string; userId?: string; userIdProvider?: () => string }) {
     this.ip = opts.ip;
     this.version = opts.version;
-    this.userId = opts.userId;
+    // Read userId lazily so a runtime correction propagates to alarms too;
+    // a static userId remains supported for callers/tests.
+    this.userIdProvider = opts.userIdProvider ?? (() => opts.userId ?? '');
   }
 
   record(type: AlarmType, level: AlarmLevel, message: string, context?: AlarmContext): void {
@@ -81,7 +83,7 @@ export class AlarmManager {
         alarm_level: item.level,
         alarm_message: item.message,
         alarm_count: String(item.count),
-        user_id: this.userId,
+        user_id: this.userIdProvider(),
         ip: this.ip,
         ver: this.version,
         __time__: now,

--- a/src/metrics/metrics-collector.ts
+++ b/src/metrics/metrics-collector.ts
@@ -138,7 +138,7 @@ export interface InfraHealthSnapshot {
 
 export class MetricsCollector {
   private readonly version: string;
-  private readonly userId: string;
+  private readonly userIdProvider: () => string;
   private readonly dataDir: string;
   private readonly canaryPolicy: string;
   private readonly agentsConfig: AgentsConfig;
@@ -162,9 +162,11 @@ export class MetricsCollector {
   private updaterConsecutiveFailures = 0;
   private lastInfraHealth: InfraHealthSnapshot | null = null;
 
-  constructor(opts: { version: string; userId: string; dataDir: string; canaryPolicy?: string; agentsConfig?: AgentsConfig; slsEndpoints?: SlsEndpoint[]; cmsWorkspace?: string; updaterLiveness?: (pidFile: string) => ProcessLiveness }) {
+  constructor(opts: { version: string; userId?: string; userIdProvider?: () => string; dataDir: string; canaryPolicy?: string; agentsConfig?: AgentsConfig; slsEndpoints?: SlsEndpoint[]; cmsWorkspace?: string; updaterLiveness?: (pidFile: string) => ProcessLiveness }) {
     this.version = opts.version;
-    this.userId = opts.userId;
+    // Read userId lazily each cycle so an operator can correct a wrong/missing
+    // userId without restarting; a static userId remains supported for callers/tests.
+    this.userIdProvider = opts.userIdProvider ?? (() => opts.userId ?? '');
     this.dataDir = opts.dataDir;
     this.canaryPolicy = opts.canaryPolicy ?? '';
     this.agentsConfig = opts.agentsConfig ?? {};
@@ -175,12 +177,14 @@ export class MetricsCollector {
     this.startTimestamp = Math.floor(Date.now() / 1000);
     this.startTime = formatTime(new Date());
     this.localIp = resolveLocalIp();
-    this.instanceId = `${opts.userId}_${this.localIp}_${this.startTimestamp}`;
+    // instance_id is a stable per-process identifier; seed it from the startup
+    // userId snapshot even though the reported user_id field refreshes at runtime.
+    this.instanceId = `${this.userIdProvider()}_${this.localIp}_${this.startTimestamp}`;
     this.initType = readInitType(opts.dataDir);
   }
 
   getUserId(): string {
-    return this.userId;
+    return this.userIdProvider();
   }
 
   collectL1(snapshot: DataflowSnapshot): L1Metrics {
@@ -215,7 +219,7 @@ export class MetricsCollector {
       hostname: os.hostname(),
       ip: this.localIp,
       instance_id: this.instanceId,
-      user_id: this.userId,
+      user_id: this.userIdProvider(),
       pid: process.pid,
       cpu: String(cpuPercent),
       mem: String(Math.round(mem.rss / 1024 / 1024)),
@@ -262,7 +266,7 @@ export class MetricsCollector {
           input_name: name,
           input_type: stats.type,
         },
-        user_id: this.userId,
+        user_id: this.userIdProvider(),
         in_events_total: String(stats.inEvents),
         in_size_bytes: String(stats.inBytes),
         out_events_total: String(stats.outEvents),
@@ -289,7 +293,7 @@ export class MetricsCollector {
           logstore: stats.logstore,
           mode: stats.mode,
         },
-        user_id: this.userId,
+        user_id: this.userIdProvider(),
         in_entries_total: String(stats.inEntries),
         in_size_bytes: String(stats.inBytes),
         out_entries_total: String(stats.outEntries),
@@ -317,7 +321,7 @@ export class MetricsCollector {
         input_name: name,
         instance_id: this.instanceId,
         source_ip: this.localIp,
-        user_id: this.userId,
+        user_id: this.userIdProvider(),
         succeed_events: String(stats.outEvents),
         failed_events: String(stats.outFailed),
         input_idle_minutes: String(idleMinutes),

--- a/src/metrics/metrics-writer.ts
+++ b/src/metrics/metrics-writer.ts
@@ -22,6 +22,8 @@ export interface MetricsWriterOptions {
   dataDir: string;
   version: string;
   userId: string;
+  /** Optional refreshable userId source; when set, overrides the static userId each cycle. */
+  userIdProvider?: () => string;
   canaryPolicy?: string;
   getSnapshot: () => DataflowSnapshot;
   alarmManager?: AlarmManager;
@@ -48,6 +50,7 @@ export class MetricsWriter {
     this.collector = new MetricsCollector({
       version: opts.version,
       userId: opts.userId,
+      userIdProvider: opts.userIdProvider,
       dataDir: opts.dataDir,
       agentsConfig: opts.agentsConfig,
       canaryPolicy: opts.canaryPolicy,

--- a/tests/unit/core/config-loader.test.ts
+++ b/tests/unit/core/config-loader.test.ts
@@ -90,6 +90,16 @@ describe('ConfigLoader', () => {
       const config = await loadConfig();
       expect(config.userId).toBe('from-file');
     });
+
+    it('treats an empty/whitespace userId as unset and falls back to hostname', async () => {
+      const os = await import('node:os');
+      mockReadJsonFile.mockResolvedValueOnce({
+        userId: '   ',
+      });
+
+      const config = await loadConfig();
+      expect(config.userId).toBe(os.hostname());
+    });
   });
 
   describe('missing config file fallback (T026)', () => {

--- a/tests/unit/core/user-id-provider.test.ts
+++ b/tests/unit/core/user-id-provider.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as os from 'node:os';
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(),
+  }),
+}));
+
+import { createUserIdProvider, USER_ID_REFRESH_INTERVAL_MS } from '../../../src/core/config-loader.js';
+
+const CONFIG_PATH = '/tmp/loongsuite-pilot-test/config.json';
+
+function makeReader(map: { current: string }): (p: string) => string {
+  return () => map.current;
+}
+
+describe('createUserIdProvider', () => {
+  it('reads userId from config on the first call', () => {
+    const file = { current: JSON.stringify({ userId: '326220' }) };
+    const get = createUserIdProvider({
+      initialUserId: 'startup-host',
+      configPath: CONFIG_PATH,
+      readFile: makeReader(file),
+      now: () => 0,
+    });
+    expect(get()).toBe('326220');
+  });
+
+  it('does not pick up config changes within the refresh interval', () => {
+    const file = { current: JSON.stringify({ userId: 'old' }) };
+    let clock = 0;
+    const get = createUserIdProvider({
+      initialUserId: 'startup',
+      configPath: CONFIG_PATH,
+      readFile: makeReader(file),
+      now: () => clock,
+    });
+    expect(get()).toBe('old');
+
+    file.current = JSON.stringify({ userId: 'new' });
+    clock = USER_ID_REFRESH_INTERVAL_MS - 1;
+    expect(get()).toBe('old'); // still cached
+  });
+
+  it('re-reads config once the refresh interval elapses', () => {
+    const file = { current: JSON.stringify({ userId: 'old' }) };
+    let clock = 0;
+    const get = createUserIdProvider({
+      initialUserId: 'startup',
+      configPath: CONFIG_PATH,
+      readFile: makeReader(file),
+      now: () => clock,
+    });
+    expect(get()).toBe('old');
+
+    file.current = JSON.stringify({ userId: '326220' });
+    clock = USER_ID_REFRESH_INTERVAL_MS;
+    expect(get()).toBe('326220');
+  });
+
+  it('honors env override over the config file', () => {
+    vi.stubEnv('LOONGSUITE_PILOT_USER_ID', 'from-env');
+    try {
+      const file = { current: JSON.stringify({ userId: 'from-file' }) };
+      const get = createUserIdProvider({
+        initialUserId: 'startup',
+        configPath: CONFIG_PATH,
+        readFile: makeReader(file),
+        now: () => 0,
+      });
+      expect(get()).toBe('from-env');
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("falls back to user.id then hostname when userId is absent", () => {
+    const legacy = createUserIdProvider({
+      initialUserId: 'startup',
+      configPath: CONFIG_PATH,
+      readFile: () => JSON.stringify({ 'user.id': 'legacy-id' }),
+      now: () => 0,
+    });
+    expect(legacy()).toBe('legacy-id');
+
+    const none = createUserIdProvider({
+      initialUserId: 'startup',
+      configPath: CONFIG_PATH,
+      readFile: () => JSON.stringify({}),
+      now: () => 0,
+    });
+    expect(none()).toBe(os.hostname());
+  });
+
+  it('treats an empty/whitespace userId as unset and falls back to hostname', () => {
+    const get = createUserIdProvider({
+      initialUserId: 'startup',
+      configPath: CONFIG_PATH,
+      readFile: () => JSON.stringify({ userId: '   ' }),
+      now: () => 0,
+    });
+    expect(get()).toBe(os.hostname());
+  });
+
+  it('keeps the last known good value when the config read fails', () => {
+    const file = { current: JSON.stringify({ userId: '326220' }) };
+    let clock = 0;
+    const get = createUserIdProvider({
+      initialUserId: 'startup',
+      configPath: CONFIG_PATH,
+      readFile: () => {
+        const v = file.current;
+        if (v === '__throw__') throw new Error('ENOENT');
+        return v;
+      },
+      now: () => clock,
+    });
+    expect(get()).toBe('326220');
+
+    file.current = '__throw__';
+    clock = USER_ID_REFRESH_INTERVAL_MS;
+    expect(get()).toBe('326220'); // unchanged on read error
+  });
+});


### PR DESCRIPTION
## Problem

`userId` is captured once at process startup. When an operator corrects a wrong or missing `userId` in `config.json`, the change does not take effect until the service restarts. As a result, self-monitoring **status/metrics/alarms** keep reporting the stale (or empty) `user_id`, while the collected AI-event logs resolve `user_id` differently (hooks fall back to `os.hostname()`). This makes it impossible to join a log's `user_id` to the corresponding status.

Additionally, the startup resolution used `??`, which preserved an empty-string `userId` instead of falling back to hostname the way the hooks (`||`) do — producing an empty `user_id` in status while logs used hostname.

## Changes

- Add a shared refreshable userId provider `createUserIdProvider()` in `config-loader.ts` that re-reads `config.json` at most once every **24h** (`USER_ID_REFRESH_INTERVAL_MS`), keeping the last known good value on a read error.
- Extract a single `resolveUserId()` helper as the source of truth for userId precedence (`env > config.userId > config['user.id'] > hostname`), shared by both `loadConfig()` (startup) and the provider (runtime refresh) so the two never diverge.
- Treat empty/whitespace-only `userId` as unset (fall back to hostname), consistent with the hooks' resolution.
- Wire the provider through `MetricsCollector` (each collection cycle), `AlarmManager`, and the orchestrator (one shared provider).

`instance_id` intentionally keeps the startup userId snapshot (a per-process identifier should stay stable); only the queryable `user_id` field refreshes.

## Effect

After an operator sets/corrects `userId` in `config.json`, self-monitoring status/metrics/alarms pick it up within 24h without a service restart, and `user_id` no longer diverges between status and logs.

## Tests

- New `tests/unit/core/user-id-provider.test.ts` (first read, in-interval caching, post-interval refresh, env override, `user.id`/hostname fallback, empty/whitespace → hostname, keep-last-good on read failure).
- Extended `tests/unit/core/config-loader.test.ts` for empty userId → hostname.
- Affected suites pass: config-loader, user-id-provider, metrics-collector, metrics-writer, alarm-manager (149 tests).
