### PR TITLE
docs: 补充 Windows Agent 支持矩阵

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ Pilot is designed to answer practical questions:
 | Qwen Code CLI | Hook                      | Yes          | Yes        | Yes         | Yes                       |
 | Wukong        | CLI API polling           | Yes          | Yes        | Yes         | Yes                       |
 
+### Documented Windows Agent Support
+
+The table above describes Pilot's general integration capabilities; it does not imply that every agent is supported on every operating system. The following agents are currently explicitly documented as supported on Windows:
+
+| Agent | Windows Integration | Trace Export | Log Export | Token Usage | Conversation / Tool Calls | Requirement |
+|-------|---------------------|--------------|------------|-------------|---------------------------|-------------|
+| Claude Code | Hook | Yes | Yes | Yes | Yes | — |
+| Cursor | Hook | Yes | Yes | Yes | Yes | — |
+| Qoder Work | Hook / local data source | Yes | Yes | No | Yes | User edition |
+| Qoder CLI | Hook | Yes | Yes | No | Yes | — |
+| Qoder IDE | Hook / local data source | Yes | Yes | Yes | Yes | Qoder 1.10.0 or later, User edition |
+| OpenCode | Plugin injection | Yes | Yes | Yes | Yes | — |
+
+Agents omitted from this Windows table do not currently have an explicit Windows support statement; omission does not necessarily mean that the agent cannot run on Windows. See the [Alibaba Cloud AI Coding Agent access guide](https://help.aliyun.com/zh/cms/cloudmonitor-2-0/ai-application-access-ai-coding-agent/) for the source support matrix and [Installation](docs/installation.md) for Windows prerequisites and setup.
+
 
 Agent definitions live in `agents.d/`. You can add new agents without changing the deployment framework; see [Agent Onboarding](docs/agent-onboarding.md).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -54,6 +54,21 @@ Pilot 主要帮助回答这些问题：
 | Qwen Code CLI | Hook | Yes | Yes | Yes | Yes |
 | Wukong | CLI API 轮询 | Yes | Yes | Yes | Yes |
 
+### Windows Agent 明确支持情况
+
+上表描述 Pilot 的总体接入能力，不代表每个 Agent 在所有操作系统上均受支持。目前文档明确说明支持 Windows 的 Agent 如下：
+
+| Agent | Windows 集成方式 | Trace 上报 | 日志上报 | Token 用量 | 对话 / 工具调用 | 使用条件 |
+|-------|------------------|------------|----------|------------|-----------------|----------|
+| Claude Code | Hook | 支持 | 支持 | 支持 | 支持 | — |
+| Cursor | Hook | 支持 | 支持 | 支持 | 支持 | — |
+| Qoder Work | Hook / 本地数据源 | 支持 | 支持 | 不支持 | 支持 | User 版本 |
+| Qoder CLI | Hook | 支持 | 支持 | 不支持 | 支持 | — |
+| Qoder IDE | Hook / 本地数据源 | 支持 | 支持 | 支持 | 支持 | Qoder 1.10.0 及以上 User 版本 |
+| OpenCode | 插件注入 | 支持 | 支持 | 支持 | 支持 | — |
+
+未列入 Windows 表格的 Agent，表示当前没有明确的 Windows 支持声明，并不一定代表无法在 Windows 上运行。支持矩阵参考[阿里云 AI Coding Agent 接入文档](https://help.aliyun.com/zh/cms/cloudmonitor-2-0/ai-application-access-ai-coding-agent/)，Windows 环境要求与安装方法见[安装指南](docs/zh-CN/installation.md)。
+
 Agent 定义位于 `agents.d/`。如需接入新的 Agent，请参考 [新 Agent 接入](docs/zh-CN/agent-onboarding.md)。
 
 ## 快速开始

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -37,6 +37,21 @@ LoongSuite Pilot runs on a developer machine and collects telemetry from support
 | Qwen Code CLI | Hook | Yes | Yes | Yes | Yes |
 | Wukong | CLI API polling | Yes | Yes | Yes | Yes |
 
+### Documented Windows Agent Support
+
+The general support table describes integration capabilities across Pilot and must not be interpreted as an operating-system compatibility matrix. The following agents are currently explicitly documented as supported on Windows:
+
+| Agent | Windows Integration | Trace Export | Log Export | Token Usage | Conversation / Tool Calls | Requirement |
+|-------|---------------------|--------------|------------|-------------|---------------------------|-------------|
+| Claude Code | Hook | Yes | Yes | Yes | Yes | — |
+| Cursor | Hook | Yes | Yes | Yes | Yes | — |
+| Qoder Work | Hook / local data source | Yes | Yes | No | Yes | User edition |
+| Qoder CLI | Hook | Yes | Yes | No | Yes | — |
+| Qoder IDE | Hook / local data source | Yes | Yes | Yes | Yes | Qoder 1.10.0 or later, User edition |
+| OpenCode | Plugin injection | Yes | Yes | Yes | Yes | — |
+
+Agents omitted from this table do not currently have an explicit Windows support statement; omission does not necessarily mean that the agent cannot run on Windows. This matrix follows the [Alibaba Cloud AI Coding Agent access guide](https://help.aliyun.com/zh/cms/cloudmonitor-2-0/ai-application-access-ai-coding-agent/). See [Installation](installation.md) for Windows prerequisites and setup.
+
 ## Data Collected
 
 Pilot focuses on activity that is useful for usage analysis, audit, and traceability:

--- a/docs/zh-CN/overview.md
+++ b/docs/zh-CN/overview.md
@@ -37,6 +37,21 @@ LoongSuite Pilot 运行在开发者本机，用于采集支持的 AI Coding Agen
 | Qwen Code CLI | Hook | Yes | Yes | Yes | Yes |
 | Wukong | CLI API 轮询 | Yes | Yes | Yes | Yes |
 
+### Windows Agent 明确支持情况
+
+总体支持表描述的是 Pilot 的接入能力，不能直接作为操作系统兼容性矩阵。目前文档明确说明支持 Windows 的 Agent 如下：
+
+| Agent | Windows 集成方式 | Trace 上报 | 日志上报 | Token 用量 | 对话 / 工具调用 | 使用条件 |
+|-------|------------------|------------|----------|------------|-----------------|----------|
+| Claude Code | Hook | 支持 | 支持 | 支持 | 支持 | — |
+| Cursor | Hook | 支持 | 支持 | 支持 | 支持 | — |
+| Qoder Work | Hook / 本地数据源 | 支持 | 支持 | 不支持 | 支持 | User 版本 |
+| Qoder CLI | Hook | 支持 | 支持 | 不支持 | 支持 | — |
+| Qoder IDE | Hook / 本地数据源 | 支持 | 支持 | 支持 | 支持 | Qoder 1.10.0 及以上 User 版本 |
+| OpenCode | 插件注入 | 支持 | 支持 | 支持 | 支持 | — |
+
+未列入此表的 Agent，表示当前没有明确的 Windows 支持声明，并不一定代表无法在 Windows 上运行。该矩阵参考[阿里云 AI Coding Agent 接入文档](https://help.aliyun.com/zh/cms/cloudmonitor-2-0/ai-application-access-ai-coding-agent/)。Windows 环境要求与安装方法见[安装指南](installation.md)。
+
 ## 采集的数据
 
 Pilot 关注对使用分析、审计和链路追踪有价值的活动：


### PR DESCRIPTION
## 背景

现有 Agent 支持表描述了 Pilot 的总体采集能力，但没有区分操作系统，容易让用户误认为所有 Agent 均已明确支持 Windows。

## 改动

- 参考阿里云官方《AI 应用接入：AI Coding Agent》中的 Windows 支持矩阵，补充 Windows Agent 明确支持情况。
- 覆盖 Claude Code、Cursor、Qoder Work、Qoder CLI、Qoder IDE 和 OpenCode。
- 标注 Qoder Work、Qoder CLI 的 Token 采集限制，以及 Qoder IDE 的版本和 User 版本要求。
- 明确说明未列出的 Agent 仅代表当前没有明确的 Windows 支持声明，不直接判定为无法运行。
- 同步更新中英文 README 和产品概览。

参考文档：
https://help.aliyun.com/zh/cms/cloudmonitor-2-0/ai-application-access-ai-coding-agent/

## 验证

- [x] `git diff --check`
- [x] Markdown 表格列数检查
- [x] 本地 Markdown 链接有效性检查
- [x] 对照仓库中的 Windows PowerShell Hook、Agent 定义和插件注入实现
