### PR TITLE
fix(codex): discover sessions from custom CODEX_HOME

### DIFF
--- a/agents.d/codex.json
+++ b/agents.d/codex.json
@@ -8,8 +8,8 @@
   },
   "hook": {
     "settingsPath": "~/.codex/hooks.json",
-    "events": ["Stop"],
-    "retiredEvents": ["SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse", "PostToolUseFailure"],
+    "events": ["SessionStart", "UserPromptSubmit", "Stop"],
+    "retiredEvents": ["PreToolUse", "PostToolUse", "PostToolUseFailure"],
     "hookCommand": "$PILOT_DATA/hooks/codex-loongsuite-pilot-hook.sh",
     "format": "nested",
     "matcher": "*",

--- a/assets/hooks/codex-hook-processor.mjs
+++ b/assets/hooks/codex-hook-processor.mjs
@@ -4,9 +4,11 @@
 /**
  * Codex Hook entry point.
  *
- * Codex rollout transcripts are the single telemetry source of truth. Stop is
- * retained only to wake the transcript tailer promptly; this process never
- * parses a transcript, accumulates Hook events, or writes telemetry JSONL.
+ * Codex rollout transcripts are the single telemetry source of truth. Early
+ * lifecycle hooks publish the effective CODEX_HOME so the transcript tailer
+ * can discover task-scoped session roots; Stop remains a best-effort wakeup.
+ * This process never parses a transcript, accumulates Hook events, or writes
+ * telemetry JSONL.
  */
 
 import fs from 'node:fs';
@@ -53,6 +55,10 @@ function safePathPart(value) {
 function writeWakeupMarker(input) {
   const sessionId = typeof input.session_id === 'string' ? input.session_id : '';
   if (!sessionId) return;
+  const configuredCodexHome = typeof process.env.CODEX_HOME === 'string'
+    ? process.env.CODEX_HOME.trim()
+    : '';
+  const codexHome = path.resolve(configuredCodexHome || path.join(os.homedir(), '.codex'));
 
   // 方案1(env):首个 turn 读 TRACEPARENT 写 session 级关联记录(fail-open, 每 session 一次)
   recordUpstreamContextOnce({ agentId: AGENT_ID, sessionId, dataDir: pilotDataDir() });
@@ -66,6 +72,8 @@ function writeWakeupMarker(input) {
     ...(typeof input.transcript_path === 'string' && input.transcript_path
       ? { transcript_path: input.transcript_path }
       : {}),
+    codex_home: codexHome,
+    session_dir: path.join(codexHome, 'sessions'),
     ...RESOURCE_ATTRIBUTE_FIELDS,
     received_at: new Date().toISOString(),
   };
@@ -94,7 +102,13 @@ function writeWakeupMarker(input) {
 function main() {
   const subcommand = (process.argv[2] || '').trim();
   try {
-    if (subcommand === 'stop') writeWakeupMarker(tryReadStdin());
+    if (
+      subcommand === 'session-start'
+      || subcommand === 'user-prompt-submit'
+      || subcommand === 'stop'
+    ) {
+      writeWakeupMarker(tryReadStdin());
+    }
   } finally {
     process.stdout.write('{}\n');
   }

--- a/assets/hooks/codex-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/codex-loongsuite-pilot-hook.ps1
@@ -10,6 +10,10 @@ $EMPTY_RESULT = '{}'
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $Processor = Join-Path $ScriptDir "codex-hook-processor.mjs"
+$PilotDataDir = Split-Path -Parent $ScriptDir
+if (-not $env:LOONGSUITE_PILOT_DATA_DIR) {
+    $env:LOONGSUITE_PILOT_DATA_DIR = $PilotDataDir
+}
 $Subcommand = if ($args.Count -gt 0) { $args[0] } else { "unknown" }
 
 function Log-Error {
@@ -54,7 +58,7 @@ function Test-NodeSuitable {
 }
 
 function Resolve-NodeBin {
-    $pinFile = Join-Path $env:USERPROFILE ".loongsuite-pilot\node-bin"
+    $pinFile = Join-Path $env:LOONGSUITE_PILOT_DATA_DIR "node-bin"
     if (Test-Path $pinFile) {
         $pinned = (Get-Content $pinFile -ErrorAction SilentlyContinue).Trim()
         if ($pinned -and (Test-NodeSuitable $pinned)) { return $pinned }

--- a/assets/hooks/codex-loongsuite-pilot-hook.sh
+++ b/assets/hooks/codex-loongsuite-pilot-hook.sh
@@ -13,6 +13,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROCESSOR="$SCRIPT_DIR/codex-hook-processor.mjs"
+PILOT_DATA_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+export LOONGSUITE_PILOT_DATA_DIR="${LOONGSUITE_PILOT_DATA_DIR:-$PILOT_DATA_DIR}"
 EMPTY_RESULT='{}'
 SUBCOMMAND="${1:-unknown}"
 
@@ -71,7 +73,7 @@ node_is_suitable() {
   return 0
 }
 
-NODE_PIN_FILE="$HOME/.loongsuite-pilot/node-bin"
+NODE_PIN_FILE="$LOONGSUITE_PILOT_DATA_DIR/node-bin"
 NODE_BIN=""
 
 if [[ -f "$NODE_PIN_FILE" ]]; then

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -25,6 +25,12 @@ Use these IDs in installer options, `agent-control.json`, and `config.json`.
 | Qwen Code CLI | `qwen-code-cli` | Hook integration; parses qwen-code transcript JSONL on Stop. |
 | Wukong | `wukong` | CLI API polling via local `wukong-cli`. |
 
+Codex collection is transcript-backed. Pilot uses the lightweight
+`SessionStart` and `UserPromptSubmit` hooks to discover the effective
+`CODEX_HOME`, including task-scoped homes created by orchestrators, and tails
+recent rollout files from that session root. `Stop` is retained as a
+best-effort wakeup and is not required for directory discovery.
+
 ## Choose Agents During Installation
 
 Use `--agents` to skip the interactive selection step:

--- a/docs/zh-CN/agents.md
+++ b/docs/zh-CN/agents.md
@@ -25,6 +25,12 @@
 | Qwen Code CLI | `qwen-code-cli` | Hook 集成；Stop 时解析 qwen-code transcript JSONL。 |
 | Wukong | `wukong` | 通过本地 `wukong-cli` 进行 CLI API 轮询。 |
 
+Codex 使用 transcript 作为采集事实源。Pilot 通过轻量的
+`SessionStart` 和 `UserPromptSubmit` Hook 发现当前实际生效的
+`CODEX_HOME`（包括编排器为单个任务创建的独立目录），并采集该 session
+根目录下最近活跃的 rollout 文件。`Stop` 仅作为尽力而为的唤醒信号，
+目录发现不依赖它。
+
 ## 安装时选择 Agent
 
 使用 `--agents` 跳过交互选择：

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -39,9 +39,13 @@ const MAX_SCAN_BYTES_PER_FILE_CYCLE = 16 * 1024 * 1024;
 // Dynamic roots come from user-local Hook markers. Keep discovery bounded so
 // stale task homes cannot turn every polling cycle into an unbounded walk.
 const MAX_WAKEUP_MARKERS_FOR_DISCOVERY = 256;
+const MAX_WAKEUP_MARKERS_PER_CLEANUP = 1_024;
 const MAX_DYNAMIC_SESSION_DIRS = 64;
 const MAX_DYNAMIC_SESSION_FILES = 64;
+const MAX_DYNAMIC_DIRECTORIES_PER_ROOT = 8;
+const MAX_DYNAMIC_ROLLOUT_FILES_PER_ROOT = 256;
 const WAKEUP_MARKER_DISCOVERY_TTL_MS = 48 * 60 * 60 * 1_000;
+const WAKEUP_MARKER_CLEANUP_INTERVAL_MS = 5 * 60 * 1_000;
 const DYNAMIC_SESSION_FILE_MAX_IDLE_MS = 15 * 60 * 1_000;
 // Values emitted by DEFAULT_RESOURCE_ENV_FIELD_MAP in assets/hooks/shared/resource-context.mjs.
 // Add new AgentTeams resource fields to both lists together.
@@ -94,6 +98,11 @@ interface DiscoveredSessionFile {
   baselineOnStart: boolean;
 }
 
+interface DynamicDirectoryWalkBudget {
+  remainingDirectories: number;
+  remainingRolloutFiles: number;
+}
+
 export interface CodexTranscriptInputOptions extends InputOptions {
   sessionDir?: string;
   wakeupDir?: string;
@@ -111,6 +120,7 @@ export class CodexTranscriptInput extends BaseInput {
   private processedTerminalTurnIdsDirty = false;
   private processedTerminalTurnIds = new Set<string>();
   private processedTerminalTurnIdOrder: string[] = [];
+  private lastWakeupMarkerCleanupAtMs = 0;
 
   constructor(opts: CodexTranscriptInputOptions) {
     super({ stateStore: opts.stateStore, pollIntervalMs: opts.pollIntervalMs ?? 30_000 });
@@ -700,17 +710,22 @@ export class CodexTranscriptInput extends BaseInput {
 
   private async discoverSessionFiles(): Promise<DiscoveredSessionFile[]> {
     const discovered = new Map<string, DiscoveredSessionFile>();
+    const canonicalDefaultSessionDir = await canonicalDirectoryPath(this.sessionDir);
     const defaultFiles: string[] = [];
     await collectRolloutFiles(this.sessionDir, defaultFiles);
     for (const filePath of defaultFiles) {
-      const canonicalPath = await canonicalFilePath(filePath);
+      const canonicalPath = path.join(
+        canonicalDefaultSessionDir,
+        path.relative(this.sessionDir, filePath),
+      );
       // Keep the configured/default path as the checkpoint key for backwards
-      // compatibility, while using the canonical path only as the dedupe key.
+      // compatibility. Canonicalizing the root once avoids a realpath syscall
+      // for every historical rollout on every collection cycle.
       discovered.set(canonicalPath, { filePath, baselineOnStart: true });
     }
 
     let remainingDynamicFiles = MAX_DYNAMIC_SESSION_FILES;
-    for (const sessionDir of await this.discoverDynamicSessionDirs()) {
+    for (const sessionDir of await this.discoverDynamicSessionDirs(canonicalDefaultSessionDir)) {
       if (remainingDynamicFiles <= 0) break;
       const files: string[] = [];
       await collectRecentRolloutFiles(
@@ -718,20 +733,23 @@ export class CodexTranscriptInput extends BaseInput {
         files,
         Date.now() - DYNAMIC_SESSION_FILE_MAX_IDLE_MS,
         remainingDynamicFiles,
+        {
+          remainingDirectories: MAX_DYNAMIC_DIRECTORIES_PER_ROOT,
+          remainingRolloutFiles: MAX_DYNAMIC_ROLLOUT_FILES_PER_ROOT,
+        },
       );
-      remainingDynamicFiles -= files.length;
       for (const filePath of files) {
-        const canonicalPath = await canonicalFilePath(filePath);
-        if (!discovered.has(canonicalPath)) {
-          discovered.set(canonicalPath, { filePath: canonicalPath, baselineOnStart: false });
-        }
+        if (discovered.has(filePath)) continue;
+        discovered.set(filePath, { filePath, baselineOnStart: false });
+        remainingDynamicFiles--;
+        if (remainingDynamicFiles <= 0) break;
       }
     }
 
     return [...discovered.values()].sort((left, right) => left.filePath.localeCompare(right.filePath));
   }
 
-  private async discoverDynamicSessionDirs(): Promise<string[]> {
+  private async discoverDynamicSessionDirs(canonicalDefaultSessionDir: string): Promise<string[]> {
     let entries: Dirent[];
     try {
       entries = await fs.readdir(this.wakeupDir, { withFileTypes: true });
@@ -739,14 +757,16 @@ export class CodexTranscriptInput extends BaseInput {
       return [];
     }
 
-    const markerEntries = entries
-      .filter(entry => entry.isFile() && entry.name.endsWith('.json'))
+    const allMarkerEntries = entries
+      .filter(entry => entry.isFile() && entry.name.endsWith('.json'));
+    const now = Date.now();
+    await this.cleanupExpiredWakeupMarkers(allMarkerEntries, now);
+    const markerEntries = allMarkerEntries
       // Marker names are Codex UUIDv7 session IDs, so descending lexical order
       // keeps the newest task markers inside the bounded discovery window.
       .sort((left, right) => right.name.localeCompare(left.name))
       .slice(0, MAX_WAKEUP_MARKERS_FOR_DISCOVERY);
     const sessionDirs = new Set<string>();
-    const now = Date.now();
 
     for (const entry of markerEntries) {
       let marker: Record<string, unknown> | null = null;
@@ -763,8 +783,15 @@ export class CodexTranscriptInput extends BaseInput {
 
       const configuredSessionDir = stringValue(marker.session_dir);
       const configuredCodexHome = stringValue(marker.codex_home);
-      const sessionDir = configuredSessionDir
-        ?? (configuredCodexHome ? path.join(configuredCodexHome, 'sessions') : undefined);
+      if (configuredSessionDir && !path.isAbsolute(configuredSessionDir)) continue;
+      if (configuredCodexHome && !path.isAbsolute(configuredCodexHome)) continue;
+
+      let sessionDir = configuredSessionDir;
+      if (configuredCodexHome) {
+        const codexHomeSessionDir = path.resolve(configuredCodexHome, 'sessions');
+        if (configuredSessionDir && path.resolve(configuredSessionDir) !== codexHomeSessionDir) continue;
+        sessionDir = codexHomeSessionDir;
+      }
       if (!sessionDir || !path.isAbsolute(sessionDir)) continue;
 
       let canonicalSessionDir: string;
@@ -774,11 +801,47 @@ export class CodexTranscriptInput extends BaseInput {
       } catch {
         continue;
       }
+      if (canonicalSessionDir === canonicalDefaultSessionDir) continue;
       sessionDirs.add(canonicalSessionDir);
       if (sessionDirs.size >= MAX_DYNAMIC_SESSION_DIRS) break;
     }
 
     return [...sessionDirs];
+  }
+
+  private async cleanupExpiredWakeupMarkers(entries: Dirent[], now: number): Promise<void> {
+    if (now - this.lastWakeupMarkerCleanupAtMs < WAKEUP_MARKER_CLEANUP_INTERVAL_MS) return;
+    this.lastWakeupMarkerCleanupAtMs = now;
+
+    const candidates = [...entries]
+      .sort((left, right) => left.name.localeCompare(right.name))
+      .slice(0, MAX_WAKEUP_MARKERS_PER_CLEANUP);
+    for (const entry of candidates) {
+      const markerPath = path.join(this.wakeupDir, entry.name);
+      let expired = false;
+      try {
+        const marker = asRecord(JSON.parse(await fs.readFile(markerPath, 'utf8')));
+        const receivedAt = stringValue(marker?.received_at);
+        const receivedAtMs = receivedAt ? Date.parse(receivedAt) : Number.NaN;
+        if (Number.isFinite(receivedAtMs)) {
+          expired = now - receivedAtMs > WAKEUP_MARKER_DISCOVERY_TTL_MS;
+        } else {
+          expired = now - (await fs.stat(markerPath)).mtimeMs > WAKEUP_MARKER_DISCOVERY_TTL_MS;
+        }
+      } catch {
+        try {
+          expired = now - (await fs.stat(markerPath)).mtimeMs > WAKEUP_MARKER_DISCOVERY_TTL_MS;
+        } catch {
+          continue;
+        }
+      }
+      if (!expired) continue;
+      try {
+        await fs.unlink(markerPath);
+      } catch {
+        // Another process or cleanup cycle may have removed the marker first.
+      }
+    }
   }
 
   private stateKey(filePath: string): string {
@@ -949,8 +1012,11 @@ async function collectRecentRolloutFiles(
   files: string[],
   modifiedAfterMs: number,
   maxFiles: number,
+  budget: DynamicDirectoryWalkBudget,
+  depth = 0,
 ): Promise<void> {
-  if (files.length >= maxFiles) return;
+  if (files.length >= maxFiles || budget.remainingDirectories <= 0) return;
+  budget.remainingDirectories--;
   let entries: Dirent[];
   try {
     entries = await fs.readdir(dir, { withFileTypes: true });
@@ -963,10 +1029,20 @@ async function collectRecentRolloutFiles(
     if (files.length >= maxFiles) return;
     const entryPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      await collectRecentRolloutFiles(entryPath, files, modifiedAfterMs, maxFiles);
+      if (!isCodexSessionDateDirectory(entry.name, depth)) continue;
+      await collectRecentRolloutFiles(entryPath, files, modifiedAfterMs, maxFiles, budget, depth + 1);
       continue;
     }
-    if (!entry.isFile() || !entry.name.startsWith('rollout-') || !entry.name.endsWith('.jsonl')) continue;
+    if (
+      depth !== 3
+      || !entry.isFile()
+      || !entry.name.startsWith('rollout-')
+      || !entry.name.endsWith('.jsonl')
+    ) {
+      continue;
+    }
+    if (budget.remainingRolloutFiles <= 0) return;
+    budget.remainingRolloutFiles--;
     try {
       if ((await fs.stat(entryPath)).mtimeMs >= modifiedAfterMs) files.push(entryPath);
     } catch {
@@ -975,11 +1051,18 @@ async function collectRecentRolloutFiles(
   }
 }
 
-async function canonicalFilePath(filePath: string): Promise<string> {
+function isCodexSessionDateDirectory(name: string, depth: number): boolean {
+  if (depth === 0) return /^\d{4}$/.test(name);
+  if (depth === 1) return /^(0[1-9]|1[0-2])$/.test(name);
+  if (depth === 2) return /^(0[1-9]|[12]\d|3[01])$/.test(name);
+  return false;
+}
+
+async function canonicalDirectoryPath(directoryPath: string): Promise<string> {
   try {
-    return await fs.realpath(filePath);
+    return await fs.realpath(directoryPath);
   } catch {
-    return filePath;
+    return path.resolve(directoryPath);
   }
 }
 

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -36,6 +36,13 @@ const MAX_EMIT_BATCH_BYTES = 1024 * 1024;
 const MAX_PERSISTED_INPUT_CONTEXT_BYTES = 1024 * 1024;
 const MAX_TERMINALS_PER_FILE_CYCLE = 100;
 const MAX_SCAN_BYTES_PER_FILE_CYCLE = 16 * 1024 * 1024;
+// Dynamic roots come from user-local Hook markers. Keep discovery bounded so
+// stale task homes cannot turn every polling cycle into an unbounded walk.
+const MAX_WAKEUP_MARKERS_FOR_DISCOVERY = 256;
+const MAX_DYNAMIC_SESSION_DIRS = 64;
+const MAX_DYNAMIC_SESSION_FILES = 64;
+const WAKEUP_MARKER_DISCOVERY_TTL_MS = 48 * 60 * 60 * 1_000;
+const DYNAMIC_SESSION_FILE_MAX_IDLE_MS = 15 * 60 * 1_000;
 // Values emitted by DEFAULT_RESOURCE_ENV_FIELD_MAP in assets/hooks/shared/resource-context.mjs.
 // Add new AgentTeams resource fields to both lists together.
 const WAKEUP_RESOURCE_ATTRIBUTE_KEYS = [
@@ -82,6 +89,11 @@ interface PendingRecoveryResult {
   processedTerminalCount: number;
 }
 
+interface DiscoveredSessionFile {
+  filePath: string;
+  baselineOnStart: boolean;
+}
+
 export interface CodexTranscriptInputOptions extends InputOptions {
   sessionDir?: string;
   wakeupDir?: string;
@@ -116,9 +128,9 @@ export class CodexTranscriptInput extends BaseInput {
 
   protected override async onStart(): Promise<void> {
     this.loadGlobalProcessedTerminalTurnIds();
-    for (const filePath of await this.discoverSessionFiles()) {
+    for (const { filePath, baselineOnStart } of await this.discoverSessionFiles()) {
       const key = this.stateKey(filePath);
-      if (!this.readCheckpoint(key)) await this.baselineFile(filePath, key);
+      if (baselineOnStart && !this.readCheckpoint(key)) await this.baselineFile(filePath, key);
     }
     this.saveGlobalProcessedTerminalTurnIds();
     await fs.mkdir(this.wakeupDir, { recursive: true });
@@ -144,7 +156,7 @@ export class CodexTranscriptInput extends BaseInput {
 
   protected override async collect(): Promise<AgentActivityEntry[]> {
     let emittedCount = 0;
-    for (const filePath of await this.discoverSessionFiles()) {
+    for (const { filePath } of await this.discoverSessionFiles()) {
       emittedCount += await this.processFile(filePath);
     }
     if (emittedCount > 0) {
@@ -686,10 +698,87 @@ export class CodexTranscriptInput extends BaseInput {
     });
   }
 
-  private async discoverSessionFiles(): Promise<string[]> {
-    const files: string[] = [];
-    await collectRolloutFiles(this.sessionDir, files);
-    return files.sort();
+  private async discoverSessionFiles(): Promise<DiscoveredSessionFile[]> {
+    const discovered = new Map<string, DiscoveredSessionFile>();
+    const defaultFiles: string[] = [];
+    await collectRolloutFiles(this.sessionDir, defaultFiles);
+    for (const filePath of defaultFiles) {
+      const canonicalPath = await canonicalFilePath(filePath);
+      // Keep the configured/default path as the checkpoint key for backwards
+      // compatibility, while using the canonical path only as the dedupe key.
+      discovered.set(canonicalPath, { filePath, baselineOnStart: true });
+    }
+
+    let remainingDynamicFiles = MAX_DYNAMIC_SESSION_FILES;
+    for (const sessionDir of await this.discoverDynamicSessionDirs()) {
+      if (remainingDynamicFiles <= 0) break;
+      const files: string[] = [];
+      await collectRecentRolloutFiles(
+        sessionDir,
+        files,
+        Date.now() - DYNAMIC_SESSION_FILE_MAX_IDLE_MS,
+        remainingDynamicFiles,
+      );
+      remainingDynamicFiles -= files.length;
+      for (const filePath of files) {
+        const canonicalPath = await canonicalFilePath(filePath);
+        if (!discovered.has(canonicalPath)) {
+          discovered.set(canonicalPath, { filePath: canonicalPath, baselineOnStart: false });
+        }
+      }
+    }
+
+    return [...discovered.values()].sort((left, right) => left.filePath.localeCompare(right.filePath));
+  }
+
+  private async discoverDynamicSessionDirs(): Promise<string[]> {
+    let entries: Dirent[];
+    try {
+      entries = await fs.readdir(this.wakeupDir, { withFileTypes: true });
+    } catch {
+      return [];
+    }
+
+    const markerEntries = entries
+      .filter(entry => entry.isFile() && entry.name.endsWith('.json'))
+      // Marker names are Codex UUIDv7 session IDs, so descending lexical order
+      // keeps the newest task markers inside the bounded discovery window.
+      .sort((left, right) => right.name.localeCompare(left.name))
+      .slice(0, MAX_WAKEUP_MARKERS_FOR_DISCOVERY);
+    const sessionDirs = new Set<string>();
+    const now = Date.now();
+
+    for (const entry of markerEntries) {
+      let marker: Record<string, unknown> | null = null;
+      try {
+        marker = asRecord(JSON.parse(await fs.readFile(path.join(this.wakeupDir, entry.name), 'utf8')));
+      } catch {
+        continue;
+      }
+      if (!marker) continue;
+
+      const receivedAt = stringValue(marker.received_at);
+      const receivedAtMs = receivedAt ? Date.parse(receivedAt) : Number.NaN;
+      if (!Number.isFinite(receivedAtMs) || now - receivedAtMs > WAKEUP_MARKER_DISCOVERY_TTL_MS) continue;
+
+      const configuredSessionDir = stringValue(marker.session_dir);
+      const configuredCodexHome = stringValue(marker.codex_home);
+      const sessionDir = configuredSessionDir
+        ?? (configuredCodexHome ? path.join(configuredCodexHome, 'sessions') : undefined);
+      if (!sessionDir || !path.isAbsolute(sessionDir)) continue;
+
+      let canonicalSessionDir: string;
+      try {
+        canonicalSessionDir = await fs.realpath(sessionDir);
+        if (!(await fs.stat(canonicalSessionDir)).isDirectory()) continue;
+      } catch {
+        continue;
+      }
+      sessionDirs.add(canonicalSessionDir);
+      if (sessionDirs.size >= MAX_DYNAMIC_SESSION_DIRS) break;
+    }
+
+    return [...sessionDirs];
   }
 
   private stateKey(filePath: string): string {
@@ -852,6 +941,45 @@ async function collectRolloutFiles(dir: string, files: string[]): Promise<void> 
     } else if (entry.isFile() && entry.name.startsWith('rollout-') && entry.name.endsWith('.jsonl')) {
       files.push(entryPath);
     }
+  }
+}
+
+async function collectRecentRolloutFiles(
+  dir: string,
+  files: string[],
+  modifiedAfterMs: number,
+  maxFiles: number,
+): Promise<void> {
+  if (files.length >= maxFiles) return;
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  entries.sort((left, right) => right.name.localeCompare(left.name));
+  for (const entry of entries) {
+    if (files.length >= maxFiles) return;
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await collectRecentRolloutFiles(entryPath, files, modifiedAfterMs, maxFiles);
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.startsWith('rollout-') || !entry.name.endsWith('.jsonl')) continue;
+    try {
+      if ((await fs.stat(entryPath)).mtimeMs >= modifiedAfterMs) files.push(entryPath);
+    } catch {
+      // The transcript may disappear while a short-lived task directory is being cleaned up.
+    }
+  }
+}
+
+async function canonicalFilePath(filePath: string): Promise<string> {
+  try {
+    return await fs.realpath(filePath);
+  } catch {
+    return filePath;
   }
 }
 

--- a/tests/unit/hooks/codex/hook-processor.test.mjs
+++ b/tests/unit/hooks/codex/hook-processor.test.mjs
@@ -7,6 +7,9 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROCESSOR = path.resolve(__dirname, '../../../../assets/hooks/codex-hook-processor.mjs');
+const SHELL_WRAPPER = path.resolve(__dirname, '../../../../assets/hooks/codex-loongsuite-pilot-hook.sh');
+const SHARED_HOOK_ASSETS = path.resolve(__dirname, '../../../../assets/hooks/shared');
+const AGENT_DEFINITION = path.resolve(__dirname, '../../../../agents.d/codex.json');
 
 let dataDir;
 
@@ -31,12 +34,26 @@ function markerPath(sessionId) {
   return path.join(dataDir, 'state', 'codex', 'transcript-wakeups', `${sessionId}.json`);
 }
 
-describe('codex Stop wakeup hook', () => {
-  test('writes an atomic wakeup marker without telemetry JSONL', () => {
+describe('codex transcript discovery hook', () => {
+  test('deploys early discovery hooks while retiring telemetry-heavy hooks', () => {
+    const definition = JSON.parse(fs.readFileSync(AGENT_DEFINITION, 'utf8'));
+
+    expect(definition.hook.events).toEqual(['SessionStart', 'UserPromptSubmit', 'Stop']);
+    expect(definition.hook.retiredEvents).toEqual([
+      'PreToolUse',
+      'PostToolUse',
+      'PostToolUseFailure',
+    ]);
+  });
+
+  test('writes an atomic wakeup marker with the effective CODEX_HOME', () => {
+    const codexHome = path.join(dataDir, 'task-codex-home');
     const result = runHook('stop', {
       session_id: 'cdx-wakeup',
       turn_id: 'turn-wakeup',
       transcript_path: '/tmp/rollout-cdx-wakeup.jsonl',
+    }, {
+      CODEX_HOME: codexHome,
     });
 
     expect(result.status).toBe(0);
@@ -45,9 +62,31 @@ describe('codex Stop wakeup hook', () => {
       session_id: 'cdx-wakeup',
       turn_id: 'turn-wakeup',
       transcript_path: '/tmp/rollout-cdx-wakeup.jsonl',
+      codex_home: codexHome,
+      session_dir: path.join(codexHome, 'sessions'),
     });
     expect(fs.existsSync(path.join(dataDir, 'logs', 'codex'))).toBe(false);
   });
+
+  test.each(['session-start', 'user-prompt-submit', 'stop'])(
+    'writes the discovery marker for %s',
+    subcommand => {
+      const codexHome = path.join(dataDir, `${subcommand}-codex-home`);
+      const result = runHook(subcommand, {
+        session_id: `cdx-${subcommand}`,
+        turn_id: `turn-${subcommand}`,
+      }, {
+        CODEX_HOME: codexHome,
+      });
+
+      expect(result.status).toBe(0);
+      expect(JSON.parse(fs.readFileSync(markerPath(`cdx-${subcommand}`), 'utf8'))).toMatchObject({
+        session_id: `cdx-${subcommand}`,
+        codex_home: codexHome,
+        session_dir: path.join(codexHome, 'sessions'),
+      });
+    },
+  );
 
   test('writes AgentTeams resource attributes into the wakeup marker', () => {
     const result = runHook('stop', {
@@ -79,7 +118,7 @@ describe('codex Stop wakeup hook', () => {
     });
   });
 
-  test('ignores non-Stop events and malformed session identifiers', () => {
+  test('ignores non-discovery events and malformed session identifiers', () => {
     runHook('pre-tool-use', { session_id: 'cdx-ignore', tool_name: 'Bash' });
     runHook('stop', { turn_id: 'turn-missing-session' });
 
@@ -105,5 +144,50 @@ describe('codex Stop wakeup hook', () => {
     const errorDir = path.join(dataDir, 'logs', 'codex', 'errors');
     const errorFile = path.join(errorDir, fs.readdirSync(errorDir)[0]);
     expect(fs.readFileSync(errorFile, 'utf8')).toContain('"stage":"wakeup_write"');
+  });
+
+  test('derives the shared Pilot data directory from the installed shell wrapper', () => {
+    if (process.platform === 'win32') return;
+    const pilotRoot = path.join(dataDir, 'shared-pilot');
+    const hookDir = path.join(pilotRoot, 'hooks');
+    const taskHome = path.join(dataDir, 'task-home');
+    const codexHome = path.join(dataDir, 'task-codex-home');
+    fs.mkdirSync(hookDir, { recursive: true });
+    fs.mkdirSync(taskHome, { recursive: true });
+    fs.copyFileSync(PROCESSOR, path.join(hookDir, 'codex-hook-processor.mjs'));
+    fs.copyFileSync(SHELL_WRAPPER, path.join(hookDir, 'codex-loongsuite-pilot-hook.sh'));
+    fs.cpSync(SHARED_HOOK_ASSETS, path.join(hookDir, 'shared'), { recursive: true });
+    fs.chmodSync(path.join(hookDir, 'codex-loongsuite-pilot-hook.sh'), 0o755);
+
+    const env = {
+      ...process.env,
+      HOME: taskHome,
+      CODEX_HOME: codexHome,
+    };
+    delete env.LOONGSUITE_PILOT_DATA_DIR;
+    const result = spawnSync('bash', [
+      path.join(hookDir, 'codex-loongsuite-pilot-hook.sh'),
+      'session-start',
+    ], {
+      input: JSON.stringify({ session_id: 'cdx-wrapper' }),
+      env,
+      encoding: 'utf8',
+      timeout: 10_000,
+    });
+
+    expect(result.status).toBe(0);
+    const marker = path.join(
+      pilotRoot,
+      'state',
+      'codex',
+      'transcript-wakeups',
+      'cdx-wrapper.json',
+    );
+    expect(JSON.parse(fs.readFileSync(marker, 'utf8'))).toMatchObject({
+      session_id: 'cdx-wrapper',
+      codex_home: codexHome,
+      session_dir: path.join(codexHome, 'sessions'),
+    });
+    expect(fs.existsSync(path.join(taskHome, '.loongsuite-pilot'))).toBe(false);
   });
 });

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -637,6 +637,115 @@ describe('CodexTranscriptInput', () => {
     );
   });
 
+  it('discovers and ingests a task-scoped CODEX_HOME before a Stop hook', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-dynamic-home-'));
+    tempDirs.push(root);
+    const { input, entries, wakeupDir, stateStore } = await createDormantInput(root);
+    const codexHome = path.join(root, 'multica-task', 'codex-home');
+    const dynamicSessionDir = path.join(codexHome, 'sessions');
+    const transcriptText = completedTurn().replace('"type":"task_complete"', '"type":"turn_aborted"');
+    const transcript = await writeTranscript(dynamicSessionDir, transcriptText);
+    await writeWakeupMarker(wakeupDir, 'session-1', {
+      session_id: 'session-1',
+      turn_id: 'turn-1',
+      codex_home: codexHome,
+      received_at: new Date().toISOString(),
+    });
+
+    await input.start();
+    await waitFor(() => entries.some(entry => entry['event.name'] === 'tool.result'));
+    await input.stop();
+
+    const canonicalTranscript = await fs.realpath(transcript);
+    expect(entries.some(entry => entry['event.name'] === 'llm.response')).toBe(true);
+    expect(entries.some(entry => entry['agent.codex.transcript_turn_id'] === 'turn-1')).toBe(true);
+    expect(transcriptCheckpoint(stateStore, canonicalTranscript).scanOffset)
+      .toBe(Buffer.byteLength(transcriptText));
+  });
+
+  it('selects the newest discovery marker when more than 256 markers exist', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-many-markers-'));
+    tempDirs.push(root);
+    const { input, entries, wakeupDir } = await createDormantInput(root);
+    const dynamicSessionDir = path.join(root, 'newest-codex-home', 'sessions');
+    await writeTranscript(dynamicSessionDir, completedTurn());
+    await fs.mkdir(wakeupDir, { recursive: true });
+    const receivedAt = new Date().toISOString();
+    await Promise.all(Array.from({ length: 256 }, (_, index) => (
+      fs.writeFile(
+        path.join(wakeupDir, `old-${String(index).padStart(3, '0')}.json`),
+        JSON.stringify({ session_id: `old-${index}`, received_at: receivedAt }),
+        'utf8',
+      )
+    )));
+    await fs.writeFile(path.join(wakeupDir, 'zzzz-newest.json'), JSON.stringify({
+      session_id: 'session-1',
+      session_dir: dynamicSessionDir,
+      received_at: receivedAt,
+    }), 'utf8');
+
+    await input.start();
+    await waitFor(() => entries.some(entry => entry['event.name'] === 'tool.result'));
+    await input.stop();
+
+    expect(entries.some(entry => entry['gen_ai.session.id'] === 'session-1')).toBe(true);
+  });
+
+  it('ignores expired dynamic CODEX_HOME discovery markers', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-stale-marker-'));
+    tempDirs.push(root);
+    const { input, entries, wakeupDir, stateStore } = await createDormantInput(root);
+    const dynamicSessionDir = path.join(root, 'stale-codex-home', 'sessions');
+    const transcript = await writeTranscript(dynamicSessionDir, completedTurn());
+    await writeWakeupMarker(wakeupDir, 'session-1', {
+      session_id: 'session-1',
+      session_dir: dynamicSessionDir,
+      received_at: new Date(Date.now() - 49 * 60 * 60 * 1_000).toISOString(),
+    });
+
+    await input.start();
+    await input.stop();
+
+    expect(entries).toHaveLength(0);
+    expect(stateStore.get(`codex-transcript:${await fs.realpath(transcript)}`).lastOffset).toBeUndefined();
+  });
+
+  it('ignores inactive rollout files under a freshly discovered CODEX_HOME', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-inactive-rollout-'));
+    tempDirs.push(root);
+    const { input, entries, wakeupDir, stateStore } = await createDormantInput(root);
+    const dynamicSessionDir = path.join(root, 'inactive-codex-home', 'sessions');
+    const transcript = await writeTranscript(dynamicSessionDir, completedTurn());
+    const inactiveAt = new Date(Date.now() - 16 * 60 * 1_000);
+    await fs.utimes(transcript, inactiveAt, inactiveAt);
+    await writeWakeupMarker(wakeupDir, 'session-1', {
+      session_id: 'session-1',
+      session_dir: dynamicSessionDir,
+      received_at: new Date().toISOString(),
+    });
+
+    await input.start();
+    await input.stop();
+
+    expect(entries).toHaveLength(0);
+    expect(stateStore.get(`codex-transcript:${await fs.realpath(transcript)}`).lastOffset).toBeUndefined();
+  });
+
+  it('continues to baseline transcripts already present in the default session directory', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-default-baseline-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
+    const transcriptText = completedTurn();
+    const transcript = await writeTranscript(sessionDir, transcriptText);
+
+    await input.start();
+    await input.stop();
+
+    expect(entries).toHaveLength(0);
+    expect(transcriptCheckpoint(stateStore, transcript).scanOffset)
+      .toBe(Buffer.byteLength(transcriptText));
+  });
+
   it('consumes a control-only aborted turn and emits later normal work in the same cycle', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-control-abort-'));
     tempDirs.push(root);

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -663,6 +663,85 @@ describe('CodexTranscriptInput', () => {
       .toBe(Buffer.byteLength(transcriptText));
   });
 
+  it('does not let the default session root consume the dynamic rollout budget', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-dynamic-budget-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, wakeupDir } = await createDormantInput(root);
+    await Promise.all(Array.from({ length: 64 }, (_, index) => (
+      writeTranscriptNamed(sessionDir, `rollout-default-${index}.jsonl`, '')
+    )));
+
+    const codexHome = path.join(root, 'multica-task', 'codex-home');
+    const dynamicSessionDir = path.join(codexHome, 'sessions');
+    await writeTranscript(dynamicSessionDir, completedTurn());
+    const receivedAt = new Date().toISOString();
+    await writeWakeupMarker(wakeupDir, 'zzzz-default', {
+      session_id: 'default-session',
+      session_dir: sessionDir,
+      received_at: receivedAt,
+    });
+    await writeWakeupMarker(wakeupDir, 'aaaa-dynamic', {
+      session_id: 'session-1',
+      codex_home: codexHome,
+      session_dir: dynamicSessionDir,
+      received_at: receivedAt,
+    });
+
+    await input.start();
+    await waitFor(() => entries.some(entry => entry['event.name'] === 'tool.result'));
+    await input.stop();
+
+    expect(entries.some(entry => entry['gen_ai.session.id'] === 'session-1')).toBe(true);
+  });
+
+  it('does not recurse outside the bounded Codex YYYY/MM/DD session layout', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-dynamic-layout-'));
+    tempDirs.push(root);
+    const { input, entries, wakeupDir, stateStore } = await createDormantInput(root);
+    const dynamicSessionDir = path.join(root, 'dynamic-codex-home', 'sessions');
+    const transcript = path.join(
+      dynamicSessionDir,
+      'unrelated',
+      'deep',
+      'tree',
+      'rollout-session-1.jsonl',
+    );
+    await fs.mkdir(path.dirname(transcript), { recursive: true });
+    await fs.writeFile(transcript, completedTurn(), 'utf8');
+    await writeWakeupMarker(wakeupDir, 'session-1', {
+      session_id: 'session-1',
+      session_dir: dynamicSessionDir,
+      received_at: new Date().toISOString(),
+    });
+
+    await input.start();
+    await input.stop();
+
+    expect(entries).toHaveLength(0);
+    expect(stateStore.get(`codex-transcript:${transcript}`).lastOffset).toBeUndefined();
+  });
+
+  it('rejects a marker whose session_dir does not match codex_home', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-marker-mismatch-'));
+    tempDirs.push(root);
+    const { input, entries, wakeupDir, stateStore } = await createDormantInput(root);
+    const codexHome = path.join(root, 'expected-codex-home');
+    const mismatchedSessionDir = path.join(root, 'unexpected-codex-home', 'sessions');
+    const transcript = await writeTranscript(mismatchedSessionDir, completedTurn());
+    await writeWakeupMarker(wakeupDir, 'session-1', {
+      session_id: 'session-1',
+      codex_home: codexHome,
+      session_dir: mismatchedSessionDir,
+      received_at: new Date().toISOString(),
+    });
+
+    await input.start();
+    await input.stop();
+
+    expect(entries).toHaveLength(0);
+    expect(stateStore.get(`codex-transcript:${transcript}`).lastOffset).toBeUndefined();
+  });
+
   it('selects the newest discovery marker when more than 256 markers exist', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-many-markers-'));
     tempDirs.push(root);
@@ -708,6 +787,7 @@ describe('CodexTranscriptInput', () => {
 
     expect(entries).toHaveLength(0);
     expect(stateStore.get(`codex-transcript:${await fs.realpath(transcript)}`).lastOffset).toBeUndefined();
+    await expect(fs.access(path.join(wakeupDir, 'session-1.json'))).rejects.toThrow();
   });
 
   it('ignores inactive rollout files under a freshly discovered CODEX_HOME', async () => {
@@ -1397,7 +1477,9 @@ describe('CodexTranscriptInput', () => {
   it('does not commit a tool wave until an output written after token_count is present', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-token-before-tool-output-'));
     tempDirs.push(root);
-    const { input, entries, sessionDir } = await createInput(root, 60_000);
+    // This test drives processFile directly, so keep the normal watcher/poll
+    // cycle dormant to avoid racing a second collection of the same append.
+    const { input, entries, sessionDir } = await createDormantInput(root);
     const initial = [
       record('2026-06-24T06:00:00.000Z', 'session_meta', { id: 'session-1', model_provider: 'openai' }),
       record('2026-06-24T06:00:01.000Z', 'turn_context', { turn_id: 'turn-1', model: 'gpt-5.5' }),
@@ -1420,7 +1502,6 @@ describe('CodexTranscriptInput', () => {
       type: 'function_call_output', call_id: 'call-1', output: '"/tmp"',
     }) + '\n', 'utf8');
     await processTranscriptOnce(input, transcript);
-    await input.stop();
 
     expect(entries.filter(entry => entry['event.name'] === 'llm.response')).toHaveLength(1);
     expect(entries.filter(entry => entry['event.name'] === 'tool.call')).toHaveLength(1);


### PR DESCRIPTION
## Summary

- publish the effective `CODEX_HOME` and session root from lightweight `SessionStart`, `UserPromptSubmit`, and `Stop` hooks
- discover recent rollout files from task-scoped Codex homes with bounded marker/root/file scanning
- preserve the existing default-session baseline and checkpoint behavior while ingesting newly discovered dynamic roots from offset zero
- derive the shared Pilot data directory from the installed hook location on Unix and Windows
- document the transcript-backed discovery behavior

## Why

Orchestrators such as Multica assign a task-specific `CODEX_HOME`. The Codex transcript input previously scanned only `~/.codex/sessions`, so those task sessions were missed. Relying on `Stop` to expose the path is insufficient because successful Multica tasks can finish with a transcript `turn_aborted` boundary without dispatching a final Stop hook.

Discovery is intentionally bounded to the newest 256 markers, 64 dynamic session roots, and 64 recently active rollout files. Markers expire after 48 hours and dynamic rollout files must have been active in the last 15 minutes.

## Validation

- `npm run typecheck`
- `npm test` — 179 test files, 1996 passed, 2 skipped
- `npm run build`
- targeted coverage for custom `CODEX_HOME`, missing Stop / `turn_aborted`, more than 256 markers, expired markers, inactive rollouts, default-directory baselining, and wrapper path isolation
- remote Multica E2E AGE-1083: task-scoped `CODEX_HOME` was discovered before completion; the final rollout ended with `turn_aborted`, checkpoint reached the full 169676-byte file, 47 normalized events and 37 OTLP spans were emitted, with no new OTLP failure file
