### PR TITLE
fix(claude-code): restore skill context and isolate prompt histories

### DIFF
--- a/assets/hooks/claude-code-hook-processor.mjs
+++ b/assets/hooks/claude-code-hook-processor.mjs
@@ -193,54 +193,50 @@ function isoToUnixNanos(isoStr) {
   return String(ms) + '000000';
 }
 
-// ─── /skill 根 SKILL.md 去重合成辅助 ───
+// ─── runtime Skill load 辅助 ───
 
 /**
- * 纯词法归一化 skill 根路径 / Read file_path,用于按精确相等比较去重。
- * runtime 为 Linux(大小写敏感 FS):禁 toLowerCase(会误配仅大小写不同的文件)、
- * 禁 realpathSync(命中 FS、路径不存在会抛、与 transcript 字符串不确定一致 → 非幂等)。
- * 只做 path.resolve(cwd,p) + normalize + 去尾斜杠。
+ * 显式 /skill 没有模型生成的 tool_use id。使用 transcript 中稳定字段生成 call id,
+ * 使同一条 meta 注入在重放时仍映射为同一个 TOOL span。
  */
-function normalizeSkillPath(cwd, p) {
-  if (!p || typeof p !== 'string') return null;
-  const resolved = cwd ? path.resolve(cwd, p) : path.resolve(p);
-  return path.normalize(resolved).replace(/\/+$/, '');
-}
-
-/**
- * 兜底合成 Read 的确定性 call id: hash(client+turnId+normalizedRootPath)。
- * 同一次 build 内幂等,tool.call/tool.result 复用同一 id → OTLP 一个 execute_tool Read span。
- */
-function deterministicSkillReadId(client, turnId, normalizedRootPath) {
+function deterministicSkillLoadId(sessionId, promptId, metaUuid, rootPath) {
   const h = crypto
-    .createHash('sha1')
-    .update(`${client}|${turnId}|${normalizedRootPath}`)
+    .createHash('sha256')
+    .update([
+      sessionId || '',
+      promptId || '',
+      metaUuid || '',
+      rootPath || '',
+    ].join('\0'))
     .digest('hex')
     .slice(0, 24);
-  return `toolu_skillread_${h}`;
+  return `toolu_skillload_${h}`;
 }
 
-/**
- * 把一个合成的 tool_call part 注入到指定 step 的 llm.response 记录的
- * gen_ai.output.messages(assistant 消息)里。参照 cursor PR #193 的做法,
- * 保证合成的 tool span 在 LLM 输出侧有对应 tool_call(ARMS 语义校验要求)。
- */
-function injectSynthesizedToolCall(records, stepId, toolCall) {
-  const llmResp = records.find(
-    (r) => r['event.name'] === 'llm.response' && r['gen_ai.step.id'] === stepId,
-  );
-  if (!llmResp) return;
-  const msgs = Array.isArray(llmResp['gen_ai.output.messages'])
-    ? llmResp['gen_ai.output.messages']
-    : [];
-  let assistantMsg = msgs.find((m) => m && m.role === 'assistant');
-  if (!assistantMsg) {
-    assistantMsg = { role: 'assistant', parts: [] };
-    msgs.push(assistantMsg);
-  }
-  if (!Array.isArray(assistantMsg.parts)) assistantMsg.parts = [];
-  assistantMsg.parts.push({ type: 'tool_call', ...toolCall });
-  llmResp['gen_ai.output.messages'] = msgs;
+function skillAttributes(skillLoad, fallbackName) {
+  const name = skillLoad?.name
+    || (typeof fallbackName === 'string' ? fallbackName.trim().replace(/^\/+/, '') : null);
+  const id = skillLoad?.id || name;
+  return {
+    ...(name ? { 'gen_ai.skill.name': name } : {}),
+    ...(id ? { 'gen_ai.skill.id': id } : {}),
+  };
+}
+
+function positiveSkillLoadTimes(skillLoad, fallbackTimestamp) {
+  const minDurationNanos = 1_000_000n; // converter uses millisecond start/end times
+  let call = BigInt(isoToUnixNanos(
+    skillLoad?.commandTimestamp || skillLoad?.metaTimestamp || fallbackTimestamp,
+  ));
+  let result = BigInt(isoToUnixNanos(
+    skillLoad?.metaTimestamp || fallbackTimestamp || skillLoad?.commandTimestamp,
+  ));
+
+  if (call === 0n && result > minDurationNanos) call = result - minDurationNanos;
+  if (call === 0n) call = BigInt(Date.now()) * 1_000_000n;
+  if (result <= call) result = call + minDurationNanos;
+
+  return { call: String(call), result: String(result) };
 }
 
 // ─── cmd handlers ───
@@ -523,6 +519,7 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
   // Phase 1: 为每个 llm_call 创建 step + 生成 LLM 事件
   const toolIdToStep = new Map(); // tool_use_id → { stepId, stepSpanId }
   const llmCalls = turn.llmCalls || [];
+  let firstStepOwner = null;
 
   for (const ev of llmCalls) {
     stepRound++;
@@ -530,6 +527,9 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
     const currentStepSpanId = generateSpanId();
     const llmSpanId = generateSpanId();
     const responseId = ev.message_id || `${currentStepId}:r`;
+    if (!firstStepOwner) {
+      firstStepOwner = { stepId: currentStepId, stepSpanId: currentStepSpanId };
+    }
 
     // 注册该 LLM 声明的所有 tool_use_id → 当前 step
     for (const toolId of (ev.declaredToolIds || [])) {
@@ -621,22 +621,13 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
     prevInputMsgs = ev._input_is_delta ? [] : inputMsgs;
   }
 
-  // /skill 兜底合成前置数据: 本 turn 所有真实 Read 的归一化 file_path(事件优先级
-  // transcript/Hook 真实 Read > 兜底合成),以及已合成过的根路径(同 turn 幂等去重)。
-  // 只用于「根 SKILL.md 是否已有真实 Read」判定,普通文件 Read 全程不触碰、不做全局去重。
-  const skillRootByToolId = turn.skillRootByToolId;
-  const realReadPaths = new Set();
-  if (skillRootByToolId && skillRootByToolId.size > 0) {
-    for (const ev of llmCalls) {
-      for (const block of (ev.output_content || [])) {
-        if (block && block.type === 'tool_use' && block.name === 'Read') {
-          const norm = normalizeSkillPath(cwd, block.input?.file_path);
-          if (norm) realReadPaths.add(norm);
-        }
-      }
-    }
-  }
-  const synthesizedSkillRoots = new Set();
+  const skillLoads = Array.isArray(turn.skillLoads) ? turn.skillLoads : [];
+  const skillLoadsByToolId = new Map(
+    skillLoads
+      .filter((load) => load.sourceToolUseId)
+      .map((load) => [load.sourceToolUseId, load]),
+  );
+  const consumedSkillLoads = new Set();
 
   // Phase 2: 为每个 tool 生成 tool.call + tool.result，归属到声明方 LLM 的 step
   for (const ev of llmCalls) {
@@ -657,6 +648,11 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
       if (toolName === 'Agent' || toolName === 'agent') continue;
 
       const toolSpanId = generateSpanId();
+      const skillLoad = toolName === 'Skill' ? skillLoadsByToolId.get(toolId) : null;
+      const skillFields = toolName === 'Skill'
+        ? skillAttributes(skillLoad, toolBlock.input?.skill || toolBlock.input?.name)
+        : {};
+      if (skillLoad) consumedSkillLoads.add(skillLoad);
 
       // tool.call
       records.push({
@@ -670,6 +666,7 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
         'gen_ai.tool.name': toolName,
         'gen_ai.tool.call.id': toolId,
         'gen_ai.tool.call.arguments': toJsonValue(toolBlock.input || {}),
+        ...skillFields,
       });
 
       // tool.result (only if we have a result timestamp)
@@ -686,6 +683,7 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
           'gen_ai.tool.call.id': toolId,
           'gen_ai.tool.call.result': toJsonValue(timestamps.resultContent || ''),
           'tool.result.status': timestamps.isError ? 'error' : 'success',
+          ...skillFields,
         };
         if (timestamps.isError) {
           resultRecord['error.type'] = 'ToolError';
@@ -696,57 +694,61 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
         records.push(resultRecord);
       }
 
-      // 显式 /skill: 保证本 turn 根 SKILL.md 恰好展示一次 Read span。
-      // 去重键 = client + turnId + 归一化根路径。若本 turn 已有真实根 Read 则不合成
-      // (真实事件优先);否则合成一条同 call-id 的 Read tool.call+tool.result,挂 Skill owner step。
-      if (toolName === 'Skill' && skillRootByToolId) {
-        const rootRaw = skillRootByToolId.get(toolId);
-        const normRoot = normalizeSkillPath(cwd, rootRaw);
-        if (
-          normRoot &&
-          !realReadPaths.has(normRoot) &&
-          !synthesizedSkillRoots.has(normRoot)
-        ) {
-          synthesizedSkillRoots.add(normRoot);
-          const readCallId = deterministicSkillReadId(AGENT_ID, turnId, normRoot);
-          const readSpanId = generateSpanId();
-          const readResultTs = timestamps.result || timestamps.call;
-          records.push({
-            time_unix_nano: isoToUnixNanos(timestamps.call),
-            'event.id': crypto.randomUUID(),
-            'event.name': 'tool.call',
-            ...baseFields,
-            span_id: readSpanId,
-            parent_span_id: owner.stepSpanId,
-            'gen_ai.step.id': owner.stepId,
-            'gen_ai.tool.name': 'Read',
-            'gen_ai.tool.call.id': readCallId,
-            'gen_ai.tool.call.arguments': toJsonValue({ file_path: normRoot }),
-          });
-          records.push({
-            time_unix_nano: isoToUnixNanos(readResultTs),
-            'event.id': crypto.randomUUID(),
-            'event.name': 'tool.result',
-            ...baseFields,
-            span_id: readSpanId,
-            parent_span_id: owner.stepSpanId,
-            'gen_ai.step.id': owner.stepId,
-            'gen_ai.tool.name': 'Read',
-            'gen_ai.tool.call.id': readCallId,
-            'gen_ai.tool.call.result': toJsonValue(''),
-            'tool.result.status': 'success',
-          });
+    }
+  }
 
-          // 参照 cursor PR #193: 在 owner step 的 LLM span output.messages 挂上
-          // 同 call id / name=Read 的 tool_call,使合成 Read span 满足 ARMS
-          // semantic.tool_matches_llm_output(工具 span 必须对应 LLM 输出侧的 tool_call)。
-          injectSynthesizedToolCall(records, owner.stepId, {
-            id: readCallId,
-            name: 'Read',
-            arguments: toJsonValue({ file_path: normRoot }),
-          });
-        }
-      }
+  // /skill 和其他 runtime meta 注入没有 LLM tool_use。将加载事实建模成
+  // extension TOOL span,但不篡改 LLM output.messages。
+  if (firstStepOwner) {
+    const synthesizedCallIds = new Set();
+    for (const skillLoad of skillLoads) {
+      if (consumedSkillLoads.has(skillLoad)) continue;
+      const callId = deterministicSkillLoadId(
+        sessionId,
+        skillLoad.promptId || turn.promptId,
+        skillLoad.metaUuid || skillLoad.metaTimestamp,
+        skillLoad.rootPath,
+      );
+      if (synthesizedCallIds.has(callId)) continue;
+      synthesizedCallIds.add(callId);
+
+      const toolSpanId = generateSpanId();
+      const skillFields = skillAttributes(skillLoad);
+      const times = positiveSkillLoadTimes(
+        skillLoad,
+        llmCalls[0]?.request_start_time || llmCalls[0]?.timestamp,
+      );
+      records.push({
+        time_unix_nano: times.call,
+        'event.id': crypto.randomUUID(),
+        'event.name': 'tool.call',
+        ...baseFields,
+        span_id: toolSpanId,
+        parent_span_id: firstStepOwner.stepSpanId,
+        'gen_ai.step.id': firstStepOwner.stepId,
+        'gen_ai.tool.name': 'load_skill',
+        'gen_ai.tool.type': 'extension',
+        'gen_ai.tool.call.id': callId,
+        'gen_ai.tool.call.arguments': toJsonValue({
+          skill: skillLoad.name || skillLoad.id || 'unknown',
+        }),
+        ...skillFields,
+      });
+      records.push({
+        time_unix_nano: times.result,
+        'event.id': crypto.randomUUID(),
+        'event.name': 'tool.result',
+        ...baseFields,
+        span_id: toolSpanId,
+        parent_span_id: firstStepOwner.stepSpanId,
+        'gen_ai.step.id': firstStepOwner.stepId,
+        'gen_ai.tool.name': 'load_skill',
+        'gen_ai.tool.type': 'extension',
+        'gen_ai.tool.call.id': callId,
+        'gen_ai.tool.call.result': toJsonValue({ success: true }),
+        'tool.result.status': 'success',
+        ...skillFields,
+      });
     }
   }
 

--- a/assets/hooks/claude-code/transcript-parser.mjs
+++ b/assets/hooks/claude-code/transcript-parser.mjs
@@ -23,20 +23,19 @@
 import fs from 'node:fs';
 import crypto from 'node:crypto';
 
-import { logHookError } from '../shared/error-logger.mjs';
-
 export const MAX_TRANSCRIPT_BYTES = 50 * 1024 * 1024; // 50 MB safety limit
 const MISSING_PROMPT_ID = '__missing_prompt_id__';
-const PARSER_AGENT_ID = 'claude-code';
 
-// Claude Code 显式 /skill 调用后,会以 isMeta user 记录注入 SKILL.md 内容,
-// 首行形如 "Base directory for this skill: <绝对路径>"。根 SKILL.md 的路径
-// 只在此注入里出现(Skill tool_use 本身不含路径),靠 sourceToolUseID 关联。
+// Claude Code 加载 skill 后,会以 isMeta user 记录注入 SKILL.md 内容,
+// 首行形如 "Base directory for this skill: <绝对路径>"。模型触发的 Skill tool
+// 通过 sourceToolUseID 关联;旧版本的模型触发正文可能没有 Base directory 头,
+// 但 sourceToolUseID 仍可精确确认它属于 Skill。用户直接输入 /skill 时没有该 ID。
 const SKILL_BASE_DIR_PREFIX = 'Base directory for this skill:';
+const COMMAND_NAME_PATTERN = /<command-name>\s*\/([^<\s]+)\s*<\/command-name>/i;
 
 /**
  * 从 isMeta 注入文本首行提取 skill 根目录,拼出根 SKILL.md 路径。
- * 只做原样拼接,不做归一化(归一化留给下游按 client+turnId 去重时统一处理)。
+ * 只做原样拼接,不访问文件系统。
  * @returns {string|null} `<baseDir>/SKILL.md` 或 null(非 skill 注入)
  */
 function extractSkillRootPath(text) {
@@ -45,7 +44,24 @@ function extractSkillRootPath(text) {
   const firstLine = nl >= 0 ? text.slice(0, nl) : text;
   const baseDir = firstLine.slice(SKILL_BASE_DIR_PREFIX.length).trim();
   if (!baseDir) return null;
-  return baseDir.replace(/\/+$/, '') + '/SKILL.md';
+  return baseDir.replace(/[\\/]+$/, '') + '/SKILL.md';
+}
+
+function normalizeSkillName(value) {
+  if (typeof value !== 'string') return null;
+  const name = value.trim().replace(/^\/+/, '');
+  return name || null;
+}
+
+function extractSlashCommandName(text) {
+  if (typeof text !== 'string') return null;
+  return normalizeSkillName(text.match(COMMAND_NAME_PATTERN)?.[1]);
+}
+
+function extractSkillNameFromRootPath(rootPath) {
+  if (typeof rootPath !== 'string') return null;
+  const parts = rootPath.replace(/[\\/]+SKILL\.md$/i, '').split(/[\\/]/).filter(Boolean);
+  return normalizeSkillName(parts.at(-1));
 }
 
 function isMetaRecord(record) {
@@ -163,8 +179,9 @@ export function parseClaudeTranscript(transcriptPath, byteOffset = 0) {
   const toolResultTimestamps = new Map(); // tool_use_id → ISO8601 timestamp
   const toolResultContents = new Map(); // tool_use_id → result content
   const toolResultErrors = new Map(); // tool_use_id → boolean (is_error)
-  const skillRootByToolId = new Map(); // Skill tool_use_id → 根 SKILL.md 路径(来自 isMeta 注入)
-  const skillToolUseIdSet = new Set(); // #1: 本次 window 内 name==='Skill' 的 tool_use id(结构信号)
+  const skillToolsById = new Map(); // Skill tool_use_id → { name, promptId }
+  const slashCommandsByPromptId = new Map(); // promptId → { name, timestamp }
+  const skillLoads = []; // 从 skill isMeta 注入还原的加载事实
   let currentPromptId = null; // 当前 turn 的 promptId(从 user record 提取)
 
   for (const line of content.split('\n')) {
@@ -217,9 +234,11 @@ export function parseClaudeTranscript(transcriptPath, byteOffset = 0) {
           if (block.type === 'tool_use' && block.id && recordTs) {
             group.toolUseTimestamps.set(block.id, recordTs);
           }
-          // #1: 顺带收集 Skill tool_use id,供 isMeta 注入做「结构确认」(与前缀解耦)。
           if (block.type === 'tool_use' && block.name === 'Skill' && block.id) {
-            skillToolUseIdSet.add(block.id);
+            skillToolsById.set(block.id, {
+              name: normalizeSkillName(block.input?.skill || block.input?.name),
+              promptId: currentPromptId,
+            });
           }
         }
       }
@@ -237,24 +256,49 @@ export function parseClaudeTranscript(transcriptPath, byteOffset = 0) {
       if (promptId) currentPromptId = promptId;
 
       const userContent = msg.content;
+      const userText = extractTextContent(userContent);
+      let metaKind = null;
 
-      // 显式 /skill 注入: 捕获 sourceToolUseID → 根 SKILL.md 路径。
-      // 仅额外捕获此映射,不改变 isMeta 其余记录被丢弃的行为。
-      // #1: 路径提取仍「前缀优先」不变(跨 parse-window 边界时 Skill 块可能已在上一
-      // window 消费,此处仍能靠前缀拿到路径,绝不比现状更窄)。
-      if (isMeta && record.sourceToolUseID) {
-        const rootPath = extractSkillRootPath(extractTextContent(userContent));
-        if (rootPath) {
-          skillRootByToolId.set(record.sourceToolUseID, rootPath);
-        } else if (skillToolUseIdSet.has(record.sourceToolUseID)) {
-          // #2 漂移可观测: 仅当「结构确认为 skill 注入(sourceToolUseID 指向本 window
-          // 的 Skill tool_use)但路径提取失败」时打点——把前缀漂移导致的静默回归变成
-          // 可检测信号。结构 gate 确保不对「非 skill 的 isMeta+sourceToolUseID」误报。
-          logHookError({
-            agentId: PARSER_AGENT_ID,
-            stage: 'skill_root_parse',
-            errorType: 'skill_root_parse_miss',
-            errorMessage: `sourceToolUseID=${record.sourceToolUseID} resolves to a Skill tool_use but SKILL.md root path extraction failed (prefix mismatch)`,
+      if (!isMeta) {
+        const commandName = extractSlashCommandName(userText);
+        if (commandName) {
+          slashCommandsByPromptId.set(promptMapKey(currentPromptId), {
+            name: commandName,
+            timestamp: recordTs,
+          });
+        }
+      }
+
+      // Skill isMeta 是 Claude 实际注入给后续 LLM 的上下文。无论是否带
+      // sourceToolUseID,带标准 Base directory 头的记录都识别。旧格式可能没有
+      // 该头,此时仅在 sourceToolUseID 精确指向真实 Skill tool_use 时识别。
+      if (isMeta) {
+        const rootPath = extractSkillRootPath(userText);
+        const sourceToolUseId = record.sourceToolUseID || null;
+        const sourceTool = sourceToolUseId ? skillToolsById.get(sourceToolUseId) : null;
+        if (rootPath || sourceTool) {
+          const slashCommand = slashCommandsByPromptId.get(promptMapKey(currentPromptId));
+          const name = sourceTool?.name
+            || slashCommand?.name
+            || extractSkillNameFromRootPath(rootPath);
+          const trigger = sourceTool
+            ? 'model_tool'
+            : slashCommand
+              ? 'slash_command'
+              : 'runtime_meta';
+
+          metaKind = 'skill_context';
+          skillLoads.push({
+            promptId: currentPromptId,
+            trigger,
+            sourceToolUseId,
+            name,
+            id: name,
+            rootPath,
+            content: userContent,
+            metaUuid: record.uuid || null,
+            commandTimestamp: slashCommand?.timestamp || null,
+            metaTimestamp: recordTs,
           });
         }
       }
@@ -277,6 +321,8 @@ export function parseClaudeTranscript(transcriptPath, byteOffset = 0) {
         timestamp: recordTs,
         promptId: currentPromptId,
         isMeta,
+        metaKind,
+        uuid: record.uuid || null,
       });
     }
   }
@@ -293,9 +339,15 @@ export function parseClaudeTranscript(transcriptPath, byteOffset = 0) {
 
   // Phase 3: 构建 llm_call 事件(带时间戳 + tool 归属信息)
   const llmCalls = [];
-  const conversationHistory = [];
-  let prevCount = 0;
+  const conversationHistoryByPromptId = new Map();
   const lastToolResultTsByPromptId = new Map();
+  const historyForPrompt = (promptId) => {
+    const key = promptMapKey(promptId);
+    if (!conversationHistoryByPromptId.has(key)) {
+      conversationHistoryByPromptId.set(key, { messages: [], emittedCount: 0 });
+    }
+    return conversationHistoryByPromptId.get(key);
+  };
   const updateLastToolResultTs = (promptId, ts) => {
     if (!ts) return;
     const key = promptMapKey(promptId);
@@ -305,8 +357,9 @@ export function parseClaudeTranscript(transcriptPath, byteOffset = 0) {
 
   for (const rec of conversationRecords) {
     if (rec.type === 'user') {
-      if (!rec.isMeta) {
-        conversationHistory.push({ role: 'user', content: rec.content });
+      const history = historyForPrompt(rec.promptId);
+      if (!rec.isMeta || rec.metaKind === 'skill_context') {
+        history.messages.push({ role: 'user', content: rec.content });
       }
       if (!rec.isMeta && Array.isArray(rec.content)) {
         for (const part of rec.content) {
@@ -326,7 +379,8 @@ export function parseClaudeTranscript(transcriptPath, byteOffset = 0) {
       const cacheRead = usage.cache_read_input_tokens || 0;
       const cacheCreate = usage.cache_creation_input_tokens || 0;
 
-      const delta = conversationHistory.slice(prevCount);
+      const history = historyForPrompt(group.promptId);
+      const delta = history.messages.slice(history.emittedCount);
 
       const declaredToolIds = [];
       for (const block of group.mergedContent) {
@@ -366,11 +420,11 @@ export function parseClaudeTranscript(transcriptPath, byteOffset = 0) {
         promptId: group.promptId,
       });
 
-      conversationHistory.push({
+      history.messages.push({
         role: 'assistant',
         content: group.mergedContent,
       });
-      prevCount = conversationHistory.length;
+      history.emittedCount = history.messages.length;
 
       for (const toolId of declaredToolIds) {
         const ts = toolResultTimestamps.get(toolId);
@@ -380,7 +434,7 @@ export function parseClaudeTranscript(transcriptPath, byteOffset = 0) {
   }
 
   // Phase 4: 按 promptId 切分 turns
-  const turns = splitIntoTurns(conversationRecords, llmCalls, skillRootByToolId);
+  const turns = splitIntoTurns(conversationRecords, llmCalls, skillLoads);
 
   return { turns, nextOffset: fileSize };
 }
@@ -392,7 +446,7 @@ export function parseClaudeTranscript(transcriptPath, byteOffset = 0) {
  * 同一 turn 内所有 user record 共享同一 promptId。
  * promptId 变化 = 新 turn 开始。
  */
-function splitIntoTurns(conversationRecords, llmCalls, skillRootByToolId = new Map()) {
+function splitIntoTurns(conversationRecords, llmCalls, skillLoads = []) {
   if (llmCalls.length === 0) return [];
 
   // 收集所有出现的 promptId(按首次出现顺序)
@@ -426,10 +480,11 @@ function splitIntoTurns(conversationRecords, llmCalls, skillRootByToolId = new M
     // 无 promptId (所有 user record 都是系统注入的),fallback 为单 turn
     const firstTs = llmCalls[0]?.timestamp || null;
     return [{
+      promptId: null,
       prompt: '',
       promptTimestamp: firstTs,
       llmCalls,
-      skillRootByToolId,
+      skillLoads,
     }];
   }
 
@@ -453,27 +508,25 @@ function splitIntoTurns(conversationRecords, llmCalls, skillRootByToolId = new M
     }
 
     turns.push({
+      promptId: pid,
       prompt: info.promptText || '',
       promptTimestamp,
       llmCalls: turnLlmCalls,
-      skillRootByToolId,
+      skillLoads: skillLoads.filter((load) => load.promptId === pid),
     });
   }
 
   // 处理没有 promptId 的 llmCalls (edge case: assistant record 出现在任何 user record 之前)
   const orphanCalls = llmCalls.filter((c) => !c.promptId);
   if (orphanCalls.length > 0) {
-    if (turns.length > 0) {
-      // 归入最后一个 turn
-      turns[turns.length - 1].llmCalls.push(...orphanCalls);
-    } else {
-      turns.push({
-        prompt: '',
-        promptTimestamp: orphanCalls[0]?.timestamp || null,
-        llmCalls: orphanCalls,
-        skillRootByToolId,
-      });
-    }
+    // 无法归属的 assistant 使用独立 fallback turn,不能污染任何真实 promptId。
+    turns.push({
+      promptId: null,
+      prompt: '',
+      promptTimestamp: orphanCalls[0]?.timestamp || null,
+      llmCalls: orphanCalls,
+      skillLoads: skillLoads.filter((load) => !load.promptId),
+    });
   }
 
   return turns;

--- a/scripts/validate-trace.mjs
+++ b/scripts/validate-trace.mjs
@@ -15,6 +15,35 @@ const KNOWN_SUBAGENT_TOOLS = new Set(['Agent']);
 const VALID_FINISH_REASONS = new Set(['stop', 'length', 'content_filter', 'tool_call', 'tool_calls', 'error', 'end_turn', 'max_tokens']);
 const VALID_PART_TYPES = new Set(['text', 'tool_call', 'tool_call_response', 'reasoning']);
 
+export function isRuntimeSkillLoadSpan(tool) {
+  return tool?.attributes?.['gen_ai.tool.type'] === 'extension' &&
+    Boolean(
+      tool.attributes?.['gen_ai.skill.id'] ||
+      tool.attributes?.['gen_ai.skill.name'],
+    );
+}
+
+export function unmatchedToolsForLlmOutput(tools, expectedToolCalls) {
+  return tools.filter((tool) => {
+    if (isRuntimeSkillLoadSpan(tool)) return false;
+    const toolCallId = tool.attributes?.['gen_ai.tool.call.id'];
+    const toolName = tool.attributes?.['gen_ai.tool.name'];
+    return !expectedToolCalls.some((toolCall) =>
+      (toolCallId && toolCall.id && toolCall.id === toolCallId) ||
+      (toolName && toolCall.name && toolCall.name === toolName));
+  });
+}
+
+export function hasModelToolSpanForOutput(tools, expectedToolCall) {
+  return tools.some((tool) => {
+    if (isRuntimeSkillLoadSpan(tool)) return false;
+    return (expectedToolCall.id &&
+        tool.attributes?.['gen_ai.tool.call.id'] === expectedToolCall.id) ||
+      (expectedToolCall.name &&
+        tool.attributes?.['gen_ai.tool.name'] === expectedToolCall.name);
+  });
+}
+
 // ─── CLI ─────────────────────────────────────────────────────────────────────
 
 function parseCli() {
@@ -694,24 +723,18 @@ function validateSemantic(trace, rules) {
         }
       } catch { continue; }
 
-      for (const tool of tools) {
+      // Runtime/user-triggered Skill loads are truthful TOOL spans but are not
+      // emitted by the model, so they intentionally have no output tool_call.
+      for (const tool of unmatchedToolsForLlmOutput(tools, expectedToolCalls)) {
         const toolCallId = tool.attributes?.['gen_ai.tool.call.id'];
         const toolName = tool.attributes?.['gen_ai.tool.name'];
-        const matched = expectedToolCalls.some(tc =>
-          (toolCallId && tc.id && tc.id === toolCallId) || (toolName && tc.name && tc.name === toolName)
-        );
-        if (!matched) {
-          checks.push(error('semantic.tool_matches_llm_output',
-            `TOOL ${toolName || toolCallId} not found in LLM output tool_calls`, tool.spanId, tool.name));
-          allToolsMatch = false;
-        }
+        checks.push(error('semantic.tool_matches_llm_output',
+          `TOOL ${toolName || toolCallId} not found in LLM output tool_calls`, tool.spanId, tool.name));
+        allToolsMatch = false;
       }
 
       for (const tc of expectedToolCalls) {
-        const matched = tools.some(t =>
-          (tc.id && t.attributes?.['gen_ai.tool.call.id'] === tc.id) ||
-          (tc.name && t.attributes?.['gen_ai.tool.name'] === tc.name)
-        );
+        const matched = hasModelToolSpanForOutput(tools, tc);
         if (!matched) {
           if (KNOWN_SUBAGENT_TOOLS.has(tc.name)) {
             checks.push(warn('semantic.tool_matches_llm_output',
@@ -1063,4 +1086,6 @@ function main() {
   process.exit(report.summary.verdict === 'FAIL' ? 1 : 0);
 }
 
-main();
+const isCliEntry = process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isCliEntry) main();

--- a/tests/unit/hooks/claude-code/skill-read.test.mjs
+++ b/tests/unit/hooks/claude-code/skill-read.test.mjs
@@ -2,18 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * skill-read.test.mjs — 显式 /skill 根 SKILL.md Read span 采集/去重/兜底合成。
- *
- * Fixture 结构来源: 真实 transcript(skill_fixture.json,来自真实 transcript
- * 598899dc t2, skill e2e-build-push) 的三层连续记录:
- *   1. assistant tool_use name=Skill, input={skill}, id=toolu_...
- *   2. user tool_result(同 id) content="Launching skill: <name>"
- *   3. user isMeta:true, sourceToolUseID=<skill id>,
- *      text="Base directory for this skill: <绝对路径>\n\n# <标题>\n\n<SKILL.md 全文>"
- * 根 SKILL.md 路径+内容只在 isMeta 注入里;Claude 不产生根 SKILL.md 原生 Read。
+ * Claude Code Skill telemetry:
+ *   - model-triggered Skill reuses the real TOOL span;
+ *   - /skill and runtime meta injection produce a load_skill extension span;
+ *   - the original isMeta body is restored to the matching prompt's LLM input.
  */
 
-import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -23,7 +18,12 @@ import { parseClaudeTranscript } from '../../../../assets/hooks/claude-code/tran
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROCESSOR = path.resolve(__dirname, '../../../../assets/hooks/claude-code-hook-processor.mjs');
-const SHELL_HOOK = path.resolve(__dirname, '../../../../assets/hooks/claude-code-loongsuite-pilot-hook.sh');
+
+const SKILL_NAME = 'e2e-build-push';
+const BASE_DIR = `/abs/workdir/.claude/skills/${SKILL_NAME}`;
+const ROOT_SKILL = `${BASE_DIR}/SKILL.md`;
+const META_BODY = `Base directory for this skill: ${BASE_DIR}\n\n# Title\n\nskill body secret`;
+const SYNTH_PREFIX = 'toolu_skillload_';
 
 let DATA_DIR;
 let TRANSCRIPT_DIR;
@@ -38,73 +38,96 @@ afterEach(() => {
   try { fs.rmSync(TRANSCRIPT_DIR, { recursive: true, force: true }); } catch {}
 });
 
-// ─── transcript 记录构造器(结构对齐 skill_fixture.json) ───
-
-function userPrompt(promptId, text, ts) {
-  return { type: 'user', promptId, timestamp: ts, message: { role: 'user', content: [{ type: 'text', text }] } };
+function userPrompt(promptId, text, timestamp) {
+  return {
+    type: 'user',
+    promptId,
+    timestamp,
+    message: { role: 'user', content: [{ type: 'text', text }] },
+  };
 }
 
-function skillToolUse(id, skillName, ts, msgId) {
+function slashPrompt(promptId, skillName, args, timestamp) {
+  return userPrompt(
+    promptId,
+    `<command-message>${skillName}</command-message>\n` +
+      `<command-name>/${skillName}</command-name>\n` +
+      `<command-args>${args}</command-args>`,
+    timestamp,
+  );
+}
+
+function skillToolUse(id, skillName, timestamp, messageId = 'msg_skill') {
   return {
     type: 'assistant',
-    timestamp: ts,
+    timestamp,
     message: {
-      id: msgId,
+      id: messageId,
       model: 'claude-opus-4-8',
       content: [{ type: 'tool_use', id, name: 'Skill', input: { skill: skillName } }],
-      usage: { input_tokens: 2, output_tokens: 144, cache_read_input_tokens: 45475, cache_creation_input_tokens: 1841 },
+      usage: { input_tokens: 2, output_tokens: 3 },
       stop_reason: 'tool_use',
     },
   };
 }
 
-function skillToolResult(id, skillName, ts) {
+function toolResult(id, content, timestamp, promptId) {
   return {
     type: 'user',
-    timestamp: ts,
-    message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: id, content: `Launching skill: ${skillName}` }] },
+    ...(promptId ? { promptId } : {}),
+    timestamp,
+    message: {
+      role: 'user',
+      content: [{ type: 'tool_result', tool_use_id: id, content }],
+    },
   };
 }
 
-// isMeta 注入。text 首行 = "Base directory for this skill: <baseDir>"。
-function skillMetaInjection(sourceToolUseID, baseDir, ts) {
+function skillMeta({
+  sourceToolUseId = null,
+  promptId,
+  timestamp,
+  uuid = 'meta-skill-stable-uuid',
+  baseDir = BASE_DIR,
+  content,
+}) {
   return {
     type: 'user',
     isMeta: true,
-    sourceToolUseID,
-    timestamp: ts,
-    message: { role: 'user', content: `Base directory for this skill: ${baseDir}\n\n# Title\n\nskill body...` },
+    ...(sourceToolUseId ? { sourceToolUseID: sourceToolUseId } : {}),
+    ...(promptId ? { promptId } : {}),
+    uuid,
+    timestamp,
+    message: {
+      role: 'user',
+      content: content ?? [{
+        type: 'text',
+        text: `Base directory for this skill: ${baseDir}\n\n# Title\n\nskill body secret`,
+      }],
+    },
   };
 }
 
-function readToolUse(id, filePath, ts, msgId) {
+function assistantToolUse(id, name, input, timestamp, messageId) {
   return {
     type: 'assistant',
-    timestamp: ts,
+    timestamp,
     message: {
-      id: msgId,
+      id: messageId,
       model: 'claude-opus-4-8',
-      content: [{ type: 'tool_use', id, name: 'Read', input: { file_path: filePath } }],
-      usage: { input_tokens: 10, output_tokens: 5 },
+      content: [{ type: 'tool_use', id, name, input }],
+      usage: { input_tokens: 5, output_tokens: 3 },
       stop_reason: 'tool_use',
     },
   };
 }
 
-function readToolResult(id, ts, content = 'file contents') {
-  return {
-    type: 'user',
-    timestamp: ts,
-    message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: id, content }] },
-  };
-}
-
-function finalAnswer(msgId, text, ts) {
+function finalAnswer(messageId, text, timestamp) {
   return {
     type: 'assistant',
-    timestamp: ts,
+    timestamp,
     message: {
-      id: msgId,
+      id: messageId,
       model: 'claude-opus-4-8',
       content: [{ type: 'text', text }],
       usage: { input_tokens: 5, output_tokens: 3 },
@@ -115,17 +138,18 @@ function finalAnswer(msgId, text, ts) {
 
 function writeTranscript(sessionId, records) {
   const file = path.join(TRANSCRIPT_DIR, `${sessionId}.jsonl`);
-  fs.writeFileSync(file, records.map((r) => JSON.stringify(r)).join('\n') + '\n', 'utf-8');
+  fs.writeFileSync(file, records.map((record) => JSON.stringify(record)).join('\n') + '\n');
   return file;
 }
 
-function appendTranscript(file, records) {
-  fs.appendFileSync(file, records.map((r) => JSON.stringify(r)).join('\n') + '\n', 'utf-8');
-}
-
-function runHook(subcommand, payload) {
-  return spawnSync('node', [PROCESSOR, subcommand], {
-    input: JSON.stringify(payload),
+function runHook(sessionId, transcriptPath) {
+  return spawnSync('node', [PROCESSOR, 'stop'], {
+    input: JSON.stringify({
+      session_id: sessionId,
+      stop_reason: 'end_turn',
+      transcript_path: transcriptPath,
+      cwd: '/abs/workdir',
+    }),
     env: { ...process.env, LOONGSUITE_PILOT_DATA_DIR: DATA_DIR },
     encoding: 'utf-8',
     timeout: 10_000,
@@ -135,436 +159,280 @@ function runHook(subcommand, payload) {
 function readJsonlRecords() {
   const dir = path.join(DATA_DIR, 'logs', 'claude-code');
   if (!fs.existsSync(dir)) return [];
-  const records = [];
-  for (const f of fs.readdirSync(dir).filter((n) => n.endsWith('.jsonl'))) {
-    for (const line of fs.readFileSync(path.join(dir, f), 'utf-8').split('\n')) {
-      const t = line.trim();
-      if (t) records.push(JSON.parse(t));
-    }
+  return fs.readdirSync(dir)
+    .filter((name) => name.endsWith('.jsonl'))
+    .flatMap((name) => fs.readFileSync(path.join(dir, name), 'utf-8').split('\n'))
+    .filter((line) => line.trim())
+    .map((line) => JSON.parse(line));
+}
+
+function events(records, eventName, toolName) {
+  return records.filter((record) =>
+    record['event.name'] === eventName &&
+    (!toolName || record['gen_ai.tool.name'] === toolName));
+}
+
+function outputToolCalls(records) {
+  return records
+    .filter((record) => record['event.name'] === 'llm.response')
+    .flatMap((record) => record['gen_ai.output.messages'] || [])
+    .flatMap((message) => message.parts || [])
+    .filter((part) => part.type === 'tool_call');
+}
+
+function collectStrings(value) {
+  if (typeof value === 'string') return [value];
+  if (Array.isArray(value)) return value.flatMap(collectStrings);
+  if (value && typeof value === 'object') {
+    return Object.values(value).flatMap(collectStrings);
   }
-  return records;
+  return [];
 }
 
-function readErrorRecords() {
-  const dir = path.join(DATA_DIR, 'logs', 'claude-code', 'errors');
-  if (!fs.existsSync(dir)) return [];
-  const records = [];
-  for (const f of fs.readdirSync(dir).filter((n) => n.endsWith('.jsonl'))) {
-    for (const line of fs.readFileSync(path.join(dir, f), 'utf-8').split('\n')) {
-      const t = line.trim();
-      if (t) records.push(JSON.parse(t));
-    }
-  }
-  return records;
-}
-
-function parseMissCount(records) {
-  return records.filter((r) => r['error.type'] === 'skill_root_parse_miss').length;
-}
-
-// isMeta 注入,但 text 为任意内容(用于模拟前缀漂移/非 skill 注入)。
-function rawMetaInjection(sourceToolUseID, text, ts) {
-  return { type: 'user', isMeta: true, sourceToolUseID, timestamp: ts, message: { role: 'user', content: text } };
-}
-
-function toolCalls(records, name) {
-  return records.filter((r) => r['event.name'] === 'tool.call' && r['gen_ai.tool.name'] === name);
-}
-
-function toolResults(records, name) {
-  return records.filter((r) => r['event.name'] === 'tool.result' && r['gen_ai.tool.name'] === name);
-}
-
-function llmResponseForStep(records, stepId) {
-  return records.find((r) => r['event.name'] === 'llm.response' && r['gen_ai.step.id'] === stepId);
-}
-
-function outputToolCalls(llmResp) {
-  const msgs = llmResp?.['gen_ai.output.messages'] || [];
-  const assistant = msgs.find((m) => m && m.role === 'assistant');
-  return (assistant?.parts || []).filter((p) => p && p.type === 'tool_call');
-}
-
-const SYNTH_PREFIX = 'toolu_skillread_';
-const BASE_DIR = '/abs/workdir/.claude/skills/e2e-build-push';
-const ROOT_SKILL = `${BASE_DIR}/SKILL.md`;
-
-// ─── parser 级: isMeta 注入 → skillRootByToolId 捕获 ───
-
-describe('transcript-parser: skillRootByToolId 捕获', () => {
-  test('isMeta 注入被解析成 sourceToolUseID → 根 SKILL.md 路径', () => {
-    const file = writeTranscript('p_sess', [
-      userPrompt('p1', '/e2e-build-push run it', '2026-07-27T02:00:00.000Z'),
-      skillToolUse('toolu_skill_1', 'e2e-build-push', '2026-07-27T02:00:01.000Z', 'msg_skill'),
-      skillToolResult('toolu_skill_1', 'e2e-build-push', '2026-07-27T02:00:02.000Z'),
-      skillMetaInjection('toolu_skill_1', BASE_DIR, '2026-07-27T02:00:02.500Z'),
-      finalAnswer('msg_final', 'done', '2026-07-27T02:00:03.000Z'),
+describe('transcript parser Skill context', () => {
+  test('model Skill tool is correlated with its isMeta body and restored to the next LLM input', () => {
+    const file = writeTranscript('implicit-parser', [
+      userPrompt('p1', 'use the skill', '2026-07-29T01:00:00.000Z'),
+      skillToolUse('toolu_skill', SKILL_NAME, '2026-07-29T01:00:01.000Z'),
+      toolResult('toolu_skill', `Launching skill: ${SKILL_NAME}`, '2026-07-29T01:00:02.000Z'),
+      skillMeta({
+        sourceToolUseId: 'toolu_skill',
+        timestamp: '2026-07-29T01:00:02.500Z',
+      }),
+      finalAnswer('msg_final', 'done', '2026-07-29T01:00:03.000Z'),
     ]);
-    const { turns } = parseClaudeTranscript(file, 0);
-    expect(turns.length).toBe(1);
-    expect(turns[0].skillRootByToolId.get('toolu_skill_1')).toBe(ROOT_SKILL);
+
+    const { turns } = parseClaudeTranscript(file);
+    expect(turns).toHaveLength(1);
+    expect(turns[0].skillLoads).toEqual([expect.objectContaining({
+      promptId: 'p1',
+      trigger: 'model_tool',
+      sourceToolUseId: 'toolu_skill',
+      name: SKILL_NAME,
+      id: SKILL_NAME,
+      rootPath: ROOT_SKILL,
+      metaUuid: 'meta-skill-stable-uuid',
+    })]);
+    const secondInput = collectStrings(turns[0].llmCalls[1].input_messages).join('\n');
+    expect(secondInput).toContain(`Launching skill: ${SKILL_NAME}`);
+    expect(secondInput).toContain(META_BODY);
   });
 
-  test('baseDir 带尾斜杠会被去掉', () => {
-    const file = writeTranscript('p_sess2', [
-      userPrompt('p1', '/foo', '2026-07-27T02:00:00.000Z'),
-      skillToolUse('toolu_skill_2', 'foo', '2026-07-27T02:00:01.000Z', 'msg_s'),
-      skillMetaInjection('toolu_skill_2', `${BASE_DIR}/`, '2026-07-27T02:00:02.000Z'),
-      finalAnswer('msg_f', 'ok', '2026-07-27T02:00:03.000Z'),
+  test('direct slash command without sourceToolUseID becomes slash_command and keeps full meta input', () => {
+    const file = writeTranscript('slash-parser', [
+      slashPrompt('p1', SKILL_NAME, 'run it', '2026-07-29T01:00:00.000Z'),
+      skillMeta({ promptId: 'p1', timestamp: '2026-07-29T01:00:00.100Z' }),
+      finalAnswer('msg_final', 'done', '2026-07-29T01:00:01.000Z'),
     ]);
-    const { turns } = parseClaudeTranscript(file, 0);
-    expect(turns[0].skillRootByToolId.get('toolu_skill_2')).toBe(ROOT_SKILL);
+
+    const { turns } = parseClaudeTranscript(file);
+    expect(turns[0].skillLoads).toEqual([expect.objectContaining({
+      trigger: 'slash_command',
+      sourceToolUseId: null,
+      name: SKILL_NAME,
+      rootPath: ROOT_SKILL,
+    })]);
+    expect(collectStrings(turns[0].llmCalls[0].input_messages)).toContain(META_BODY);
   });
 
-  test('非 skill 的 isMeta(text 不以前缀开头)不进 map', () => {
-    const file = writeTranscript('p_sess3', [
-      userPrompt('p1', 'hi', '2026-07-27T02:00:00.000Z'),
+  test('conversationHistory is isolated by promptId and non-Skill meta remains excluded', () => {
+    const file = writeTranscript('prompt-isolation', [
       {
-        type: 'user', isMeta: true, sourceToolUseID: 'toolu_x', timestamp: '2026-07-27T02:00:00.500Z',
-        message: { role: 'user', content: 'System reminder: something unrelated' },
+        ...userPrompt('clear-prompt', 'local caveat', '2026-07-29T01:00:00.000Z'),
+        isMeta: true,
       },
-      finalAnswer('msg_f', 'ok', '2026-07-27T02:00:01.000Z'),
+      slashPrompt('clear-prompt', 'clear', '', '2026-07-29T01:00:00.100Z'),
+      slashPrompt('skill-prompt', SKILL_NAME, 'run it', '2026-07-29T01:00:01.000Z'),
+      skillMeta({ promptId: 'skill-prompt', timestamp: '2026-07-29T01:00:01.100Z' }),
+      finalAnswer('msg_final', 'done', '2026-07-29T01:00:02.000Z'),
     ]);
-    const { turns } = parseClaudeTranscript(file, 0);
-    expect(turns[0].skillRootByToolId.size).toBe(0);
+
+    const { turns } = parseClaudeTranscript(file);
+    const input = collectStrings(
+      turns.find((turn) => turn.promptId === 'skill-prompt').llmCalls[0].input_messages,
+    ).join('\n');
+    expect(input).toContain(`/${SKILL_NAME}`);
+    expect(input).toContain(META_BODY);
+    expect(input).not.toContain('/clear');
+    expect(input).not.toContain('local caveat');
   });
 
-  test('isMeta 缺 sourceToolUseID 不进 map', () => {
-    const file = writeTranscript('p_sess4', [
-      userPrompt('p1', '/foo', '2026-07-27T02:00:00.000Z'),
-      { type: 'user', isMeta: true, timestamp: '2026-07-27T02:00:00.500Z', message: { role: 'user', content: `Base directory for this skill: ${BASE_DIR}` } },
-      finalAnswer('msg_f', 'ok', '2026-07-27T02:00:01.000Z'),
+  test('assistant records with no promptId stay in an independent fallback turn', () => {
+    const file = writeTranscript('missing-prompt', [
+      finalAnswer('msg_orphan', 'orphan answer', '2026-07-29T01:00:00.000Z'),
+      userPrompt('p1', 'real prompt', '2026-07-29T01:00:01.000Z'),
+      finalAnswer('msg_real', 'real answer', '2026-07-29T01:00:02.000Z'),
     ]);
-    const { turns } = parseClaudeTranscript(file, 0);
-    expect(turns[0].skillRootByToolId.size).toBe(0);
-  });
-});
 
-// ─── Step C 加固 #1(识别与解析解耦)+ #2(漂移可观测 skill_root_parse_miss) ───
-
-describe('transcript-parser: skill 识别加固 + 漂移可观测', () => {
-  // 在临时 DATA_DIR 下直调 parser(logHookError 走 LOONGSUITE_PILOT_DATA_DIR)。
-  function withDataDir(fn) {
-    const prev = process.env.LOONGSUITE_PILOT_DATA_DIR;
-    process.env.LOONGSUITE_PILOT_DATA_DIR = DATA_DIR;
-    try { return fn(); } finally {
-      if (prev === undefined) delete process.env.LOONGSUITE_PILOT_DATA_DIR;
-      else process.env.LOONGSUITE_PILOT_DATA_DIR = prev;
-    }
-  }
-
-  test('跨 parse-window: Skill 块在上一 window 已消费、isMeta 在本 window → 仍靠前缀捕获路径,不漏配、不误报 miss', () => {
-    const file = writeTranscript('win', [
-      userPrompt('p1', '/e2e-build-push', '2026-07-27T02:00:00.000Z'),
-      skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T02:00:01.000Z', 'msg_skill'),
-      skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T02:00:02.000Z'),
-    ]);
-    const w1 = withDataDir(() => parseClaudeTranscript(file, 0));
-    expect(w1.turns.length).toBeGreaterThan(0);
-
-    // window2: Skill 块已越过 offset,本 window 的 assistantGroups 无 Skill tool_use
-    appendTranscript(file, [
-      skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-27T02:00:03.000Z'),
-      finalAnswer('msg_final', 'done', '2026-07-27T02:00:04.000Z'),
-    ]);
-    const w2 = withDataDir(() => parseClaudeTranscript(file, w1.nextOffset));
-    // 前缀优先仍生效 → 路径被捕获(行为不比现状更窄)
-    expect(w2.turns[0].skillRootByToolId.get('toolu_skill')).toBe(ROOT_SKILL);
-    // 结构未确认(Skill 块不在本 window)但前缀命中 → 不是 miss
-    expect(parseMissCount(readErrorRecords())).toBe(0);
+    const { turns } = parseClaudeTranscript(file);
+    expect(turns).toHaveLength(2);
+    const realTurn = turns.find((turn) => turn.promptId === 'p1');
+    const fallbackTurn = turns.find((turn) => turn.promptId === null);
+    expect(realTurn.llmCalls.map((call) => call.message_id)).toEqual(['msg_real']);
+    expect(fallbackTurn.llmCalls.map((call) => call.message_id)).toEqual(['msg_orphan']);
+    expect(collectStrings(realTurn.llmCalls[0].input_messages)).not.toContain('orphan answer');
   });
 
-  test('非 skill 的 isMeta+sourceToolUseID(指向非 Skill 工具、无前缀)→ 不误报 skill_root_parse_miss', () => {
-    const file = writeTranscript('nonskill', [
-      userPrompt('p1', 'read a file', '2026-07-27T02:00:00.000Z'),
-      readToolUse('toolu_read', '/abs/workdir/foo.txt', '2026-07-27T02:00:01.000Z', 'msg_r'),
-      readToolResult('toolu_read', '2026-07-27T02:00:01.500Z'),
-      rawMetaInjection('toolu_read', 'System reminder: unrelated injected content, no skill prefix', '2026-07-27T02:00:02.000Z'),
-      finalAnswer('msg_final', 'done', '2026-07-27T02:00:03.000Z'),
+  test('Skill-shaped meta without tool or slash correlation uses runtime_meta fallback', () => {
+    const file = writeTranscript('runtime-meta', [
+      userPrompt('p1', 'hello', '2026-07-29T01:00:00.000Z'),
+      skillMeta({ promptId: 'p1', timestamp: '2026-07-29T01:00:00.100Z' }),
+      finalAnswer('msg_final', 'done', '2026-07-29T01:00:01.000Z'),
     ]);
-    const { turns } = withDataDir(() => parseClaudeTranscript(file, 0));
-    expect(turns[0].skillRootByToolId.size).toBe(0);
-    expect(parseMissCount(readErrorRecords())).toBe(0);
+
+    const { turns } = parseClaudeTranscript(file);
+    expect(turns[0].skillLoads[0]).toEqual(expect.objectContaining({
+      trigger: 'runtime_meta',
+      name: SKILL_NAME,
+    }));
   });
 
-  test('结构确认为 skill 注入(sourceToolUseID→Skill)但前缀失配 → 正确计数 skill_root_parse_miss', () => {
-    const file = writeTranscript('drift', [
-      userPrompt('p1', '/e2e-build-push', '2026-07-27T02:00:00.000Z'),
-      skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T02:00:01.000Z', 'msg_skill'),
-      skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T02:00:02.000Z'),
-      // 前缀漂移: text 不以 "Base directory for this skill:" 开头
-      rawMetaInjection('toolu_skill', `Skill base dir (v-next wording): ${BASE_DIR}\n\n# Title`, '2026-07-27T02:00:02.500Z'),
-      finalAnswer('msg_final', 'done', '2026-07-27T02:00:03.000Z'),
+  test('legacy Skill meta without a base-dir prefix is restored through sourceToolUseID', () => {
+    const legacyBody = '# Legacy Skill\n\nComplete skill instructions';
+    const file = writeTranscript('legacy-source-linked', [
+      userPrompt('p1', 'use skill', '2026-07-29T01:00:00.000Z'),
+      skillToolUse('toolu_skill', SKILL_NAME, '2026-07-29T01:00:01.000Z'),
+      skillMeta({
+        sourceToolUseId: 'toolu_skill',
+        timestamp: '2026-07-29T01:00:02.000Z',
+        content: legacyBody,
+      }),
+      finalAnswer('msg_final', 'done', '2026-07-29T01:00:03.000Z'),
     ]);
-    const { turns } = withDataDir(() => parseClaudeTranscript(file, 0));
-    // 路径提取失败 → 不进 map(合成侧维持现状,不改变行为)
-    expect(turns[0].skillRootByToolId.size).toBe(0);
-    // 结构确认 → 打点 miss
-    const errs = readErrorRecords();
-    expect(parseMissCount(errs)).toBe(1);
-    expect(errs.find((r) => r['error.type'] === 'skill_root_parse_miss').stage).toBe('skill_root_parse');
+
+    const { turns } = parseClaudeTranscript(file);
+    expect(turns[0].skillLoads).toEqual([expect.objectContaining({
+      trigger: 'model_tool',
+      sourceToolUseId: 'toolu_skill',
+      name: SKILL_NAME,
+      id: SKILL_NAME,
+      rootPath: null,
+      content: legacyBody,
+    })]);
+    expect(collectStrings(turns[0].llmCalls[1].input_messages)).toContain(legacyBody);
   });
 });
 
-// ─── 端到端: 六场景 ───
-
-describe('claude-code hook: /skill 根 SKILL.md Read span', () => {
-  test('场景1: /skill + 一个原生根 Read → 不合成,仅保留真实 Read', () => {
-    const t = writeTranscript('s1', [
-      userPrompt('p1', '/e2e-build-push', '2026-07-27T03:00:00.000Z'),
-      skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:01.000Z', 'msg_skill'),
-      skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:02.000Z'),
-      skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-27T03:00:02.500Z'),
-      readToolUse('toolu_realread', ROOT_SKILL, '2026-07-27T03:00:03.000Z', 'msg_read'),
-      readToolResult('toolu_realread', '2026-07-27T03:00:04.000Z'),
-      finalAnswer('msg_final', 'done', '2026-07-27T03:00:05.000Z'),
+describe('Claude Code Skill TOOL events', () => {
+  test('implicit Skill enriches the real TOOL and does not synthesize Read or load_skill', () => {
+    const transcript = writeTranscript('implicit-hook', [
+      userPrompt('p1', 'use the skill', '2026-07-29T02:00:00.000Z'),
+      skillToolUse('toolu_skill', SKILL_NAME, '2026-07-29T02:00:01.000Z'),
+      toolResult('toolu_skill', `Launching skill: ${SKILL_NAME}`, '2026-07-29T02:00:02.000Z'),
+      skillMeta({
+        sourceToolUseId: 'toolu_skill',
+        timestamp: '2026-07-29T02:00:02.100Z',
+      }),
+      finalAnswer('msg_final', 'done', '2026-07-29T02:00:03.000Z'),
     ]);
-    const r = runHook('stop', { session_id: 's1', stop_reason: 'end_turn', transcript_path: t, cwd: '/abs/workdir' });
-    expect(r.status).toBe(0);
-    const recs = readJsonlRecords();
-    const reads = toolCalls(recs, 'Read');
-    expect(reads.length).toBe(1);
-    expect(reads[0]['gen_ai.tool.call.id']).toBe('toolu_realread');
-    expect(reads.some((x) => x['gen_ai.tool.call.id'].startsWith(SYNTH_PREFIX))).toBe(false);
-    expect(toolCalls(recs, 'Skill').length).toBe(1);
-    // 有真实根 Read → 不注入合成 tool_call 到任何 LLM 输出侧
-    const allInjected = recs
-      .filter((r) => r['event.name'] === 'llm.response')
-      .flatMap((r) => outputToolCalls(r))
-      .filter((p) => (p.id || '').startsWith(SYNTH_PREFIX));
-    expect(allInjected.length).toBe(0);
+
+    expect(runHook('implicit-hook', transcript).status).toBe(0);
+    const records = readJsonlRecords();
+    const calls = events(records, 'tool.call', 'Skill');
+    const results = events(records, 'tool.result', 'Skill');
+    expect(calls).toHaveLength(1);
+    expect(results).toHaveLength(1);
+    expect(calls[0]).toEqual(expect.objectContaining({
+      'gen_ai.tool.call.id': 'toolu_skill',
+      'gen_ai.skill.name': SKILL_NAME,
+      'gen_ai.skill.id': SKILL_NAME,
+    }));
+    expect(results[0]).toEqual(expect.objectContaining({
+      'gen_ai.skill.name': SKILL_NAME,
+      'gen_ai.skill.id': SKILL_NAME,
+    }));
+    expect(events(records, 'tool.call', 'load_skill')).toHaveLength(0);
+    expect(events(records, 'tool.call', 'Read')).toHaveLength(0);
+    expect(collectStrings(events(records, 'llm.request')[1])).toContain(META_BODY);
   });
 
-  test('场景2: /skill + 多个不同 ID 的重复根 Read → 全保留,不合成', () => {
-    const t = writeTranscript('s2', [
-      userPrompt('p1', '/e2e-build-push', '2026-07-27T03:00:00.000Z'),
-      skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:01.000Z', 'msg_skill'),
-      skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:02.000Z'),
-      skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-27T03:00:02.500Z'),
-      readToolUse('toolu_read_a', ROOT_SKILL, '2026-07-27T03:00:03.000Z', 'msg_ra'),
-      readToolResult('toolu_read_a', '2026-07-27T03:00:03.500Z'),
-      readToolUse('toolu_read_b', ROOT_SKILL, '2026-07-27T03:00:04.000Z', 'msg_rb'),
-      readToolResult('toolu_read_b', '2026-07-27T03:00:04.500Z'),
-      finalAnswer('msg_final', 'done', '2026-07-27T03:00:05.000Z'),
-    ]);
-    const r = runHook('stop', { session_id: 's2', stop_reason: 'end_turn', transcript_path: t, cwd: '/abs/workdir' });
-    expect(r.status).toBe(0);
-    const recs = readJsonlRecords();
-    const reads = toolCalls(recs, 'Read');
-    expect(reads.length).toBe(2);
-    const ids = reads.map((x) => x['gen_ai.tool.call.id']).sort();
-    expect(ids).toEqual(['toolu_read_a', 'toolu_read_b']);
-    expect(reads.some((x) => x['gen_ai.tool.call.id'].startsWith(SYNTH_PREFIX))).toBe(false);
-  });
-
-  test('场景3: /skill 无原生 Read → 兜底合成一条,call/result 同 id,挂 Skill owner step', () => {
-    const t = writeTranscript('s3', [
-      userPrompt('p1', '/e2e-build-push', '2026-07-27T03:00:00.000Z'),
-      skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:01.000Z', 'msg_skill'),
-      skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:02.000Z'),
-      skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-27T03:00:02.500Z'),
-      finalAnswer('msg_final', 'done', '2026-07-27T03:00:05.000Z'),
-    ]);
-    const r = runHook('stop', { session_id: 's3', stop_reason: 'end_turn', transcript_path: t, cwd: '/abs/workdir' });
-    expect(r.status).toBe(0);
-    const recs = readJsonlRecords();
-    const readCalls = toolCalls(recs, 'Read');
-    const readResults = toolResults(recs, 'Read');
-    expect(readCalls.length).toBe(1);
-    expect(readResults.length).toBe(1);
-    const callId = readCalls[0]['gen_ai.tool.call.id'];
-    expect(callId.startsWith(SYNTH_PREFIX)).toBe(true);
-    expect(readResults[0]['gen_ai.tool.call.id']).toBe(callId); // call/result 同 id → OTLP 一个 span
-    expect(readCalls[0]['gen_ai.tool.call.arguments']).toEqual({ file_path: ROOT_SKILL });
-    // owner step == Skill 声明所在 step
-    const skillCall = toolCalls(recs, 'Skill')[0];
-    expect(readCalls[0]['gen_ai.step.id']).toBe(skillCall['gen_ai.step.id']);
-    // 时间戳非零(取 Skill 的 call/result)
-    expect(readCalls[0].time_unix_nano).not.toBe('0');
-
-    // 参照 cursor PR #193: owner step 的 LLM span output.messages 挂上同 id/name=Read 的 tool_call
-    const ownerResp = llmResponseForStep(recs, readCalls[0]['gen_ai.step.id']);
-    expect(ownerResp).toBeDefined();
-    const injected = outputToolCalls(ownerResp).find((p) => p.id === callId);
-    expect(injected).toBeDefined();
-    expect(injected.name).toBe('Read');
-    expect(injected.arguments).toEqual({ file_path: ROOT_SKILL });
-    // owner step 输出侧仍保留原 Skill tool_call(未覆盖)
-    expect(outputToolCalls(ownerResp).some((p) => p.name === 'Skill')).toBe(true);
-  });
-
-  test('场景3b: 合成 call id 确定性(相同 client+turnId+rootPath 两次运行 id 相同)', () => {
-    const records = [
-      userPrompt('p1', '/e2e-build-push', '2026-07-27T03:00:00.000Z'),
-      skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:01.000Z', 'msg_skill'),
-      skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:02.000Z'),
-      skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-27T03:00:02.500Z'),
-      finalAnswer('msg_final', 'done', '2026-07-27T03:00:05.000Z'),
+  test('direct slash creates one deterministic load_skill extension TOOL without fake LLM output', () => {
+    const sourceRecords = [
+      slashPrompt('p1', SKILL_NAME, 'run it', '2026-07-29T02:00:00.000Z'),
+      skillMeta({ promptId: 'p1', timestamp: '2026-07-29T02:00:00.100Z' }),
+      assistantToolUse(
+        'toolu_reference',
+        'Read',
+        { file_path: `${BASE_DIR}/references/guide.md` },
+        '2026-07-29T02:00:01.000Z',
+        'msg_read',
+      ),
+      toolResult('toolu_reference', 'reference body', '2026-07-29T02:00:01.100Z', 'p1'),
+      finalAnswer('msg_final', 'done', '2026-07-29T02:00:02.000Z'),
     ];
-    // 两个独立 DATA_DIR、相同 session_id(→ 相同 turnId :t1)+相同根路径 → 同确定性 id。
-    const idFromFreshDataDir = () => {
-      const prevDataDir = DATA_DIR;
-      DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-skill-det-'));
+
+    const idFromFreshRun = () => {
+      const previousDataDir = DATA_DIR;
+      DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-skill-id-'));
       try {
-        const t = writeTranscript('det', records);
-        runHook('stop', { session_id: 'det', stop_reason: 'end_turn', transcript_path: t, cwd: '/abs/workdir' });
-        return toolCalls(readJsonlRecords(), 'Read')[0]['gen_ai.tool.call.id'];
+        const transcript = writeTranscript('slash-hook', sourceRecords);
+        expect(runHook('slash-hook', transcript).status).toBe(0);
+        const records = readJsonlRecords();
+        const loadCalls = events(records, 'tool.call', 'load_skill');
+        const loadResults = events(records, 'tool.result', 'load_skill');
+        expect(loadCalls).toHaveLength(1);
+        expect(loadResults).toHaveLength(1);
+        expect(loadCalls[0]).toEqual(expect.objectContaining({
+          'gen_ai.tool.type': 'extension',
+          'gen_ai.skill.name': SKILL_NAME,
+          'gen_ai.skill.id': SKILL_NAME,
+          'gen_ai.tool.call.arguments': { skill: SKILL_NAME },
+        }));
+        expect(loadResults[0]['gen_ai.tool.call.id']).toBe(loadCalls[0]['gen_ai.tool.call.id']);
+        expect(BigInt(loadResults[0].time_unix_nano)).toBeGreaterThan(BigInt(loadCalls[0].time_unix_nano));
+        expect(events(records, 'tool.call', 'Read').map((record) =>
+          record['gen_ai.tool.call.id'])).toEqual(['toolu_reference']);
+        expect(outputToolCalls(records).some((part) =>
+          part.name === 'load_skill' || part.id?.startsWith(SYNTH_PREFIX))).toBe(false);
+        return loadCalls[0]['gen_ai.tool.call.id'];
       } finally {
         try { fs.rmSync(DATA_DIR, { recursive: true, force: true }); } catch {}
-        DATA_DIR = prevDataDir;
+        DATA_DIR = previousDataDir;
       }
     };
-    const id1 = idFromFreshDataDir();
-    const id2 = idFromFreshDataDir();
-    expect(id1.startsWith(SYNTH_PREFIX)).toBe(true);
-    expect(id1).toBe(id2);
+
+    const id1 = idFromFreshRun();
+    const id2 = idFromFreshRun();
+    expect(id1).toMatch(/^toolu_skillload_[0-9a-f]{24}$/);
+    expect(id2).toBe(id1);
   });
 
-  test('场景4: 根 SKILL.md + references 同读 → references 保留,不重复合成', () => {
-    const refPath = `${BASE_DIR}/references/guide.md`;
-    const t = writeTranscript('s4', [
-      userPrompt('p1', '/e2e-build-push', '2026-07-27T03:00:00.000Z'),
-      skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:01.000Z', 'msg_skill'),
-      skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:02.000Z'),
-      skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-27T03:00:02.500Z'),
-      readToolUse('toolu_root', ROOT_SKILL, '2026-07-27T03:00:03.000Z', 'msg_root'),
-      readToolResult('toolu_root', '2026-07-27T03:00:03.500Z'),
-      readToolUse('toolu_ref', refPath, '2026-07-27T03:00:04.000Z', 'msg_ref'),
-      readToolResult('toolu_ref', '2026-07-27T03:00:04.500Z'),
-      finalAnswer('msg_final', 'done', '2026-07-27T03:00:05.000Z'),
+  test('captureMessageContent=false strips Skill body and tool payload but preserves Skill attributes', () => {
+    fs.writeFileSync(path.join(DATA_DIR, 'config.json'), JSON.stringify({
+      agents: { 'claude-code': { enabled: true, captureMessageContent: false } },
+    }));
+    const transcript = writeTranscript('private-skill', [
+      slashPrompt('p1', SKILL_NAME, 'run it', '2026-07-29T02:00:00.000Z'),
+      skillMeta({ promptId: 'p1', timestamp: '2026-07-29T02:00:00.100Z' }),
+      finalAnswer('msg_final', 'done', '2026-07-29T02:00:01.000Z'),
     ]);
-    const r = runHook('stop', { session_id: 's4', stop_reason: 'end_turn', transcript_path: t, cwd: '/abs/workdir' });
-    expect(r.status).toBe(0);
-    const recs = readJsonlRecords();
-    const reads = toolCalls(recs, 'Read');
-    const ids = reads.map((x) => x['gen_ai.tool.call.id']).sort();
-    expect(ids).toEqual(['toolu_ref', 'toolu_root']); // 真实根 + references 都在,零合成
-    expect(reads.some((x) => x['gen_ai.tool.call.id'].startsWith(SYNTH_PREFIX))).toBe(false);
+
+    expect(runHook('private-skill', transcript).status).toBe(0);
+    const records = readJsonlRecords();
+    const call = events(records, 'tool.call', 'load_skill')[0];
+    const result = events(records, 'tool.result', 'load_skill')[0];
+    expect(call['gen_ai.skill.name']).toBe(SKILL_NAME);
+    expect(call['gen_ai.skill.id']).toBe(SKILL_NAME);
+    expect(call).not.toHaveProperty('gen_ai.tool.call.arguments');
+    expect(result).not.toHaveProperty('gen_ai.tool.call.result');
+    expect(JSON.stringify(records)).not.toContain('skill body secret');
   });
 
-  test('场景5: 普通文件重复读(无 /skill)→ 都保留,不误删,无合成', () => {
-    const t = writeTranscript('s5', [
-      userPrompt('p1', 'read the file twice', '2026-07-27T03:00:00.000Z'),
-      readToolUse('toolu_n1', '/abs/workdir/foo.txt', '2026-07-27T03:00:01.000Z', 'msg_n1'),
-      readToolResult('toolu_n1', '2026-07-27T03:00:01.500Z'),
-      readToolUse('toolu_n2', '/abs/workdir/foo.txt', '2026-07-27T03:00:02.000Z', 'msg_n2'),
-      readToolResult('toolu_n2', '2026-07-27T03:00:02.500Z'),
-      finalAnswer('msg_final', 'done', '2026-07-27T03:00:03.000Z'),
-    ]);
-    const r = runHook('stop', { session_id: 's5', stop_reason: 'end_turn', transcript_path: t, cwd: '/abs/workdir' });
-    expect(r.status).toBe(0);
-    const recs = readJsonlRecords();
-    expect(toolCalls(recs, 'Read').length).toBe(2);
-    expect(toolCalls(recs, 'Skill').length).toBe(0);
-    expect(recs.some((x) => (x['gen_ai.tool.call.id'] || '').startsWith(SYNTH_PREFIX))).toBe(false);
-  });
-
-  test('场景6: 无 /skill 普通对话 → 不产生任何 Skill/合成 Read', () => {
-    const t = writeTranscript('s6', [
-      userPrompt('p1', 'hello', '2026-07-27T03:00:00.000Z'),
-      finalAnswer('msg_final', 'hi there', '2026-07-27T03:00:01.000Z'),
-    ]);
-    const r = runHook('stop', { session_id: 's6', stop_reason: 'end_turn', transcript_path: t, cwd: '/abs/workdir' });
-    expect(r.status).toBe(0);
-    const recs = readJsonlRecords();
-    expect(toolCalls(recs, 'Read').length).toBe(0);
-    expect(toolCalls(recs, 'Skill').length).toBe(0);
-  });
-
-  // architect P1-3: 跨 hook-run / 延迟真实 Read 边界。
-  // 真实根 Read 落在后一次 hook 分块(turnId 不同),前一块已合成 → 去重键
-  // client+turnId+rootPath 不同 → 无法跨 build 抑制。此为已知边界(architect 定为非 P0)。
-  test('场景7: 跨 hook-run 延迟真实 Read — 记录当前边界行为', () => {
-    const t = writeTranscript('s7', [
-      userPrompt('p1', '/e2e-build-push', '2026-07-27T03:00:00.000Z'),
-      skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:01.000Z', 'msg_skill'),
-      skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-27T03:00:02.000Z'),
-      skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-27T03:00:02.500Z'),
-    ]);
-    // 第一次 hook run: 只有 Skill,尚无真实根 Read → 兜底合成一条
-    let r1 = runHook('stop', { session_id: 's7', stop_reason: 'end_turn', transcript_path: t, cwd: '/abs/workdir' });
-    expect(r1.status).toBe(0);
-    const afterRun1 = readJsonlRecords();
-    const synthAfter1 = toolCalls(afterRun1, 'Read').filter((x) => x['gen_ai.tool.call.id'].startsWith(SYNTH_PREFIX));
-    expect(synthAfter1.length).toBe(1);
-    const synthTurn = synthAfter1[0]['gen_ai.turn.id'];
-
-    // 第二次 hook run: 追加延迟的真实根 Read(落在新分块,新 turnId)
-    appendTranscript(t, [
-      readToolUse('toolu_lateroot', ROOT_SKILL, '2026-07-27T03:00:06.000Z', 'msg_late'),
-      readToolResult('toolu_lateroot', '2026-07-27T03:00:06.500Z'),
-      finalAnswer('msg_final', 'done', '2026-07-27T03:00:07.000Z'),
-    ]);
-    let r2 = runHook('stop', { session_id: 's7', stop_reason: 'end_turn', transcript_path: t, cwd: '/abs/workdir' });
-    expect(r2.status).toBe(0);
-    const afterRun2 = readJsonlRecords();
-    // 真实根 Read 已出现(其真实 id)
-    const realLate = toolCalls(afterRun2, 'Read').find((x) => x['gen_ai.tool.call.id'] === 'toolu_lateroot');
-    expect(realLate).toBeDefined();
-    // 已知边界: 合成 Read 与延迟真实 Read 落在不同 turn(无法跨 build 去重)
-    expect(realLate['gen_ai.turn.id']).not.toBe(synthTurn);
-  });
-});
-
-// ─── 不变量: Skill 与其 isMeta 注入必落同一 parse 窗口(跨窗口切分不可达) ───
-//
-// 前提(源码 + 真实 transcript 实证):
-//   1. 只注册 Stop 类 hook(Stop / SubagentStart / SubagentStop)——无 PreToolUse/PostToolUse。
-//   2. transcript_offset 仅在 cmdStop 导出成功后推进;两个 subagent handler 不解析 transcript、不动 offset。
-//      → 每个解析窗口 = 一次 Stop = [上次 offset, EOF],边界恒对齐 turn 末尾。
-//   3. Skill tool_use 与其 sourceToolUseID 注入是同一 turn 内连续记录(真实数据 meta 恒在 2–5 条内)。
-//   ⇒ 二者必落同窗,"一半在 window1、一半在 window2"在现状模型下构造不出来。
-//
-// 本 describe = test-only 不变量护栏:不改生产/合成逻辑。一旦未来误加 mid-turn hook 让
-// 该场景变可达(扩 DISPATCH / .sh 白名单、在 stop 之外解析 transcript),下列静态断言立即变红,
-// 把"静默丢 Read"的回归风险暴露出来,而不是悄悄回退到"缺失根 Read"。
-describe('不变量: 同窗 Skill+注入 / offset 仅 Stop 推进 / 无 mid-turn hook', () => {
-  test('① 一个完整 turn(Skill tool_use + 紧随 isMeta 注入)在单窗内被解析、命中并正常合成', () => {
-    const t = writeTranscript('inv1', [
-      userPrompt('p1', '/e2e-build-push', '2026-07-28T02:00:00.000Z'),
-      skillToolUse('toolu_skill', 'e2e-build-push', '2026-07-28T02:00:01.000Z', 'msg_skill'),
-      skillToolResult('toolu_skill', 'e2e-build-push', '2026-07-28T02:00:02.000Z'),
-      skillMetaInjection('toolu_skill', BASE_DIR, '2026-07-28T02:00:02.500Z'),
-      finalAnswer('msg_final', 'done', '2026-07-28T02:00:03.000Z'),
+  test('ordinary Read tools are unchanged and never produce Skill load events', () => {
+    const transcript = writeTranscript('ordinary-read', [
+      userPrompt('p1', 'read it twice', '2026-07-29T02:00:00.000Z'),
+      assistantToolUse('read-a', 'Read', { file_path: '/tmp/a' }, '2026-07-29T02:00:01.000Z', 'msg_a'),
+      toolResult('read-a', 'a', '2026-07-29T02:00:01.100Z', 'p1'),
+      assistantToolUse('read-b', 'Read', { file_path: '/tmp/a' }, '2026-07-29T02:00:02.000Z', 'msg_b'),
+      toolResult('read-b', 'a', '2026-07-29T02:00:02.100Z', 'p1'),
+      finalAnswer('msg_final', 'done', '2026-07-29T02:00:03.000Z'),
     ]);
 
-    // 单次 parse 窗口 [0, EOF] 即涵盖整个 turn:Skill 块与注入同窗,skillRootByToolId 命中。
-    const { turns, nextOffset } = parseClaudeTranscript(t, 0);
-    expect(turns.length).toBe(1);
-    expect(turns[0].skillRootByToolId.get('toolu_skill')).toBe(ROOT_SKILL);
-    expect(nextOffset).toBe(fs.statSync(t).size); // 窗口对齐到 EOF(= turn 末尾)
-
-    // 同窗 → 合成正常:根 Read=1(确定性 id、call/result 成对)+ owner LLM 输出侧背书 tool_call。
-    const r = runHook('stop', { session_id: 'inv1', stop_reason: 'end_turn', transcript_path: t, cwd: '/abs/workdir' });
-    expect(r.status).toBe(0);
-    const recs = readJsonlRecords();
-    const reads = toolCalls(recs, 'Read');
-    expect(reads.length).toBe(1);
-    const callId = reads[0]['gen_ai.tool.call.id'];
-    expect(callId.startsWith(SYNTH_PREFIX)).toBe(true);
-    expect(toolResults(recs, 'Read').map((x) => x['gen_ai.tool.call.id'])).toEqual([callId]);
-    const ownerResp = llmResponseForStep(recs, reads[0]['gen_ai.step.id']);
-    expect(outputToolCalls(ownerResp).some((p) => p.id === callId && p.name === 'Read')).toBe(true);
-  });
-
-  test('② 静态钉死: 仅 Stop 类 hook、offset 仅 Stop 推进、transcript 仅 Stop 解析', () => {
-    const src = fs.readFileSync(PROCESSOR, 'utf-8');
-
-    // 无 mid-turn hook:源码不出现 PreToolUse/PostToolUse
-    expect(src).not.toMatch(/PreToolUse|PostToolUse/);
-
-    // DISPATCH 只认三个 Stop 类 subcommand
-    const dispatchBlock = src.match(/const DISPATCH = \{([\s\S]*?)\};/)[1];
-    const keys = [...dispatchBlock.matchAll(/'([^']+)':/g)].map((m) => m[1]).sort();
-    expect(keys).toEqual(['stop', 'subagent-start', 'subagent-stop']);
-
-    // transcript 仅在(cmdStop 调用的)exportSession 里解析一次;offset 提升仅一处。
-    expect((src.match(/parseClaudeTranscript\(/g) || []).length).toBe(1);
-    expect((src.match(/state\.transcript_offset\s*=/g) || []).length).toBe(1);
-
-    // shell 入口白名单同样只放行三个 Stop 类 subcommand
-    const sh = fs.readFileSync(SHELL_HOOK, 'utf-8');
-    expect(sh).toMatch(/stop\|subagent-start\|subagent-stop\)/);
-    expect(sh).not.toMatch(/PreToolUse|PostToolUse/);
+    expect(runHook('ordinary-read', transcript).status).toBe(0);
+    const records = readJsonlRecords();
+    expect(events(records, 'tool.call', 'Read').map((record) =>
+      record['gen_ai.tool.call.id'])).toEqual(['read-a', 'read-b']);
+    expect(events(records, 'tool.call', 'load_skill')).toHaveLength(0);
+    expect(events(records, 'tool.call', 'Skill')).toHaveLength(0);
   });
 });

--- a/tests/unit/validate-trace.test.mjs
+++ b/tests/unit/validate-trace.test.mjs
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'vitest';
+import {
+  hasModelToolSpanForOutput,
+  isRuntimeSkillLoadSpan,
+  unmatchedToolsForLlmOutput,
+} from '../../scripts/validate-trace.mjs';
+
+function tool(attributes) {
+  return { spanId: attributes['gen_ai.tool.call.id'], attributes };
+}
+
+describe('semantic.tool_matches_llm_output runtime Skill handling', () => {
+  test('extension TOOL with Skill attributes does not require an LLM output tool_call', () => {
+    const runtimeSkill = tool({
+      'gen_ai.tool.name': 'load_skill',
+      'gen_ai.tool.type': 'extension',
+      'gen_ai.tool.call.id': 'toolu_skillload_1',
+      'gen_ai.skill.name': 'dws',
+      'gen_ai.skill.id': 'dws',
+    });
+
+    expect(isRuntimeSkillLoadSpan(runtimeSkill)).toBe(true);
+    expect(unmatchedToolsForLlmOutput([runtimeSkill], [])).toEqual([]);
+    expect(hasModelToolSpanForOutput([runtimeSkill], {
+      id: 'toolu_skillload_1',
+      name: 'load_skill',
+    })).toBe(false);
+  });
+
+  test('ordinary and model-triggered tools still require matching LLM output', () => {
+    const ordinary = tool({
+      'gen_ai.tool.name': 'Read',
+      'gen_ai.tool.type': 'function',
+      'gen_ai.tool.call.id': 'toolu_read_1',
+    });
+    const modelSkill = tool({
+      'gen_ai.tool.name': 'Skill',
+      'gen_ai.tool.type': 'function',
+      'gen_ai.tool.call.id': 'toolu_skill_1',
+      'gen_ai.skill.name': 'dws',
+      'gen_ai.skill.id': 'dws',
+    });
+
+    expect(isRuntimeSkillLoadSpan(ordinary)).toBe(false);
+    expect(isRuntimeSkillLoadSpan(modelSkill)).toBe(false);
+    expect(unmatchedToolsForLlmOutput([ordinary, modelSkill], [])).toEqual([
+      ordinary,
+      modelSkill,
+    ]);
+    expect(unmatchedToolsForLlmOutput([ordinary, modelSkill], [
+      { id: 'toolu_read_1', name: 'Read' },
+      { id: 'toolu_skill_1', name: 'Skill' },
+    ])).toEqual([]);
+    expect(hasModelToolSpanForOutput([ordinary, modelSkill], {
+      id: 'toolu_skill_1',
+      name: 'Skill',
+    })).toBe(true);
+  });
+
+  test('extension without Skill attributes is not exempted', () => {
+    const extensionTool = tool({
+      'gen_ai.tool.name': 'runtime_extension',
+      'gen_ai.tool.type': 'extension',
+      'gen_ai.tool.call.id': 'runtime_1',
+    });
+
+    expect(isRuntimeSkillLoadSpan(extensionTool)).toBe(false);
+    expect(unmatchedToolsForLlmOutput([extensionTool], [])).toEqual([extensionTool]);
+  });
+});


### PR DESCRIPTION
## Summary

- restore complete Claude Code Skill meta content to the matching LLM input context
- isolate conversation history and emitted deltas by `promptId`
- reuse real `Skill` TOOL spans for model-triggered loads and create `load_skill` extension TOOL spans for slash/runtime loads
- remove the synthetic root `Read` span and fake LLM tool call behavior introduced by #194
- allow runtime Skill extension spans in trace validation without weakening reverse LLM-to-TOOL validation

## Skill modeling

- Model-triggered Skill loads retain the real tool call ID, arguments, result, and timestamps, with `gen_ai.skill.name/id` added.
- Explicit `/skill` loads produce deterministic `load_skill` call/result events attached to the first LLM STEP, without changing LLM output messages.
- Skill meta with the standard `Base directory for this skill:` header is retained even without `sourceToolUseID`.
- Legacy Skill meta without that header is retained only when `sourceToolUseID` resolves to a real `Skill` tool use.
- Non-Skill meta such as local command caveats and reminders remains excluded.

## Validation

- `npm run typecheck`
- `npm run build`
- `npm test`: 2,099 passed, 5 skipped
- Read-only validation against local Claude Code data:
  - 141 transcripts, 55,202 records, 1,457 turns, and 11,639 LLM calls
  - 27 recognized Skill meta records: 25 standard-header and 2 legacy source-linked
  - 26 effective Skill loads restored to the correct LLM input; one additional slash load was aborted before any LLM call
  - 13 Skill-bearing sessions replayed twice, producing 15,161 events per pass
  - zero cross-prompt user messages, non-Skill meta leaks, missing Skill bodies, fake LLM tool calls, unstable synthetic IDs, or Hook errors
