### PR TITLE
fix(cursor): stabilize trace step assembly

### DIFF
--- a/assets/hooks/cursor/react-assembler.mjs
+++ b/assets/hooks/cursor/react-assembler.mjs
@@ -286,7 +286,7 @@ function buildParentSteps(events, ctx) {
   let pendingToolResults = [];
   const synthesizedSubagentIds = new Set();
 
-  const stepEvents = events.filter(e =>
+  const stepEvents = dedupeAfterAgentThoughtEvents(events).filter(e =>
     e.hook_event === 'afterAgentThought' ||
     e.hook_event === 'afterAgentResponse' ||
     e.hook_event === 'preToolUse' ||
@@ -295,6 +295,34 @@ function buildParentSteps(events, ctx) {
   );
 
   const stepToolCalls = new Map();
+  const activeSyncToolCalls = new Map();
+
+  function syncToolKey(ev) {
+    return `${ev.tool_use_id || ''}\u0000${ev.tool_name || ''}`;
+  }
+
+  function markSyncToolStarted(ev) {
+    if (isSubagentTool(ev.tool_name)) return;
+    const key = syncToolKey(ev);
+    activeSyncToolCalls.set(key, (activeSyncToolCalls.get(key) || 0) + 1);
+  }
+
+  function markSyncToolFinished(ev) {
+    if (isSubagentTool(ev.tool_name)) return;
+    const key = syncToolKey(ev);
+    const count = activeSyncToolCalls.get(key) || 0;
+    if (count <= 1) activeSyncToolCalls.delete(key);
+    else activeSyncToolCalls.set(key, count - 1);
+  }
+
+  function canOpenStepAfterTools(ev) {
+    if (!currentStepHasTools) return false;
+    if (activeSyncToolCalls.size > 0) return false;
+    if (previousToolResults.length === 0) return false;
+
+    const latestResultEndTs = latestToolResultEndTs(previousToolResults);
+    return latestResultEndTs == null || tsMs(ev) >= timestampMs(latestResultEndTs);
+  }
 
   function finalizeCurrentLlmResponse() {
     if (!currentLlmResponse) return;
@@ -366,9 +394,14 @@ function buildParentSteps(events, ctx) {
     // Compute delta for this step:
     //   s1: user prompt (if any) — already pre-seeded in cumulative.
     //   s2+: tool results from previous step — append to cumulative.
+    const latestResultEndTs = latestToolResultEndTs(previousToolResults);
     const deltaMessages = buildDeltaMessages(isFirst, userPrompt, previousToolResults, cumulativeInputMessages);
 
-    const { timestamp: reqTs, source: reqTsSource } = llmRequestStartTime(ev, lastStepEndTs);
+    const requestStart = llmRequestStartTime(ev, lastStepEndTs);
+    const { timestamp: reqTs, source: reqTsSource } = clampRequestStartToToolResults(
+      requestStart,
+      latestResultEndTs,
+    );
     records.push(buildLlmRequestWithTs(
       reqTs, ev, ctx, currentStepId,
       deltaMessages,
@@ -405,7 +438,7 @@ function buildParentSteps(events, ctx) {
   for (const ev of stepEvents) {
 
     if (ev.hook_event === 'afterAgentThought') {
-      if (currentStepId === null || currentStepHasTools) {
+      if (currentStepId === null || canOpenStepAfterTools(ev)) {
         openNewStep(ev, stepRound === 0, ctx.userPrompt);
         currentLlmResponse = buildLlmResponse(ev, ctx, currentStepId, 'reasoning');
         if (flushPendingTools(currentStepId)) currentStepHasTools = true;
@@ -426,7 +459,7 @@ function buildParentSteps(events, ctx) {
         openImplicitStep(reqTs, reqTsSource);
       }
 
-      if (currentStepId !== null && currentStepHasTools) {
+      if (currentStepId !== null && canOpenStepAfterTools(ev)) {
         openNewStep(ev, false, null);
         currentLlmResponse = buildLlmResponseWithToken(ev, ctx, currentStepId, 'text');
         if (flushPendingTools(currentStepId)) currentStepHasTools = true;
@@ -445,6 +478,7 @@ function buildParentSteps(events, ctx) {
     }
 
     else if (ev.hook_event === 'preToolUse') {
+      markSyncToolStarted(ev);
       if (!currentStepId) {
         pendingToolRecords.push(buildToolCall(ev, ctx, '__pending__'));
         pendingToolCalls.push({
@@ -457,7 +491,12 @@ function buildParentSteps(events, ctx) {
         if (isSubagentTool(ev.tool_name) && ctx.subagentResults?.has(ev.tool_use_id)) {
           const sr = ctx.subagentResults.get(ev.tool_use_id);
           pendingToolRecords.push(buildSubagentResult(ev, sr, ctx, '__pending__'));
-          pendingToolResults.push({ toolName: ev.tool_name, toolUseId: ev.tool_use_id, result: sr.resultText });
+          pendingToolResults.push({
+            toolName: ev.tool_name,
+            toolUseId: ev.tool_use_id,
+            result: sr.resultText,
+            endTs: sr.endTs,
+          });
           if (ev.tool_use_id) synthesizedSubagentIds.add(ev.tool_use_id);
         }
       } else {
@@ -471,7 +510,12 @@ function buildParentSteps(events, ctx) {
           toolObservedAt = childStartTs;
           records.push(buildToolCallWithTs(childStartTs, ev, ctx, currentStepId));
           records.push(buildSubagentResult(ev, sr, ctx, currentStepId));
-          previousToolResults.push({ toolName: ev.tool_name, toolUseId: ev.tool_use_id, result: sr.resultText });
+          previousToolResults.push({
+            toolName: ev.tool_name,
+            toolUseId: ev.tool_use_id,
+            result: sr.resultText,
+            endTs: sr.endTs,
+          });
           lastStepEndTs = sr.endTs;
           if (ev.tool_use_id) synthesizedSubagentIds.add(ev.tool_use_id);
         } else {
@@ -490,16 +534,29 @@ function buildParentSteps(events, ctx) {
     }
 
     else if (ev.hook_event === 'postToolUse' || ev.hook_event === 'postToolUseFailure') {
-      if (synthesizedSubagentIds.has(ev.tool_use_id)) continue;
+      if (isSubagentTool(ev.tool_name) && synthesizedSubagentIds.has(ev.tool_use_id)) continue;
+      markSyncToolFinished(ev);
 
       if (!currentStepId) {
         pendingToolRecords.push(buildToolResult(ev, ctx, '__pending__'));
         applyToolDurationToCall(pendingToolRecords, '__pending__', ev);
-        pendingToolResults.push({ toolName: ev.tool_name, toolUseId: ev.tool_use_id, result: ev.tool_output, error: ev.error_message });
+        pendingToolResults.push({
+          toolName: ev.tool_name,
+          toolUseId: ev.tool_use_id,
+          result: ev.tool_output,
+          error: ev.error_message,
+          endTs: ev._journal_ts,
+        });
       } else {
         applyToolDurationToCall(records, currentStepId, ev);
         records.push(buildToolResult(ev, ctx, currentStepId));
-        previousToolResults.push({ toolName: ev.tool_name, toolUseId: ev.tool_use_id, result: ev.tool_output, error: ev.error_message });
+        previousToolResults.push({
+          toolName: ev.tool_name,
+          toolUseId: ev.tool_use_id,
+          result: ev.tool_output,
+          error: ev.error_message,
+          endTs: ev._journal_ts,
+        });
         // Track step end time
         lastStepEndTs = ev._journal_ts;
       }
@@ -817,6 +874,20 @@ function llmRequestStartTime(ev, fallbackTs) {
   };
 }
 
+function clampRequestStartToToolResults(requestStart, latestResultEndTs) {
+  if (latestResultEndTs == null) return requestStart;
+  const requestStartMs = timestampMs(requestStart.timestamp);
+  const latestResultEndMs = timestampMs(latestResultEndTs);
+  if (!Number.isFinite(requestStartMs) || !Number.isFinite(latestResultEndMs)) {
+    return requestStart;
+  }
+  if (requestStartMs >= latestResultEndMs) return requestStart;
+  return {
+    timestamp: latestResultEndTs,
+    source: 'previous_tool_result_end',
+  };
+}
+
 function durationStartMs(ev) {
   const endMs = tsMs(ev);
   const durationMs = Number(ev?.duration_ms);
@@ -825,6 +896,91 @@ function durationStartMs(ev) {
 }
 
 // ─── Helpers ───
+
+/**
+ * Cursor can emit each logical afterAgentThought twice: once with the base
+ * generation id and once with a "<base>-<index>-<random>" id. Pair these
+ * variants exactly and drop only the suffixed copy. There is intentionally no
+ * timing window: hook process scheduling can delay the duplicate arbitrarily.
+ */
+function dedupeAfterAgentThoughtEvents(events) {
+  const thoughtEvents = events.filter(event =>
+    event.hook_event === 'afterAgentThought' &&
+    typeof event.generation_id === 'string'
+  );
+  const generationIds = new Set(thoughtEvents.map(event => event.generation_id));
+  const annotated = events.map(event => {
+    if (
+      event.hook_event !== 'afterAgentThought' ||
+      typeof event.conversation_id !== 'string' ||
+      typeof event.generation_id !== 'string' ||
+      typeof event.text !== 'string'
+    ) {
+      return { event, duplicateKey: null, isSuffixedVariant: false };
+    }
+
+    const durationMs = Number(event.duration_ms);
+    if (!Number.isFinite(durationMs)) {
+      return { event, duplicateKey: null, isSuffixedVariant: false };
+    }
+
+    const suffixMatch = event.generation_id.match(/^(.+)-(\d+)-([a-z0-9]{4,})$/i);
+    const suffixBase = suffixMatch?.[1];
+    const isSuffixedVariant = Boolean(suffixBase && generationIds.has(suffixBase));
+    const canonicalGenerationId = isSuffixedVariant
+      ? suffixBase
+      : event.generation_id;
+    const duplicateKey = JSON.stringify([
+      event.conversation_id,
+      canonicalGenerationId,
+      event.text,
+      durationMs,
+    ]);
+    return { event, duplicateKey, isSuffixedVariant };
+  });
+
+  const availableBaseCounts = new Map();
+  for (const item of annotated) {
+    if (item.duplicateKey && !item.isSuffixedVariant) {
+      availableBaseCounts.set(
+        item.duplicateKey,
+        (availableBaseCounts.get(item.duplicateKey) || 0) + 1,
+      );
+    }
+  }
+
+  const consumedBaseCounts = new Map();
+  return annotated
+    .filter(item => {
+      if (!item.duplicateKey || !item.isSuffixedVariant) return true;
+      const available = availableBaseCounts.get(item.duplicateKey) || 0;
+      const consumed = consumedBaseCounts.get(item.duplicateKey) || 0;
+      if (consumed >= available) return true;
+      consumedBaseCounts.set(item.duplicateKey, consumed + 1);
+      return false;
+    })
+    .map(item => item.event);
+}
+
+function latestToolResultEndTs(toolResults) {
+  let latestTs = null;
+  let latestMs = Number.NEGATIVE_INFINITY;
+  for (const result of toolResults) {
+    const endMs = timestampMs(result?.endTs);
+    if (Number.isFinite(endMs) && endMs > latestMs) {
+      latestMs = endMs;
+      latestTs = result.endTs;
+    }
+  }
+  return latestTs;
+}
+
+function timestampMs(value) {
+  if (typeof value === 'number') return value;
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === 'string') return new Date(value).getTime();
+  return Number.NaN;
+}
 
 function appendPart(llmResponse, partType, text) {
   const msgs = llmResponse['gen_ai.output.messages'];

--- a/assets/hooks/cursor/react-assembler.mjs
+++ b/assets/hooks/cursor/react-assembler.mjs
@@ -301,6 +301,31 @@ function buildParentSteps(events, ctx) {
     return `${ev.tool_use_id || ''}\u0000${ev.tool_name || ''}`;
   }
 
+  function parseSyncToolKey(key) {
+    const separatorIndex = key.indexOf('\u0000');
+    return {
+      toolUseId: separatorIndex >= 0 ? key.slice(0, separatorIndex) : key,
+      toolName: separatorIndex >= 0 ? key.slice(separatorIndex + 1) : '',
+    };
+  }
+
+  function drainActiveSyncTool(key) {
+    const count = activeSyncToolCalls.get(key) || 0;
+    if (count <= 1) activeSyncToolCalls.delete(key);
+    else activeSyncToolCalls.set(key, count - 1);
+  }
+
+  function syncToolCompletionMatches(key, ev) {
+    const active = parseSyncToolKey(key);
+    const resultToolUseId = ev.tool_use_id || '';
+    const resultToolName = ev.tool_name || '';
+    if (active.toolName !== resultToolName) return false;
+    if (active.toolUseId && resultToolUseId) {
+      return active.toolUseId === resultToolUseId;
+    }
+    return true;
+  }
+
   function markSyncToolStarted(ev) {
     if (isSubagentTool(ev.tool_name)) return;
     const key = syncToolKey(ev);
@@ -310,15 +335,52 @@ function buildParentSteps(events, ctx) {
   function markSyncToolFinished(ev) {
     if (isSubagentTool(ev.tool_name)) return;
     const key = syncToolKey(ev);
-    const count = activeSyncToolCalls.get(key) || 0;
-    if (count <= 1) activeSyncToolCalls.delete(key);
-    else activeSyncToolCalls.set(key, count - 1);
+    if (activeSyncToolCalls.has(key)) {
+      drainActiveSyncTool(key);
+      return;
+    }
+
+    // Cursor occasionally omits tool_use_id on one side of the hook pair.
+    // Fall back to tool name only when it identifies exactly one active call.
+    const fallbackKeys = [...activeSyncToolCalls.keys()]
+      .filter(activeKey => syncToolCompletionMatches(activeKey, ev));
+    if (fallbackKeys.length === 1) {
+      drainActiveSyncTool(fallbackKeys[0]);
+    }
   }
 
-  function canOpenStepAfterTools(ev) {
+  function recoverLeakedSyncTools(eventIndex) {
+    let recovered = false;
+    for (const [key, activeCount] of activeSyncToolCalls) {
+      let remainingCompletions = 0;
+      for (let i = eventIndex + 1; i < stepEvents.length; i++) {
+        const futureEvent = stepEvents[i];
+        if (
+          (futureEvent.hook_event === 'postToolUse' ||
+            futureEvent.hook_event === 'postToolUseFailure') &&
+          !isSubagentTool(futureEvent.tool_name) &&
+          syncToolCompletionMatches(key, futureEvent)
+        ) {
+          remainingCompletions++;
+        }
+      }
+
+      if (remainingCompletions === 0) {
+        activeSyncToolCalls.delete(key);
+        recovered = true;
+      } else if (remainingCompletions < activeCount) {
+        activeSyncToolCalls.set(key, remainingCompletions);
+        recovered = true;
+      }
+    }
+    return recovered;
+  }
+
+  function canOpenStepAfterTools(ev, eventIndex) {
     if (!currentStepHasTools) return false;
+    const recoveredLeakedTool = recoverLeakedSyncTools(eventIndex);
     if (activeSyncToolCalls.size > 0) return false;
-    if (previousToolResults.length === 0) return false;
+    if (previousToolResults.length === 0) return recoveredLeakedTool;
 
     const latestResultEndTs = latestToolResultEndTs(previousToolResults);
     return latestResultEndTs == null || tsMs(ev) >= timestampMs(latestResultEndTs);
@@ -435,10 +497,11 @@ function buildParentSteps(events, ctx) {
     currentStepHasTools = true;
   }
 
-  for (const ev of stepEvents) {
+  for (let eventIndex = 0; eventIndex < stepEvents.length; eventIndex++) {
+    const ev = stepEvents[eventIndex];
 
     if (ev.hook_event === 'afterAgentThought') {
-      if (currentStepId === null || canOpenStepAfterTools(ev)) {
+      if (currentStepId === null || canOpenStepAfterTools(ev, eventIndex)) {
         openNewStep(ev, stepRound === 0, ctx.userPrompt);
         currentLlmResponse = buildLlmResponse(ev, ctx, currentStepId, 'reasoning');
         if (flushPendingTools(currentStepId)) currentStepHasTools = true;
@@ -459,7 +522,7 @@ function buildParentSteps(events, ctx) {
         openImplicitStep(reqTs, reqTsSource);
       }
 
-      if (currentStepId !== null && canOpenStepAfterTools(ev)) {
+      if (currentStepId !== null && canOpenStepAfterTools(ev, eventIndex)) {
         openNewStep(ev, false, null);
         currentLlmResponse = buildLlmResponseWithToken(ev, ctx, currentStepId, 'text');
         if (flushPendingTools(currentStepId)) currentStepHasTools = true;

--- a/tests/unit/hooks/cursor-react-assembler.test.ts
+++ b/tests/unit/hooks/cursor-react-assembler.test.ts
@@ -159,6 +159,233 @@ describe('Cursor react assembler', () => {
     });
   });
 
+  it('deduplicates exact base/suffixed afterAgentThought pairs without a timing window', () => {
+    const { records } = assembleTurn([
+      {
+        _journal_ts: iso(0),
+        hook_event: 'beforeSubmitPrompt',
+        conversation_id: 'conv-thought-dedupe',
+        generation_id: 'turn-thought-dedupe',
+        model: 'gpt-5.4',
+        prompt: 'inspect the file',
+      },
+      {
+        _journal_ts: iso(100),
+        hook_event: 'afterAgentThought',
+        conversation_id: 'conv-thought-dedupe',
+        generation_id: 'turn-thought-dedupe',
+        model: 'gpt-5.4',
+        text: 'I will read the file.',
+        duration_ms: 80,
+      },
+      {
+        _journal_ts: iso(200),
+        hook_event: 'preToolUse',
+        conversation_id: 'conv-thought-dedupe',
+        generation_id: 'turn-thought-dedupe',
+        tool_name: 'Read',
+        tool_use_id: 'call-thought-dedupe',
+        tool_input: { path: 'a.ts' },
+      },
+      {
+        _journal_ts: iso(300),
+        hook_event: 'postToolUse',
+        conversation_id: 'conv-thought-dedupe',
+        generation_id: 'turn-thought-dedupe',
+        tool_name: 'Read',
+        tool_use_id: 'call-thought-dedupe',
+        tool_output: 'file contents',
+        duration_ms: 100,
+      },
+      {
+        // The duplicate is intentionally delayed well beyond 100ms.
+        _journal_ts: iso(5000),
+        hook_event: 'afterAgentThought',
+        conversation_id: 'conv-thought-dedupe',
+        generation_id: 'turn-thought-dedupe-0-rgr9',
+        model: 'gpt-5.4',
+        text: 'I will read the file.',
+        duration_ms: 80,
+      },
+      {
+        _journal_ts: iso(5200),
+        hook_event: 'afterAgentThought',
+        conversation_id: 'conv-thought-dedupe',
+        generation_id: 'turn-thought-dedupe',
+        model: 'gpt-5.4',
+        text: 'Now I can answer.',
+        duration_ms: 100,
+      },
+      {
+        _journal_ts: iso(5300),
+        hook_event: 'afterAgentResponse',
+        conversation_id: 'conv-thought-dedupe',
+        generation_id: 'turn-thought-dedupe',
+        model: 'gpt-5.4',
+        text: 'done',
+      },
+      {
+        _journal_ts: iso(5400),
+        hook_event: 'stop',
+        conversation_id: 'conv-thought-dedupe',
+        generation_id: 'turn-thought-dedupe',
+        status: 'completed',
+      },
+    ], { stopConversationId: 'conv-thought-dedupe' });
+
+    const requests = records.filter(record => record['event.name'] === 'llm.request');
+    const secondResponse = records.find(record =>
+      record['event.name'] === 'llm.response' &&
+      record['gen_ai.step.id'] === 'turn-thought-dedupe:s2'
+    );
+    const reasoningParts = secondResponse?.['gen_ai.output.messages']?.[0]?.parts
+      ?.filter((part: Record<string, unknown>) => part.type === 'reasoning') ?? [];
+
+    expect(requests).toHaveLength(2);
+    expect(reasoningParts).toEqual([
+      { type: 'reasoning', content: 'Now I can answer.' },
+    ]);
+  });
+
+  it('does not deduplicate identical base afterAgentThought events without a suffixed pair', () => {
+    const { records } = assembleTurn([
+      {
+        _journal_ts: iso(0),
+        hook_event: 'beforeSubmitPrompt',
+        conversation_id: 'conv-base-thoughts',
+        generation_id: 'turn-base-thoughts',
+        model: 'gpt-5.4',
+        prompt: 'continue',
+      },
+      {
+        _journal_ts: iso(100),
+        hook_event: 'afterAgentThought',
+        conversation_id: 'conv-base-thoughts',
+        generation_id: 'turn-base-thoughts',
+        model: 'gpt-5.4',
+        text: 'Same text can be emitted by two real callbacks.',
+        duration_ms: 80,
+      },
+      {
+        _journal_ts: iso(200),
+        hook_event: 'afterAgentThought',
+        conversation_id: 'conv-base-thoughts',
+        generation_id: 'turn-base-thoughts',
+        model: 'gpt-5.4',
+        text: 'Same text can be emitted by two real callbacks.',
+        duration_ms: 80,
+      },
+      {
+        _journal_ts: iso(300),
+        hook_event: 'stop',
+        conversation_id: 'conv-base-thoughts',
+        generation_id: 'turn-base-thoughts',
+        status: 'completed',
+      },
+    ], { stopConversationId: 'conv-base-thoughts' });
+
+    const response = records.find(record => record['event.name'] === 'llm.response');
+    const reasoningParts = response?.['gen_ai.output.messages']?.[0]?.parts
+      ?.filter((part: Record<string, unknown>) => part.type === 'reasoning') ?? [];
+
+    expect(reasoningParts).toHaveLength(2);
+  });
+
+  it('does not open a new step while a synchronous tool is still active', () => {
+    const { records } = assembleTurn([
+      {
+        _journal_ts: iso(0),
+        hook_event: 'beforeSubmitPrompt',
+        conversation_id: 'conv-active-tool',
+        generation_id: 'turn-active-tool',
+        model: 'gpt-5.4',
+        prompt: 'inspect the file',
+      },
+      {
+        _journal_ts: iso(100),
+        hook_event: 'afterAgentThought',
+        conversation_id: 'conv-active-tool',
+        generation_id: 'turn-active-tool',
+        model: 'gpt-5.4',
+        text: 'I will inspect it.',
+        duration_ms: 80,
+      },
+      {
+        _journal_ts: iso(200),
+        hook_event: 'preToolUse',
+        conversation_id: 'conv-active-tool',
+        generation_id: 'turn-active-tool',
+        tool_name: 'Read',
+        tool_use_id: 'call-active-read',
+        tool_input: { path: 'a.ts' },
+      },
+      {
+        _journal_ts: iso(300),
+        hook_event: 'afterAgentThought',
+        conversation_id: 'conv-active-tool',
+        generation_id: 'turn-active-tool',
+        model: 'gpt-5.4',
+        text: 'This callback arrived before the read result.',
+        duration_ms: 50,
+      },
+      {
+        _journal_ts: iso(500),
+        hook_event: 'postToolUse',
+        conversation_id: 'conv-active-tool',
+        generation_id: 'turn-active-tool',
+        tool_name: 'Read',
+        tool_use_id: 'call-active-read',
+        tool_output: 'file contents',
+        duration_ms: 300,
+      },
+      {
+        _journal_ts: iso(700),
+        hook_event: 'afterAgentThought',
+        conversation_id: 'conv-active-tool',
+        generation_id: 'turn-active-tool',
+        model: 'gpt-5.4',
+        text: 'Now the result is available.',
+        duration_ms: 100,
+      },
+      {
+        _journal_ts: iso(800),
+        hook_event: 'afterAgentResponse',
+        conversation_id: 'conv-active-tool',
+        generation_id: 'turn-active-tool',
+        model: 'gpt-5.4',
+        text: 'done',
+      },
+      {
+        _journal_ts: iso(900),
+        hook_event: 'stop',
+        conversation_id: 'conv-active-tool',
+        generation_id: 'turn-active-tool',
+        status: 'completed',
+      },
+    ], { stopConversationId: 'conv-active-tool' });
+
+    const requests = records.filter(record => record['event.name'] === 'llm.request');
+    const firstResponse = records.find(record =>
+      record['event.name'] === 'llm.response' &&
+      record['gen_ai.step.id'] === 'turn-active-tool:s1'
+    );
+    const secondRequest = records.find(record =>
+      record['event.name'] === 'llm.request' &&
+      record['gen_ai.step.id'] === 'turn-active-tool:s2'
+    );
+    const firstReasoning = firstResponse?.['gen_ai.output.messages']?.[0]?.parts
+      ?.filter((part: Record<string, unknown>) => part.type === 'reasoning')
+      ?.map((part: Record<string, unknown>) => part.content);
+
+    expect(requests).toHaveLength(2);
+    expect(firstReasoning).toEqual([
+      'I will inspect it.',
+      'This callback arrived before the read result.',
+    ]);
+    expect(BigInt(secondRequest!.time_unix_nano)).toBeGreaterThanOrEqual(BigInt(ns(500)));
+    expect(secondRequest?.['gen_ai.input.messages_delta']?.[0]?.parts).toHaveLength(1);
+  });
+
   it('guards LLM spans by moving start before the earliest buffered tool call', () => {
     const { records } = assembleTurn([
       {
@@ -398,6 +625,318 @@ describe('Cursor react assembler', () => {
         parts: [{ type: 'text', content: 'delegate this' }],
       });
       expect(secondStepFull[1]).toMatchObject({ role: 'tool' });
+    } finally {
+      fs.rmSync(transcriptDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not consume a pre-collected Subagent result before its endTs', () => {
+    const transcriptDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-subagent-causality-'));
+    try {
+      const parentTranscriptPath = path.join(transcriptDir, 'parent.jsonl');
+      const subagentDir = path.join(transcriptDir, 'subagents');
+      const childConvId = 'child-causality';
+      fs.mkdirSync(subagentDir, { recursive: true });
+      fs.writeFileSync(path.join(subagentDir, `${childConvId}.jsonl`), '', 'utf-8');
+
+      const { records } = assembleTurn([
+        {
+          _journal_ts: iso(0),
+          hook_event: 'beforeSubmitPrompt',
+          conversation_id: 'parent-causality',
+          generation_id: 'turn-subagent-causality',
+          model: 'gpt-5.4',
+          prompt: 'delegate this',
+        },
+        {
+          _journal_ts: iso(100),
+          hook_event: 'afterAgentThought',
+          conversation_id: 'parent-causality',
+          generation_id: 'turn-subagent-causality',
+          model: 'gpt-5.4',
+          text: 'I will delegate this.',
+          duration_ms: 80,
+        },
+        {
+          _journal_ts: iso(200),
+          hook_event: 'preToolUse',
+          conversation_id: 'parent-causality',
+          generation_id: 'turn-subagent-causality',
+          tool_name: 'Task',
+          tool_use_id: 'call-subagent-causality',
+          tool_input: { prompt: 'inspect details' },
+        },
+        {
+          _journal_ts: iso(300),
+          hook_event: 'afterAgentThought',
+          conversation_id: childConvId,
+          generation_id: 'child-turn-causality',
+          model: 'gpt-5.4',
+          text: 'Child is working.',
+          duration_ms: 50,
+        },
+        {
+          // This is a distinct callback, but it is earlier than the child endTs.
+          _journal_ts: iso(400),
+          hook_event: 'afterAgentThought',
+          conversation_id: 'parent-causality',
+          generation_id: 'turn-subagent-causality',
+          model: 'gpt-5.4',
+          text: 'The child has not finished yet.',
+          duration_ms: 100,
+        },
+        {
+          _journal_ts: iso(800),
+          hook_event: 'afterAgentResponse',
+          conversation_id: childConvId,
+          generation_id: 'child-turn-causality',
+          model: 'gpt-5.4',
+          text: 'child final result',
+        },
+        {
+          // duration_ms backdates the raw request start to 500ms. The request
+          // must still be clamped to the child result endTs at 800ms.
+          _journal_ts: iso(900),
+          hook_event: 'afterAgentThought',
+          conversation_id: 'parent-causality',
+          generation_id: 'turn-subagent-causality',
+          model: 'gpt-5.4',
+          text: 'Now I can use the child result.',
+          duration_ms: 400,
+        },
+        {
+          _journal_ts: iso(950),
+          hook_event: 'afterAgentResponse',
+          conversation_id: 'parent-causality',
+          generation_id: 'turn-subagent-causality',
+          model: 'gpt-5.4',
+          text: 'done',
+        },
+        {
+          _journal_ts: iso(1000),
+          hook_event: 'stop',
+          conversation_id: 'parent-causality',
+          generation_id: 'turn-subagent-causality',
+          transcript_path: parentTranscriptPath,
+          status: 'completed',
+        },
+      ], { stopConversationId: 'parent-causality', transcriptPath: parentTranscriptPath });
+
+      const parentRequests = records.filter(record =>
+        record['event.name'] === 'llm.request' &&
+        !record['gen_ai.agent.scope']
+      );
+      const firstResponse = records.find(record =>
+        record['event.name'] === 'llm.response' &&
+        record['gen_ai.step.id'] === 'turn-subagent-causality:s1'
+      );
+      const secondRequest = records.find(record =>
+        record['event.name'] === 'llm.request' &&
+        record['gen_ai.step.id'] === 'turn-subagent-causality:s2'
+      );
+      const firstReasoning = firstResponse?.['gen_ai.output.messages']?.[0]?.parts
+        ?.filter((part: Record<string, unknown>) => part.type === 'reasoning')
+        ?.map((part: Record<string, unknown>) => part.content);
+
+      expect(parentRequests).toHaveLength(2);
+      expect(firstReasoning).toEqual([
+        'I will delegate this.',
+        'The child has not finished yet.',
+      ]);
+      expect(secondRequest).toMatchObject({
+        time_unix_nano: ns(800),
+        observed_time_unix_nano: ns(800),
+        'agent.cursor.llm_request_time_source': 'previous_tool_result_end',
+      });
+      expect(secondRequest?.['gen_ai.input.messages_delta']?.[0]?.parts?.[0]).toMatchObject({
+        type: 'tool_call_response',
+        id: 'call-subagent-causality',
+        response: 'child final result',
+      });
+    } finally {
+      fs.rmSync(transcriptDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps parallel Task calls from a duplicated thought in the same parent step', () => {
+    const transcriptDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-parallel-subagents-'));
+    try {
+      const parentTranscriptPath = path.join(transcriptDir, 'parent.jsonl');
+      const subagentDir = path.join(transcriptDir, 'subagents');
+      fs.mkdirSync(subagentDir, { recursive: true });
+      fs.writeFileSync(path.join(subagentDir, 'child-task-1.jsonl'), '', 'utf-8');
+      fs.writeFileSync(path.join(subagentDir, 'child-task-2.jsonl'), '', 'utf-8');
+
+      const { records } = assembleTurn([
+        {
+          _journal_ts: iso(0),
+          hook_event: 'beforeSubmitPrompt',
+          conversation_id: 'parent-parallel',
+          generation_id: 'turn-parallel',
+          model: 'composer-2.5-fast',
+          prompt: 'run two subagents in parallel',
+        },
+        {
+          _journal_ts: iso(100),
+          hook_event: 'afterAgentThought',
+          conversation_id: 'parent-parallel',
+          generation_id: 'turn-parallel',
+          model: 'composer-2.5-fast',
+          text: 'I will launch both tasks in parallel.',
+          duration_ms: 80,
+        },
+        {
+          _journal_ts: iso(200),
+          hook_event: 'preToolUse',
+          conversation_id: 'parent-parallel',
+          generation_id: 'turn-parallel',
+          tool_name: 'Task',
+          tool_use_id: 'call-task-1',
+          tool_input: { prompt: 'solve task 1' },
+        },
+        {
+          _journal_ts: iso(210),
+          hook_event: 'afterAgentThought',
+          conversation_id: 'parent-parallel',
+          generation_id: 'turn-parallel-0-rgr9',
+          model: 'composer-2.5-fast',
+          text: 'I will launch both tasks in parallel.',
+          duration_ms: 80,
+        },
+        {
+          _journal_ts: iso(220),
+          hook_event: 'preToolUse',
+          conversation_id: 'parent-parallel',
+          generation_id: 'turn-parallel',
+          tool_name: 'Task',
+          tool_use_id: 'call-task-2',
+          tool_input: { prompt: 'solve task 2' },
+        },
+        {
+          _journal_ts: iso(300),
+          hook_event: 'afterAgentThought',
+          conversation_id: 'child-task-1',
+          generation_id: 'child-turn-1',
+          model: 'composer-2.5-fast',
+          text: 'working on task 1',
+          duration_ms: 40,
+        },
+        {
+          _journal_ts: iso(320),
+          hook_event: 'afterAgentThought',
+          conversation_id: 'child-task-2',
+          generation_id: 'child-turn-2',
+          model: 'composer-2.5-fast',
+          text: 'working on task 2',
+          duration_ms: 40,
+        },
+        {
+          _journal_ts: iso(500),
+          hook_event: 'afterAgentResponse',
+          conversation_id: 'child-task-1',
+          generation_id: 'child-turn-1',
+          model: 'composer-2.5-fast',
+          text: 'task 1 result',
+        },
+        {
+          _journal_ts: iso(600),
+          hook_event: 'afterAgentResponse',
+          conversation_id: 'child-task-2',
+          generation_id: 'child-turn-2',
+          model: 'composer-2.5-fast',
+          text: 'task 2 result',
+        },
+        {
+          _journal_ts: iso(700),
+          hook_event: 'afterAgentThought',
+          conversation_id: 'parent-parallel',
+          generation_id: 'turn-parallel',
+          model: 'composer-2.5-fast',
+          text: 'Both tasks finished; I will verify them.',
+          duration_ms: 60,
+        },
+        {
+          _journal_ts: iso(710),
+          hook_event: 'preToolUse',
+          conversation_id: 'parent-parallel',
+          generation_id: 'turn-parallel',
+          tool_name: 'Shell',
+          tool_use_id: 'call-verify-1',
+          tool_input: { command: 'verify task 1' },
+        },
+        {
+          _journal_ts: iso(720),
+          hook_event: 'preToolUse',
+          conversation_id: 'parent-parallel',
+          generation_id: 'turn-parallel',
+          tool_name: 'Shell',
+          tool_use_id: 'call-verify-2',
+          tool_input: { command: 'verify task 2' },
+        },
+        {
+          _journal_ts: iso(800),
+          hook_event: 'postToolUse',
+          conversation_id: 'parent-parallel',
+          generation_id: 'turn-parallel',
+          tool_name: 'Shell',
+          tool_use_id: 'call-verify-1',
+          tool_output: 'ok 1',
+          duration_ms: 90,
+        },
+        {
+          _journal_ts: iso(810),
+          hook_event: 'postToolUse',
+          conversation_id: 'parent-parallel',
+          generation_id: 'turn-parallel',
+          tool_name: 'Shell',
+          tool_use_id: 'call-verify-2',
+          tool_output: 'ok 2',
+          duration_ms: 90,
+        },
+        {
+          _journal_ts: iso(900),
+          hook_event: 'afterAgentThought',
+          conversation_id: 'parent-parallel',
+          generation_id: 'turn-parallel',
+          model: 'composer-2.5-fast',
+          text: 'Everything passed.',
+          duration_ms: 50,
+        },
+        {
+          _journal_ts: iso(950),
+          hook_event: 'afterAgentResponse',
+          conversation_id: 'parent-parallel',
+          generation_id: 'turn-parallel',
+          model: 'composer-2.5-fast',
+          text: 'done',
+        },
+        {
+          _journal_ts: iso(1000),
+          hook_event: 'stop',
+          conversation_id: 'parent-parallel',
+          generation_id: 'turn-parallel',
+          transcript_path: parentTranscriptPath,
+          status: 'completed',
+        },
+      ], { stopConversationId: 'parent-parallel', transcriptPath: parentTranscriptPath });
+
+      const parentRecords = records.filter(record => !record['gen_ai.agent.scope']);
+      const parentRequests = parentRecords.filter(record => record['event.name'] === 'llm.request');
+      const firstStepTaskCalls = parentRecords.filter(record =>
+        record['event.name'] === 'tool.call' &&
+        record['gen_ai.step.id'] === 'turn-parallel:s1' &&
+        record['gen_ai.tool.name'] === 'Task'
+      );
+      const secondRequest = parentRecords.find(record =>
+        record['event.name'] === 'llm.request' &&
+        record['gen_ai.step.id'] === 'turn-parallel:s2'
+      );
+      const secondStepInputParts = secondRequest?.['gen_ai.input.messages_delta']?.[0]?.parts ?? [];
+
+      expect(parentRequests).toHaveLength(3);
+      expect(firstStepTaskCalls).toHaveLength(2);
+      expect(secondStepInputParts).toHaveLength(2);
+      expect(BigInt(secondRequest!.time_unix_nano)).toBeGreaterThanOrEqual(BigInt(ns(600)));
     } finally {
       fs.rmSync(transcriptDir, { recursive: true, force: true });
     }

--- a/tests/unit/hooks/cursor-react-assembler.test.ts
+++ b/tests/unit/hooks/cursor-react-assembler.test.ts
@@ -386,6 +386,240 @@ describe('Cursor react assembler', () => {
     expect(secondRequest?.['gen_ai.input.messages_delta']?.[0]?.parts).toHaveLength(1);
   });
 
+  it('recovers the next step when a synchronous tool completion hook is missing', () => {
+    const { records } = assembleTurn([
+      {
+        _journal_ts: iso(0),
+        hook_event: 'beforeSubmitPrompt',
+        conversation_id: 'conv-missing-tool-result',
+        generation_id: 'turn-missing-tool-result',
+        model: 'gpt-5.4',
+        prompt: 'inspect and continue',
+      },
+      {
+        _journal_ts: iso(100),
+        hook_event: 'afterAgentThought',
+        conversation_id: 'conv-missing-tool-result',
+        generation_id: 'turn-missing-tool-result',
+        model: 'gpt-5.4',
+        text: 'I will inspect the file.',
+        duration_ms: 50,
+      },
+      {
+        _journal_ts: iso(200),
+        hook_event: 'preToolUse',
+        conversation_id: 'conv-missing-tool-result',
+        generation_id: 'turn-missing-tool-result',
+        tool_name: 'Read',
+        tool_use_id: 'call-result-never-arrives',
+        tool_input: { path: 'missing.ts' },
+      },
+      {
+        _journal_ts: iso(400),
+        hook_event: 'afterAgentThought',
+        conversation_id: 'conv-missing-tool-result',
+        generation_id: 'turn-missing-tool-result',
+        model: 'gpt-5.4',
+        text: 'I can continue despite the missing completion hook.',
+        duration_ms: 50,
+      },
+      {
+        _journal_ts: iso(500),
+        hook_event: 'preToolUse',
+        conversation_id: 'conv-missing-tool-result',
+        generation_id: 'turn-missing-tool-result',
+        tool_name: 'Shell',
+        tool_use_id: 'call-normal-shell',
+        tool_input: { command: 'echo ok' },
+      },
+      {
+        _journal_ts: iso(600),
+        hook_event: 'postToolUse',
+        conversation_id: 'conv-missing-tool-result',
+        generation_id: 'turn-missing-tool-result',
+        tool_name: 'Shell',
+        tool_use_id: 'call-normal-shell',
+        tool_output: 'ok',
+      },
+      {
+        _journal_ts: iso(800),
+        hook_event: 'afterAgentThought',
+        conversation_id: 'conv-missing-tool-result',
+        generation_id: 'turn-missing-tool-result',
+        model: 'gpt-5.4',
+        text: 'The normal tool completed.',
+        duration_ms: 50,
+      },
+      {
+        _journal_ts: iso(900),
+        hook_event: 'afterAgentResponse',
+        conversation_id: 'conv-missing-tool-result',
+        generation_id: 'turn-missing-tool-result',
+        model: 'gpt-5.4',
+        text: 'done',
+      },
+      {
+        _journal_ts: iso(1000),
+        hook_event: 'stop',
+        conversation_id: 'conv-missing-tool-result',
+        generation_id: 'turn-missing-tool-result',
+        status: 'completed',
+      },
+    ], { stopConversationId: 'conv-missing-tool-result' });
+
+    const requests = records.filter(record => record['event.name'] === 'llm.request');
+    const responses = records.filter(record => record['event.name'] === 'llm.response');
+    const secondRequest = requests.find(record =>
+      record['gen_ai.step.id'] === 'turn-missing-tool-result:s2'
+    );
+    const thirdRequest = requests.find(record =>
+      record['gen_ai.step.id'] === 'turn-missing-tool-result:s3'
+    );
+
+    expect(requests).toHaveLength(3);
+    expect(responses).toHaveLength(3);
+    expect(secondRequest?.['gen_ai.input.messages_delta']).toBeUndefined();
+    expect(thirdRequest?.['gen_ai.input.messages_delta']?.[0]?.parts).toEqual([
+      {
+        type: 'tool_call_response',
+        id: 'call-normal-shell',
+        response: 'ok',
+      },
+    ]);
+  });
+
+  it('drains active synchronous tools on postToolUseFailure', () => {
+    const { records } = assembleTurn([
+      {
+        _journal_ts: iso(0),
+        hook_event: 'beforeSubmitPrompt',
+        conversation_id: 'conv-tool-failure',
+        generation_id: 'turn-tool-failure',
+        model: 'gpt-5.4',
+        prompt: 'read a missing file',
+      },
+      {
+        _journal_ts: iso(100),
+        hook_event: 'afterAgentThought',
+        conversation_id: 'conv-tool-failure',
+        generation_id: 'turn-tool-failure',
+        model: 'gpt-5.4',
+        text: 'I will read it.',
+        duration_ms: 50,
+      },
+      {
+        _journal_ts: iso(200),
+        hook_event: 'preToolUse',
+        conversation_id: 'conv-tool-failure',
+        generation_id: 'turn-tool-failure',
+        tool_name: 'Read',
+        tool_use_id: 'call-failing-read',
+        tool_input: { path: 'missing.ts' },
+      },
+      {
+        _journal_ts: iso(300),
+        hook_event: 'postToolUseFailure',
+        conversation_id: 'conv-tool-failure',
+        generation_id: 'turn-tool-failure',
+        tool_name: 'Read',
+        tool_use_id: 'call-failing-read',
+        error_message: 'File not found',
+      },
+      {
+        _journal_ts: iso(500),
+        hook_event: 'afterAgentThought',
+        conversation_id: 'conv-tool-failure',
+        generation_id: 'turn-tool-failure',
+        model: 'gpt-5.4',
+        text: 'The read failed, so I will recover.',
+        duration_ms: 50,
+      },
+      {
+        _journal_ts: iso(600),
+        hook_event: 'afterAgentResponse',
+        conversation_id: 'conv-tool-failure',
+        generation_id: 'turn-tool-failure',
+        model: 'gpt-5.4',
+        text: 'done',
+      },
+      {
+        _journal_ts: iso(700),
+        hook_event: 'stop',
+        conversation_id: 'conv-tool-failure',
+        generation_id: 'turn-tool-failure',
+        status: 'completed',
+      },
+    ], { stopConversationId: 'conv-tool-failure' });
+
+    const requests = records.filter(record => record['event.name'] === 'llm.request');
+    expect(requests).toHaveLength(2);
+    expect(requests[1]?.['gen_ai.input.messages_delta']?.[0]?.parts).toEqual([
+      {
+        type: 'tool_call_response',
+        id: 'call-failing-read',
+        response: 'File not found',
+      },
+    ]);
+  });
+
+  it('falls back to tool name when a completion hook omits tool_use_id', () => {
+    const { records } = assembleTurn([
+      {
+        _journal_ts: iso(0),
+        hook_event: 'beforeSubmitPrompt',
+        conversation_id: 'conv-result-without-id',
+        generation_id: 'turn-result-without-id',
+        model: 'gpt-5.4',
+        prompt: 'read a file',
+      },
+      {
+        _journal_ts: iso(100),
+        hook_event: 'afterAgentThought',
+        conversation_id: 'conv-result-without-id',
+        generation_id: 'turn-result-without-id',
+        model: 'gpt-5.4',
+        text: 'I will read it.',
+        duration_ms: 50,
+      },
+      {
+        _journal_ts: iso(200),
+        hook_event: 'preToolUse',
+        conversation_id: 'conv-result-without-id',
+        generation_id: 'turn-result-without-id',
+        tool_name: 'Read',
+        tool_use_id: 'call-read-with-id',
+        tool_input: { path: 'a.ts' },
+      },
+      {
+        _journal_ts: iso(300),
+        hook_event: 'postToolUseFailure',
+        conversation_id: 'conv-result-without-id',
+        generation_id: 'turn-result-without-id',
+        tool_name: 'Read',
+        error_message: 'File not found',
+      },
+      {
+        _journal_ts: iso(500),
+        hook_event: 'afterAgentThought',
+        conversation_id: 'conv-result-without-id',
+        generation_id: 'turn-result-without-id',
+        model: 'gpt-5.4',
+        text: 'The completion omitted its id, but the next step must recover.',
+        duration_ms: 50,
+      },
+      {
+        _journal_ts: iso(600),
+        hook_event: 'stop',
+        conversation_id: 'conv-result-without-id',
+        generation_id: 'turn-result-without-id',
+        status: 'completed',
+      },
+    ], { stopConversationId: 'conv-result-without-id' });
+
+    const requests = records.filter(record => record['event.name'] === 'llm.request');
+    expect(requests).toHaveLength(2);
+  });
+
   it('guards LLM spans by moving start before the earliest buffered tool call', () => {
     const { records } = assembleTurn([
       {


### PR DESCRIPTION
## Summary

- precisely deduplicate paired base/suffixed `afterAgentThought` callbacks without a time-window assumption
- prevent a new step from opening while synchronous tools are still running
- recover leaked active-tool state when a matching completion hook is absent, without changing timestamp policy
- make synthesized Subagent results causally available at `endTs` and clamp the following request timestamp accordingly
- add regression coverage for duplicate thoughts, active/missing/failing tools, parallel Subagents, and result timing

## Validation

- `npm run typecheck`
- Cursor assembler regressions: 55 passed, 2 skipped
- full suite before the follow-up: 2001 passed, 2 skipped; 3 unrelated hook subprocess tests timed out under full concurrency and passed on isolated rerun (36/36)