### PR TITLE
fix(cursor): capture manually attached skills

### DIFF
--- a/assets/hooks/cursor-hook-processor.mjs
+++ b/assets/hooks/cursor-hook-processor.mjs
@@ -181,7 +181,8 @@ function injectSkillRecords(records, skills, runtimeConfig = {}) {
       'gen_ai.tool.call.id': toolCallId,
       'gen_ai.tool.call.arguments': { path: skill.skillPath },
       'gen_ai.skill.name': skill.skillName,
-      'agent.cursor.skill_detection_source': 'transcript_post_assembly',
+      'agent.cursor.skill_detection_source':
+        skill.detectionSource || 'transcript_post_assembly',
     }, runtimeConfig));
 
     // tool.result
@@ -194,7 +195,8 @@ function injectSkillRecords(records, skills, runtimeConfig = {}) {
       'gen_ai.tool.name': 'Read',
       'gen_ai.tool.call.id': toolCallId,
       'gen_ai.skill.name': skill.skillName,
-      'agent.cursor.skill_detection_source': 'transcript_post_assembly',
+      'agent.cursor.skill_detection_source':
+        skill.detectionSource || 'transcript_post_assembly',
     }, runtimeConfig));
   }
 
@@ -364,10 +366,19 @@ async function main() {
         if (transcriptPathForSkill && promptForSkill?.prompt && records.length > 0) {
           const { detectSkillFromTranscript } = await import('./cursor/skill-detector.mjs');
           const detectedSkills = detectSkillFromTranscript(transcriptPathForSkill, promptForSkill.prompt);
-          // The Windows transcript assembler already materializes transcript
-          // tool_use entries. Only compensate paths assembled from hook events.
-          if (detectedSkills && detectedSkills.length > 0 && !assembledFromTranscript) {
-            injectSkillRecords(records, detectedSkills, runtimeConfig);
+          if (detectedSkills && detectedSkills.length > 0) {
+            // The Windows transcript assembler already materializes transcript
+            // Read tool_use entries. Always synthesize Read for explicit manual
+            // attachments; compensate actual transcript reads only on hook-event
+            // assembly paths so Windows does not emit duplicate Read records.
+            const readSkills = detectedSkills.filter(skill =>
+              skill.detectionSources?.includes('manual_attachment') ||
+              (!assembledFromTranscript &&
+                skill.detectionSources?.includes('transcript_read'))
+            );
+            if (readSkills.length > 0) {
+              injectSkillRecords(records, readSkills, runtimeConfig);
+            }
           }
         }
       } catch { /* best-effort skill detection — never block output */ }

--- a/assets/hooks/cursor-hook-processor.mjs
+++ b/assets/hooks/cursor-hook-processor.mjs
@@ -204,6 +204,23 @@ function injectSkillRecords(records, skills, runtimeConfig = {}) {
   records.splice(targetLlmIdx + 1, 0, ...insertRecords);
 }
 
+function filterSkillsForReadInjection(skills, assembledFromTranscript) {
+  return skills.filter(skill => {
+    const sources = skill.detectionSources || [];
+
+    if (!assembledFromTranscript) {
+      return sources.includes('manual_attachment') ||
+        sources.includes('transcript_read');
+    }
+
+    // The transcript assembler already materializes real Read tool_use entries.
+    // Only synthesize a Read when manual attachment is the sole evidence. A skill
+    // with both sources already has its real transcript Read in the assembled step.
+    return sources.includes('manual_attachment') &&
+      !sources.includes('transcript_read');
+  });
+}
+
 async function main() {
   const dataDir = resolveDataDir();
   const raw = await readStdin();
@@ -368,13 +385,11 @@ async function main() {
           const detectedSkills = detectSkillFromTranscript(transcriptPathForSkill, promptForSkill.prompt);
           if (detectedSkills && detectedSkills.length > 0) {
             // The Windows transcript assembler already materializes transcript
-            // Read tool_use entries. Always synthesize Read for explicit manual
-            // attachments; compensate actual transcript reads only on hook-event
-            // assembly paths so Windows does not emit duplicate Read records.
-            const readSkills = detectedSkills.filter(skill =>
-              skill.detectionSources?.includes('manual_attachment') ||
-              (!assembledFromTranscript &&
-                skill.detectionSources?.includes('transcript_read'))
+            // Read tool_use entries. Synthesize only pure manual attachments on
+            // that path; hook-event assembly still needs both evidence sources.
+            const readSkills = filterSkillsForReadInjection(
+              detectedSkills,
+              assembledFromTranscript,
             );
             if (readSkills.length > 0) {
               injectSkillRecords(records, readSkills, runtimeConfig);
@@ -454,4 +469,4 @@ if (
   });
 }
 
-export { injectSkillRecords };
+export { filterSkillsForReadInjection, injectSkillRecords };

--- a/assets/hooks/cursor/skill-detector.mjs
+++ b/assets/hooks/cursor/skill-detector.mjs
@@ -1,21 +1,33 @@
 /**
  * skill-detector.mjs — Detect skill usage from Cursor transcript post-assembly.
  *
- * Strategy: After assembly completes, scan the transcript to find Read tool_use
- * entries targeting ~/.cursor/skills/<name>/SKILL.md paths within the matched turn.
+ * Strategy: After assembly completes, match the transcript user row for the
+ * current turn, then collect skills from either:
+ * - Cursor's <manually_attached_skills> metadata on that user row; or
+ * - Read tool_use entries targeting ~/.cursor/skills/<name>/SKILL.md.
  */
 
 import fs from 'node:fs';
 
 // Path pattern: /.cursor/skills/<skill-name>/SKILL.md (case-insensitive)
 const SKILL_PATH_RE = /[/\\]\.cursor[/\\]skills[/\\]([\w-]+)[/\\]SKILL\.md/i;
+const MANUALLY_ATTACHED_SKILLS_RE =
+  /<manually_attached_skills>([\s\S]*?)<\/manually_attached_skills>/i;
+const ATTACHED_SKILL_HEADER_RE =
+  /(?:^|\r?\n)Skill Name:\s*([^\r\n]+)\r?\nPath:\s*([^\r\n]+)\r?\nSKILL\.md content:\s*(?:\r?\n|$)/g;
+const USER_QUERY_RE = /<user_query>\s*([\s\S]*?)\s*<\/user_query>/i;
 
 /**
  * Detect skill usage from transcript for a specific turn.
  *
  * @param {string} transcriptPath - Path to the transcript JSONL file
  * @param {string} userPrompt - The user prompt text to match the correct turn
- * @returns {{ skillName: string, skillPath: string }[] | null}
+ * @returns {{
+ *   skillName: string,
+ *   skillPath: string,
+ *   detectionSource: 'manual_attachment' | 'transcript_read',
+ *   detectionSources: ('manual_attachment' | 'transcript_read')[]
+ * }[] | null}
  */
 export function detectSkillFromTranscript(transcriptPath, userPrompt) {
   if (!transcriptPath || !userPrompt) return null;
@@ -35,25 +47,39 @@ export function detectSkillFromTranscript(transcriptPath, userPrompt) {
 
   if (entries.length === 0) return null;
 
-  // Step 1: Find the user message that matches our prompt
-  // The user prompt in transcript is wrapped in <user_query> tags and may have <timestamp>
-  // Match strategy: normalize both sides and check inclusion
+  // Step 1: Find the latest user message that matches our prompt. Prefer the
+  // explicit <user_query> payload so inlined skill content cannot accidentally
+  // satisfy the prompt match.
   const normalizedPrompt = normalizeForMatch(userPrompt);
 
   let matchedTurnStart = -1;
+  let matchedUserText = '';
   for (let i = 0; i < entries.length; i++) {
     const e = entries[i];
     if (e.role !== 'user') continue;
     const userText = extractUserText(e);
-    if (userText && normalizeForMatch(userText).includes(normalizedPrompt)) {
+    const userQuery = extractUserQuery(userText);
+    const normalizedCandidate = normalizeForMatch(userQuery || userText);
+    if (
+      normalizedCandidate === normalizedPrompt ||
+      (!userQuery && normalizedCandidate.includes(normalizedPrompt))
+    ) {
       matchedTurnStart = i;
+      matchedUserText = userText;
     }
   }
 
   if (matchedTurnStart < 0) return null;
 
-  // Step 2: Scan assistant messages after matched user message until next turn_ended or next user message
-  const skills = [];
+  // Step 2: Cursor inlines explicitly attached skills into the matched user row.
+  // This is the strongest per-turn signal and does not require a Read tool call.
+  const detected = new Map();
+  for (const skill of extractManuallyAttachedSkills(matchedUserText)) {
+    addDetectedSkill(detected, skill, 'manual_attachment');
+  }
+
+  // Step 3: Scan assistant messages after the matched user message until the
+  // turn boundary for actual Read SKILL.md tool calls.
   for (let i = matchedTurnStart + 1; i < entries.length; i++) {
     const e = entries[i];
     if (e.type === 'turn_ended' || e.role === 'user') break;
@@ -61,20 +87,20 @@ export function detectSkillFromTranscript(transcriptPath, userPrompt) {
     if (e.role === 'assistant' && e.message?.content) {
       for (const block of e.message.content) {
         if (block.type === 'tool_use' && (block.name === 'Read' || block.name === 'ReadFile')) {
-          const filePath = block.input?.path || '';
+          const filePath = block.input?.path || block.input?.file_path || '';
           const match = filePath.match(SKILL_PATH_RE);
           if (match) {
-            skills.push({
+            addDetectedSkill(detected, {
               skillName: match[1],
               skillPath: filePath,
-            });
+            }, 'transcript_read');
           }
         }
       }
     }
   }
 
-  return skills.length > 0 ? skills : null;
+  return detected.size > 0 ? [...detected.values()] : null;
 }
 
 /**
@@ -85,6 +111,55 @@ function extractUserText(entry) {
   if (!Array.isArray(content)) return '';
   const textParts = content.filter(b => b.type === 'text');
   return textParts.map(b => b.text || '').join('\n');
+}
+
+function extractUserQuery(userText) {
+  if (!userText) return '';
+  return userText.match(USER_QUERY_RE)?.[1]?.trim() || '';
+}
+
+/**
+ * Parse only Cursor's generated attachment headers. The inlined SKILL.md body
+ * is intentionally ignored and never returned to callers.
+ */
+export function extractManuallyAttachedSkills(userText) {
+  if (!userText) return [];
+  const container = userText.match(MANUALLY_ATTACHED_SKILLS_RE)?.[1];
+  if (!container) return [];
+
+  const skills = [];
+  ATTACHED_SKILL_HEADER_RE.lastIndex = 0;
+  for (const match of container.matchAll(ATTACHED_SKILL_HEADER_RE)) {
+    const declaredName = match[1].trim();
+    const skillPath = match[2].trim();
+    const pathMatch = skillPath.match(SKILL_PATH_RE);
+    if (!declaredName || !pathMatch) continue;
+    skills.push({
+      skillName: declaredName,
+      skillPath,
+    });
+  }
+  return skills;
+}
+
+function addDetectedSkill(detected, skill, source) {
+  const key = `${skill.skillName.toLowerCase()}\0${skill.skillPath.toLowerCase()}`;
+  const existing = detected.get(key);
+  if (existing) {
+    if (!existing.detectionSources.includes(source)) {
+      existing.detectionSources.push(source);
+    }
+    if (source === 'manual_attachment') {
+      existing.detectionSource = source;
+    }
+    return;
+  }
+
+  detected.set(key, {
+    ...skill,
+    detectionSource: source,
+    detectionSources: [source],
+  });
 }
 
 /**

--- a/tests/unit/hooks/cursor/inject-skill-records.test.mjs
+++ b/tests/unit/hooks/cursor/inject-skill-records.test.mjs
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { injectSkillRecords } from '../../../../assets/hooks/cursor-hook-processor.mjs';
+import {
+  filterSkillsForReadInjection,
+  injectSkillRecords,
+} from '../../../../assets/hooks/cursor-hook-processor.mjs';
 
 const PROCESSOR_URL = new URL('../../../../assets/hooks/cursor-hook-processor.mjs', import.meta.url);
 
@@ -43,6 +46,35 @@ function makeLlmRequest(overrides = {}) {
 function makeSkill(name = 'my-skill', skillPath = '/Users/test/.cursor/skills/my-skill/SKILL.md') {
   return { skillName: name, skillPath };
 }
+
+describe('filterSkillsForReadInjection', () => {
+  const skillWithSources = (...detectionSources) => ({
+    ...makeSkill(),
+    detectionSources,
+  });
+
+  it('should synthesize pure manual attachments after transcript assembly', () => {
+    const skills = [skillWithSources('manual_attachment')];
+
+    expect(filterSkillsForReadInjection(skills, true)).toEqual(skills);
+  });
+
+  it('should not synthesize transcript reads after transcript assembly', () => {
+    const transcriptOnly = skillWithSources('transcript_read');
+    const dualSource = skillWithSources('manual_attachment', 'transcript_read');
+
+    expect(filterSkillsForReadInjection([transcriptOnly, dualSource], true)).toEqual([]);
+  });
+
+  it('should synthesize manual attachments and transcript reads on hook-event assembly paths', () => {
+    const manualOnly = skillWithSources('manual_attachment');
+    const transcriptOnly = skillWithSources('transcript_read');
+    const dualSource = skillWithSources('manual_attachment', 'transcript_read');
+    const skills = [manualOnly, transcriptOnly, dualSource];
+
+    expect(filterSkillsForReadInjection(skills, false)).toEqual(skills);
+  });
+});
 
 describe('injectSkillRecords', () => {
   it('should inject tool_call part into llm.response output.messages', () => {

--- a/tests/unit/hooks/cursor/inject-skill-records.test.mjs
+++ b/tests/unit/hooks/cursor/inject-skill-records.test.mjs
@@ -235,6 +235,45 @@ describe('injectSkillRecords', () => {
     expect(JSON.stringify(records)).not.toContain(skillPath);
   });
 
+  it('should synthesize Read records for a manually attached skill path', () => {
+    const records = [makeLlmResponse()];
+    const skills = [{
+      ...makeSkill(
+        'count-if-statements',
+        '/Users/test/.cursor/skills/count-if-statements/SKILL.md',
+      ),
+      detectionSource: 'manual_attachment',
+      detectionSources: ['manual_attachment'],
+    }];
+
+    injectSkillRecords(records, skills);
+
+    const assistantMsg = records[0]['gen_ai.output.messages']
+      .find(message => message.role === 'assistant');
+    expect(assistantMsg.parts).toContainEqual(expect.objectContaining({
+      type: 'tool_call',
+      name: 'Read',
+      arguments: {
+        path: '/Users/test/.cursor/skills/count-if-statements/SKILL.md',
+      },
+    }));
+    expect(records[1]).toMatchObject({
+      'event.name': 'tool.call',
+      'gen_ai.tool.name': 'Read',
+      'gen_ai.tool.call.arguments': {
+        path: '/Users/test/.cursor/skills/count-if-statements/SKILL.md',
+      },
+      'gen_ai.skill.name': 'count-if-statements',
+      'agent.cursor.skill_detection_source': 'manual_attachment',
+    });
+    expect(records[2]).toMatchObject({
+      'event.name': 'tool.result',
+      'gen_ai.tool.name': 'Read',
+      'gen_ai.skill.name': 'count-if-statements',
+      'agent.cursor.skill_detection_source': 'manual_attachment',
+    });
+  });
+
   it('should not execute main when imported', () => {
     const imported = spawnSync(
       process.execPath,

--- a/tests/unit/hooks/cursor/skill-detector.test.mjs
+++ b/tests/unit/hooks/cursor/skill-detector.test.mjs
@@ -44,6 +44,155 @@ describe('detectSkillFromTranscript', () => {
     expect(result).toHaveLength(1);
     expect(result[0].skillName).toBe('leetcode-solver');
     expect(result[0].skillPath).toBe('/Users/yunshen/.cursor/skills/leetcode-solver/SKILL.md');
+    expect(result[0].detectionSource).toBe('transcript_read');
+    expect(result[0].detectionSources).toEqual(['transcript_read']);
+  });
+
+  it('should detect a manually attached skill without a Read tool call', () => {
+    const lines = [
+      { role: 'user', message: { content: [{ type: 'text', text: [
+        '<manually_attached_skills>',
+        'The user has manually attached the following skills to their message.',
+        '',
+        'Skill Name: count-if-statements',
+        'Path: /Users/test/.cursor/skills/count-if-statements/SKILL.md',
+        'SKILL.md content:',
+        '# Count If Statements',
+        '',
+        'The full content is inlined but must not be emitted.',
+        '</manually_attached_skills>',
+        '<timestamp>Friday, Jul 24, 2026, 4:23 PM (UTC+8)</timestamp>',
+        '<user_query>',
+        '/count-if-statements 统计leetcode_334的if数量',
+        '</user_query>',
+      ].join('\n') }] } },
+      { role: 'assistant', message: { content: [
+        { type: 'tool_use', name: 'Shell', input: {
+          command: 'python3 ~/.cursor/skills/count-if-statements/scripts/count_if.py leetcode_334.py',
+        } },
+      ] } },
+      { type: 'turn_ended' },
+    ];
+
+    ({ dir: tempDir, filePath: transcriptPath } = createTempTranscript(lines));
+
+    const result = detectSkillFromTranscript(
+      transcriptPath,
+      '/count-if-statements 统计leetcode_334的if数量',
+    );
+    expect(result).toEqual([{
+      skillName: 'count-if-statements',
+      skillPath: '/Users/test/.cursor/skills/count-if-statements/SKILL.md',
+      detectionSource: 'manual_attachment',
+      detectionSources: ['manual_attachment'],
+    }]);
+  });
+
+  it('should prefer the explicit user_query when inlined skill content contains another prompt', () => {
+    const lines = [
+      { role: 'user', message: { content: [{ type: 'text', text: [
+        '<manually_attached_skills>',
+        'Skill Name: prompt-helper',
+        'Path: /Users/test/.cursor/skills/prompt-helper/SKILL.md',
+        'SKILL.md content:',
+        'fix the bug',
+        '</manually_attached_skills>',
+        '<user_query>',
+        'run the attached helper',
+        '</user_query>',
+      ].join('\n') }] } },
+      { type: 'turn_ended' },
+    ];
+
+    ({ dir: tempDir, filePath: transcriptPath } = createTempTranscript(lines));
+
+    expect(detectSkillFromTranscript(transcriptPath, 'fix the bug')).toBeNull();
+    expect(detectSkillFromTranscript(transcriptPath, 'run the attached helper')).toHaveLength(1);
+  });
+
+  it('should deduplicate manual attachment and Read evidence for the same skill', () => {
+    const lines = [
+      { role: 'user', message: { content: [{ type: 'text', text: [
+        '<manually_attached_skills>',
+        'Skill Name: my-skill',
+        'Path: /Users/test/.cursor/skills/my-skill/SKILL.md',
+        'SKILL.md content:',
+        '# My Skill',
+        '</manually_attached_skills>',
+        '<user_query>',
+        'use my skill',
+        '</user_query>',
+      ].join('\n') }] } },
+      { role: 'assistant', message: { content: [
+        { type: 'tool_use', name: 'Read', input: {
+          path: '/Users/test/.cursor/skills/my-skill/SKILL.md',
+        } },
+      ] } },
+      { type: 'turn_ended' },
+    ];
+
+    ({ dir: tempDir, filePath: transcriptPath } = createTempTranscript(lines));
+
+    const result = detectSkillFromTranscript(transcriptPath, 'use my skill');
+    expect(result).toHaveLength(1);
+    expect(result[0].detectionSource).toBe('manual_attachment');
+    expect(result[0].detectionSources).toEqual(['manual_attachment', 'transcript_read']);
+  });
+
+  it('should detect multiple manually attached skills in one turn', () => {
+    const lines = [
+      { role: 'user', message: { content: [{ type: 'text', text: [
+        '<manually_attached_skills>',
+        'Skill Name: skill-a',
+        'Path: /Users/test/.cursor/skills/skill-a/SKILL.md',
+        'SKILL.md content:',
+        '# Skill A',
+        '',
+        'Skill Name: skill-b',
+        'Path: /Users/test/.cursor/skills/skill-b/SKILL.md',
+        'SKILL.md content:',
+        '# Skill B',
+        '</manually_attached_skills>',
+        '<user_query>',
+        'use both attached skills',
+        '</user_query>',
+      ].join('\n') }] } },
+      { type: 'turn_ended' },
+    ];
+
+    ({ dir: tempDir, filePath: transcriptPath } = createTempTranscript(lines));
+
+    const result = detectSkillFromTranscript(transcriptPath, 'use both attached skills');
+    expect(result.map(skill => skill.skillName)).toEqual(['skill-a', 'skill-b']);
+    expect(result.every(skill => skill.detectionSource === 'manual_attachment')).toBe(true);
+  });
+
+  it('should choose the latest turn when identical prompts are repeated', () => {
+    const makeUser = skillName => ({
+      role: 'user',
+      message: { content: [{ type: 'text', text: [
+        '<manually_attached_skills>',
+        `Skill Name: ${skillName}`,
+        `Path: /Users/test/.cursor/skills/${skillName}/SKILL.md`,
+        'SKILL.md content:',
+        `# ${skillName}`,
+        '</manually_attached_skills>',
+        '<user_query>',
+        'repeat this prompt',
+        '</user_query>',
+      ].join('\n') }] },
+    });
+    const lines = [
+      makeUser('old-skill'),
+      { type: 'turn_ended' },
+      makeUser('new-skill'),
+      { type: 'turn_ended' },
+    ];
+
+    ({ dir: tempDir, filePath: transcriptPath } = createTempTranscript(lines));
+
+    const result = detectSkillFromTranscript(transcriptPath, 'repeat this prompt');
+    expect(result.map(skill => skill.skillName)).toEqual(['new-skill']);
   });
 
   it('should return null when transcript has no skill reads', () => {


### PR DESCRIPTION
## Summary

- detect Cursor-native skills from `<manually_attached_skills>` on the matched user transcript row
- synthesize a paired Read tool call/result when Cursor inlines the skill without emitting Read hooks
- preserve transcript Read detection and avoid duplicate Windows records
- match the explicit `<user_query>` when selecting the turn

## Tests

- `npm test -- --run tests/unit/hooks/cursor/skill-detector.test.mjs tests/unit/hooks/cursor/inject-skill-records.test.mjs`
- 2 test files, 28 tests passed