### PR TITLE
fix(codex): propagate invocation span attributes

### DIFF
--- a/assets/hooks/codex-hook-processor.mjs
+++ b/assets/hooks/codex-hook-processor.mjs
@@ -19,6 +19,7 @@ import { logHookError } from './shared/error-logger.mjs';
 import { recordUpstreamContextOnce } from './shared/upstream-context.mjs';
 import {
   collectResourceAttributesFromEnv,
+  parseSpanAttributesFromEnv,
 } from './shared/resource-context.mjs';
 
 const AGENT_ID = 'codex';
@@ -52,6 +53,67 @@ function safePathPart(value) {
   return path.basename(String(value)).replace(/[^a-zA-Z0-9_-]/g, '_') || 'unknown';
 }
 
+function writeAtomicJson(directory, fileName, payload, {
+  writeStage,
+  writeErrorType,
+  cleanupStage,
+  cleanupErrorType,
+}) {
+  const marker = path.join(directory, fileName);
+  const temporary = path.join(directory, `.${fileName}.${process.pid}.${crypto.randomUUID()}.tmp`);
+  try {
+    fs.mkdirSync(directory, { recursive: true });
+    fs.writeFileSync(temporary, JSON.stringify(payload), 'utf8');
+    try {
+      fs.renameSync(temporary, marker);
+    } catch (renameError) {
+      // Windows rename does not replace an existing destination. Hook events
+      // may repeat for one session/turn, so remove the stale marker and retry.
+      if (!['EEXIST', 'EPERM'].includes(renameError?.code)) throw renameError;
+      fs.rmSync(marker, { force: true });
+      fs.renameSync(temporary, marker);
+    }
+  } catch (error) {
+    logHookError({
+      agentId: AGENT_ID,
+      stage: writeStage,
+      errorType: writeErrorType,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    });
+    try { fs.unlinkSync(temporary); } catch (cleanupError) {
+      logHookError({
+        agentId: AGENT_ID,
+        stage: cleanupStage,
+        errorType: cleanupErrorType,
+        errorMessage: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+      });
+    }
+  }
+}
+
+function writeTurnSpanContext(input) {
+  const sessionId = typeof input.session_id === 'string' ? input.session_id : '';
+  const turnId = typeof input.turn_id === 'string' ? input.turn_id : '';
+  if (!sessionId || !turnId) return;
+
+  const spanAttributes = parseSpanAttributesFromEnv(process.env, { agentId: AGENT_ID });
+  if (Object.keys(spanAttributes).length === 0) return;
+
+  const directory = path.join(pilotDataDir(), 'state', 'codex', 'transcript-span-contexts');
+  const fileName = `${safePathPart(sessionId)}--${safePathPart(turnId)}.json`;
+  writeAtomicJson(directory, fileName, {
+    session_id: sessionId,
+    turn_id: turnId,
+    spanAttributes,
+    received_at: new Date().toISOString(),
+  }, {
+    writeStage: 'span_context_write',
+    writeErrorType: 'SPAN_CONTEXT_WRITE_ERROR',
+    cleanupStage: 'span_context_cleanup',
+    cleanupErrorType: 'SPAN_CONTEXT_CLEANUP_ERROR',
+  });
+}
+
 function writeWakeupMarker(input) {
   const sessionId = typeof input.session_id === 'string' ? input.session_id : '';
   if (!sessionId) return;
@@ -64,8 +126,6 @@ function writeWakeupMarker(input) {
   recordUpstreamContextOnce({ agentId: AGENT_ID, sessionId, dataDir: pilotDataDir() });
 
   const directory = path.join(pilotDataDir(), 'state', 'codex', 'transcript-wakeups');
-  const marker = path.join(directory, `${safePathPart(sessionId)}.json`);
-  const temporary = path.join(directory, `.${safePathPart(sessionId)}.${process.pid}.${crypto.randomUUID()}.tmp`);
   const payload = {
     session_id: sessionId,
     ...(typeof input.turn_id === 'string' && input.turn_id ? { turn_id: input.turn_id } : {}),
@@ -77,34 +137,12 @@ function writeWakeupMarker(input) {
     ...RESOURCE_ATTRIBUTE_FIELDS,
     received_at: new Date().toISOString(),
   };
-  try {
-    fs.mkdirSync(directory, { recursive: true });
-    fs.writeFileSync(temporary, JSON.stringify(payload), 'utf8');
-    try {
-      fs.renameSync(temporary, marker);
-    } catch (renameError) {
-      // Windows rename does not replace an existing destination. Stop may fire
-      // repeatedly for one session, so remove the stale marker and retry.
-      if (!['EEXIST', 'EPERM'].includes(renameError?.code)) throw renameError;
-      fs.rmSync(marker, { force: true });
-      fs.renameSync(temporary, marker);
-    }
-  } catch (error) {
-    logHookError({
-      agentId: AGENT_ID,
-      stage: 'wakeup_write',
-      errorType: 'WAKEUP_WRITE_ERROR',
-      errorMessage: error instanceof Error ? error.message : String(error),
-    });
-    try { fs.unlinkSync(temporary); } catch (cleanupError) {
-      logHookError({
-        agentId: AGENT_ID,
-        stage: 'wakeup_cleanup',
-        errorType: 'WAKEUP_CLEANUP_ERROR',
-        errorMessage: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
-      });
-    }
-  }
+  writeAtomicJson(directory, `${safePathPart(sessionId)}.json`, payload, {
+    writeStage: 'wakeup_write',
+    writeErrorType: 'WAKEUP_WRITE_ERROR',
+    cleanupStage: 'wakeup_cleanup',
+    cleanupErrorType: 'WAKEUP_CLEANUP_ERROR',
+  });
 }
 
 function main() {
@@ -115,7 +153,13 @@ function main() {
       || subcommand === 'user-prompt-submit'
       || subcommand === 'stop'
     ) {
-      writeWakeupMarker(tryReadStdin());
+      const input = tryReadStdin();
+      if (subcommand === 'user-prompt-submit' || subcommand === 'stop') {
+        // Persist invocation attributes before publishing the wakeup so the
+        // asynchronous transcript reader cannot observe the turn first.
+        writeTurnSpanContext(input);
+      }
+      writeWakeupMarker(input);
     }
   } finally {
     process.stdout.write('{}\n');

--- a/docs/trace-output.md
+++ b/docs/trace-output.md
@@ -311,7 +311,8 @@ Notes:
 - Unlike source #2 (spans only), passthrough attributes are ordinary top-level record fields, so they appear in **both** the event log (SLS / JSONL) and the trace spans — same behavior as the git fields.
 - Reserved-prefix keys (`gen_ai.`, `git.`, `workspace.`, `event.`, `trace_`, `user.`, `cost_`, `agent.`) and sensitive names (token/secret/password/…) are dropped by the hook. Use a dedicated namespace such as `multica.*`.
 - Values must not contain a comma `,` (it is the pair separator); a value is also capped at 512 chars.
-- Only keys matching a configured prefix are passed through; all other top-level fields are unaffected. Supported for agents whose records are built in-process (claude-code, qoder, opencode).
+- Only keys matching a configured prefix are passed through; all other top-level fields are unaffected. Supported for claude-code, codex, qoder, and opencode.
+- Codex snapshots these process-level attributes on `UserPromptSubmit` (with `Stop` as a fail-open fallback) and correlates them to transcript records by session and turn. This prevents a resumed session launched by a different invocation from reusing the previous invocation's attributes.
 
 ## Verify Trace Output
 

--- a/docs/zh-CN/trace-output.md
+++ b/docs/zh-CN/trace-output.md
@@ -310,7 +310,8 @@ Pilot 会将 Trace 发送到 `http://localhost:3000/api/public/otel/v1/traces`�
 说明：
 - 与来源 #2（仅 span）不同，透传属性是普通的顶层 record 字段，因此会**同时**出现在 event log（SLS / JSONL）和 trace span 上——与 git 字段行为一致。
 - 保留前缀 key（`gen_ai.`、`git.`、`workspace.`、`event.`、`trace_`、`user.`、`cost_`、`agent.`）以及敏感命名（token/secret/password/…）会被 hook 丢弃。请使用 `multica.*` 等专用命名空间。
-- 仅匹配所配置前缀的 key 会被透传，其它顶层字段不受影响。支持在进程内构建 record 的 agent（claude-code、qoder、opencode）。
+- 仅匹配所配置前缀的 key 会被透传，其它顶层字段不受影响。目前支持 claude-code、codex、qoder 和 opencode。
+- Codex 会在 `UserPromptSubmit` 时保存这些进程级属性（以 `Stop` 作为 fail-open 兜底），并按 session 与 turn 关联到 transcript 记录，避免同一个 session 被不同调用恢复时沿用上一次调用的属性。
 - value 不能包含逗号 `,`（逗号是键值对分隔符）；单个 value 长度上限 512 字符。
 
 ## 验证 Trace 输出

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import type { Dirent, FSWatcher } from 'node:fs';
 import { ClientType, CollectionMethod } from '../../types/index.js';
 import type { AgentActivityEntry, JsonValue } from '../../types/index.js';
+import { isReservedKey } from '../../normalization/global-attributes.js';
 import { directoryExists, resolveHome } from '../../utils/fs-utils.js';
 import { BaseInput, type InputOptions } from '../base/base-input.js';
 import {
@@ -40,12 +41,15 @@ const MAX_SCAN_BYTES_PER_FILE_CYCLE = 16 * 1024 * 1024;
 // stale task homes cannot turn every polling cycle into an unbounded walk.
 const MAX_WAKEUP_MARKERS_FOR_DISCOVERY = 256;
 const MAX_WAKEUP_MARKERS_PER_CLEANUP = 1_024;
+const MAX_SPAN_CONTEXTS_PER_CLEANUP = 1_024;
 const MAX_DYNAMIC_SESSION_DIRS = 64;
 const MAX_DYNAMIC_SESSION_FILES = 64;
 const MAX_DYNAMIC_DIRECTORIES_PER_ROOT = 8;
 const MAX_DYNAMIC_ROLLOUT_FILES_PER_ROOT = 256;
 const WAKEUP_MARKER_DISCOVERY_TTL_MS = 48 * 60 * 60 * 1_000;
 const WAKEUP_MARKER_CLEANUP_INTERVAL_MS = 5 * 60 * 1_000;
+const SPAN_CONTEXT_TTL_MS = 48 * 60 * 60 * 1_000;
+const SPAN_CONTEXT_CLEANUP_INTERVAL_MS = 5 * 60 * 1_000;
 const DYNAMIC_SESSION_FILE_MAX_IDLE_MS = 15 * 60 * 1_000;
 // Values emitted by DEFAULT_RESOURCE_ENV_FIELD_MAP in assets/hooks/shared/resource-context.mjs.
 // Add new AgentTeams resource fields to both lists together.
@@ -54,6 +58,9 @@ const WAKEUP_RESOURCE_ATTRIBUTE_KEYS = [
   'agentteams.instance.id',
 ];
 const MAX_WAKEUP_RESOURCE_ATTRIBUTE_VALUE_LENGTH = 512;
+const MAX_SPAN_ATTRIBUTE_VALUE_LENGTH = 512;
+const SENSITIVE_SPAN_ATTRIBUTE_NAME_RE =
+  /(^|[_.-])(TOKEN|SECRET|PASSWORD|CREDENTIAL|COOKIE)([_.-]|$)|^(API_KEY|API_HEADER)$/i;
 
 interface JsonLine {
   startOffset: number;
@@ -106,6 +113,7 @@ interface DynamicDirectoryWalkBudget {
 export interface CodexTranscriptInputOptions extends InputOptions {
   sessionDir?: string;
   wakeupDir?: string;
+  spanContextDir?: string;
 }
 
 export class CodexTranscriptInput extends BaseInput {
@@ -115,17 +123,20 @@ export class CodexTranscriptInput extends BaseInput {
 
   private readonly sessionDir: string;
   private readonly wakeupDir: string;
+  private readonly spanContextDir: string;
   private wakeupWatcher: FSWatcher | null = null;
   private processedTerminalTurnIdsLoaded = false;
   private processedTerminalTurnIdsDirty = false;
   private processedTerminalTurnIds = new Set<string>();
   private processedTerminalTurnIdOrder: string[] = [];
   private lastWakeupMarkerCleanupAtMs = 0;
+  private lastSpanContextCleanupAtMs = 0;
 
   constructor(opts: CodexTranscriptInputOptions) {
     super({ stateStore: opts.stateStore, pollIntervalMs: opts.pollIntervalMs ?? 30_000 });
     this.sessionDir = opts.sessionDir ?? resolveHome(DEFAULT_SESSION_DIR);
     this.wakeupDir = opts.wakeupDir ?? defaultWakeupDir();
+    this.spanContextDir = opts.spanContextDir ?? defaultSpanContextDir();
   }
 
   static getWatchPaths(): string[] {
@@ -143,7 +154,10 @@ export class CodexTranscriptInput extends BaseInput {
       if (baselineOnStart && !this.readCheckpoint(key)) await this.baselineFile(filePath, key);
     }
     this.saveGlobalProcessedTerminalTurnIds();
-    await fs.mkdir(this.wakeupDir, { recursive: true });
+    await Promise.all([
+      fs.mkdir(this.wakeupDir, { recursive: true }),
+      fs.mkdir(this.spanContextDir, { recursive: true }),
+    ]);
     try {
       this.wakeupWatcher = fsSync.watch(this.wakeupDir, { persistent: false }, () => {
         this.requestCollection();
@@ -165,6 +179,7 @@ export class CodexTranscriptInput extends BaseInput {
   }
 
   protected override async collect(): Promise<AgentActivityEntry[]> {
+    await this.cleanupExpiredSpanContexts(Date.now());
     let emittedCount = 0;
     for (const { filePath } of await this.discoverSessionFiles()) {
       emittedCount += await this.processFile(filePath);
@@ -520,8 +535,16 @@ export class CodexTranscriptInput extends BaseInput {
       ? endOffset
       : extraction.consumedEndOffset;
 
-    const resourceAttributes = await this.readWakeupResourceAttributes(turn.sessionId);
-    const outputEntries = resourceAttributes ? attachWakeupResourceAttributes(entries, resourceAttributes) : entries;
+    const [resourceAttributes, spanAttributes] = await Promise.all([
+      this.readWakeupResourceAttributes(turn.sessionId),
+      this.readTurnSpanAttributes(turn.sessionId, activeTurn.turnId),
+    ]);
+    let outputEntries = resourceAttributes
+      ? attachWakeupResourceAttributes(entries, resourceAttributes)
+      : entries;
+    if (spanAttributes) {
+      outputEntries = attachTurnSpanAttributes(outputEntries, spanAttributes);
+    }
     return {
       kind: outputEntries.length > 0 ? 'processed-emitted' : 'processed-empty',
       entries: outputEntries,
@@ -660,6 +683,68 @@ export class CodexTranscriptInput extends BaseInput {
       return undefined;
     }
     return resourceAttributes;
+  }
+
+  private async readTurnSpanAttributes(
+    sessionId: string,
+    turnId: string,
+  ): Promise<Record<string, string> | undefined> {
+    const marker = path.join(this.spanContextDir, spanContextMarkerName(sessionId, turnId));
+    let raw: string;
+    try {
+      raw = await fs.readFile(marker, 'utf8');
+    } catch {
+      return undefined;
+    }
+
+    let markerRecord: Record<string, unknown> | null = null;
+    try {
+      markerRecord = asRecord(JSON.parse(raw));
+    } catch {
+      this.logger.debug('Codex span context could not be parsed; invocation attributes skipped', { marker });
+      return undefined;
+    }
+
+    if (
+      !markerRecord
+      || stringValue(markerRecord.session_id) !== sessionId
+      || stringValue(markerRecord.turn_id) !== turnId
+    ) {
+      this.logger.debug('Codex span context identifiers do not match the transcript turn', {
+        marker,
+        sessionId,
+        turnId,
+      });
+      return undefined;
+    }
+
+    const receivedAt = stringValue(markerRecord.received_at);
+    const receivedAtMs = receivedAt ? Date.parse(receivedAt) : Number.NaN;
+    if (Number.isFinite(receivedAtMs) && Date.now() - receivedAtMs > SPAN_CONTEXT_TTL_MS) {
+      this.logger.debug('Codex span context is expired; invocation attributes skipped', { marker });
+      return undefined;
+    }
+
+    const markerAttributes = asRecord(markerRecord.spanAttributes);
+    if (!markerAttributes) return undefined;
+
+    const spanAttributes: Record<string, string> = {};
+    for (const [rawKey, rawValue] of Object.entries(markerAttributes)) {
+      const key = rawKey.trim();
+      if (
+        !key
+        || isReservedKey(key)
+        || SENSITIVE_SPAN_ATTRIBUTE_NAME_RE.test(key)
+        || typeof rawValue !== 'string'
+      ) {
+        continue;
+      }
+      const value = rawValue.trim();
+      if (!value || value.length > MAX_SPAN_ATTRIBUTE_VALUE_LENGTH) continue;
+      spanAttributes[key] = value;
+    }
+
+    return Object.keys(spanAttributes).length > 0 ? spanAttributes : undefined;
   }
 
   private async baselineFile(filePath: string, key: string): Promise<void> {
@@ -840,6 +925,49 @@ export class CodexTranscriptInput extends BaseInput {
         await fs.unlink(markerPath);
       } catch {
         // Another process or cleanup cycle may have removed the marker first.
+      }
+    }
+  }
+
+  private async cleanupExpiredSpanContexts(now: number): Promise<void> {
+    if (now - this.lastSpanContextCleanupAtMs < SPAN_CONTEXT_CLEANUP_INTERVAL_MS) return;
+    this.lastSpanContextCleanupAtMs = now;
+
+    let entries: Dirent[];
+    try {
+      entries = await fs.readdir(this.spanContextDir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    const candidates = entries
+      .filter(entry => entry.isFile() && entry.name.endsWith('.json'))
+      .sort((left, right) => left.name.localeCompare(right.name))
+      .slice(0, MAX_SPAN_CONTEXTS_PER_CLEANUP);
+    for (const entry of candidates) {
+      const markerPath = path.join(this.spanContextDir, entry.name);
+      let expired = false;
+      try {
+        const marker = asRecord(JSON.parse(await fs.readFile(markerPath, 'utf8')));
+        const receivedAt = stringValue(marker?.received_at);
+        const receivedAtMs = receivedAt ? Date.parse(receivedAt) : Number.NaN;
+        if (Number.isFinite(receivedAtMs)) {
+          expired = now - receivedAtMs > SPAN_CONTEXT_TTL_MS;
+        } else {
+          expired = now - (await fs.stat(markerPath)).mtimeMs > SPAN_CONTEXT_TTL_MS;
+        }
+      } catch {
+        try {
+          expired = now - (await fs.stat(markerPath)).mtimeMs > SPAN_CONTEXT_TTL_MS;
+        } catch {
+          continue;
+        }
+      }
+      if (!expired) continue;
+      try {
+        await fs.unlink(markerPath);
+      } catch {
+        // Another process or cleanup cycle may have removed the context first.
       }
     }
   }
@@ -1301,6 +1429,18 @@ function attachWakeupResourceAttributes(
   return entries;
 }
 
+function attachTurnSpanAttributes(
+  entries: AgentActivityEntry[],
+  spanAttributes: Record<string, string>,
+): AgentActivityEntry[] {
+  for (const entry of entries) {
+    for (const [key, value] of Object.entries(spanAttributes)) {
+      if (entry[key] === undefined) entry[key] = value;
+    }
+  }
+  return entries;
+}
+
 function persistedInputContext(
   context: CodexTranscriptInputContext,
   sourceRange: CodexTranscriptSourceRange | undefined,
@@ -1334,7 +1474,16 @@ function safeWakeupSessionPart(value: string): string {
   return path.basename(String(value)).replace(/[^a-zA-Z0-9_-]/g, '_') || 'unknown';
 }
 
+function spanContextMarkerName(sessionId: string, turnId: string): string {
+  return `${safeWakeupSessionPart(sessionId)}--${safeWakeupSessionPart(turnId)}.json`;
+}
+
 function defaultWakeupDir(): string {
   const dataDir = process.env.LOONGSUITE_PILOT_DATA_DIR || path.join(os.homedir(), '.loongsuite-pilot');
   return path.join(dataDir, 'state', 'codex', 'transcript-wakeups');
+}
+
+function defaultSpanContextDir(): string {
+  const dataDir = process.env.LOONGSUITE_PILOT_DATA_DIR || path.join(os.homedir(), '.loongsuite-pilot');
+  return path.join(dataDir, 'state', 'codex', 'transcript-span-contexts');
 }

--- a/tests/unit/hooks/codex/hook-processor.test.mjs
+++ b/tests/unit/hooks/codex/hook-processor.test.mjs
@@ -22,9 +22,13 @@ afterEach(() => {
 });
 
 function runHook(subcommand, payload, extraEnv = {}) {
+  const env = { ...process.env, LOONGSUITE_PILOT_DATA_DIR: dataDir, ...extraEnv };
+  if (!Object.hasOwn(extraEnv, 'LOONGSUITE_PILOT_SPAN_ATTRIBUTES')) {
+    delete env.LOONGSUITE_PILOT_SPAN_ATTRIBUTES;
+  }
   return spawnSync('node', [PROCESSOR, subcommand], {
     input: JSON.stringify(payload),
-    env: { ...process.env, LOONGSUITE_PILOT_DATA_DIR: dataDir, ...extraEnv },
+    env,
     encoding: 'utf-8',
     timeout: 10_000,
   });
@@ -32,6 +36,16 @@ function runHook(subcommand, payload, extraEnv = {}) {
 
 function markerPath(sessionId) {
   return path.join(dataDir, 'state', 'codex', 'transcript-wakeups', `${sessionId}.json`);
+}
+
+function spanContextPath(sessionId, turnId) {
+  return path.join(
+    dataDir,
+    'state',
+    'codex',
+    'transcript-span-contexts',
+    `${sessionId}--${turnId}.json`,
+  );
 }
 
 describe('codex transcript discovery hook', () => {
@@ -108,6 +122,84 @@ describe('codex transcript discovery hook', () => {
     expect(JSON.stringify(marker)).not.toContain('should-not-leak');
   });
 
+  test.each(['user-prompt-submit', 'stop'])(
+    'writes filtered invocation span attributes for %s',
+    subcommand => {
+      const longValue = 'x'.repeat(513);
+      const result = runHook(subcommand, {
+        session_id: 'cdx-span-context',
+        turn_id: 'turn-span-context',
+      }, {
+        LOONGSUITE_PILOT_SPAN_ATTRIBUTES: [
+          'multica.issue.id=issue-1',
+          'multica.agent.name=codex',
+          'gen_ai.agent.name=must-not-overwrite',
+          'multica.secret=must-not-leak',
+          `multica.long=${longValue}`,
+          'malformed',
+        ].join(','),
+      });
+
+      expect(result.status).toBe(0);
+      expect(JSON.parse(fs.readFileSync(
+        spanContextPath('cdx-span-context', 'turn-span-context'),
+        'utf8',
+      ))).toMatchObject({
+        session_id: 'cdx-span-context',
+        turn_id: 'turn-span-context',
+        spanAttributes: {
+          'multica.issue.id': 'issue-1',
+          'multica.agent.name': 'codex',
+        },
+        received_at: expect.any(String),
+      });
+      const serialized = fs.readFileSync(
+        spanContextPath('cdx-span-context', 'turn-span-context'),
+        'utf8',
+      );
+      expect(serialized).not.toContain('must-not-overwrite');
+      expect(serialized).not.toContain('must-not-leak');
+      expect(serialized).not.toContain(longValue);
+    },
+  );
+
+  test('does not persist invocation span attributes for SessionStart', () => {
+    const result = runHook('session-start', {
+      session_id: 'cdx-session-start',
+      turn_id: 'turn-session-start',
+    }, {
+      LOONGSUITE_PILOT_SPAN_ATTRIBUTES: 'multica.issue.id=issue-session-start',
+    });
+
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(spanContextPath('cdx-session-start', 'turn-session-start'))).toBe(false);
+    expect(fs.existsSync(markerPath('cdx-session-start'))).toBe(true);
+  });
+
+  test('keeps invocation span attributes isolated by turn within one session', () => {
+    runHook('user-prompt-submit', {
+      session_id: 'cdx-shared-session',
+      turn_id: 'turn-1',
+    }, {
+      LOONGSUITE_PILOT_SPAN_ATTRIBUTES: 'multica.issue.id=issue-1',
+    });
+    runHook('user-prompt-submit', {
+      session_id: 'cdx-shared-session',
+      turn_id: 'turn-2',
+    }, {
+      LOONGSUITE_PILOT_SPAN_ATTRIBUTES: 'multica.issue.id=issue-2',
+    });
+
+    expect(JSON.parse(fs.readFileSync(
+      spanContextPath('cdx-shared-session', 'turn-1'),
+      'utf8',
+    )).spanAttributes).toEqual({ 'multica.issue.id': 'issue-1' });
+    expect(JSON.parse(fs.readFileSync(
+      spanContextPath('cdx-shared-session', 'turn-2'),
+      'utf8',
+    )).spanAttributes).toEqual({ 'multica.issue.id': 'issue-2' });
+  });
+
   test('keeps only the latest wakeup for one session', () => {
     runHook('stop', { session_id: 'cdx-overwrite', turn_id: 'turn-1' });
     runHook('stop', { session_id: 'cdx-overwrite', turn_id: 'turn-2' });
@@ -144,6 +236,30 @@ describe('codex transcript discovery hook', () => {
     const errorDir = path.join(dataDir, 'logs', 'codex', 'errors');
     const errorFile = path.join(errorDir, fs.readdirSync(errorDir)[0]);
     expect(fs.readFileSync(errorFile, 'utf8')).toContain('"stage":"wakeup_write"');
+  });
+
+  test('logs span context write failures without blocking the wakeup marker', () => {
+    fs.mkdirSync(path.join(dataDir, 'state', 'codex'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dataDir, 'state', 'codex', 'transcript-span-contexts'),
+      'not-a-directory',
+    );
+
+    const result = runHook('user-prompt-submit', {
+      session_id: 'cdx-span-error',
+      turn_id: 'turn-span-error',
+    }, {
+      LOONGSUITE_PILOT_SPAN_ATTRIBUTES: 'multica.issue.id=issue-error',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe('{}');
+    expect(fs.existsSync(markerPath('cdx-span-error'))).toBe(true);
+    const errorDir = path.join(dataDir, 'logs', 'codex', 'errors');
+    const errorFiles = fs.readdirSync(errorDir);
+    expect(errorFiles.some(file => (
+      fs.readFileSync(path.join(errorDir, file), 'utf8').includes('"stage":"span_context_write"')
+    ))).toBe(true);
   });
 
   test('derives the shared Pilot data directory from the installed shell wrapper', () => {

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -230,13 +230,21 @@ async function createInput(root: string, pollIntervalMs = 10): Promise<{
   batches: AgentActivityEntry[][];
   sessionDir: string;
   wakeupDir: string;
+  spanContextDir: string;
   stateStore: StateStore;
 }> {
   const stateStore = new StateStore(path.join(root, 'input-state.json'));
   await stateStore.load();
   const sessionDir = path.join(root, 'sessions');
   const wakeupDir = path.join(root, 'wakeups');
-  const input = new CodexTranscriptInput({ stateStore, sessionDir, wakeupDir, pollIntervalMs });
+  const spanContextDir = path.join(root, 'span-contexts');
+  const input = new CodexTranscriptInput({
+    stateStore,
+    sessionDir,
+    wakeupDir,
+    spanContextDir,
+    pollIntervalMs,
+  });
   const entries: AgentActivityEntry[] = [];
   const batches: AgentActivityEntry[][] = [];
   input.on('entries', batch => {
@@ -244,7 +252,7 @@ async function createInput(root: string, pollIntervalMs = 10): Promise<{
     entries.push(...batch);
   });
   await input.start();
-  return { input, entries, batches, sessionDir, wakeupDir, stateStore };
+  return { input, entries, batches, sessionDir, wakeupDir, spanContextDir, stateStore };
 }
 
 async function createDormantInput(root: string): Promise<{
@@ -253,20 +261,28 @@ async function createDormantInput(root: string): Promise<{
   batches: AgentActivityEntry[][];
   sessionDir: string;
   wakeupDir: string;
+  spanContextDir: string;
   stateStore: StateStore;
 }> {
   const stateStore = new StateStore(path.join(root, 'input-state.json'));
   await stateStore.load();
   const sessionDir = path.join(root, 'sessions');
   const wakeupDir = path.join(root, 'wakeups');
-  const input = new CodexTranscriptInput({ stateStore, sessionDir, wakeupDir, pollIntervalMs: 60_000 });
+  const spanContextDir = path.join(root, 'span-contexts');
+  const input = new CodexTranscriptInput({
+    stateStore,
+    sessionDir,
+    wakeupDir,
+    spanContextDir,
+    pollIntervalMs: 60_000,
+  });
   const entries: AgentActivityEntry[] = [];
   const batches: AgentActivityEntry[][] = [];
   input.on('entries', batch => {
     batches.push([...batch]);
     entries.push(...batch);
   });
-  return { input, entries, batches, sessionDir, wakeupDir, stateStore };
+  return { input, entries, batches, sessionDir, wakeupDir, spanContextDir, stateStore };
 }
 
 async function writeTranscript(sessionDir: string, text: string): Promise<string> {
@@ -279,6 +295,18 @@ async function writeTranscript(sessionDir: string, text: string): Promise<string
 async function writeWakeupMarker(wakeupDir: string, sessionId: string, payload: Record<string, unknown>): Promise<void> {
   await fs.mkdir(wakeupDir, { recursive: true });
   await fs.writeFile(path.join(wakeupDir, `${sessionId}.json`), JSON.stringify(payload), 'utf8');
+}
+
+async function writeSpanContext(
+  spanContextDir: string,
+  sessionId: string,
+  turnId: string,
+  payload: Record<string, unknown>,
+): Promise<string> {
+  await fs.mkdir(spanContextDir, { recursive: true });
+  const marker = path.join(spanContextDir, `${sessionId}--${turnId}.json`);
+  await fs.writeFile(marker, JSON.stringify(payload), 'utf8');
+  return marker;
 }
 
 async function writeTranscriptNamed(sessionDir: string, name: string, text: string): Promise<string> {
@@ -616,6 +644,152 @@ describe('CodexTranscriptInput', () => {
       });
     }
     expect(JSON.stringify(entries)).not.toContain(longWorkerName);
+  });
+
+  it('projects turn-scoped invocation attributes onto every Codex record', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-span-context-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, spanContextDir } = await createInput(root);
+    await writeSpanContext(spanContextDir, 'session-1', 'turn-1', {
+      session_id: 'session-1',
+      turn_id: 'turn-1',
+      spanAttributes: {
+        'multica.issue.id': 'issue-1',
+        'multica.agent.name': 'codex-agent',
+        'multica.runtime.name': 'codex',
+      },
+      received_at: new Date().toISOString(),
+    });
+    await writeTranscript(sessionDir, completedTurn());
+
+    await waitFor(() => entries.filter(entry => entry['event.name'] === 'llm.response').length === 3);
+    await input.stop();
+
+    expect(new Set(entries.map(entry => entry['event.name']))).toEqual(new Set([
+      'other',
+      'llm.request',
+      'llm.response',
+      'tool.call',
+      'tool.result',
+    ]));
+    for (const entry of entries) {
+      expect(entry['multica.issue.id']).toBe('issue-1');
+      expect(entry['multica.agent.name']).toBe('codex-agent');
+      expect(entry['multica.runtime.name']).toBe('codex');
+    }
+  });
+
+  it('keeps invocation attributes isolated by turn within one Codex session', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-span-isolation-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, spanContextDir } = await createInput(root);
+    await writeSpanContext(spanContextDir, 'session-1', 'turn-1', {
+      session_id: 'session-1',
+      turn_id: 'turn-1',
+      spanAttributes: { 'multica.issue.id': 'issue-1' },
+      received_at: new Date().toISOString(),
+    });
+    await writeSpanContext(spanContextDir, 'session-1', 'turn-2', {
+      session_id: 'session-1',
+      turn_id: 'turn-2',
+      spanAttributes: { 'multica.issue.id': 'issue-2' },
+      received_at: new Date().toISOString(),
+    });
+    await writeTranscriptNamed(
+      sessionDir,
+      'rollout-session-1.jsonl',
+      [
+        ...simpleCompletedTurn(
+          'session-1', 'turn-1', 'first issue', 'first completed', 100, 10,
+          '2026-06-24T06:00:00.000Z',
+        ),
+        ...simpleCompletedTurn(
+          'session-1', 'turn-2', 'second issue', 'second completed', 120, 12,
+          '2026-06-24T06:01:00.000Z',
+        ).slice(1),
+      ].join('\n') + '\n',
+    );
+
+    await waitFor(() => responsesForTurn(entries, 'turn-2').length === 1);
+    await input.stop();
+
+    const firstTurnEntries = entries.filter(entry =>
+      entry['agent.codex.transcript_turn_id'] === 'turn-1');
+    const secondTurnEntries = entries.filter(entry =>
+      entry['agent.codex.transcript_turn_id'] === 'turn-2');
+    expect(firstTurnEntries.length).toBeGreaterThan(0);
+    expect(secondTurnEntries.length).toBeGreaterThan(0);
+    expect(new Set(firstTurnEntries.map(entry => entry['multica.issue.id']))).toEqual(new Set(['issue-1']));
+    expect(new Set(secondTurnEntries.map(entry => entry['multica.issue.id']))).toEqual(new Set(['issue-2']));
+  });
+
+  it('defensively filters invalid invocation attributes from span contexts', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-span-filter-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, spanContextDir } = await createInput(root);
+    const longValue = 'x'.repeat(513);
+    await writeSpanContext(spanContextDir, 'session-1', 'turn-1', {
+      session_id: 'session-1',
+      turn_id: 'turn-1',
+      spanAttributes: {
+        'multica.issue.id': ' issue-1 ',
+        'gen_ai.agent.name': 'must-not-overwrite',
+        'multica.api_token': 'must-not-leak',
+        'multica.long': longValue,
+        'multica.number': 42,
+      },
+      received_at: new Date().toISOString(),
+    });
+    await writeTranscript(sessionDir, completedTurn());
+
+    await waitFor(() => entries.filter(entry => entry['event.name'] === 'llm.response').length === 3);
+    await input.stop();
+
+    for (const entry of entries) {
+      expect(entry['multica.issue.id']).toBe('issue-1');
+      expect(entry['gen_ai.agent.name']).not.toBe('must-not-overwrite');
+      expect(entry['multica.api_token']).toBeUndefined();
+      expect(entry['multica.long']).toBeUndefined();
+      expect(entry['multica.number']).toBeUndefined();
+    }
+    expect(JSON.stringify(entries)).not.toContain('must-not-leak');
+    expect(JSON.stringify(entries)).not.toContain(longValue);
+  });
+
+  it('rejects a span context whose payload identifiers do not match its file name', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-span-mismatch-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, spanContextDir } = await createInput(root);
+    await writeSpanContext(spanContextDir, 'session-1', 'turn-1', {
+      session_id: 'different-session',
+      turn_id: 'turn-1',
+      spanAttributes: { 'multica.issue.id': 'wrong-issue' },
+      received_at: new Date().toISOString(),
+    });
+    await writeTranscript(sessionDir, completedTurn());
+
+    await waitFor(() => entries.filter(entry => entry['event.name'] === 'llm.response').length === 3);
+    await input.stop();
+
+    expect(entries.every(entry => entry['multica.issue.id'] === undefined)).toBe(true);
+  });
+
+  it('removes expired turn span contexts with bounded cleanup', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-span-cleanup-'));
+    tempDirs.push(root);
+    const { input, spanContextDir } = await createDormantInput(root);
+    const marker = await writeSpanContext(spanContextDir, 'session-1', 'turn-1', {
+      session_id: 'session-1',
+      turn_id: 'turn-1',
+      spanAttributes: { 'multica.issue.id': 'expired-issue' },
+      received_at: new Date(Date.now() - 49 * 60 * 60 * 1_000).toISOString(),
+    });
+
+    await (input as unknown as {
+      cleanupExpiredSpanContexts(now: number): Promise<void>;
+    }).cleanupExpiredSpanContexts(Date.now());
+
+    await expect(fs.access(marker)).rejects.toThrow();
   });
 
   it('debug logs when an existing wakeup marker lacks resourceAttributes', async () => {
@@ -1140,6 +1314,7 @@ describe('CodexTranscriptInput', () => {
       stateStore: loadedState,
       sessionDir,
       wakeupDir: path.join(root, 'wakeups'),
+      spanContextDir: path.join(root, 'span-contexts'),
       pollIntervalMs: 60_000,
     });
     const entries: AgentActivityEntry[] = [];
@@ -1371,7 +1546,9 @@ describe('CodexTranscriptInput', () => {
   it('keeps token-delimited message waves as separate steps across collection cycles', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-message-waves-'));
     tempDirs.push(root);
-    const { input, entries, sessionDir, stateStore } = await createInput(root, 60_000);
+    // This test drives processFile directly; keep the background poller dormant
+    // so it cannot race the explicit collection cycles below.
+    const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
     const firstWave = [
       record('2026-06-24T06:00:00.000Z', 'session_meta', { id: 'session-1', model_provider: 'openai' }),
       record('2026-06-24T06:00:01.000Z', 'turn_context', { turn_id: 'turn-1', model: 'gpt-5.5' }),


### PR DESCRIPTION
## Summary

- parse LOONGSUITE_PILOT_SPAN_ATTRIBUTES from Codex UserPromptSubmit hooks, with Stop as a fail-open fallback
- persist invocation attributes by session and turn before publishing the transcript wakeup marker
- project validated attributes onto every recovered Codex transcript record and clean up expired contexts
- document Codex passthrough support and add hook, isolation, filtering, and cleanup coverage

## Testing

- pnpm typecheck
- pnpm build
- targeted Codex hook, transcript input, shared parser, and OTLP conversion tests: 77 passed
- full pnpm test: 2024 passed, 5 skipped, 1 unrelated local-worker activation test failed because its temporary capture file was not created; the same test also fails when rerun alone