### PR TITLE
feat(claude-code): gate /skill root Read synthesis to user-typed slash (XJK path) (follow-up to #194)

### DIFF
--- a/assets/hooks/claude-code-hook-processor.mjs
+++ b/assets/hooks/claude-code-hook-processor.mjs
@@ -699,11 +699,22 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
       // 显式 /skill: 保证本 turn 根 SKILL.md 恰好展示一次 Read span。
       // 去重键 = client + turnId + 归一化根路径。若本 turn 已有真实根 Read 则不合成
       // (真实事件优先);否则合成一条同 call-id 的 Read tool.call+tool.result,挂 Skill owner step。
-      if (toolName === 'Skill' && skillRootByToolId) {
+      //
+      // origin gate: 仅对 user-typed slash /skill (XJK 路径, prompt 同时含
+      // <skill-format>true</skill-format> 与 <command-name>q</command-name>) 激活合成;
+      // 模型自主调 Skill (无 markup) 不合成。Multica 托管 SDK-CLI 模式下永不触发, 属预期。
+      // per-skill-call: 仅当 user-typed q 与本 Skill tool_use 的 input.skill 精确相等才合成,
+      // 同 turn 内其它模型自主 Skill 调用 (input.skill !== q) 不合成。
+      const promptText = turn?.prompt || '';
+      const cmdNameMatch = promptText.match(/<command-name>([^<]+)<\/command-name>/);
+      const isUserTypedSkill = cmdNameMatch !== null
+        && /<skill-format>true<\/skill-format>/.test(promptText);
+      if (toolName === 'Skill' && skillRootByToolId && isUserTypedSkill) {
         const rootRaw = skillRootByToolId.get(toolId);
         const normRoot = normalizeSkillPath(cwd, rootRaw);
         if (
           normRoot &&
+          toolBlock.input?.skill === cmdNameMatch[1] &&
           !realReadPaths.has(normRoot) &&
           !synthesizedSkillRoots.has(normRoot)
         ) {

--- a/assets/hooks/claude-code-hook-processor.mjs
+++ b/assets/hooks/claude-code-hook-processor.mjs
@@ -523,11 +523,20 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
   // Phase 1: 为每个 llm_call 创建 step + 生成 LLM 事件
   const toolIdToStep = new Map(); // tool_use_id → { stepId, stepSpanId }
   const llmCalls = turn.llmCalls || [];
+  // user-typed /skill 合成挂 owner step = turn 首个 LLM step;result ts 取首个 LLM response。
+  let firstStepId = null;
+  let firstStepSpanId = null;
+  let firstLlmResponseTs = null;
 
   for (const ev of llmCalls) {
     stepRound++;
     const currentStepId = `${turnId}:s${stepRound}`;
     const currentStepSpanId = generateSpanId();
+    if (firstStepId === null) {
+      firstStepId = currentStepId;
+      firstStepSpanId = currentStepSpanId;
+      firstLlmResponseTs = ev.timestamp || null;
+    }
     const llmSpanId = generateSpanId();
     const responseId = ev.message_id || `${currentStepId}:r`;
 
@@ -625,8 +634,10 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
   // transcript/Hook 真实 Read > 兜底合成),以及已合成过的根路径(同 turn 幂等去重)。
   // 只用于「根 SKILL.md 是否已有真实 Read」判定,普通文件 Read 全程不触碰、不做全局去重。
   const skillRootByToolId = turn.skillRootByToolId;
+  const userTypedSkillRoots = turn.userTypedSkillRoots;
+  const hasUserTypedRoots = !!(userTypedSkillRoots && userTypedSkillRoots.size > 0);
   const realReadPaths = new Set();
-  if (skillRootByToolId && skillRootByToolId.size > 0) {
+  if ((skillRootByToolId && skillRootByToolId.size > 0) || hasUserTypedRoots) {
     for (const ev of llmCalls) {
       for (const block of (ev.output_content || [])) {
         if (block && block.type === 'tool_use' && block.name === 'Read') {
@@ -637,6 +648,61 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
     }
   }
   const synthesizedSkillRoots = new Set();
+
+  // user-typed /skill 兜底合成 (turn 级入口):
+  // CC UI 直接以 isMeta + sourceToolUseID 缺席注入 SKILL.md 内容时,本 turn 无 Skill
+  // tool_use 可挂(参见下方 :702 no-op),故在此合成根 Read span,挂 owner step = turn 首个 LLM step。
+  // 去重键 = client + turnId + 归一化根路径,复用 deterministicSkillReadId / synthesizedSkillRoots。
+  if (hasUserTypedRoots && firstStepId) {
+    // P0 时间戳: call/result 必须不同,防 validate-trace time.non_zero_duration ERROR。
+    // call ts = 用户敲 /skill 时刻 (promptTimestamp);
+    // result ts = 本 turn 首个 LLM response (读完成于模型开始回应前),取不到 → promptTs + 1ns 兜底。
+    const callNs = isoToUnixNanos(turn.promptTimestamp);
+    const firstRespNs = isoToUnixNanos(firstLlmResponseTs);
+    let resultNs = (!firstRespNs || firstRespNs === '0' || firstRespNs === callNs)
+      ? (() => { try { return String(BigInt(callNs) + 1n); } catch { return callNs; } })()
+      : firstRespNs;
+    for (const rootRaw of userTypedSkillRoots) {
+      const normRoot = normalizeSkillPath(cwd, rootRaw);
+      if (!normRoot) continue;
+      if (realReadPaths.has(normRoot) || synthesizedSkillRoots.has(normRoot)) continue;
+      synthesizedSkillRoots.add(normRoot);
+      const readCallId = deterministicSkillReadId(AGENT_ID, turnId, normRoot);
+      const readSpanId = generateSpanId();
+      records.push({
+        time_unix_nano: callNs,
+        'event.id': crypto.randomUUID(),
+        'event.name': 'tool.call',
+        ...baseFields,
+        span_id: readSpanId,
+        parent_span_id: firstStepSpanId,
+        'gen_ai.step.id': firstStepId,
+        'gen_ai.tool.name': 'Read',
+        'gen_ai.tool.call.id': readCallId,
+        'gen_ai.tool.call.arguments': toJsonValue({ file_path: normRoot }),
+      });
+      records.push({
+        time_unix_nano: resultNs,
+        'event.id': crypto.randomUUID(),
+        'event.name': 'tool.result',
+        ...baseFields,
+        span_id: readSpanId,
+        parent_span_id: firstStepSpanId,
+        'gen_ai.step.id': firstStepId,
+        'gen_ai.tool.name': 'Read',
+        'gen_ai.tool.call.id': readCallId,
+        'gen_ai.tool.call.result': toJsonValue(''),
+        'tool.result.status': 'success',
+      });
+      // 参照 cursor PR #193: owner step 的 LLM span output.messages 挂同 id/name=Read 的 tool_call,
+      // 使合成 Read span 满足 ARMS semantic.tool_matches_llm_output。
+      injectSynthesizedToolCall(records, firstStepId, {
+        id: readCallId,
+        name: 'Read',
+        arguments: toJsonValue({ file_path: normRoot }),
+      });
+    }
+  }
 
   // Phase 2: 为每个 tool 生成 tool.call + tool.result，归属到声明方 LLM 的 step
   for (const ev of llmCalls) {
@@ -696,68 +762,10 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
         records.push(resultRecord);
       }
 
-      // 显式 /skill: 保证本 turn 根 SKILL.md 恰好展示一次 Read span。
-      // 去重键 = client + turnId + 归一化根路径。若本 turn 已有真实根 Read 则不合成
-      // (真实事件优先);否则合成一条同 call-id 的 Read tool.call+tool.result,挂 Skill owner step。
-      //
-      // origin gate: 仅对 user-typed slash /skill (XJK 路径, prompt 同时含
-      // <skill-format>true</skill-format> 与 <command-name>q</command-name>) 激活合成;
-      // 模型自主调 Skill (无 markup) 不合成。Multica 托管 SDK-CLI 模式下永不触发, 属预期。
-      // per-skill-call: 仅当 user-typed q 与本 Skill tool_use 的 input.skill 精确相等才合成,
-      // 同 turn 内其它模型自主 Skill 调用 (input.skill !== q) 不合成。
-      const promptText = turn?.prompt || '';
-      const cmdNameMatch = promptText.match(/<command-name>([^<]+)<\/command-name>/);
-      const isUserTypedSkill = cmdNameMatch !== null
-        && /<skill-format>true<\/skill-format>/.test(promptText);
-      if (toolName === 'Skill' && skillRootByToolId && isUserTypedSkill) {
-        const rootRaw = skillRootByToolId.get(toolId);
-        const normRoot = normalizeSkillPath(cwd, rootRaw);
-        if (
-          normRoot &&
-          toolBlock.input?.skill === cmdNameMatch[1] &&
-          !realReadPaths.has(normRoot) &&
-          !synthesizedSkillRoots.has(normRoot)
-        ) {
-          synthesizedSkillRoots.add(normRoot);
-          const readCallId = deterministicSkillReadId(AGENT_ID, turnId, normRoot);
-          const readSpanId = generateSpanId();
-          const readResultTs = timestamps.result || timestamps.call;
-          records.push({
-            time_unix_nano: isoToUnixNanos(timestamps.call),
-            'event.id': crypto.randomUUID(),
-            'event.name': 'tool.call',
-            ...baseFields,
-            span_id: readSpanId,
-            parent_span_id: owner.stepSpanId,
-            'gen_ai.step.id': owner.stepId,
-            'gen_ai.tool.name': 'Read',
-            'gen_ai.tool.call.id': readCallId,
-            'gen_ai.tool.call.arguments': toJsonValue({ file_path: normRoot }),
-          });
-          records.push({
-            time_unix_nano: isoToUnixNanos(readResultTs),
-            'event.id': crypto.randomUUID(),
-            'event.name': 'tool.result',
-            ...baseFields,
-            span_id: readSpanId,
-            parent_span_id: owner.stepSpanId,
-            'gen_ai.step.id': owner.stepId,
-            'gen_ai.tool.name': 'Read',
-            'gen_ai.tool.call.id': readCallId,
-            'gen_ai.tool.call.result': toJsonValue(''),
-            'tool.result.status': 'success',
-          });
-
-          // 参照 cursor PR #193: 在 owner step 的 LLM span output.messages 挂上
-          // 同 call id / name=Read 的 tool_call,使合成 Read span 满足 ARMS
-          // semantic.tool_matches_llm_output(工具 span 必须对应 LLM 输出侧的 tool_call)。
-          injectSynthesizedToolCall(records, owner.stepId, {
-            id: readCallId,
-            name: 'Read',
-            arguments: toJsonValue({ file_path: normRoot }),
-          });
-        }
-      }
+      // model-auto Skill 不再合成根 Read (用户边界: 仅 user-typed slash /skill 合成)。
+      // user-typed 合成在上方 turn 级入口 (hasUserTypedRoots 分支),此处 model-auto 路径 no-op。
+      // 未来若需 model-auto 合成可从 git 历史恢复本块。
+      if (toolName === 'Skill' && skillRootByToolId) { /* no-op */ }
     }
   }
 

--- a/assets/hooks/claude-code/transcript-parser.mjs
+++ b/assets/hooks/claude-code/transcript-parser.mjs
@@ -163,8 +163,11 @@ export function parseClaudeTranscript(transcriptPath, byteOffset = 0) {
   const toolResultTimestamps = new Map(); // tool_use_id → ISO8601 timestamp
   const toolResultContents = new Map(); // tool_use_id → result content
   const toolResultErrors = new Map(); // tool_use_id → boolean (is_error)
-  const skillRootByToolId = new Map(); // Skill tool_use_id → 根 SKILL.md 路径(来自 isMeta 注入)
+  const skillRootByToolId = new Map(); // Skill tool_use_id → 根 SKILL.md 路径(来自 isMeta 注入,model-auto 路径)
   const skillToolUseIdSet = new Set(); // #1: 本次 window 内 name==='Skill' 的 tool_use id(结构信号)
+  // user-typed /skill 路径: CC UI 直接以 isMeta=True + sourceToolUseID 缺席注入 SKILL.md 内容。
+  // 按 promptId 键、Set<rootPath> 值(防同 turn 多 user-typed skill 后写覆盖)。
+  const userTypedSkillRootByPromptId = new Map(); // promptMapKey(promptId) → Set<rootPath>
   let currentPromptId = null; // 当前 turn 的 promptId(从 user record 提取)
 
   for (const line of content.split('\n')) {
@@ -238,23 +241,32 @@ export function parseClaudeTranscript(transcriptPath, byteOffset = 0) {
 
       const userContent = msg.content;
 
-      // 显式 /skill 注入: 捕获 sourceToolUseID → 根 SKILL.md 路径。
-      // 仅额外捕获此映射,不改变 isMeta 其余记录被丢弃的行为。
+      // 显式 /skill 注入: 双分支捕获根 SKILL.md 路径。
+      //   - model-auto (sourceToolUseID present): 回链 Skill tool_use,写 skillRootByToolId
+      //   - user-typed (sourceToolUseID 缺席): CC UI 直接注入,写 userTypedSkillRootByPromptId
+      // 仅额外捕获映射,不改变 isMeta 其余记录被丢弃的行为。
       // #1: 路径提取仍「前缀优先」不变(跨 parse-window 边界时 Skill 块可能已在上一
       // window 消费,此处仍能靠前缀拿到路径,绝不比现状更窄)。
-      if (isMeta && record.sourceToolUseID) {
+      if (isMeta) {
         const rootPath = extractSkillRootPath(extractTextContent(userContent));
         if (rootPath) {
-          skillRootByToolId.set(record.sourceToolUseID, rootPath);
-        } else if (skillToolUseIdSet.has(record.sourceToolUseID)) {
-          // #2 漂移可观测: 仅当「结构确认为 skill 注入(sourceToolUseID 指向本 window
-          // 的 Skill tool_use)但路径提取失败」时打点——把前缀漂移导致的静默回归变成
-          // 可检测信号。结构 gate 确保不对「非 skill 的 isMeta+sourceToolUseID」误报。
+          if (record.sourceToolUseID) {
+            skillRootByToolId.set(record.sourceToolUseID, rootPath);
+          } else {
+            const pkey = promptMapKey(currentPromptId);
+            if (!userTypedSkillRootByPromptId.has(pkey)) {
+              userTypedSkillRootByPromptId.set(pkey, new Set());
+            }
+            userTypedSkillRootByPromptId.get(pkey).add(rootPath);
+          }
+        } else if (record.sourceToolUseID && skillToolUseIdSet.has(record.sourceToolUseID)) {
+          // #2 漂移可观测: 仅 model-auto 分支(sourceToolUseID present + 结构确认 Skill +
+          // 前缀失配)打点。user-typed 分支无「结构确认」锚点(无 sourceToolUseID),不打 parse_miss。
           logHookError({
             agentId: PARSER_AGENT_ID,
             stage: 'skill_root_parse',
             errorType: 'skill_root_parse_miss',
-            errorMessage: `sourceToolUseID=${record.sourceToolUseID} resolves to a Skill tool_use but SKILL.md root path extraction failed (prefix mismatch)`,
+            errorMessage: `sourceToolUseID=${record.sourceToolUseID} resolves to a Skill tool use but SKILL.md root path extraction failed (prefix mismatch)`,
           });
         }
       }
@@ -380,7 +392,7 @@ export function parseClaudeTranscript(transcriptPath, byteOffset = 0) {
   }
 
   // Phase 4: 按 promptId 切分 turns
-  const turns = splitIntoTurns(conversationRecords, llmCalls, skillRootByToolId);
+  const turns = splitIntoTurns(conversationRecords, llmCalls, skillRootByToolId, userTypedSkillRootByPromptId);
 
   return { turns, nextOffset: fileSize };
 }
@@ -392,8 +404,12 @@ export function parseClaudeTranscript(transcriptPath, byteOffset = 0) {
  * 同一 turn 内所有 user record 共享同一 promptId。
  * promptId 变化 = 新 turn 开始。
  */
-function splitIntoTurns(conversationRecords, llmCalls, skillRootByToolId = new Map()) {
+function splitIntoTurns(conversationRecords, llmCalls, skillRootByToolId = new Map(), userTypedSkillRootByPromptId = new Map()) {
   if (llmCalls.length === 0) return [];
+
+  // user-typed /skill 根路径按 promptId 分桶(已在 parser 主循环捕获)。
+  // fallback turn(promptId 全缺)用 promptMapKey(null) 查桶。
+  const userTypedRootsFor = (pid) => userTypedSkillRootByPromptId.get(promptMapKey(pid)) || new Set();
 
   // 收集所有出现的 promptId(按首次出现顺序)
   const promptIdOrder = [];
@@ -430,6 +446,7 @@ function splitIntoTurns(conversationRecords, llmCalls, skillRootByToolId = new M
       promptTimestamp: firstTs,
       llmCalls,
       skillRootByToolId,
+      userTypedSkillRoots: userTypedRootsFor(null),
     }];
   }
 
@@ -457,6 +474,7 @@ function splitIntoTurns(conversationRecords, llmCalls, skillRootByToolId = new M
       promptTimestamp,
       llmCalls: turnLlmCalls,
       skillRootByToolId,
+      userTypedSkillRoots: userTypedRootsFor(pid),
     });
   }
 
@@ -472,6 +490,7 @@ function splitIntoTurns(conversationRecords, llmCalls, skillRootByToolId = new M
         promptTimestamp: orphanCalls[0]?.timestamp || null,
         llmCalls: orphanCalls,
         skillRootByToolId,
+        userTypedSkillRoots: userTypedRootsFor(null),
       });
     }
   }

--- a/tests/unit/hooks/claude-code/skill-read.test.mjs
+++ b/tests/unit/hooks/claude-code/skill-read.test.mjs
@@ -40,6 +40,12 @@ afterEach(() => {
 
 // ─── transcript 记录构造器(结构对齐 skill_fixture.json) ───
 
+// XJK 路径 user-typed slash /skill: prompt 内嵌 <command-name>q</command-name>
+// + <skill-format>true</skill-format>。q 无前导 '/'。
+function xjkSkillPrompt(skillName) {
+  return `<command-name>${skillName}</command-name><skill-format>true</skill-format>`;
+}
+
 function userPrompt(promptId, text, ts) {
   return { type: 'user', promptId, timestamp: ts, message: { role: 'user', content: [{ type: 'text', text }] } };
 }
@@ -255,7 +261,7 @@ describe('transcript-parser: skill 识别加固 + 漂移可观测', () => {
 
   test('跨 parse-window: Skill 块在上一 window 已消费、isMeta 在本 window → 仍靠前缀捕获路径,不漏配、不误报 miss', () => {
     const file = writeTranscript('win', [
-      userPrompt('p1', '/e2e-build-push', '2026-07-27T02:00:00.000Z'),
+      userPrompt('p1', xjkSkillPrompt('e2e-build-push'), '2026-07-27T02:00:00.000Z'),
       skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T02:00:01.000Z', 'msg_skill'),
       skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T02:00:02.000Z'),
     ]);
@@ -289,7 +295,7 @@ describe('transcript-parser: skill 识别加固 + 漂移可观测', () => {
 
   test('结构确认为 skill 注入(sourceToolUseID→Skill)但前缀失配 → 正确计数 skill_root_parse_miss', () => {
     const file = writeTranscript('drift', [
-      userPrompt('p1', '/e2e-build-push', '2026-07-27T02:00:00.000Z'),
+      userPrompt('p1', xjkSkillPrompt('e2e-build-push'), '2026-07-27T02:00:00.000Z'),
       skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T02:00:01.000Z', 'msg_skill'),
       skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T02:00:02.000Z'),
       // 前缀漂移: text 不以 "Base directory for this skill:" 开头
@@ -311,7 +317,7 @@ describe('transcript-parser: skill 识别加固 + 漂移可观测', () => {
 describe('claude-code hook: /skill 根 SKILL.md Read span', () => {
   test('场景1: /skill + 一个原生根 Read → 不合成,仅保留真实 Read', () => {
     const t = writeTranscript('s1', [
-      userPrompt('p1', '/e2e-build-push', '2026-07-27T03:00:00.000Z'),
+      userPrompt('p1', xjkSkillPrompt('e2e-build-push'), '2026-07-27T03:00:00.000Z'),
       skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:01.000Z', 'msg_skill'),
       skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:02.000Z'),
       skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-27T03:00:02.500Z'),
@@ -337,7 +343,7 @@ describe('claude-code hook: /skill 根 SKILL.md Read span', () => {
 
   test('场景2: /skill + 多个不同 ID 的重复根 Read → 全保留,不合成', () => {
     const t = writeTranscript('s2', [
-      userPrompt('p1', '/e2e-build-push', '2026-07-27T03:00:00.000Z'),
+      userPrompt('p1', xjkSkillPrompt('e2e-build-push'), '2026-07-27T03:00:00.000Z'),
       skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:01.000Z', 'msg_skill'),
       skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:02.000Z'),
       skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-27T03:00:02.500Z'),
@@ -359,7 +365,7 @@ describe('claude-code hook: /skill 根 SKILL.md Read span', () => {
 
   test('场景3: /skill 无原生 Read → 兜底合成一条,call/result 同 id,挂 Skill owner step', () => {
     const t = writeTranscript('s3', [
-      userPrompt('p1', '/e2e-build-push', '2026-07-27T03:00:00.000Z'),
+      userPrompt('p1', xjkSkillPrompt('e2e-build-push'), '2026-07-27T03:00:00.000Z'),
       skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:01.000Z', 'msg_skill'),
       skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:02.000Z'),
       skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-27T03:00:02.500Z'),
@@ -395,7 +401,7 @@ describe('claude-code hook: /skill 根 SKILL.md Read span', () => {
 
   test('场景3b: 合成 call id 确定性(相同 client+turnId+rootPath 两次运行 id 相同)', () => {
     const records = [
-      userPrompt('p1', '/e2e-build-push', '2026-07-27T03:00:00.000Z'),
+      userPrompt('p1', xjkSkillPrompt('e2e-build-push'), '2026-07-27T03:00:00.000Z'),
       skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:01.000Z', 'msg_skill'),
       skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:02.000Z'),
       skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-27T03:00:02.500Z'),
@@ -423,7 +429,7 @@ describe('claude-code hook: /skill 根 SKILL.md Read span', () => {
   test('场景4: 根 SKILL.md + references 同读 → references 保留,不重复合成', () => {
     const refPath = `${BASE_DIR}/references/guide.md`;
     const t = writeTranscript('s4', [
-      userPrompt('p1', '/e2e-build-push', '2026-07-27T03:00:00.000Z'),
+      userPrompt('p1', xjkSkillPrompt('e2e-build-push'), '2026-07-27T03:00:00.000Z'),
       skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:01.000Z', 'msg_skill'),
       skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:02.000Z'),
       skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-27T03:00:02.500Z'),
@@ -476,7 +482,7 @@ describe('claude-code hook: /skill 根 SKILL.md Read span', () => {
   // client+turnId+rootPath 不同 → 无法跨 build 抑制。此为已知边界(architect 定为非 P0)。
   test('场景7: 跨 hook-run 延迟真实 Read — 记录当前边界行为', () => {
     const t = writeTranscript('s7', [
-      userPrompt('p1', '/e2e-build-push', '2026-07-27T03:00:00.000Z'),
+      userPrompt('p1', xjkSkillPrompt('e2e-build-push'), '2026-07-27T03:00:00.000Z'),
       skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:01.000Z', 'msg_skill'),
       skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:02.000Z'),
       skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-27T03:00:02.500Z'),
@@ -521,7 +527,7 @@ describe('claude-code hook: /skill 根 SKILL.md Read span', () => {
 describe('不变量: 同窗 Skill+注入 / offset 仅 Stop 推进 / 无 mid-turn hook', () => {
   test('① 一个完整 turn(Skill tool_use + 紧随 isMeta 注入)在单窗内被解析、命中并正常合成', () => {
     const t = writeTranscript('inv1', [
-      userPrompt('p1', '/e2e-build-push', '2026-07-28T02:00:00.000Z'),
+      userPrompt('p1', xjkSkillPrompt('e2e-build-push'), '2026-07-28T02:00:00.000Z'),
       skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-28T02:00:01.000Z', 'msg_skill'),
       skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-28T02:00:02.000Z'),
       skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-28T02:00:02.500Z'),
@@ -566,5 +572,104 @@ describe('不变量: 同窗 Skill+注入 / offset 仅 Stop 推进 / 无 mid-turn
     const sh = fs.readFileSync(SHELL_HOOK, 'utf-8');
     expect(sh).toMatch(/stop\|subagent-start\|subagent-stop\)/);
     expect(sh).not.toMatch(/PreToolUse|PostToolUse/);
+  });
+});
+
+// ─── origin gate: 仅 user-typed slash /skill (XJK 路径) 才合成 ───
+//
+// XJK 路径 prompt 含 <command-name>q</command-name> + <skill-format>true</skill-format>,
+// q 无前导 '/' 且须与 Skill tool_use 的 input.skill 精确相等才合成。
+// 模型自主调 Skill (无 markup) 不合成 —— Multica 托管 SDK-CLI 模式下永不触发,属预期。
+
+describe('origin gate: 仅 user-typed slash /skill 才合成', () => {
+  test('① user-typed /skill (markup + input.skill == q) → 合成根 Read span', () => {
+    const t = writeTranscript('og1', [
+      userPrompt('p1', xjkSkillPrompt('e2e-build-push'), '2026-07-28T03:00:00.000Z'),
+      skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-28T03:00:01.000Z', 'msg_skill'),
+      skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-28T03:00:02.000Z'),
+      skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-28T03:00:02.500Z'),
+      finalAnswer('msg_final', 'done', '2026-07-28T03:00:05.000Z'),
+    ]);
+    const r = runHook('stop', { session_id: 'og1', stop_reason: 'end_turn', transcript_path: t, cwd: '/abs/workdir' });
+    expect(r.status).toBe(0);
+    const recs = readJsonlRecords();
+    const readCalls = toolCalls(recs, 'Read');
+    expect(readCalls.length).toBe(1);
+    expect(readCalls[0]['gen_ai.tool.call.id'].startsWith(SYNTH_PREFIX)).toBe(true);
+    const ownerResp = llmResponseForStep(recs, readCalls[0]['gen_ai.step.id']);
+    expect(outputToolCalls(ownerResp).some((p) => p.id === readCalls[0]['gen_ai.tool.call.id'] && p.name === 'Read')).toBe(true);
+  });
+
+  test('② 模型自主调 Skill (自然语言 prompt、无 markup) → 不合成根 Read', () => {
+    const t = writeTranscript('og2', [
+      // 自然语言 prompt,无 <command-name>/<skill-format> markup → 非用户 slash /skill
+      userPrompt('p1', 'please run the e2e-build-push skill now', '2026-07-28T03:00:00.000Z'),
+      skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-28T03:00:01.000Z', 'msg_skill'),
+      skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-28T03:00:02.000Z'),
+      skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-28T03:00:02.500Z'),
+      finalAnswer('msg_final', 'done', '2026-07-28T03:00:05.000Z'),
+    ]);
+    const r = runHook('stop', { session_id: 'og2', stop_reason: 'end_turn', transcript_path: t, cwd: '/abs/workdir' });
+    expect(r.status).toBe(0);
+    const recs = readJsonlRecords();
+    // 模型自主 Skill 调用:Skill span 本身仍照常输出,但根 Read 不合成、不背书
+    expect(toolCalls(recs, 'Skill').length).toBe(1);
+    expect(toolCalls(recs, 'Read').length).toBe(0);
+    const allInjected = recs
+      .filter((x) => x['event.name'] === 'llm.response')
+      .flatMap((r2) => outputToolCalls(r2))
+      .filter((p) => (p.id || '').startsWith(SYNTH_PREFIX));
+    expect(allInjected.length).toBe(0);
+  });
+
+  test('③ per-skill-call 边界: 同 turn 内 user-typed q=A + 模型自主 skill=B → 仅 A 合成、B 不合成', () => {
+    const BASE_B = '/abs/workdir/.claude/skills/another-skill';
+    const ROOT_B = `${BASE_B}/SKILL.md`;
+    // prompt markup 只声明 A → q='e2e-build-push'; B 未在 markup 中
+    const t = writeTranscript('og3', [
+      userPrompt('p1', xjkSkillPrompt('e2e-build-push'), '2026-07-28T03:00:00.000Z'),
+      // 第一个 Skill: input.skill = A = 'e2e-build-push' == q → 合成
+      skillToolUse('toolu_a', 'e2e-build-push', '2026-07-28T03:00:01.000Z', 'msg_a'),
+      skillToolResult('toolu_a', 'e2e-build-push', '2026-07-28T03:00:02.000Z'),
+      skillMetaInjection('toolu_a', BASE_DIR, '2026-07-28T03:00:02.500Z'),
+      // 第二个 Skill: input.skill = B = 'another-skill' != q → 不合成
+      skillToolUse('toolu_b', 'another-skill', '2026-07-28T03:00:03.000Z', 'msg_b'),
+      skillToolResult('toolu_b', 'another-skill', '2026-07-28T03:00:04.000Z'),
+      skillMetaInjection('toolu_b', BASE_B, '2026-07-28T03:00:04.500Z'),
+      finalAnswer('msg_final', 'done', '2026-07-28T03:00:07.000Z'),
+    ]);
+    const r = runHook('stop', { session_id: 'og3', stop_reason: 'end_turn', transcript_path: t, cwd: '/abs/workdir' });
+    expect(r.status).toBe(0);
+    const recs = readJsonlRecords();
+    const readCalls = toolCalls(recs, 'Read');
+    // 仅 A 合成(1 条),B 不合成
+    expect(readCalls.length).toBe(1);
+    expect(readCalls[0]['gen_ai.tool.call.id'].startsWith(SYNTH_PREFIX)).toBe(true);
+    // 合成的 Read 参数是 A 的根路径,B 的根路径未出现
+    expect(readCalls[0]['gen_ai.tool.call.arguments']).toEqual({ file_path: ROOT_SKILL });
+    expect(readCalls.some((x) => x['gen_ai.tool.call.arguments']?.file_path === ROOT_B)).toBe(false);
+    // 两个 Skill span 都照常输出
+    expect(toolCalls(recs, 'Skill').length).toBe(2);
+  });
+
+  test('④ 防误判: prompt 字面讨论 <skill-format>true</skill-format> 但无 <command-name> → 不合成', () => {
+    const t = writeTranscript('og4', [
+      // prompt 含 <skill-format>true</skill-format> 字面但无 <command-name> → gate 不通过
+      userPrompt('p1', 'note: <skill-format>true</skill-format> is the skill trigger token, but no command name given', '2026-07-28T03:00:00.000Z'),
+      skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-28T03:00:01.000Z', 'msg_skill'),
+      skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-28T03:00:02.000Z'),
+      skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-28T03:00:02.500Z'),
+      finalAnswer('msg_final', 'done', '2026-07-28T03:00:05.000Z'),
+    ]);
+    const r = runHook('stop', { session_id: 'og4', stop_reason: 'end_turn', transcript_path: t, cwd: '/abs/workdir' });
+    expect(r.status).toBe(0);
+    const recs = readJsonlRecords();
+    expect(toolCalls(recs, 'Skill').length).toBe(1);
+    expect(toolCalls(recs, 'Read').length).toBe(0);
+    const allInjected = recs
+      .filter((x) => x['event.name'] === 'llm.response')
+      .flatMap((r2) => outputToolCalls(r2))
+      .filter((p) => (p.id || '').startsWith(SYNTH_PREFIX));
+    expect(allInjected.length).toBe(0);
   });
 });

--- a/tests/unit/hooks/claude-code/skill-read.test.mjs
+++ b/tests/unit/hooks/claude-code/skill-read.test.mjs
@@ -38,13 +38,7 @@ afterEach(() => {
   try { fs.rmSync(TRANSCRIPT_DIR, { recursive: true, force: true }); } catch {}
 });
 
-// ─── transcript 记录构造器(结构对齐 skill_fixture.json) ───
-
-// XJK 路径 user-typed slash /skill: prompt 内嵌 <command-name>q</command-name>
-// + <skill-format>true</skill-format>。q 无前导 '/'。
-function xjkSkillPrompt(skillName) {
-  return `<command-name>${skillName}</command-name><skill-format>true</skill-format>`;
-}
+// ─── transcript 记录构造器(结构对齐 skill_fixture.json + PTY session f45f32d4) ───
 
 function userPrompt(promptId, text, ts) {
   return { type: 'user', promptId, timestamp: ts, message: { role: 'user', content: [{ type: 'text', text }] } };
@@ -72,7 +66,7 @@ function skillToolResult(id, skillName, ts) {
   };
 }
 
-// isMeta 注入。text 首行 = "Base directory for this skill: <baseDir>"。
+// model-auto isMeta 注入: sourceToolUseID 指向 Skill tool_use,text 首行前缀。
 function skillMetaInjection(sourceToolUseID, baseDir, ts) {
   return {
     type: 'user',
@@ -81,6 +75,24 @@ function skillMetaInjection(sourceToolUseID, baseDir, ts) {
     timestamp: ts,
     message: { role: 'user', content: `Base directory for this skill: ${baseDir}\n\n# Title\n\nskill body...` },
   };
+}
+
+// user-typed /skill isMeta 注入 (PTY session f45f32d4 L5 范式):
+// CC UI 直接注入 SKILL.md 内容,isMeta=true,无 sourceToolUseID 字段。
+// sourceToolUseID 缺席是 user-typed /skill 的可靠独有信号 (vs model-auto 带指向 Skill tool_use 的 id)。
+function userTypedSkillMetaInjection(baseDir, ts, falsyStyle = 'undefined') {
+  const rec = {
+    type: 'user',
+    isMeta: true,
+    timestamp: ts,
+    message: { role: 'user', content: `Base directory for this skill: ${baseDir}\n\n# Title\n\nskill body...` },
+  };
+  // 覆盖四种 falsy 形态: undefined (字段缺) / null / '' (空串) / 不设
+  if (falsyStyle === 'null') rec.sourceToolUseID = null;
+  else if (falsyStyle === 'empty') rec.sourceToolUseID = '';
+  else if (falsyStyle === 'undefined') rec.sourceToolUseID = undefined;
+  // 'absent' 不设字段
+  return rec;
 }
 
 function readToolUse(id, filePath, ts, msgId) {
@@ -261,7 +273,7 @@ describe('transcript-parser: skill 识别加固 + 漂移可观测', () => {
 
   test('跨 parse-window: Skill 块在上一 window 已消费、isMeta 在本 window → 仍靠前缀捕获路径,不漏配、不误报 miss', () => {
     const file = writeTranscript('win', [
-      userPrompt('p1', xjkSkillPrompt('e2e-build-push'), '2026-07-27T02:00:00.000Z'),
+      userPrompt('p1', '/e2e-build-push', '2026-07-27T02:00:00.000Z'),
       skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T02:00:01.000Z', 'msg_skill'),
       skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T02:00:02.000Z'),
     ]);
@@ -295,7 +307,7 @@ describe('transcript-parser: skill 识别加固 + 漂移可观测', () => {
 
   test('结构确认为 skill 注入(sourceToolUseID→Skill)但前缀失配 → 正确计数 skill_root_parse_miss', () => {
     const file = writeTranscript('drift', [
-      userPrompt('p1', xjkSkillPrompt('e2e-build-push'), '2026-07-27T02:00:00.000Z'),
+      userPrompt('p1', '/e2e-build-push', '2026-07-27T02:00:00.000Z'),
       skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T02:00:01.000Z', 'msg_skill'),
       skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T02:00:02.000Z'),
       // 前缀漂移: text 不以 "Base directory for this skill:" 开头
@@ -317,7 +329,7 @@ describe('transcript-parser: skill 识别加固 + 漂移可观测', () => {
 describe('claude-code hook: /skill 根 SKILL.md Read span', () => {
   test('场景1: /skill + 一个原生根 Read → 不合成,仅保留真实 Read', () => {
     const t = writeTranscript('s1', [
-      userPrompt('p1', xjkSkillPrompt('e2e-build-push'), '2026-07-27T03:00:00.000Z'),
+      userPrompt('p1', '/e2e-build-push', '2026-07-27T03:00:00.000Z'),
       skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:01.000Z', 'msg_skill'),
       skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:02.000Z'),
       skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-27T03:00:02.500Z'),
@@ -343,7 +355,7 @@ describe('claude-code hook: /skill 根 SKILL.md Read span', () => {
 
   test('场景2: /skill + 多个不同 ID 的重复根 Read → 全保留,不合成', () => {
     const t = writeTranscript('s2', [
-      userPrompt('p1', xjkSkillPrompt('e2e-build-push'), '2026-07-27T03:00:00.000Z'),
+      userPrompt('p1', '/e2e-build-push', '2026-07-27T03:00:00.000Z'),
       skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:01.000Z', 'msg_skill'),
       skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:02.000Z'),
       skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-27T03:00:02.500Z'),
@@ -363,12 +375,11 @@ describe('claude-code hook: /skill 根 SKILL.md Read span', () => {
     expect(reads.some((x) => x['gen_ai.tool.call.id'].startsWith(SYNTH_PREFIX))).toBe(false);
   });
 
-  test('场景3: /skill 无原生 Read → 兜底合成一条,call/result 同 id,挂 Skill owner step', () => {
+  test('场景3: user-typed /skill 无原生 Read → 兜底合成一条,call/result 同 id,挂 turn 首个 LLM step', () => {
     const t = writeTranscript('s3', [
-      userPrompt('p1', xjkSkillPrompt('e2e-build-push'), '2026-07-27T03:00:00.000Z'),
-      skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:01.000Z', 'msg_skill'),
-      skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:02.000Z'),
-      skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-27T03:00:02.500Z'),
+      userPrompt('p1', '/e2e-build-push', '2026-07-27T03:00:00.000Z'),
+      // user-typed 路径: CC UI 直接注入 SKILL.md,isMeta + sourceToolUseID 缺席,无 Skill tool_use
+      userTypedSkillMetaInjection(BASE_DIR, '2026-07-27T03:00:02.500Z'),
       finalAnswer('msg_final', 'done', '2026-07-27T03:00:05.000Z'),
     ]);
     const r = runHook('stop', { session_id: 's3', stop_reason: 'end_turn', transcript_path: t, cwd: '/abs/workdir' });
@@ -382,11 +393,12 @@ describe('claude-code hook: /skill 根 SKILL.md Read span', () => {
     expect(callId.startsWith(SYNTH_PREFIX)).toBe(true);
     expect(readResults[0]['gen_ai.tool.call.id']).toBe(callId); // call/result 同 id → OTLP 一个 span
     expect(readCalls[0]['gen_ai.tool.call.arguments']).toEqual({ file_path: ROOT_SKILL });
-    // owner step == Skill 声明所在 step
-    const skillCall = toolCalls(recs, 'Skill')[0];
-    expect(readCalls[0]['gen_ai.step.id']).toBe(skillCall['gen_ai.step.id']);
-    // 时间戳非零(取 Skill 的 call/result)
+    // P0: call/result 时间戳不同(防 validate-trace non_zero_duration ERROR)
     expect(readCalls[0].time_unix_nano).not.toBe('0');
+    expect(readResults[0].time_unix_nano).not.toBe(readCalls[0].time_unix_nano);
+    // owner step == turn 首个 LLM step(user-typed 无 Skill tool_use 可挂)
+    const firstResp = recs.find((x) => x['event.name'] === 'llm.response');
+    expect(readCalls[0]['gen_ai.step.id']).toBe(firstResp['gen_ai.step.id']);
 
     // 参照 cursor PR #193: owner step 的 LLM span output.messages 挂上同 id/name=Read 的 tool_call
     const ownerResp = llmResponseForStep(recs, readCalls[0]['gen_ai.step.id']);
@@ -395,16 +407,14 @@ describe('claude-code hook: /skill 根 SKILL.md Read span', () => {
     expect(injected).toBeDefined();
     expect(injected.name).toBe('Read');
     expect(injected.arguments).toEqual({ file_path: ROOT_SKILL });
-    // owner step 输出侧仍保留原 Skill tool_call(未覆盖)
-    expect(outputToolCalls(ownerResp).some((p) => p.name === 'Skill')).toBe(true);
+    // user-typed 路径无 Skill tool_use → owner step 输出侧无 Skill tool_call
+    expect(outputToolCalls(ownerResp).some((p) => p.name === 'Skill')).toBe(false);
   });
 
   test('场景3b: 合成 call id 确定性(相同 client+turnId+rootPath 两次运行 id 相同)', () => {
     const records = [
-      userPrompt('p1', xjkSkillPrompt('e2e-build-push'), '2026-07-27T03:00:00.000Z'),
-      skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:01.000Z', 'msg_skill'),
-      skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:02.000Z'),
-      skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-27T03:00:02.500Z'),
+      userPrompt('p1', '/e2e-build-push', '2026-07-27T03:00:00.000Z'),
+      userTypedSkillMetaInjection(BASE_DIR, '2026-07-27T03:00:02.500Z'),
       finalAnswer('msg_final', 'done', '2026-07-27T03:00:05.000Z'),
     ];
     // 两个独立 DATA_DIR、相同 session_id(→ 相同 turnId :t1)+相同根路径 → 同确定性 id。
@@ -429,7 +439,7 @@ describe('claude-code hook: /skill 根 SKILL.md Read span', () => {
   test('场景4: 根 SKILL.md + references 同读 → references 保留,不重复合成', () => {
     const refPath = `${BASE_DIR}/references/guide.md`;
     const t = writeTranscript('s4', [
-      userPrompt('p1', xjkSkillPrompt('e2e-build-push'), '2026-07-27T03:00:00.000Z'),
+      userPrompt('p1', '/e2e-build-push', '2026-07-27T03:00:00.000Z'),
       skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:01.000Z', 'msg_skill'),
       skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:02.000Z'),
       skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-27T03:00:02.500Z'),
@@ -480,14 +490,13 @@ describe('claude-code hook: /skill 根 SKILL.md Read span', () => {
   // architect P1-3: 跨 hook-run / 延迟真实 Read 边界。
   // 真实根 Read 落在后一次 hook 分块(turnId 不同),前一块已合成 → 去重键
   // client+turnId+rootPath 不同 → 无法跨 build 抑制。此为已知边界(architect 定为非 P0)。
-  test('场景7: 跨 hook-run 延迟真实 Read — 记录当前边界行为', () => {
+  test('场景7: 跨 hook-run 延迟真实 Read — 记录当前边界行为(user-typed 路径)', () => {
     const t = writeTranscript('s7', [
-      userPrompt('p1', xjkSkillPrompt('e2e-build-push'), '2026-07-27T03:00:00.000Z'),
-      skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:01.000Z', 'msg_skill'),
-      skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:02.000Z'),
-      skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-27T03:00:02.500Z'),
+      userPrompt('p1', '/e2e-build-push', '2026-07-27T03:00:00.000Z'),
+      userTypedSkillMetaInjection(BASE_DIR, '2026-07-27T03:00:02.500Z'),
+      finalAnswer('msg_a', 'partial', '2026-07-27T03:00:03.000Z'),
     ]);
-    // 第一次 hook run: 只有 Skill,尚无真实根 Read → 兜底合成一条
+    // 第一次 hook run: user-typed /skill,尚无真实根 Read → 兜底合成一条
     let r1 = runHook('stop', { session_id: 's7', stop_reason: 'end_turn', transcript_path: t, cwd: '/abs/workdir' });
     expect(r1.status).toBe(0);
     const afterRun1 = readJsonlRecords();
@@ -495,11 +504,12 @@ describe('claude-code hook: /skill 根 SKILL.md Read span', () => {
     expect(synthAfter1.length).toBe(1);
     const synthTurn = synthAfter1[0]['gen_ai.turn.id'];
 
-    // 第二次 hook run: 追加延迟的真实根 Read(落在新分块,新 turnId)
+    // 第二次 hook run: 新 turn(新 promptId)追加真实根 Read
     appendTranscript(t, [
-      readToolUse('toolu_lateroot', ROOT_SKILL, '2026-07-27T03:00:06.000Z', 'msg_late'),
-      readToolResult('toolu_lateroot', '2026-07-27T03:00:06.500Z'),
-      finalAnswer('msg_final', 'done', '2026-07-27T03:00:07.000Z'),
+      userPrompt('p2', 'now read the root', '2026-07-27T03:00:06.000Z'),
+      readToolUse('toolu_lateroot', ROOT_SKILL, '2026-07-27T03:00:06.500Z', 'msg_late'),
+      readToolResult('toolu_lateroot', '2026-07-27T03:00:07.000Z'),
+      finalAnswer('msg_final', 'done', '2026-07-27T03:00:08.000Z'),
     ]);
     let r2 = runHook('stop', { session_id: 's7', stop_reason: 'end_turn', transcript_path: t, cwd: '/abs/workdir' });
     expect(r2.status).toBe(0);
@@ -512,32 +522,30 @@ describe('claude-code hook: /skill 根 SKILL.md Read span', () => {
   });
 });
 
-// ─── 不变量: Skill 与其 isMeta 注入必落同一 parse 窗口(跨窗口切分不可达) ───
+// ─── 不变量: user-typed /skill 注入与其 turn 必落同一 parse 窗口(跨窗口切分不可达) ───
 //
-// 前提(源码 + 真实 transcript 实证):
+// 前提(源码 + 真实 transcript 实证,PTY session f45f32d4):
 //   1. 只注册 Stop 类 hook(Stop / SubagentStart / SubagentStop)——无 PreToolUse/PostToolUse。
 //   2. transcript_offset 仅在 cmdStop 导出成功后推进;两个 subagent handler 不解析 transcript、不动 offset。
 //      → 每个解析窗口 = 一次 Stop = [上次 offset, EOF],边界恒对齐 turn 末尾。
-//   3. Skill tool_use 与其 sourceToolUseID 注入是同一 turn 内连续记录(真实数据 meta 恒在 2–5 条内)。
+//   3. user-typed /skill 的 isMeta 注入(sourceToolUseID 缺席)与其 user prompt 同 turn 连续记录。
 //   ⇒ 二者必落同窗,"一半在 window1、一半在 window2"在现状模型下构造不出来。
 //
 // 本 describe = test-only 不变量护栏:不改生产/合成逻辑。一旦未来误加 mid-turn hook 让
 // 该场景变可达(扩 DISPATCH / .sh 白名单、在 stop 之外解析 transcript),下列静态断言立即变红,
 // 把"静默丢 Read"的回归风险暴露出来,而不是悄悄回退到"缺失根 Read"。
-describe('不变量: 同窗 Skill+注入 / offset 仅 Stop 推进 / 无 mid-turn hook', () => {
-  test('① 一个完整 turn(Skill tool_use + 紧随 isMeta 注入)在单窗内被解析、命中并正常合成', () => {
+describe('不变量: 同窗 user-typed 注入 / offset 仅 Stop 推进 / 无 mid-turn hook', () => {
+  test('① 一个完整 turn(user-typed isMeta 注入 + sourceToolUseID 缺席)在单窗内被解析、命中并正常合成', () => {
     const t = writeTranscript('inv1', [
-      userPrompt('p1', xjkSkillPrompt('e2e-build-push'), '2026-07-28T02:00:00.000Z'),
-      skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-28T02:00:01.000Z', 'msg_skill'),
-      skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-28T02:00:02.000Z'),
-      skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-28T02:00:02.500Z'),
+      userPrompt('p1', '/e2e-build-push', '2026-07-28T02:00:00.000Z'),
+      userTypedSkillMetaInjection(BASE_DIR, '2026-07-28T02:00:01.000Z'),
       finalAnswer('msg_final', 'done', '2026-07-28T02:00:03.000Z'),
     ]);
 
-    // 单次 parse 窗口 [0, EOF] 即涵盖整个 turn:Skill 块与注入同窗,skillRootByToolId 命中。
+    // 单次 parse 窗口 [0, EOF] 即涵盖整个 turn:user-typed 注入同窗,userTypedSkillRoots 命中。
     const { turns, nextOffset } = parseClaudeTranscript(t, 0);
     expect(turns.length).toBe(1);
-    expect(turns[0].skillRootByToolId.get('toolu_skill')).toBe(ROOT_SKILL);
+    expect(turns[0].userTypedSkillRoots.has(ROOT_SKILL)).toBe(true);
     expect(nextOffset).toBe(fs.statSync(t).size); // 窗口对齐到 EOF(= turn 末尾)
 
     // 同窗 → 合成正常:根 Read=1(确定性 id、call/result 成对)+ owner LLM 输出侧背书 tool_call。
@@ -575,19 +583,18 @@ describe('不变量: 同窗 Skill+注入 / offset 仅 Stop 推进 / 无 mid-turn
   });
 });
 
-// ─── origin gate: 仅 user-typed slash /skill (XJK 路径) 才合成 ───
+// ─── origin gate 修订: 仅 user-typed /skill (isMeta + sourceToolUseID 缺席) 才合成 ───
 //
-// XJK 路径 prompt 含 <command-name>q</command-name> + <skill-format>true</skill-format>,
-// q 无前导 '/' 且须与 Skill tool_use 的 input.skill 精确相等才合成。
-// 模型自主调 Skill (无 markup) 不合成 —— Multica 托管 SDK-CLI 模式下永不触发,属预期。
+// 判别信号(researcher Round 9 PTY 实证 + architect APPROVED):
+//   isMeta=True + "Base directory for this skill:" 前缀 + sourceToolUseID 缺席
+//   → CC UI 直接注入 SKILL.md,user-typed /skill 路径(无 Skill tool_use 中介)。
+// model-auto Skill(isMeta + sourceToolUseID 指向 Skill tool_use)→ 不合成(用户边界)。
 
-describe('origin gate: 仅 user-typed slash /skill 才合成', () => {
-  test('① user-typed /skill (markup + input.skill == q) → 合成根 Read span', () => {
+describe('origin gate: 仅 user-typed /skill 才合成', () => {
+  test('① user-typed /skill (isMeta + 前缀 + sourceToolUseID 缺席) → 合成根 Read span', () => {
     const t = writeTranscript('og1', [
-      userPrompt('p1', xjkSkillPrompt('e2e-build-push'), '2026-07-28T03:00:00.000Z'),
-      skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-28T03:00:01.000Z', 'msg_skill'),
-      skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-28T03:00:02.000Z'),
-      skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-28T03:00:02.500Z'),
+      userPrompt('p1', '/e2e-build-push', '2026-07-28T03:00:00.000Z'),
+      userTypedSkillMetaInjection(BASE_DIR, '2026-07-28T03:00:02.500Z'),
       finalAnswer('msg_final', 'done', '2026-07-28T03:00:05.000Z'),
     ]);
     const r = runHook('stop', { session_id: 'og1', stop_reason: 'end_turn', transcript_path: t, cwd: '/abs/workdir' });
@@ -596,13 +603,17 @@ describe('origin gate: 仅 user-typed slash /skill 才合成', () => {
     const readCalls = toolCalls(recs, 'Read');
     expect(readCalls.length).toBe(1);
     expect(readCalls[0]['gen_ai.tool.call.id'].startsWith(SYNTH_PREFIX)).toBe(true);
+    expect(readCalls[0]['gen_ai.tool.call.arguments']).toEqual({ file_path: ROOT_SKILL });
+    // P0: call/result 时间戳不同
+    expect(toolResults(recs, 'Read')[0].time_unix_nano).not.toBe(readCalls[0].time_unix_nano);
     const ownerResp = llmResponseForStep(recs, readCalls[0]['gen_ai.step.id']);
     expect(outputToolCalls(ownerResp).some((p) => p.id === readCalls[0]['gen_ai.tool.call.id'] && p.name === 'Read')).toBe(true);
+    // user-typed 路径无 Skill tool_use → 无 Skill span
+    expect(toolCalls(recs, 'Skill').length).toBe(0);
   });
 
-  test('② 模型自主调 Skill (自然语言 prompt、无 markup) → 不合成根 Read', () => {
+  test('② 模型自主 Skill (isMeta + sourceToolUseID 指向 Skill tool_use) → 不合成根 Read', () => {
     const t = writeTranscript('og2', [
-      // 自然语言 prompt,无 <command-name>/<skill-format> markup → 非用户 slash /skill
       userPrompt('p1', 'please run the e2e-build-push skill now', '2026-07-28T03:00:00.000Z'),
       skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-28T03:00:01.000Z', 'msg_skill'),
       skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-28T03:00:02.000Z'),
@@ -622,54 +633,74 @@ describe('origin gate: 仅 user-typed slash /skill 才合成', () => {
     expect(allInjected.length).toBe(0);
   });
 
-  test('③ per-skill-call 边界: 同 turn 内 user-typed q=A + 模型自主 skill=B → 仅 A 合成、B 不合成', () => {
-    const BASE_B = '/abs/workdir/.claude/skills/another-skill';
-    const ROOT_B = `${BASE_B}/SKILL.md`;
-    // prompt markup 只声明 A → q='e2e-build-push'; B 未在 markup 中
+  test('③ 本 turn 已有真实根 Read → 跳过合成(P1)', () => {
     const t = writeTranscript('og3', [
-      userPrompt('p1', xjkSkillPrompt('e2e-build-push'), '2026-07-28T03:00:00.000Z'),
-      // 第一个 Skill: input.skill = A = 'e2e-build-push' == q → 合成
-      skillToolUse('toolu_a', 'e2e-build-push', '2026-07-28T03:00:01.000Z', 'msg_a'),
-      skillToolResult('toolu_a', 'e2e-build-push', '2026-07-28T03:00:02.000Z'),
-      skillMetaInjection('toolu_a', BASE_DIR, '2026-07-28T03:00:02.500Z'),
-      // 第二个 Skill: input.skill = B = 'another-skill' != q → 不合成
-      skillToolUse('toolu_b', 'another-skill', '2026-07-28T03:00:03.000Z', 'msg_b'),
-      skillToolResult('toolu_b', 'another-skill', '2026-07-28T03:00:04.000Z'),
-      skillMetaInjection('toolu_b', BASE_B, '2026-07-28T03:00:04.500Z'),
-      finalAnswer('msg_final', 'done', '2026-07-28T03:00:07.000Z'),
+      userPrompt('p1', '/e2e-build-push', '2026-07-28T03:00:00.000Z'),
+      userTypedSkillMetaInjection(BASE_DIR, '2026-07-28T03:00:00.500Z'),
+      // 模型自主真实 Read 了根 SKILL.md → realReadPaths 命中 → 跳过合成
+      readToolUse('toolu_realroot', ROOT_SKILL, '2026-07-28T03:00:01.000Z', 'msg_read'),
+      readToolResult('toolu_realroot', '2026-07-28T03:00:01.500Z'),
+      finalAnswer('msg_final', 'done', '2026-07-28T03:00:05.000Z'),
     ]);
     const r = runHook('stop', { session_id: 'og3', stop_reason: 'end_turn', transcript_path: t, cwd: '/abs/workdir' });
     expect(r.status).toBe(0);
     const recs = readJsonlRecords();
-    const readCalls = toolCalls(recs, 'Read');
-    // 仅 A 合成(1 条),B 不合成
-    expect(readCalls.length).toBe(1);
-    expect(readCalls[0]['gen_ai.tool.call.id'].startsWith(SYNTH_PREFIX)).toBe(true);
-    // 合成的 Read 参数是 A 的根路径,B 的根路径未出现
-    expect(readCalls[0]['gen_ai.tool.call.arguments']).toEqual({ file_path: ROOT_SKILL });
-    expect(readCalls.some((x) => x['gen_ai.tool.call.arguments']?.file_path === ROOT_B)).toBe(false);
-    // 两个 Skill span 都照常输出
-    expect(toolCalls(recs, 'Skill').length).toBe(2);
+    const reads = toolCalls(recs, 'Read');
+    // 仅真实根 Read(其真实 id),零合成
+    expect(reads.length).toBe(1);
+    expect(reads[0]['gen_ai.tool.call.id']).toBe('toolu_realroot');
+    expect(reads.some((x) => x['gen_ai.tool.call.id'].startsWith(SYNTH_PREFIX))).toBe(false);
   });
 
-  test('④ 防误判: prompt 字面讨论 <skill-format>true</skill-format> 但无 <command-name> → 不合成', () => {
-    const t = writeTranscript('og4', [
-      // prompt 含 <skill-format>true</skill-format> 字面但无 <command-name> → gate 不通过
-      userPrompt('p1', 'note: <skill-format>true</skill-format> is the skill trigger token, but no command name given', '2026-07-28T03:00:00.000Z'),
-      skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-28T03:00:01.000Z', 'msg_skill'),
-      skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-28T03:00:02.000Z'),
-      skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-28T03:00:02.500Z'),
+  test('④ sourceToolUseID 四种 falsy (undefined / null / "" / 字段缺) → 全归 user-typed 分支(P1)', () => {
+    for (const style of ['undefined', 'null', 'empty', 'absent']) {
+      // 每种 falsy 形态用独立 DATA_DIR,避免跨迭代合成记录累计
+      const prevDataDir = DATA_DIR;
+      DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-skill-falsy-'));
+      try {
+        const t = writeTranscript(`og4_${style}`, [
+          userPrompt('p1', '/e2e-build-push', '2026-07-28T03:00:00.000Z'),
+          userTypedSkillMetaInjection(BASE_DIR, '2026-07-28T03:00:02.500Z', style),
+          finalAnswer('msg_final', 'done', '2026-07-28T03:00:05.000Z'),
+        ]);
+        const r = runHook('stop', { session_id: `og4_${style}`, stop_reason: 'end_turn', transcript_path: t, cwd: '/abs/workdir' });
+        expect(r.status).toBe(0);
+        const recs = readJsonlRecords();
+        const readCalls = toolCalls(recs, 'Read');
+        expect(readCalls.length).toBe(1);
+        expect(readCalls[0]['gen_ai.tool.call.id'].startsWith(SYNTH_PREFIX)).toBe(true);
+        expect(readCalls[0]['gen_ai.tool.call.arguments']).toEqual({ file_path: ROOT_SKILL });
+      } finally {
+        try { fs.rmSync(DATA_DIR, { recursive: true, force: true }); } catch {}
+        DATA_DIR = prevDataDir;
+      }
+    }
+  });
+
+  test('⑤ 同 turn 多 user-typed skill → Set 容器,都合成(P2,随 #1 Set 改造配套)', () => {
+    const BASE_B = '/abs/workdir/.claude/skills/another-skill';
+    const ROOT_B = `${BASE_B}/SKILL.md`;
+    const t = writeTranscript('og5', [
+      userPrompt('p1', '/e2e-build-push and /another-skill', '2026-07-28T03:00:00.000Z'),
+      // 同 turn 内两个 user-typed skill 注入(Set 容器防后写覆盖)
+      userTypedSkillMetaInjection(BASE_DIR, '2026-07-28T03:00:00.500Z'),
+      userTypedSkillMetaInjection(BASE_B, '2026-07-28T03:00:01.000Z'),
       finalAnswer('msg_final', 'done', '2026-07-28T03:00:05.000Z'),
     ]);
-    const r = runHook('stop', { session_id: 'og4', stop_reason: 'end_turn', transcript_path: t, cwd: '/abs/workdir' });
+    const r = runHook('stop', { session_id: 'og5', stop_reason: 'end_turn', transcript_path: t, cwd: '/abs/workdir' });
     expect(r.status).toBe(0);
     const recs = readJsonlRecords();
-    expect(toolCalls(recs, 'Skill').length).toBe(1);
-    expect(toolCalls(recs, 'Read').length).toBe(0);
-    const allInjected = recs
-      .filter((x) => x['event.name'] === 'llm.response')
-      .flatMap((r2) => outputToolCalls(r2))
-      .filter((p) => (p.id || '').startsWith(SYNTH_PREFIX));
-    expect(allInjected.length).toBe(0);
+    const readCalls = toolCalls(recs, 'Read');
+    // 两个 user-typed skill → 两条合成根 Read(Set 容器都命中)
+    expect(readCalls.length).toBe(2);
+    const roots = readCalls.map((x) => x['gen_ai.tool.call.arguments']?.file_path).sort();
+    expect(roots).toEqual([ROOT_B, ROOT_SKILL].sort());
+    expect(readCalls.every((x) => x['gen_ai.tool.call.id'].startsWith(SYNTH_PREFIX))).toBe(true);
+    // owner step 同 = turn 首个 LLM step
+    const firstResp = recs.find((x) => x['event.name'] === 'llm.response');
+    expect(readCalls.every((x) => x['gen_ai.step.id'] === firstResp['gen_ai.step.id'])).toBe(true);
+    const ownerResp = llmResponseForStep(recs, firstResp['gen_ai.step.id']);
+    const injectedIds = outputToolCalls(ownerResp).filter((p) => p.name === 'Read').map((p) => p.id);
+    expect(injectedIds.length).toBe(2);
   });
 });


### PR DESCRIPTION
## 背景

PR #194 已合并进 main 时，origin gate commit 尚未 push——main 当前对**模型自主调 Skill** 也补根 Read span（越界 synth），违反用户边界"仅 user prompt 显式 `/skill` 才合成"。本 PR 作为 #194 的 follow-up，把 origin gate 落地到 main，修正该越界。

> 说明：#194 是 squash merge，原 3 个 commit SHA 不在 main ancestry；同分支开 PR 会显示 4 个 commit + 冗余 diff。故从 `origin/main` 切新分支 `fix/claude-skill-origin-gate-AGE-1126`，得到干净的 commit 序列（base=main）。

## 本 PR 改动（修订版 gate — Round 10 复活）

### 判别信号（三元组）
synth 仅对 **user-typed `/skill`** 激活：CC UI 直接注入 SKILL.md 内容为 **`isMeta=True` user message**，且 **`sourceToolUseID` 缺席**（无对应 Skill tool_use）。模型自主调 Skill 路径下 `isMeta=True` 但 `sourceToolUseID` 指向 Skill tool_use → 不合成。

### 三个文件
- `assets/hooks/claude-code/transcript-parser.mjs` — `isMeta` 双分支：`sourceToolUseID` present → `skillRootByToolId`（model-auto，不变）；缺席 → 新建 `userTypedSkillRootByPromptId`（`Map<promptMapKey, Set<rootPath>>`）。`skill_root_parse_miss` 漂移打点不动。
- `assets/hooks/claude-code-hook-processor.mjs` — turn 级 synth 入口（`realReadPaths` 收集后、Phase 2 循环前）：遍历 `turn.userTypedSkillRoots`，复用 `deterministicSkillReadId`/`synthesizedSkillRoots`/`normalizeSkillPath`/`injectSynthesizedToolCall`。P0 时间戳：call ts = `turn.promptTimestamp`，result ts = 本 turn 首个 LLM response ts（取不到或等于 → `BigInt(callNs) + 1n` 兜底）。删除旧 `<skill-format>` synth body 留 no-op + 注释。
- `tests/unit/hooks/claude-code/skill-read.test.mjs` — 替换上轮 4 条旧 origin-gate 用例为 5 条新用例：user-typed→合成 / model-auto→不合成 / 真实根 Read 已存在→跳过 / sourceToolUseID 四种 falsy→全归 user-typed / 同 turn 多 user-typed skill→Set 容器都合成。

## 预期语义

- synth 仅对 **user-typed `/skill`**（CC UI 直接注入 SKILL.md 内容为 `isMeta=True` user message，`sourceToolUseID` 缺席）激活；
- **模型自主调 Skill**（`isMeta=True` + `sourceToolUseID` 指向 Skill tool_use）**不合成**；
- 判别信号 = `isMeta=True` + "Base directory for this skill:" 前缀 + `sourceToolUseID` 缺席 三元组；
- Multica 托管 SDK-CLI 模式下 prompt 永不含 isMeta skill 注入（CC UI 路径不走），故 synth **永不触发**，属预期。

## 验证证据

- **单测 65/65 PASS**（含 5 条新 origin-gate 用例）。
- **tester Round 10 E2E**（真实 claude CLI trace）：
  - PTY user-typed `/skill`：合成根 Read span `toolu_skillread_41a1587c3bc23f8d6c6b4830` 出现、归属 owner step1、backing 含 Read tool_call、call≠result ts（2.562s）、`validate-trace` **0 ERROR**、`time.non_zero_duration` PASS。
  - case ① model-auto：0 synth span、parser 双分支判别正确（`sourceToolUseID` present → model-auto 分支；缺席 → user-typed 分支）。
  - CP5 准出全过。
- 准出 5 条全满足：单测 65/65 / 真实 claude CLI trace / validate 0 ERROR / STEP≥3+TOOL≥2 / `gen_ai.output.messages` 含 Read tool_call 非空。

关联 AGE-1126。follow-up to #194。
