### PR TITLE
fix(deploy): upgrade rollback, hook cleanup without node, conditional data dir removal

### DIFF
--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -597,9 +597,6 @@ deploy_package() {
             return 1
         fi
 
-        echo "$dir_name" > "$current_file.tmp"
-        mv -f "$current_file.tmp" "$current_file"
-
         PERMANENT_DIR="$target"
     else
         msg "==> 部署到 $PERMANENT_DIR ..." \
@@ -635,6 +632,12 @@ deploy_package() {
     msg "    如使用 Codex 桌面版，首次启动需在桌面端手动信任 hooks" \
         "    If using Codex desktop app, please manually trust hooks on first launch"
     echo ""
+
+    # Write current pointer only after all deploy steps succeed
+    if [ -n "$ver" ] && [ -n "$commit" ]; then
+        echo "$dir_name" > "$current_file.tmp"
+        mv -f "$current_file.tmp" "$current_file"
+    fi
 }
 
 # ============================================================
@@ -1593,15 +1596,28 @@ cmd_upgrade() {
         echo ""
         msg "⚠️  部署失败，正在回滚到旧版本..." \
             "⚠️  Deployment failed, rolling back to old version..."
+        local _rollback_ok=1
         if command -v loongsuite-pilot &>/dev/null; then
-            loongsuite-pilot rollback 2>/dev/null || true
-            loongsuite-pilot start 2>/dev/null || true
+            loongsuite-pilot rollback 2>/dev/null || _rollback_ok=0
         elif [ -f "$HOME/.local/bin/loongsuite-pilot" ]; then
-            "$HOME/.local/bin/loongsuite-pilot" rollback 2>/dev/null || true
-            "$HOME/.local/bin/loongsuite-pilot" start 2>/dev/null || true
+            "$HOME/.local/bin/loongsuite-pilot" rollback 2>/dev/null || _rollback_ok=0
         fi
-        msg "❌ 升级失败（部署/依赖安装出错），已回滚到 v${old_ver:-unknown} 并重启服务" \
-            "❌ Upgrade failed (deploy/dependency error), rolled back to v${old_ver:-unknown} and restarted"
+        if [ "$_rollback_ok" -eq 1 ]; then
+            if command -v loongsuite-pilot &>/dev/null; then
+                loongsuite-pilot start 2>/dev/null || _rollback_ok=0
+            elif [ -f "$HOME/.local/bin/loongsuite-pilot" ]; then
+                "$HOME/.local/bin/loongsuite-pilot" start 2>/dev/null || _rollback_ok=0
+            fi
+        fi
+        if [ "$_rollback_ok" -eq 1 ]; then
+            msg "❌ 升级失败（部署/依赖安装出错），已回滚到 v${old_ver:-unknown} 并重启服务" \
+                "❌ Upgrade failed (deploy/dependency error), rolled back to v${old_ver:-unknown} and restarted"
+        else
+            msg "❌ 升级失败且自动回滚未成功，请手动恢复:" \
+                "❌ Upgrade failed and auto-rollback did not succeed. Manual recovery:"
+            msg "   loongsuite-pilot rollback && loongsuite-pilot start" \
+                "   loongsuite-pilot rollback && loongsuite-pilot start"
+        fi
         exit 1
     fi
     install_loongsuite_pilot_command
@@ -1631,15 +1647,23 @@ cmd_upgrade() {
 
     loongsuite-pilot stop 2>/dev/null || true
 
+    local _rb_ok=1
     if command -v loongsuite-pilot &>/dev/null; then
-        loongsuite-pilot rollback 2>/dev/null || true
+        loongsuite-pilot rollback 2>/dev/null || _rb_ok=0
     else
-        "$HOME/.local/bin/loongsuite-pilot" rollback 2>/dev/null || true
+        "$HOME/.local/bin/loongsuite-pilot" rollback 2>/dev/null || _rb_ok=0
     fi
 
-    msg "❌ 升级失败，已回滚到 v${old_ver:-unknown}" \
-        "❌ Upgrade failed, rolled back to v${old_ver:-unknown}"
-    msg "   请检查日志: loongsuite-pilot log" "   Check logs: loongsuite-pilot log"
+    if [ "$_rb_ok" -eq 1 ]; then
+        msg "❌ 升级失败，已回滚到 v${old_ver:-unknown}" \
+            "❌ Upgrade failed, rolled back to v${old_ver:-unknown}"
+        msg "   请检查日志: loongsuite-pilot log" "   Check logs: loongsuite-pilot log"
+    else
+        msg "❌ 升级失败且回滚未成功，请手动恢复:" \
+            "❌ Upgrade failed and rollback did not succeed. Manual recovery:"
+        msg "   loongsuite-pilot rollback && loongsuite-pilot start" \
+            "   loongsuite-pilot rollback && loongsuite-pilot start"
+    fi
     exit 1
 }
 
@@ -1693,8 +1717,8 @@ remove_hook_configs() {
     if command -v node &>/dev/null; then
         _has_node=1
     else
-        msg "    ⚠️  未找到 Node.js，将使用 sed 回退方式清理 hook" \
-            "    ⚠️  Node.js not found, using sed fallback for hook cleanup"
+        msg "    ⚠️  未找到 Node.js，含 hook 的配置文件将跳过自动清理" \
+            "    ⚠️  Node.js not found, config files with hooks will skip auto-cleanup"
     fi
 
     for cfg in "${configs[@]}"; do
@@ -1733,48 +1757,10 @@ try {
 } catch(e) { process.stderr.write(e.message); process.exit(1); }
 " "$cfg" "$HOOK_MARKER" && ok=1
         else
-            # awk fallback: remove JSON objects/lines containing the marker
+            # Node unavailable: skip auto-cleanup to avoid over-deletion
             if grep -q "$HOOK_MARKER" "$cfg" 2>/dev/null; then
-                local tmp_file
-                tmp_file=$(mktemp)
-                awk -v marker="$HOOK_MARKER" '
-                BEGIN { depth = 0; in_block = 0; block = ""; block_depth = 0; buf = ""; has_buf = 0 }
-                function emit(line) {
-                    if (line ~ /^[ \t]*[\]}]/ && has_buf) {
-                        sub(/,[ \t]*$/, "", buf)
-                    }
-                    if (has_buf) print buf
-                    buf = line; has_buf = 1
-                }
-                {
-                    line = $0
-                    lsd = depth
-                    tmp = line; opens = gsub(/{/, "{", tmp)
-                    tmp = line; closes = gsub(/}/, "}", tmp)
-
-                    if (!in_block) {
-                        if (index(line, marker) > 0) { depth += opens - closes; next }
-                        if (opens > 0 && closes == 0 && lsd >= 2) {
-                            in_block = 1; block_depth = lsd; block = line
-                            depth += opens - closes
-                            next
-                        }
-                        emit(line)
-                        depth += opens - closes
-                    } else {
-                        block = block "\n" line
-                        if (closes > 0 && lsd - closes <= block_depth) {
-                            if (index(block, marker) == 0) emit(block)
-                            in_block = 0; block = ""
-                        }
-                        depth += opens - closes
-                    }
-                    next
-                }
-                END { if (in_block && index(block, marker) == 0) emit(block); if (has_buf) print buf }
-                ' "$cfg" > "$tmp_file" 2>/dev/null
-                mv "$tmp_file" "$cfg"
-                ok=1
+                msg "    ⚠️  跳过: $short (无 Node.js，请手动删除含 $HOOK_MARKER 的 hook 条目)" \
+                    "    ⚠️  Skipped: $short (no Node.js, manually remove hook entries containing $HOOK_MARKER)"
             else
                 ok=1
             fi

--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -1733,11 +1733,46 @@ try {
 } catch(e) { process.stderr.write(e.message); process.exit(1); }
 " "$cfg" "$HOOK_MARKER" && ok=1
         else
-            # sed fallback: remove lines containing the marker
+            # awk fallback: remove JSON objects/lines containing the marker
             if grep -q "$HOOK_MARKER" "$cfg" 2>/dev/null; then
                 local tmp_file
                 tmp_file=$(mktemp)
-                grep -v "$HOOK_MARKER" "$cfg" > "$tmp_file" 2>/dev/null || true
+                awk -v marker="$HOOK_MARKER" '
+                BEGIN { depth = 0; in_block = 0; block = ""; block_depth = 0; buf = ""; has_buf = 0 }
+                function emit(line) {
+                    if (line ~ /^[ \t]*[\]}]/ && has_buf) {
+                        sub(/,[ \t]*$/, "", buf)
+                    }
+                    if (has_buf) print buf
+                    buf = line; has_buf = 1
+                }
+                {
+                    line = $0
+                    lsd = depth
+                    tmp = line; opens = gsub(/{/, "{", tmp)
+                    tmp = line; closes = gsub(/}/, "}", tmp)
+
+                    if (!in_block) {
+                        if (index(line, marker) > 0) { depth += opens - closes; next }
+                        if (opens > 0 && closes == 0 && lsd >= 2) {
+                            in_block = 1; block_depth = lsd; block = line
+                            depth += opens - closes
+                            next
+                        }
+                        emit(line)
+                        depth += opens - closes
+                    } else {
+                        block = block "\n" line
+                        if (closes > 0 && lsd - closes <= block_depth) {
+                            if (index(block, marker) == 0) emit(block)
+                            in_block = 0; block = ""
+                        }
+                        depth += opens - closes
+                    }
+                    next
+                }
+                END { if (in_block && index(block, marker) == 0) emit(block); if (has_buf) print buf }
+                ' "$cfg" > "$tmp_file" 2>/dev/null
                 mv "$tmp_file" "$cfg"
                 ok=1
             else

--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -592,7 +592,10 @@ deploy_package() {
         msg "==> 部署到 $target ..." "==> Deploying to $target ..."
         mkdir -p "$versions_dir"
         rm -rf "$target"
-        cp -r "$src" "$target"
+        if ! cp -r "$src" "$target"; then
+            msg "    ❌ 文件部署失败" "    ❌ File deployment failed"
+            return 1
+        fi
 
         echo "$dir_name" > "$current_file.tmp"
         mv -f "$current_file.tmp" "$current_file"
@@ -603,7 +606,10 @@ deploy_package() {
             "==> Deploying to $PERMANENT_DIR ..."
         mkdir -p "$(dirname "$PERMANENT_DIR")"
         rm -rf "$PERMANENT_DIR"
-        cp -r "$src" "$PERMANENT_DIR"
+        if ! cp -r "$src" "$PERMANENT_DIR"; then
+            msg "    ❌ 文件部署失败" "    ❌ File deployment failed"
+            return 1
+        fi
     fi
     msg "    ✅ 部署完成" "    ✅ Deployed"
     echo ""
@@ -611,13 +617,19 @@ deploy_package() {
     deploy_bootstrap_scripts
 
     msg "==> 安装依赖..." "==> Installing dependencies..."
-    (cd "$PERMANENT_DIR" && "$NPM_BIN" install --production --no-optional 2>&1 | tail -1)
+    if ! (cd "$PERMANENT_DIR" && "$NPM_BIN" install --production --no-optional 2>&1 | tail -1); then
+        msg "    ❌ 依赖安装失败" "    ❌ Dependency installation failed"
+        return 1
+    fi
     msg "    ✅ 依赖安装完成" "    ✅ Dependencies installed"
     echo ""
 
     msg "==> 部署 hook 脚本..." "==> Deploying hook scripts..."
     if [ -f scripts/postinstall.js ]; then
-        "$NODE_BIN" scripts/postinstall.js
+        "$NODE_BIN" scripts/postinstall.js || {
+            msg "    ❌ Hook 脚本部署失败" "    ❌ Hook script deployment failed"
+            return 1
+        }
     fi
     msg "    ✅ Hook 脚本已部署" "    ✅ Hook scripts deployed"
     msg "    如使用 Codex 桌面版，首次启动需在桌面端手动信任 hooks" \
@@ -1577,7 +1589,21 @@ cmd_upgrade() {
 
     # Deploy new version to versions/<ver>_<commit>/
     # Old version stays untouched; deploy_package writes current/previous pointers
-    deploy_package "$INSTALL_SRC"
+    if ! deploy_package "$INSTALL_SRC"; then
+        echo ""
+        msg "⚠️  部署失败，正在回滚到旧版本..." \
+            "⚠️  Deployment failed, rolling back to old version..."
+        if command -v loongsuite-pilot &>/dev/null; then
+            loongsuite-pilot rollback 2>/dev/null || true
+            loongsuite-pilot start 2>/dev/null || true
+        elif [ -f "$HOME/.local/bin/loongsuite-pilot" ]; then
+            "$HOME/.local/bin/loongsuite-pilot" rollback 2>/dev/null || true
+            "$HOME/.local/bin/loongsuite-pilot" start 2>/dev/null || true
+        fi
+        msg "❌ 升级失败（部署/依赖安装出错），已回滚到 v${old_ver:-unknown} 并重启服务" \
+            "❌ Upgrade failed (deploy/dependency error), rolled back to v${old_ver:-unknown} and restarted"
+        exit 1
+    fi
     install_loongsuite_pilot_command
 
     # Start the new version
@@ -1663,12 +1689,20 @@ remove_hook_configs() {
         "$HOME/.qwen/settings.json"
     )
 
+    local _has_node=0
+    if command -v node &>/dev/null; then
+        _has_node=1
+    else
+        msg "    ⚠️  未找到 Node.js，将使用 sed 回退方式清理 hook" \
+            "    ⚠️  Node.js not found, using sed fallback for hook cleanup"
+    fi
+
     for cfg in "${configs[@]}"; do
         [ -f "$cfg" ] || continue
         local short="${cfg/#$HOME/\~}"
 
         local ok=0
-        if command -v node &>/dev/null; then
+        if [ "$_has_node" -eq 1 ]; then
             node -e "
 const fs = require('fs');
 const cfg = process.argv[1];
@@ -1698,6 +1732,17 @@ try {
   }
 } catch(e) { process.stderr.write(e.message); process.exit(1); }
 " "$cfg" "$HOOK_MARKER" && ok=1
+        else
+            # sed fallback: remove lines containing the marker
+            if grep -q "$HOOK_MARKER" "$cfg" 2>/dev/null; then
+                local tmp_file
+                tmp_file=$(mktemp)
+                grep -v "$HOOK_MARKER" "$cfg" > "$tmp_file" 2>/dev/null || true
+                mv "$tmp_file" "$cfg"
+                ok=1
+            else
+                ok=1
+            fi
         fi
 
         if [ "$ok" -eq 1 ]; then
@@ -1895,20 +1940,7 @@ cmd_uninstall() {
     msg "    ✅ 服务已停止" "    ✅ Service stopped"
     echo ""
 
-    # Remove package directory
-    msg "==> 删除安装目录..." "==> Removing installation..."
-    rm -rf "$HOME/.loongsuite-pilot"
-    msg "    ✅ 已删除 $HOME/.loongsuite-pilot" \
-        "    ✅ Removed $HOME/.loongsuite-pilot"
-
-    # Remove loongsuite-pilot command
-    msg "==> 删除 loongsuite-pilot 命令..." "==> Removing loongsuite-pilot command..."
-    rm -f "$HOME/.local/bin/loongsuite-pilot"
-    rm -f /usr/local/bin/loongsuite-pilot 2>/dev/null || true
-    msg "    ✅ loongsuite-pilot 命令已删除" "    ✅ loongsuite-pilot command removed"
-    echo ""
-
-    # Remove hook entries from tool configs
+    # Remove hook entries from tool configs BEFORE removing install dir
     msg "==> 清理 hook 配置..." "==> Cleaning up hook configs..."
     remove_hook_configs
     remove_qodercli_token_intercept
@@ -1928,6 +1960,24 @@ cmd_uninstall() {
 
     msg "==> 清理 Pi Coding Agent Extension 配置..." "==> Cleaning up Pi Coding Agent extension config..."
     remove_pi_coding_agent_extension
+    echo ""
+
+    # Remove installation artifacts
+    msg "==> 删除安装目录..." "==> Removing installation..."
+    local _cache_dir="$HOME/.loongsuite-pilot"
+    rm -rf "${_cache_dir:?}/versions"
+    rm -rf "${_cache_dir:?}/bin"
+    rm -rf "${_cache_dir:?}/package"
+    rm -f "${_cache_dir:?}/current"
+    rm -f "${_cache_dir:?}/previous"
+    rm -f "${_cache_dir:?}/node-bin"
+    msg "    ✅ 已删除安装文件" "    ✅ Installation files removed"
+
+    # Remove loongsuite-pilot command
+    msg "==> 删除 loongsuite-pilot 命令..." "==> Removing loongsuite-pilot command..."
+    rm -f "$HOME/.local/bin/loongsuite-pilot"
+    rm -f /usr/local/bin/loongsuite-pilot 2>/dev/null || true
+    msg "    ✅ loongsuite-pilot 命令已删除" "    ✅ loongsuite-pilot command removed"
     echo ""
 
     # Data directory


### PR DESCRIPTION
## 背景

修复 3 个部署脚本问题（对应内部 Issue sls/loongsuite-pilot#686433）

## 核心改动

1. **升级失败自动回滚**：`deploy_package()` 失败时自动执行 rollback + restart，恢复旧版本
2. **卸载顺序优化**：先清理 hook 配置再删目录；Node 不可用时使用 sed/grep 回退清理
3. **条件删除 DATA_DIR**：未传 `--purge` 时仅删安装产物（versions/、bin/、package/ 等），保留用户数据

## 修改文件

| 文件 | 说明 |
|------|------|
| `deploy/installer-opensource.sh` | 开源安装器：升级回滚 + 卸载顺序 + 条件删除 |

## 验证结果

- bash -n 语法检查：通过
- shellcheck --severity=warning：无新增 warning
- 本地安装/升级/卸载 E2E 验证通过

Fixes sls/loongsuite-pilot#686433