### PR TITLE
chore(deps): update otel-util-genai to beta.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@alicloud/log": "^1.2.6",
-        "@loongsuite/otel-util-genai": "^0.1.0-beta.9",
+        "@loongsuite/otel-util-genai": "^0.1.0-beta.13",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.57.0",
         "@opentelemetry/otlp-transformer": "^0.57.0",
@@ -657,9 +657,9 @@
       }
     },
     "node_modules/@loongsuite/otel-util-genai": {
-      "version": "0.1.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@loongsuite/otel-util-genai/-/otel-util-genai-0.1.0-beta.9.tgz",
-      "integrity": "sha512-XbepHcGnhMKJh1gqee0zxkliE5fI+kSy3TCWjpSzgnwKEECy2hz+KoyxbP6H+CI6TxdUdD8XqY/kR/ZcCBAK6g==",
+      "version": "0.1.0-beta.13",
+      "resolved": "https://registry.npmjs.org/@loongsuite/otel-util-genai/-/otel-util-genai-0.1.0-beta.13.tgz",
+      "integrity": "sha512-uOhfykO7iNX9bXINBk0KIMwXjawzAQHw5XrkXh2i2hdUrBQjma6PRleg6hpF0oB6D+XvwhHyK62/b9Qe+KL7rQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.40.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@alicloud/log": "^1.2.6",
-    "@loongsuite/otel-util-genai": "^0.1.0-beta.9",
+    "@loongsuite/otel-util-genai": "^0.1.0-beta.13",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.57.0",
     "@opentelemetry/otlp-transformer": "^0.57.0",


### PR DESCRIPTION
## Summary

- update `@loongsuite/otel-util-genai` from `^0.1.0-beta.9` to `^0.1.0-beta.13`
- refresh the npm lockfile to use the published beta.13 tarball and integrity
- enable the newly published GenAI Skill attribute detection support in pilot

## Validation

- `npm run typecheck`
- `npm test` (175 files, 1943 passed, 2 skipped)
- `npm run build`
- local end-to-end Cursor validation confirmed `gen_ai.skill.name` and `gen_ai.skill.id` on TOOL spans