### PR TITLE
fix(opencode): apply configured log poll interval

### DIFF
--- a/src/core/config-loader.ts
+++ b/src/core/config-loader.ts
@@ -372,6 +372,7 @@ function buildListenersConfig(
     'cursor-hook': { enabled: true, pollInterval: 30_000 },
     'claude-code-log': { enabled: true, pollInterval: 30_000 },
     'codex-transcript': { enabled: true, pollInterval: 30_000 },
+    'opencode-log': { enabled: true, pollInterval: 30_000 },
     'pi-coding-agent-log': { enabled: true, pollInterval: 30_000 },
   };
 

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -1058,6 +1058,7 @@ export class Orchestrator extends EventEmitter {
     const opencodeLogInput = new OpenCodeLogInput({
       stateStore: this.stateStore,
       logDir: opencodeLogDir,
+      pollIntervalMs: listenerCfg['opencode-log']?.pollInterval,
     });
     this.inputManager.registerInput(opencodeLogInput);
     entries.push(

--- a/tests/unit/core/config-loader.test.ts
+++ b/tests/unit/core/config-loader.test.ts
@@ -265,6 +265,7 @@ describe('ConfigLoader', () => {
       expect(config.listeners['qoder-cli-session'].enabled).toBe(true);
       expect(config.listeners['cursor-hook'].enabled).toBe(true);
       expect(config.listeners['codex-transcript']).toEqual({ enabled: true, pollInterval: 30_000 });
+      expect(config.listeners['opencode-log']).toEqual({ enabled: true, pollInterval: 30_000 });
       expect(config.listeners['pi-coding-agent-log']).toEqual({ enabled: true, pollInterval: 30_000 });
     });
 
@@ -272,12 +273,14 @@ describe('ConfigLoader', () => {
       mockReadJsonFile.mockResolvedValueOnce({
         listeners: {
           qoder: { enabled: false, pollInterval: 120000 },
+          'opencode-log': { pollInterval: 1000 },
         },
       });
 
       const config = await loadConfig();
       expect(config.listeners.qoder.enabled).toBe(false);
       expect(config.listeners.qoder.pollInterval).toBe(120000);
+      expect(config.listeners['opencode-log']).toEqual({ enabled: true, pollInterval: 1000 });
     });
 
     it('migrates a legacy codex-log listener override to codex-transcript', async () => {

--- a/tests/unit/core/orchestrator.test.ts
+++ b/tests/unit/core/orchestrator.test.ts
@@ -250,6 +250,20 @@ describe('Orchestrator', () => {
       expect(events).toEqual(['starting', 'started']);
       await orch.stop();
     });
+
+    it('passes the configured OpenCode log poll interval to the input', async () => {
+      const config = makeConfig();
+      config.listeners['opencode-log'] = { enabled: true, pollInterval: 1000 };
+
+      const orch = new Orchestrator(config);
+      await orch.start();
+
+      const input = (orch as any).inputManager.getInput('opencode-log');
+      expect(input).toBeDefined();
+      expect(input.pollIntervalMs).toBe(1000);
+
+      await orch.stop();
+    });
   });
 
   describe('stop sequence (T039)', () => {


### PR DESCRIPTION
## Summary

- register `opencode-log` in the default listener configuration
- pass `listeners["opencode-log"].pollInterval` to the actual `OpenCodeLogInput`
- add regression coverage for config loading and orchestrator wiring

## Motivation

The OpenCode JSONL collector always used its hard-coded 30-second polling interval because the listener configuration was only passed to agent discovery, not to the input itself. After this change, users can reduce local trace collection latency through `~/.loongsuite-pilot/config.json`, while the default remains 30 seconds.

## Testing

- `npm run typecheck`
- `npm test` — 183 test files passed, 2079 tests passed