### PR TITLE
fix(codex): wait for complete transcript prompt before ENTRY

### DIFF
--- a/src/inputs/codex-transcript/codex-transcript-builder.ts
+++ b/src/inputs/codex-transcript/codex-transcript-builder.ts
@@ -58,7 +58,7 @@ export function buildCodexTranscriptSegment(
   const contextStepCount = opts.contextStepCount ?? turn.steps.length;
   let nextInputContext = inputContext;
 
-  if (includePrompt && turn.prompt) {
+  if (includePrompt && turn.promptReady && turn.prompt) {
     records.push(buildEntry({
       ...base,
       timestamp: turn.startedAtMs,

--- a/src/inputs/codex-transcript/codex-transcript-extractor.ts
+++ b/src/inputs/codex-transcript/codex-transcript-extractor.ts
@@ -108,6 +108,7 @@ function extractCodexTurn(
   let terminalAtMs = 0;
   let status: CodexTerminalStatus | null = null;
   let sawTerminal = false;
+  let sawSubmittedUserMessage = false;
   let finalText: string | undefined;
   let model = opts.model ?? 'unknown';
   let cwd = opts.cwd;
@@ -210,6 +211,7 @@ function extractCodexTurn(
     if (record.type === 'event_msg') {
       if (payload.type === 'user_message') {
         appendPrompt(stringValue(payload.message));
+        sawSubmittedUserMessage = true;
         markActivity(timestamp);
         continue;
       }
@@ -412,6 +414,10 @@ function extractCodexTurn(
 
   const resolvedStatus = status ?? 'completed';
   const steps = stepEnvelopes.map(envelope => envelope.step);
+  const promptReady = Boolean(
+    prompt
+    && (sawSubmittedUserMessage || steps.length > 0 || sawTerminal),
+  );
   const turn: CodexExtractedTranscriptTurn = {
     sessionId: meta?.sessionId || fallbackSessionId,
     transcriptTurnId: expectedTurnId,
@@ -421,6 +427,7 @@ function extractCodexTurn(
     startedAtMs: startedAtMs || terminalAtMs,
     terminalAtMs,
     ...(prompt ? { prompt } : {}),
+    promptReady,
     inputMessages,
     ...(cwd ? { cwd } : {}),
     ...(developerInstructions ? { developerInstructions } : {}),

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -521,7 +521,6 @@ export class CodexTranscriptInput extends BaseInput {
       }
     }
 
-    if (turn.prompt) activeTurn.emittedPrompt = true;
     activeTurn.emittedStepCount = (activeTurn.emittedStepCount ?? 0) + closedStepCount;
 
     const lastClosedRange = closedStepCount > 0

--- a/src/inputs/codex-transcript/codex-transcript-types.ts
+++ b/src/inputs/codex-transcript/codex-transcript-types.ts
@@ -135,6 +135,12 @@ export interface CodexExtractedTranscriptTurn {
   startedAtMs: number;
   terminalAtMs: number;
   prompt?: string;
+  /**
+   * True once the transcript proves that the submitted prompt is complete.
+   * A user response_item alone may only be Codex control context while the
+   * UserPromptSubmit wakeup races the persisted user message.
+   */
+  promptReady: boolean;
   inputMessages: JsonValue[];
   cwd?: string;
   developerInstructions?: string;

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -1824,6 +1824,62 @@ describe('CodexTranscriptInput', () => {
     });
   });
 
+  it('waits for the submitted user message before emitting a prompt assembled across scans', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-prompt-ready-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
+    const environmentContext = '<environment_context>\n  <cwd>C:\\project</cwd>\n</environment_context>';
+    const initial = [
+      record('2026-06-24T06:00:00.000Z', 'session_meta', {
+        id: 'session-1', model_provider: 'openai',
+      }),
+      record('2026-06-24T06:00:01.000Z', 'event_msg', {
+        type: 'task_started', turn_id: 'turn-1',
+      }),
+      record('2026-06-24T06:00:01.100Z', 'response_item', {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: environmentContext }],
+      }),
+      record('2026-06-24T06:00:01.200Z', 'turn_context', {
+        turn_id: 'turn-1', model: 'gpt-5.5', cwd: 'C:\\project',
+      }),
+    ];
+    const transcript = await writeTranscript(sessionDir, initial.join('\n') + '\n');
+
+    await processTranscriptOnce(input, transcript);
+
+    expect(entries).toHaveLength(0);
+    expect((transcriptCheckpoint(stateStore, transcript) as {
+      activeTurn?: { emittedPrompt?: boolean };
+    }).activeTurn?.emittedPrompt).not.toBe(true);
+
+    await fs.appendFile(transcript, [
+      record('2026-06-24T06:00:01.700Z', 'response_item', {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: '修复 Windows 采集' }],
+      }),
+      record('2026-06-24T06:00:01.710Z', 'event_msg', {
+        type: 'user_message', message: '修复 Windows 采集',
+      }),
+    ].join('\n') + '\n', 'utf8');
+    await processTranscriptOnce(input, transcript);
+    await processTranscriptOnce(input, transcript);
+
+    const promptEntries = entries.filter(entry => entry['event.name'] === 'other');
+    expect(promptEntries).toHaveLength(1);
+    expect(promptEntries[0]).toMatchObject({
+      'gen_ai.input.messages_delta': [{
+        role: 'user',
+        parts: [{ type: 'text', content: `${environmentContext}\n修复 Windows 采集` }],
+      }],
+    });
+    expect((transcriptCheckpoint(stateStore, transcript) as {
+      activeTurn?: { emittedPrompt?: boolean };
+    }).activeTurn?.emittedPrompt).toBe(true);
+  });
+
   it('does not shift a token sample without a completed response wave onto a later step', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-unmatched-token-'));
     tempDirs.push(root);


### PR DESCRIPTION
## Summary

- gate Codex prompt emission on structural transcript completion
- preserve the existing combined `<environment_context>\nuser prompt` ENTRY content
- mark `emittedPrompt` only after an `other` entry is actually emitted
- add a regression test for the Windows `UserPromptSubmit` wakeup race across incremental scans

## Why

`SessionStart`, `UserPromptSubmit`, and `Stop` all update the transcript wakeup marker so Pilot can discover task-scoped `CODEX_HOME` roots. On Windows, the `UserPromptSubmit` marker can wake the collector after `<environment_context>` is persisted but before the submitted user message reaches the rollout transcript. The partial environment context was therefore emitted and permanently deduplicated as the ENTRY prompt.

This change keeps early discovery and wakeups intact, but waits for `event_msg.user_message`, response-step evidence, or a terminal record before treating the accumulated prompt as complete.

## Validation

- `npm test -- --run tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts` (42 passed)
- `npm run typecheck`
- `git diff --check`