### PR TITLE
feat: support native Windows local workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,25 @@ jobs:
       - run: npm run typecheck
       - run: npm test
       - run: npm run build
+
+  windows-local-worker:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      - run: >-
+          npx vitest run
+          tests/unit/deployment/worker-manifest-supervisor.test.ts
+          tests/unit/local-workers/instance-store.test.ts
+          tests/unit/local-workers/worker-cli.test.ts
+          tests/unit/deploy/windows-worker-cli-wrapper.test.mjs
+      - run: >-
+          npx vitest run
+          tests/unit/deployment/plugin-probe-strategy.test.ts
+          -t "uses the existing external tar extractor for local worker bundles"
+      - run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
           npx vitest run
           tests/unit/deployment/worker-manifest-supervisor.test.ts
           tests/unit/local-workers/instance-store.test.ts
+          tests/unit/local-workers/private-directory.test.ts
           tests/unit/local-workers/worker-cli.test.ts
           tests/unit/deploy/windows-worker-cli-wrapper.test.mjs
       - run: >-

--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -223,8 +223,8 @@ function Check-Deps {
     }
 
     # Pin node binary path
-    if (-not (Test-Path $DataDir)) { New-Item -ItemType Directory -Path $DataDir -Force | Out-Null }
-    Set-Content -Path (Join-Path $DataDir "node-bin") -Value $script:NODE_BIN
+    if (-not (Test-Path $CACHE_DIR)) { New-Item -ItemType Directory -Path $CACHE_DIR -Force | Out-Null }
+    Set-Content -Path (Join-Path $CACHE_DIR "node-bin") -Value $script:NODE_BIN
 
     # Derive npm
     $npmPath = Join-Path (Split-Path $script:NODE_BIN) "npm.cmd"

--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -8,17 +8,12 @@
 #   loongsuite-pilot status
 #   loongsuite-pilot info
 #   loongsuite-pilot rollback
+#   loongsuite-pilot worker connect|list|status|disconnect|delete
 #   loongsuite-pilot help
 
-[CmdletBinding()]
-param(
-    [Parameter(Position = 0)]
-    [string]$Command = "status",
-
-    [Parameter(Position = 1, ValueFromRemainingArguments)]
-    [string[]]$SubArgs
-)
-
+$CliArgs = @($args)
+$Command = if ($CliArgs.Count -ge 1) { [string]$CliArgs[0] } else { "status" }
+$SubArgs = if ($CliArgs.Count -ge 2) { [string[]]$CliArgs[1..($CliArgs.Count - 1)] } else { @() }
 $ErrorActionPreference = "Stop"
 
 # ============================================================
@@ -1085,6 +1080,34 @@ function Cmd-Log {
 }
 
 # ============================================================
+# CMD: worker (foreground local Worker management CLI)
+# ============================================================
+function Cmd-Worker {
+    $versionDir = Resolve-CurrentVersion
+    if (-not $versionDir) {
+        Write-Error "Current loongsuite-pilot version not found"
+        exit 1
+    }
+
+    $entry = Join-Path $versionDir "dist\index.js"
+    if (-not (Test-Path $entry -PathType Leaf)) {
+        Write-Error "Worker CLI entrypoint missing"
+        exit 1
+    }
+
+    $nodeBin = Resolve-Node
+    if (-not $nodeBin) {
+        Write-Error "node runtime not found"
+        exit 1
+    }
+
+    $env:LOONGSUITE_PILOT_DATA_DIR = $DATA_DIR
+    $env:LOONGSUITE_PILOT_CACHE_DIR = $CACHE_DIR
+    & $nodeBin $entry "worker" @SubArgs
+    exit $LASTEXITCODE
+}
+
+# ============================================================
 # CMD: help
 # ============================================================
 # Manage span-attributes.json — user-defined attributes injected into trace
@@ -1151,6 +1174,8 @@ function Cmd-Help {
     Write-Host "  log             Tail the service log"
     Write-Host "  span-attr ...   Manage custom trace span attributes (set/unset/list/clear)"
     Write-Host "  rollback        Roll back to the previous version"
+    Write-Host "  worker          Manage local Workers:"
+    Write-Host "                    worker connect/list/status/disconnect/delete"
     Write-Host "  help            Show this help message"
 }
 
@@ -1165,6 +1190,7 @@ switch ($Command.ToLower()) {
     "info"               { Cmd-Info }
     "log"                { Cmd-Log }
     "rollback"           { Cmd-Rollback }
+    "worker"             { Cmd-Worker }
     "restart-collector"  { Cmd-RestartCollector }
     "restart-updater"    { Cmd-RestartUpdater }
     "run"                { Cmd-Run }

--- a/src/deployment/plugin-probe-strategy.ts
+++ b/src/deployment/plugin-probe-strategy.ts
@@ -88,10 +88,23 @@ export class PluginProbeStrategy implements DeployStrategy {
       const destDir = config.source.destDir;
       const existingRoot = await this.resolvePackageRoot(destDir);
 
-      await this.workerSupervisor.stopIfPresent(def.id, destDir, {
+      const stopped = await this.workerSupervisor.stopIfPresent(def.id, destDir, {
         instance: options.instance,
         runtimeOptions: options.runtimeOptions,
       });
+      if (!stopped && def.localWorkerRuntime && options.instance) {
+        logger.error('local worker stop failed; bundle replacement aborted', {
+          agentId: def.id,
+          instanceId: options.instance.id,
+          destDir,
+        });
+        return {
+          success: false,
+          agentId: def.id,
+          deployMode: 'plugin-probe',
+          error: 'local worker stop failed; bundle replacement aborted',
+        };
+      }
 
       const existingUninstallScript = existingRoot ? path.join(existingRoot, 'scripts', 'uninstall.sh') : '';
       if (existingUninstallScript && await fileExists(existingUninstallScript)) {

--- a/src/deployment/plugin-probe-strategy.ts
+++ b/src/deployment/plugin-probe-strategy.ts
@@ -24,15 +24,21 @@ export interface PluginProbeDeployOptions {
   runtimeOptions?: Record<string, string | boolean>;
 }
 
+export interface PluginProbeStrategyOptions {
+  platform?: NodeJS.Platform;
+}
+
 export class PluginProbeStrategy implements DeployStrategy {
   private readonly dataDir: string;
   private readonly pilotDir: string;
   private readonly workerSupervisor: WorkerManifestSupervisor;
+  private readonly platform: NodeJS.Platform;
 
-  constructor(dataDir: string, pilotDir: string) {
+  constructor(dataDir: string, pilotDir: string, options: PluginProbeStrategyOptions = {}) {
     this.dataDir = dataDir;
     this.pilotDir = pilotDir;
-    this.workerSupervisor = new WorkerManifestSupervisor();
+    this.platform = options.platform ?? process.platform;
+    this.workerSupervisor = new WorkerManifestSupervisor({ platform: this.platform });
   }
 
   async detect(def: AgentDefinition): Promise<boolean> {
@@ -89,8 +95,12 @@ export class PluginProbeStrategy implements DeployStrategy {
 
       const existingUninstallScript = existingRoot ? path.join(existingRoot, 'scripts', 'uninstall.sh') : '';
       if (existingUninstallScript && await fileExists(existingUninstallScript)) {
-        logger.info('running uninstall script before update', { agentId: def.id });
-        await this.runScript(existingUninstallScript, existingRoot!, def.id);
+        if (this.platform === 'win32' && def.localWorkerRuntime) {
+          logger.info('skipping Unix uninstall script for Windows local worker bundle', { agentId: def.id });
+        } else {
+          logger.info('running uninstall script before update', { agentId: def.id });
+          await this.runScript(existingUninstallScript, existingRoot!, def.id);
+        }
       }
 
       const acquired = await this.acquirePackageIntoDest(config.source);
@@ -102,9 +112,13 @@ export class PluginProbeStrategy implements DeployStrategy {
       const installCwd = packageRoot ?? destDir;
       const installScript = await this.resolveInstallScript(def.id, installCwd);
       if (installScript) {
-        const ok = await this.runScript(installScript, installCwd, def.id);
-        if (!ok) {
-          return { success: false, agentId: def.id, deployMode: 'plugin-probe', error: 'install script failed' };
+        if (this.platform === 'win32' && def.localWorkerRuntime && path.extname(installScript).toLowerCase() === '.sh') {
+          logger.info('skipping Unix install script for Windows local worker bundle', { agentId: def.id });
+        } else {
+          const ok = await this.runScript(installScript, installCwd, def.id);
+          if (!ok) {
+            return { success: false, agentId: def.id, deployMode: 'plugin-probe', error: 'install script failed' };
+          }
         }
       } else {
         logger.debug('no install script found, skipping', { agentId: def.id });
@@ -120,7 +134,7 @@ export class PluginProbeStrategy implements DeployStrategy {
         const workerStarted = await this.workerSupervisor.startIfPresent(
           def.id,
           destDir,
-          this.buildScriptEnv(def.id),
+          this.buildScriptEnv(def.id, !!def.localWorkerRuntime),
           {
             instance: options.instance,
             runtimeOptions: options.runtimeOptions,
@@ -128,6 +142,14 @@ export class PluginProbeStrategy implements DeployStrategy {
         );
         if (!workerStarted) {
           logger.warn('plugin deployed but worker failed to start', { agentId: def.id });
+          if (def.localWorkerRuntime && options.instance) {
+            return {
+              success: false,
+              agentId: def.id,
+              deployMode: 'plugin-probe',
+              error: 'local worker manifest failed to start',
+            };
+          }
         }
       }
 
@@ -266,14 +288,18 @@ export class PluginProbeStrategy implements DeployStrategy {
     return undefined;
   }
 
-  private buildScriptEnv(agentId: string): Record<string, string> {
+  private buildScriptEnv(agentId: string, localWorker = false): Record<string, string> {
     const nodeBin = process.execPath;
     const nodeDir = path.dirname(nodeBin);
-    const npmBin = path.join(nodeDir, 'npm');
+    const npmBin = path.join(
+      nodeDir,
+      localWorker && this.platform === 'win32' ? 'npm.cmd' : 'npm',
+    );
     const existingPath = process.env.PATH ?? '/usr/bin:/bin:/usr/sbin:/sbin';
+    const delimiter = localWorker ? (this.platform === 'win32' ? ';' : ':') : ':';
     const augmentedPath = existingPath.includes(nodeDir)
       ? existingPath
-      : `${nodeDir}:${existingPath}`;
+      : `${nodeDir}${delimiter}${existingPath}`;
 
     return {
       ...process.env as Record<string, string>,

--- a/src/deployment/worker-manifest-supervisor.ts
+++ b/src/deployment/worker-manifest-supervisor.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs/promises';
 import { createWriteStream, type Dirent } from 'node:fs';
 import * as path from 'node:path';
-import { spawn } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
 import { createLogger } from '../utils/logger.js';
 import { ensureDir, fileExists } from '../utils/fs-utils.js';
 
@@ -41,8 +41,30 @@ export interface WorkerManifestOptions {
   runtimeOptions?: Record<string, string | boolean>;
 }
 
+export interface WorkerManifestSupervisorOptions {
+  platform?: NodeJS.Platform;
+  nodeExecutable?: string;
+}
+
+class WorkerManifestContractError extends Error {
+  constructor(
+    readonly reason: string,
+    message: string,
+    readonly detail: Record<string, unknown> = {},
+  ) {
+    super(message);
+  }
+}
+
 export class WorkerManifestSupervisor {
   private readonly runtimes = new Map<string, WorkerRuntime>();
+  private readonly platform: NodeJS.Platform;
+  private readonly nodeExecutable: string;
+
+  constructor(options: WorkerManifestSupervisorOptions = {}) {
+    this.platform = options.platform ?? process.platform;
+    this.nodeExecutable = options.nodeExecutable ?? process.execPath;
+  }
 
   async startIfPresent(
     agentId: string,
@@ -144,14 +166,41 @@ export class WorkerManifestSupervisor {
     await ensureDir(path.dirname(paths.status));
     await ensureDir(path.dirname(paths.log));
 
-    const command = manifest.command.map(part => this.expand(part, bundleRoot, env, options));
-    const executable = this.resolveCommand(bundleRoot, command[0]);
-    const args = command.slice(1);
     const cwd = this.resolvePath(bundleRoot, this.expand(manifest.cwd ?? '.', bundleRoot, env, options));
     const workerEnv = {
       ...env,
       ...this.expandEnv(manifest.env ?? {}, bundleRoot, env, options),
     };
+    if (this.platform === 'win32' && !workerEnv.HOME && workerEnv.USERPROFILE) {
+      workerEnv.HOME = workerEnv.USERPROFILE;
+    }
+
+    let executable: string;
+    let args: string[];
+    try {
+      const resolved = await this.resolveManifestCommand(bundleRoot, cwd, manifest, env, options);
+      executable = resolved.executable;
+      args = resolved.args;
+    } catch (err) {
+      const contractError = err instanceof WorkerManifestContractError ? err : undefined;
+      await this.writeStatus(paths.status, {
+        state: 'failed',
+        name: manifest.name,
+        agentId,
+        reason: contractError?.reason ?? 'WorkerManifestInvalid',
+        error: err instanceof Error ? err.message : String(err),
+        ...contractError?.detail,
+        updatedAt: new Date().toISOString(),
+      });
+      logger.error('worker manifest rejected', {
+        agentId,
+        manifest: manifest.name,
+        reason: contractError?.reason ?? 'WorkerManifestInvalid',
+        ...contractError?.detail,
+      });
+      return false;
+    }
+
     const log = createWriteStream(paths.log, { flags: 'a' });
 
     await this.writeStatus(paths.status, {
@@ -168,6 +217,7 @@ export class WorkerManifestSupervisor {
         env: workerEnv,
         stdio: ['ignore', 'pipe', 'pipe'],
         detached: true,
+        windowsHide: this.platform === 'win32',
       });
       let settled = false;
       let startPersisted = false;
@@ -283,18 +333,52 @@ export class WorkerManifestSupervisor {
       updatedAt: new Date().toISOString(),
     });
 
-    try {
-      this.signalProcessGroup(pid, 'SIGTERM');
-    } catch (err) {
-      logger.warn('failed to stop worker', { agentId, pid, error: String(err) });
-      return false;
+    logger.info('worker process tree stop requested', {
+      agentId,
+      pid,
+      platform: this.platform,
+    });
+
+    let remainingPids: number[] = [];
+    if (this.platform === 'win32') {
+      remainingPids = await this.stopWindowsProcessTree(agentId, pid);
+    } else {
+      try {
+        this.signalProcessGroup(pid, 'SIGTERM');
+      } catch (err) {
+        logger.warn('failed to request worker process group stop', { agentId, pid, error: String(err) });
+        return false;
+      }
+
+      await this.waitForExit(pid, 5000);
+      try {
+        // Kill the process group even if its leader exited, because descendants may remain.
+        this.signalProcessGroup(pid, 'SIGKILL');
+        logger.info('worker process group force cleanup requested', { agentId, pid });
+      } catch {
+        // Process group may have exited between checks.
+      }
     }
 
     await this.waitForExit(pid, 5000);
-    try {
-      this.signalProcessGroup(pid, 'SIGKILL');
-    } catch {
-      // Process group may have exited between checks.
+    if (this.isAlive(pid) || remainingPids.length > 0) {
+      await this.writeStatus(paths.status, {
+        state: 'failed',
+        name: manifest.name,
+        agentId,
+        pid,
+        reason: 'WorkerProcessTreeStopFailed',
+        error: 'worker process remained alive after process tree cleanup',
+        remainingPids,
+        updatedAt: new Date().toISOString(),
+      });
+      logger.error('worker process tree stop failed', {
+        agentId,
+        pid,
+        platform: this.platform,
+        remainingPids,
+      });
+      return false;
     }
 
     await fs.rm(paths.pid, { force: true });
@@ -307,6 +391,255 @@ export class WorkerManifestSupervisor {
     });
     logger.info('worker stopped', { agentId, pid });
     return true;
+  }
+
+  private async resolveManifestCommand(
+    bundleRoot: string,
+    cwd: string,
+    manifest: WorkerManifest,
+    env: Record<string, string>,
+    options: WorkerManifestOptions,
+  ): Promise<{ executable: string; args: string[] }> {
+    this.validatePilotPlaceholders(manifest);
+    const command = manifest.command.map(part => this.expand(part, bundleRoot, env, options));
+    let executable: string;
+
+    if (manifest.command[0] === '${pilot:node}') {
+      executable = await this.resolvePilotNode();
+      logger.info('worker manifest command resolved', {
+        manifest: manifest.name,
+        commandSource: 'pilot-node',
+        nodeVersion: process.version,
+        executableName: path.basename(executable),
+      });
+    } else {
+      executable = this.resolveCommand(bundleRoot, command[0]);
+    }
+
+    const args = command.slice(1);
+    await this.validatePlatformEntrypoint(bundleRoot, cwd, manifest, executable, args);
+    return { executable, args };
+  }
+
+  private validatePilotPlaceholders(manifest: WorkerManifest): void {
+    const fields = [
+      ...manifest.command.map((value, index) => ({ value, location: `command[${index}]` })),
+      { value: manifest.cwd, location: 'cwd' },
+      ...Object.entries(manifest.env ?? {}).map(([name, value]) => ({ value, location: `env.${name}` })),
+      ...Object.entries(manifest.paths ?? {}).map(([name, value]) => ({ value, location: `paths.${name}` })),
+    ];
+
+    for (const field of fields) {
+      if (!field.value?.includes('${pilot:')) continue;
+      if (field.location === 'command[0]' && field.value === '${pilot:node}') continue;
+      throw new WorkerManifestContractError(
+        'WorkerManifestPlaceholderInvalid',
+        `unsupported Pilot placeholder in ${field.location}`,
+        { placeholderLocation: field.location },
+      );
+    }
+  }
+
+  private async resolvePilotNode(): Promise<string> {
+    if (!path.isAbsolute(this.nodeExecutable)) {
+      throw new WorkerManifestContractError(
+        'WorkerManifestPlaceholderInvalid',
+        'Pilot Node executable must be an absolute path',
+      );
+    }
+    try {
+      const stat = await fs.stat(this.nodeExecutable);
+      if (!stat.isFile()) throw new Error('not a regular file');
+    } catch (err) {
+      throw new WorkerManifestContractError(
+        'WorkerManifestPlaceholderInvalid',
+        `Pilot Node executable is unavailable: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    return this.nodeExecutable;
+  }
+
+  private async validatePlatformEntrypoint(
+    bundleRoot: string,
+    cwd: string,
+    manifest: WorkerManifest,
+    executable: string,
+    args: string[],
+  ): Promise<void> {
+    if (this.platform !== 'win32') return;
+
+    const usesPilotNode = manifest.command[0] === '${pilot:node}';
+    const entry = usesPilotNode ? args[0] : executable;
+    if (!entry) {
+      throw new WorkerManifestContractError(
+        'WorkerManifestPlaceholderInvalid',
+        'Pilot Node manifest command requires an entrypoint argument',
+      );
+    }
+
+    const entryPath = this.resolveEntrypointPath(bundleRoot, cwd, entry);
+    const entryType = await this.classifyEntrypoint(entry, entryPath);
+    if (entryType !== 'unix-shell') return;
+
+    throw new WorkerManifestContractError(
+      'RuntimeBundlePlatformUnsupported',
+      'runtime bundle uses a Unix shell entrypoint that is not supported on native Windows',
+      {
+        bundleName: manifest.name,
+        bundleVersion: manifest.version ?? 'unknown',
+        platform: this.platform,
+        entryType,
+        action: 'upgrade to a Runtime Bundle with a Node .mjs/.js entrypoint',
+      },
+    );
+  }
+
+  private resolveEntrypointPath(bundleRoot: string, cwd: string, entry: string): string {
+    if (path.isAbsolute(entry)) return entry;
+    if (entry.includes('/') || entry.includes('\\') || entry.startsWith('.')) {
+      return path.resolve(cwd || bundleRoot, entry);
+    }
+    return entry;
+  }
+
+  private async classifyEntrypoint(rawEntry: string, resolvedEntry: string): Promise<'unix-shell' | 'native'> {
+    const basename = path.basename(rawEntry).toLowerCase();
+    if (path.extname(basename).toLowerCase() === '.sh'
+      || ['bash', 'bash.exe', 'sh', 'sh.exe', 'zsh', 'zsh.exe', 'dash', 'dash.exe', 'ksh', 'ksh.exe']
+        .includes(basename)) {
+      return 'unix-shell';
+    }
+
+    if (!await fileExists(resolvedEntry)) return 'native';
+    try {
+      const handle = await fs.open(resolvedEntry, 'r');
+      try {
+        const buffer = Buffer.alloc(256);
+        const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+        const firstLine = buffer.subarray(0, bytesRead).toString('utf-8').split(/\r?\n/, 1)[0];
+        if (/^#!.*(?:^|[/\s])(?:ba|z|da|k)?sh(?:\s|$)/i.test(firstLine)) return 'unix-shell';
+      } finally {
+        await handle.close();
+      }
+    } catch {
+      // spawn() will report unreadable or missing entrypoints through the existing failure path.
+    }
+    return 'native';
+  }
+
+  private async stopWindowsProcessTree(agentId: string, pid: number): Promise<number[]> {
+    let descendants: number[] = [];
+    try {
+      descendants = await this.listWindowsDescendantPids(pid);
+    } catch (err) {
+      logger.warn('worker process tree discovery failed', { agentId, pid, error: String(err) });
+    }
+
+    const trackedPids = [pid, ...descendants];
+    try {
+      await this.runTaskkill(pid, false);
+      logger.info('worker process tree graceful stop requested', {
+        agentId,
+        pid,
+        platform: this.platform,
+        descendantCount: descendants.length,
+      });
+    } catch (err) {
+      if (this.isAlive(pid)) {
+        logger.warn('worker process tree graceful stop failed', { agentId, pid, error: String(err) });
+      }
+    }
+
+    await this.waitForPidsExit(trackedPids, 5000);
+    const remaining = trackedPids.filter(candidate => this.isAlive(candidate));
+    if (remaining.length === 0) return [];
+
+    for (const candidate of remaining) {
+      try {
+        await this.runTaskkill(candidate, true);
+      } catch (err) {
+        if (this.isAlive(candidate)) {
+          logger.warn('worker process tree force cleanup failed', {
+            agentId,
+            pid,
+            candidatePid: candidate,
+            error: String(err),
+          });
+        }
+      }
+    }
+    logger.info('worker process tree force cleanup requested', {
+      agentId,
+      pid,
+      platform: this.platform,
+      targetPids: remaining,
+    });
+
+    await this.waitForPidsExit(remaining, 5000);
+    return remaining.filter(candidate => this.isAlive(candidate));
+  }
+
+  private listWindowsDescendantPids(rootPid: number): Promise<number[]> {
+    if (!Number.isSafeInteger(rootPid) || rootPid <= 0) {
+      return Promise.reject(new Error('worker pid must be a positive integer'));
+    }
+    const script = `
+$rootPid = [uint32]$env:LOONGSUITE_WORKER_ROOT_PID
+$processes = @(Get-CimInstance Win32_Process | Select-Object ProcessId, ParentProcessId)
+$pending = @($rootPid)
+$result = @()
+while ($pending.Count -gt 0) {
+  $parentPid = $pending[0]
+  $pending = @($pending | Select-Object -Skip 1)
+  $children = @($processes | Where-Object { $_.ParentProcessId -eq $parentPid })
+  foreach ($child in $children) {
+    $childPid = [uint32]$child.ProcessId
+    if ($result -notcontains $childPid) {
+      $result += $childPid
+      $pending += $childPid
+    }
+  }
+}
+[Console]::Out.Write(($result -join ","))
+`;
+    return new Promise((resolve, reject) => {
+      execFile('powershell.exe', [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        script,
+      ], {
+        env: {
+          ...process.env,
+          LOONGSUITE_WORKER_ROOT_PID: String(rootPid),
+        },
+        windowsHide: true,
+      }, (err, stdout) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        const pids = String(stdout)
+          .split(',')
+          .map(value => Number.parseInt(value.trim(), 10))
+          .filter(value => Number.isSafeInteger(value) && value > 0);
+        resolve([...new Set(pids)]);
+      });
+    });
+  }
+
+  private runTaskkill(pid: number, force: boolean): Promise<void> {
+    if (!Number.isSafeInteger(pid) || pid <= 0) {
+      return Promise.reject(new Error('worker pid must be a positive integer'));
+    }
+    const args = ['/PID', String(pid), '/T'];
+    if (force) args.push('/F');
+    return new Promise((resolve, reject) => {
+      execFile('taskkill.exe', args, { windowsHide: true }, err => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
   }
 
   private async handleExit(
@@ -408,8 +741,8 @@ export class WorkerManifestSupervisor {
 
   private resolveCommand(bundleRoot: string, command: string): string {
     if (path.isAbsolute(command)) return command;
-    if (command.includes(path.sep) || command.startsWith('.')) {
-      return path.join(bundleRoot, command);
+    if (command.includes('/') || command.includes('\\') || command.startsWith('.')) {
+      return path.resolve(bundleRoot, command);
     }
     return command;
   }
@@ -457,6 +790,14 @@ export class WorkerManifestSupervisor {
     const started = Date.now();
     while (Date.now() - started < timeoutMs) {
       if (!this.isAlive(pid)) return;
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+  }
+
+  private async waitForPidsExit(pids: number[], timeoutMs: number): Promise<void> {
+    const started = Date.now();
+    while (Date.now() - started < timeoutMs) {
+      if (pids.every(pid => !this.isAlive(pid))) return;
       await new Promise(resolve => setTimeout(resolve, 100));
     }
   }

--- a/src/deployment/worker-manifest-supervisor.ts
+++ b/src/deployment/worker-manifest-supervisor.ts
@@ -36,6 +36,17 @@ interface WorkerRuntime {
   stopping: boolean;
 }
 
+interface WindowsProcessIdentity {
+  pid: number;
+  creationTime: string;
+  executablePath: string;
+}
+
+interface TrackedWindowsProcess {
+  pid: number;
+  identity?: WindowsProcessIdentity;
+}
+
 export interface WorkerManifestOptions {
   instance?: Record<string, string>;
   runtimeOptions?: Record<string, string | boolean>;
@@ -56,6 +67,8 @@ class WorkerManifestContractError extends Error {
   }
 }
 
+class WorkerProcessIdentityError extends Error {}
+
 export class WorkerManifestSupervisor {
   private readonly runtimes = new Map<string, WorkerRuntime>();
   private readonly platform: NodeJS.Platform;
@@ -75,7 +88,8 @@ export class WorkerManifestSupervisor {
     const location = await this.findManifest(installDir);
     if (!location) return true;
 
-    await this.stopIfPresent(agentId, installDir, options);
+    const stopped = await this.stopIfPresent(agentId, installDir, options);
+    if (!stopped && this.platform === 'win32') return false;
 
     const manifest = await this.readManifest(location.manifestPath);
     if (!manifest) return false;
@@ -227,11 +241,15 @@ export class WorkerManifestSupervisor {
         settled = true;
         log.end();
         await fs.rm(paths.pid, { force: true });
+        await fs.rm(this.processIdentityPath(paths.pid), { force: true });
         this.runtimes.delete(paths.pid);
         await this.writeStatus(paths.status, {
           state: 'failed',
           name: manifest.name,
           agentId,
+          reason: err instanceof WorkerProcessIdentityError
+            ? 'WorkerProcessIdentityUnavailable'
+            : undefined,
           error: String(err),
           updatedAt: new Date().toISOString(),
         });
@@ -262,22 +280,66 @@ export class WorkerManifestSupervisor {
         return false;
       }
 
+      let processIdentity: WindowsProcessIdentity | undefined;
+      if (this.shouldVerifyWindowsProcessIdentity()) {
+        try {
+          processIdentity = await this.readWindowsProcessIdentity(child.pid);
+        } catch (err) {
+          if (earlyExit) {
+            processIdentity = undefined;
+          } else {
+            try {
+              child.kill('SIGKILL');
+            } catch {
+              // The child may have exited while its identity was queried.
+            }
+            await failStart(new WorkerProcessIdentityError(String(err)));
+            return false;
+          }
+        }
+        if (!processIdentity && !earlyExit) {
+          try {
+            child.kill('SIGKILL');
+          } catch {
+            // The child may have exited before its identity could be recorded.
+          }
+          await failStart(new WorkerProcessIdentityError('worker process identity was not found'));
+          return false;
+        }
+      }
+
       child.unref();
       if (settled) return false;
 
       const activeRuntime = runtime ?? { restarts: 0, stopping: false };
-      this.runtimes.set(paths.pid, activeRuntime);
-      await fs.writeFile(paths.pid, `${child.pid}\n`, 'utf-8');
-      if (settled) return false;
-      await this.writeStatus(paths.status, {
-        state: 'running',
-        name: manifest.name,
-        agentId,
-        pid: child.pid,
-        startedAt: new Date().toISOString(),
-        restartCount: runtime?.restarts ?? 0,
-      });
-      if (settled) return false;
+      try {
+        if (processIdentity) {
+          await this.writeStatus(this.processIdentityPath(paths.pid), { ...processIdentity });
+          if (settled) return false;
+        }
+        await fs.writeFile(paths.pid, `${child.pid}\n`, 'utf-8');
+        if (settled) return false;
+        this.runtimes.set(paths.pid, activeRuntime);
+        await this.writeStatus(paths.status, {
+          state: 'running',
+          name: manifest.name,
+          agentId,
+          pid: child.pid,
+          startedAt: new Date().toISOString(),
+          restartCount: runtime?.restarts ?? 0,
+          processIdentity,
+        });
+        if (settled) return false;
+      } catch (err) {
+        try {
+          child.kill('SIGKILL');
+        } catch {
+          // The child may have exited while its start state was persisted.
+        }
+        await failStart(err);
+        return false;
+      }
+
       startPersisted = true;
 
       if (earlyExit) {
@@ -325,11 +387,97 @@ export class WorkerManifestSupervisor {
     const pid = await this.readPid(paths.pid);
     if (!pid) return true;
 
+    let processIdentity: WindowsProcessIdentity | undefined;
+    if (this.shouldVerifyWindowsProcessIdentity()) {
+      processIdentity = await this.readStoredWindowsProcessIdentity(this.processIdentityPath(paths.pid), pid);
+      if (!processIdentity) {
+        await this.writeStatus(paths.status, {
+          state: 'failed',
+          name: manifest.name,
+          agentId,
+          pid,
+          reason: 'WorkerProcessIdentityMissing',
+          error: 'worker pid exists without a recorded Windows process identity',
+          updatedAt: new Date().toISOString(),
+        });
+        logger.error('worker process identity missing; refusing to stop pid', { agentId, pid });
+        return false;
+      }
+
+      let actualIdentity: WindowsProcessIdentity | undefined;
+      try {
+        actualIdentity = await this.readWindowsProcessIdentity(pid);
+      } catch (err) {
+        await this.writeStatus(paths.status, {
+          state: 'failed',
+          name: manifest.name,
+          agentId,
+          pid,
+          reason: 'WorkerProcessIdentityCheckFailed',
+          error: String(err),
+          processIdentity,
+          updatedAt: new Date().toISOString(),
+        });
+        logger.error('worker process identity check failed; refusing to stop pid', {
+          agentId,
+          pid,
+          error: String(err),
+        });
+        return false;
+      }
+
+      if (!actualIdentity) {
+        await fs.rm(paths.pid, { force: true });
+        await fs.rm(this.processIdentityPath(paths.pid), { force: true });
+        this.runtimes.delete(paths.pid);
+        await this.writeStatus(paths.status, {
+          state: 'stopped',
+          name: manifest.name,
+          agentId,
+          pid,
+          reason: 'WorkerProcessNotFound',
+          stoppedAt: new Date().toISOString(),
+        });
+        logger.info('stale worker pid removed because the process no longer exists', { agentId, pid });
+        return true;
+      }
+
+      if (!this.isSameWindowsProcess(processIdentity, actualIdentity)) {
+        await fs.rm(paths.pid, { force: true });
+        await fs.rm(this.processIdentityPath(paths.pid), { force: true });
+        this.runtimes.delete(paths.pid);
+        await this.writeStatus(paths.status, {
+          state: 'stopped',
+          name: manifest.name,
+          agentId,
+          pid,
+          reason: 'WorkerPidIdentityMismatch',
+          stoppedAt: new Date().toISOString(),
+        });
+        logger.warn('stale worker pid ignored because the Windows process identity changed', {
+          agentId,
+          pid,
+          expectedCreationTime: processIdentity.creationTime,
+          actualCreationTime: actualIdentity.creationTime,
+          actualExecutableName: path.win32.basename(actualIdentity.executablePath),
+        });
+        return true;
+      }
+
+      logger.info('worker process identity matched', {
+        agentId,
+        pid,
+        creationTime: processIdentity.creationTime,
+        executableName: path.win32.basename(processIdentity.executablePath),
+      });
+    }
+
     await this.writeStatus(paths.status, {
       state: 'stopping',
       name: manifest.name,
       agentId,
       pid,
+      processIdentity,
       updatedAt: new Date().toISOString(),
     });
 
@@ -341,7 +489,7 @@ export class WorkerManifestSupervisor {
 
     let remainingPids: number[] = [];
     if (this.platform === 'win32') {
-      remainingPids = await this.stopWindowsProcessTree(agentId, pid);
+      remainingPids = await this.stopWindowsProcessTree(agentId, pid, processIdentity);
     } else {
       try {
         this.signalProcessGroup(pid, 'SIGTERM');
@@ -361,7 +509,7 @@ export class WorkerManifestSupervisor {
     }
 
     await this.waitForExit(pid, 5000);
-    if (this.isAlive(pid) || remainingPids.length > 0) {
+    if ((this.platform !== 'win32' && this.isAlive(pid)) || remainingPids.length > 0) {
       await this.writeStatus(paths.status, {
         state: 'failed',
         name: manifest.name,
@@ -382,6 +530,7 @@ export class WorkerManifestSupervisor {
     }
 
     await fs.rm(paths.pid, { force: true });
+    await fs.rm(this.processIdentityPath(paths.pid), { force: true });
     await this.writeStatus(paths.status, {
       state: 'stopped',
       name: manifest.name,
@@ -527,15 +676,20 @@ export class WorkerManifestSupervisor {
     return 'native';
   }
 
-  private async stopWindowsProcessTree(agentId: string, pid: number): Promise<number[]> {
-    let descendants: number[] = [];
+  private async stopWindowsProcessTree(
+    agentId: string,
+    pid: number,
+    rootIdentity?: WindowsProcessIdentity,
+  ): Promise<number[]> {
+    let descendants: TrackedWindowsProcess[] = [];
     try {
-      descendants = await this.listWindowsDescendantPids(pid);
+      descendants = await this.listWindowsDescendantProcesses(pid);
     } catch (err) {
       logger.warn('worker process tree discovery failed', { agentId, pid, error: String(err) });
     }
 
-    const trackedPids = [pid, ...descendants];
+    const trackedProcesses = [{ pid, identity: rootIdentity }, ...descendants];
+    const trackedPids = trackedProcesses.map(processInfo => processInfo.pid);
     try {
       await this.runTaskkill(pid, false);
       logger.info('worker process tree graceful stop requested', {
@@ -551,18 +705,30 @@ export class WorkerManifestSupervisor {
     }
 
     await this.waitForPidsExit(trackedPids, 5000);
-    const remaining = trackedPids.filter(candidate => this.isAlive(candidate));
+    const remaining = trackedProcesses.filter(processInfo => this.isAlive(processInfo.pid));
     if (remaining.length === 0) return [];
 
-    for (const candidate of remaining) {
+    const forceTargets: number[] = [];
+    for (const processInfo of remaining) {
+      const identityState = await this.readTrackedWindowsProcessState(agentId, processInfo);
+      if (identityState !== 'same') {
+        logger.warn('worker process force cleanup skipped because identity is not confirmed', {
+          agentId,
+          pid,
+          candidatePid: processInfo.pid,
+          identityState,
+        });
+        continue;
+      }
       try {
-        await this.runTaskkill(candidate, true);
+        await this.runTaskkill(processInfo.pid, true);
+        forceTargets.push(processInfo.pid);
       } catch (err) {
-        if (this.isAlive(candidate)) {
+        if (this.isAlive(processInfo.pid)) {
           logger.warn('worker process tree force cleanup failed', {
             agentId,
             pid,
-            candidatePid: candidate,
+            candidatePid: processInfo.pid,
             error: String(err),
           });
         }
@@ -572,35 +738,53 @@ export class WorkerManifestSupervisor {
       agentId,
       pid,
       platform: this.platform,
-      targetPids: remaining,
+      targetPids: forceTargets,
     });
 
-    await this.waitForPidsExit(remaining, 5000);
-    return remaining.filter(candidate => this.isAlive(candidate));
+    await this.waitForPidsExit(remaining.map(processInfo => processInfo.pid), 5000);
+    const finalRemaining: number[] = [];
+    for (const processInfo of remaining) {
+      const identityState = await this.readTrackedWindowsProcessState(agentId, processInfo);
+      if (identityState === 'same' || identityState === 'unknown') {
+        finalRemaining.push(processInfo.pid);
+      }
+    }
+    return finalRemaining;
   }
 
-  private listWindowsDescendantPids(rootPid: number): Promise<number[]> {
+  private listWindowsDescendantProcesses(rootPid: number): Promise<TrackedWindowsProcess[]> {
     if (!Number.isSafeInteger(rootPid) || rootPid <= 0) {
       return Promise.reject(new Error('worker pid must be a positive integer'));
     }
     const script = `
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
 $rootPid = [uint32]$env:LOONGSUITE_WORKER_ROOT_PID
-$processes = @(Get-CimInstance Win32_Process | Select-Object ProcessId, ParentProcessId)
+$processes = @(Get-CimInstance Win32_Process | Select-Object ProcessId, ParentProcessId, CreationDate, ExecutablePath)
 $pending = @($rootPid)
 $result = @()
+$seen = @()
 while ($pending.Count -gt 0) {
   $parentPid = $pending[0]
   $pending = @($pending | Select-Object -Skip 1)
   $children = @($processes | Where-Object { $_.ParentProcessId -eq $parentPid })
   foreach ($child in $children) {
     $childPid = [uint32]$child.ProcessId
-    if ($result -notcontains $childPid) {
-      $result += $childPid
+    if ($seen -notcontains $childPid) {
+      $seen += $childPid
+      $result += [ordered]@{
+        pid = $childPid
+        creationTime = if ($null -ne $child.CreationDate) {
+          $child.CreationDate.ToUniversalTime().ToString("O")
+        } else {
+          ""
+        }
+        executablePath = [string]$child.ExecutablePath
+      }
       $pending += $childPid
     }
   }
 }
-[Console]::Out.Write(($result -join ","))
+[Console]::Out.Write((ConvertTo-Json -InputObject $result -Compress))
 `;
     return new Promise((resolve, reject) => {
       execFile('powershell.exe', [
@@ -619,13 +803,154 @@ while ($pending.Count -gt 0) {
           reject(err);
           return;
         }
-        const pids = String(stdout)
-          .split(',')
-          .map(value => Number.parseInt(value.trim(), 10))
-          .filter(value => Number.isSafeInteger(value) && value > 0);
-        resolve([...new Set(pids)]);
+        const output = String(stdout).trim();
+        if (!output) {
+          resolve([]);
+          return;
+        }
+        try {
+          const parsed = JSON.parse(output) as unknown;
+          const values = Array.isArray(parsed) ? parsed : [parsed];
+          const seen = new Set<number>();
+          const processes: TrackedWindowsProcess[] = [];
+          for (const value of values) {
+            if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+            const pid = Number((value as Record<string, unknown>).pid);
+            if (!Number.isSafeInteger(pid) || pid <= 0 || seen.has(pid)) continue;
+            seen.add(pid);
+            const identity = this.parseWindowsProcessIdentity(value);
+            processes.push({
+              pid,
+              identity: identity?.pid === pid ? identity : undefined,
+            });
+          }
+          resolve(processes);
+        } catch (parseErr) {
+          reject(parseErr);
+        }
       });
     });
+  }
+
+  private async readTrackedWindowsProcessState(
+    agentId: string,
+    processInfo: TrackedWindowsProcess,
+  ): Promise<'same' | 'gone' | 'changed' | 'unknown'> {
+    if (!processInfo.identity) {
+      return this.isAlive(processInfo.pid) ? 'unknown' : 'gone';
+    }
+
+    try {
+      const actualIdentity = await this.readWindowsProcessIdentity(processInfo.pid);
+      if (!actualIdentity) return 'gone';
+      return this.isSameWindowsProcess(processInfo.identity, actualIdentity) ? 'same' : 'changed';
+    } catch (err) {
+      logger.warn('worker process identity recheck failed', {
+        agentId,
+        pid: processInfo.pid,
+        error: String(err),
+      });
+      return 'unknown';
+    }
+  }
+
+  private readWindowsProcessIdentity(pid: number): Promise<WindowsProcessIdentity | undefined> {
+    if (!Number.isSafeInteger(pid) || pid <= 0) {
+      return Promise.reject(new Error('worker pid must be a positive integer'));
+    }
+    const script = `
+$ErrorActionPreference = "Stop"
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+$targetPid = [uint32]$env:LOONGSUITE_WORKER_PID
+$process = Get-CimInstance Win32_Process -Filter "ProcessId = $targetPid"
+if ($null -ne $process) {
+  $identity = [ordered]@{
+    pid = [uint32]$process.ProcessId
+    creationTime = $process.CreationDate.ToUniversalTime().ToString("O")
+    executablePath = [string]$process.ExecutablePath
+  }
+  [Console]::Out.Write((ConvertTo-Json -InputObject $identity -Compress))
+}
+`;
+    return new Promise((resolve, reject) => {
+      execFile('powershell.exe', [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        script,
+      ], {
+        env: {
+          ...process.env,
+          LOONGSUITE_WORKER_PID: String(pid),
+        },
+        windowsHide: true,
+        timeout: 5000,
+      }, (err, stdout) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        const output = String(stdout).trim();
+        if (!output) {
+          resolve(undefined);
+          return;
+        }
+        try {
+          resolve(this.parseWindowsProcessIdentity(JSON.parse(output)));
+        } catch (parseErr) {
+          reject(parseErr);
+        }
+      });
+    });
+  }
+
+  private async readStoredWindowsProcessIdentity(
+    identityPath: string,
+    pid: number,
+  ): Promise<WindowsProcessIdentity | undefined> {
+    try {
+      const identity = this.parseWindowsProcessIdentity(
+        JSON.parse(await fs.readFile(identityPath, 'utf-8')),
+      );
+      return identity?.pid === pid ? identity : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private parseWindowsProcessIdentity(value: unknown): WindowsProcessIdentity | undefined {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+    const record = value as Record<string, unknown>;
+    const pid = Number(record.pid);
+    const creationTime = typeof record.creationTime === 'string' ? record.creationTime : '';
+    const executablePath = typeof record.executablePath === 'string' ? record.executablePath : '';
+    if (!Number.isSafeInteger(pid) || pid <= 0 || !creationTime) return undefined;
+    return {
+      pid,
+      creationTime,
+      executablePath,
+    };
+  }
+
+  private isSameWindowsProcess(
+    expected: WindowsProcessIdentity,
+    actual: WindowsProcessIdentity,
+  ): boolean {
+    if (expected.pid !== actual.pid || expected.creationTime !== actual.creationTime) return false;
+    if (!expected.executablePath) return true;
+    return this.normalizeWindowsPath(expected.executablePath) === this.normalizeWindowsPath(actual.executablePath);
+  }
+
+  private normalizeWindowsPath(value: string): string {
+    return path.win32.normalize(value).toLowerCase();
+  }
+
+  private shouldVerifyWindowsProcessIdentity(): boolean {
+    return this.platform === 'win32' && process.platform === 'win32';
+  }
+
+  private processIdentityPath(pidPath: string): string {
+    return `${pidPath}.identity.json`;
   }
 
   private runTaskkill(pid: number, force: boolean): Promise<void> {
@@ -655,6 +980,7 @@ while ($pending.Count -gt 0) {
   ): Promise<void> {
     const paths = this.resolvePaths(bundleRoot, manifest, options);
     await fs.rm(paths.pid, { force: true });
+    await fs.rm(this.processIdentityPath(paths.pid), { force: true });
 
     const failed = code !== 0 || signal !== null;
     const policy = manifest.restartPolicy ?? {};

--- a/src/local-workers/instance-store.ts
+++ b/src/local-workers/instance-store.ts
@@ -235,16 +235,19 @@ export async function readLocalWorkerView(
   const runtimeMember = readRecord(runtimeSnapshot?.member);
   const pid = readNumber(supervisor?.pid);
   const alive = pid ? isAlive(pid) : false;
+  const supervisorFailed = String(supervisor?.state ?? '') === 'failed';
   const heartbeatAt = readTimestampMs(worker?.updatedAt ?? worker?.lastHeartbeatAt ?? worker?.heartbeatAt);
   const workerPhase = String(worker?.phase ?? worker?.state ?? '').toLowerCase();
   const degraded = isWorkerDegraded(worker)
     || (alive && heartbeatAt !== undefined && Date.now() - heartbeatAt > LOCAL_WORKER_HEARTBEAT_STALE_MS);
 
   let state = 'pending';
-  if (!instance.enabled) {
-    state = 'disabled';
-  } else if (String(supervisor?.state ?? '') === 'failed') {
+  if (supervisorFailed) {
     state = 'failed';
+  } else if (!instance.enabled && alive) {
+    state = 'stopping';
+  } else if (!instance.enabled) {
+    state = 'disabled';
   } else if (alive && workerPhase === 'waiting') {
     state = 'waiting';
   } else if (degraded) {
@@ -263,10 +266,12 @@ export async function readLocalWorkerView(
     workDir: instance.workDir,
     enabled: instance.enabled,
     state,
-    reason: readString(worker?.reason) ?? readString(supervisor?.reason),
-    message: readString(worker?.message)
-      ?? readString(worker?.error)
-      ?? readString(supervisor?.error),
+    reason: supervisorFailed
+      ? readString(supervisor?.reason) ?? readString(worker?.reason)
+      : readString(worker?.reason) ?? readString(supervisor?.reason),
+    message: supervisorFailed
+      ? readString(supervisor?.error) ?? readString(worker?.message) ?? readString(worker?.error)
+      : readString(worker?.message) ?? readString(worker?.error) ?? readString(supervisor?.error),
     pid,
     workerName: readString(worker?.workerName)
       ?? readString(worker?.runtimeName)

--- a/src/local-workers/instance-store.ts
+++ b/src/local-workers/instance-store.ts
@@ -2,6 +2,7 @@ import * as crypto from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { ensureDir, readJsonFile, resolveHome, writeJsonFile } from '../utils/fs-utils.js';
+import { preparePrivateLocalWorkerDirectory } from './private-directory.js';
 
 export type RuntimeOptionValue = string | boolean;
 export type RuntimeOptions = Record<string, RuntimeOptionValue>;
@@ -40,6 +41,8 @@ export interface LocalWorkerView {
   workDir: string;
   enabled: boolean;
   state: string;
+  reason?: string;
+  message?: string;
   pid?: number;
   workerName?: string;
   teamName?: string;
@@ -104,9 +107,15 @@ export async function connectLocalWorker(opts: ConnectLocalWorkerOptions): Promi
   const dir = instanceDir(opts.dataDir, id);
   const now = new Date().toISOString();
 
-  await ensureDir(stateDir(opts.dataDir, id));
-  await ensureDir(logDir(opts.dataDir, id));
-  await writeBootstrapToken(dir, token);
+  try {
+    await preparePrivateLocalWorkerDirectory(dir);
+    await ensureDir(stateDir(opts.dataDir, id));
+    await ensureDir(logDir(opts.dataDir, id));
+    await writeBootstrapToken(dir, token);
+  } catch (err) {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    throw err;
+  }
 
   const instance: LocalWorkerInstance = {
     schemaVersion: 'loongsuite.localWorker.v1',
@@ -132,6 +141,7 @@ export async function reconnectLocalWorker(opts: ReconnectLocalWorkerOptions): P
   if (token === '') throw new Error('bootstrap token is required');
 
   const dir = instanceDir(opts.dataDir, instance.id);
+  await preparePrivateLocalWorkerDirectory(dir);
   await ensureDir(stateDir(opts.dataDir, instance.id));
   await ensureDir(logDir(opts.dataDir, instance.id));
   if (token) await writeBootstrapToken(dir, token);
@@ -226,6 +236,7 @@ export async function readLocalWorkerView(
   const pid = readNumber(supervisor?.pid);
   const alive = pid ? isAlive(pid) : false;
   const heartbeatAt = readTimestampMs(worker?.updatedAt ?? worker?.lastHeartbeatAt ?? worker?.heartbeatAt);
+  const workerPhase = String(worker?.phase ?? worker?.state ?? '').toLowerCase();
   const degraded = isWorkerDegraded(worker)
     || (alive && heartbeatAt !== undefined && Date.now() - heartbeatAt > LOCAL_WORKER_HEARTBEAT_STALE_MS);
 
@@ -234,6 +245,8 @@ export async function readLocalWorkerView(
     state = 'disabled';
   } else if (String(supervisor?.state ?? '') === 'failed') {
     state = 'failed';
+  } else if (alive && workerPhase === 'waiting') {
+    state = 'waiting';
   } else if (degraded) {
     state = 'degraded';
   } else if (alive) {
@@ -250,6 +263,10 @@ export async function readLocalWorkerView(
     workDir: instance.workDir,
     enabled: instance.enabled,
     state,
+    reason: readString(worker?.reason) ?? readString(supervisor?.reason),
+    message: readString(worker?.message)
+      ?? readString(worker?.error)
+      ?? readString(supervisor?.error),
     pid,
     workerName: readString(worker?.workerName)
       ?? readString(worker?.runtimeName)

--- a/src/local-workers/local-worker-activation-service.ts
+++ b/src/local-workers/local-worker-activation-service.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 import type { AgentDefinition } from '../types/index.js';
 import { PluginProbeStrategy } from '../deployment/plugin-probe-strategy.js';
 import { createLogger } from '../utils/logger.js';
-import { ensureDir, writeJsonFile } from '../utils/fs-utils.js';
+import { ensureDir, readJsonFile, writeJsonFile } from '../utils/fs-utils.js';
 import {
   bootstrapTokenPath,
   bundleDir,
@@ -121,7 +121,14 @@ export class LocalWorkerActivationService {
     });
 
     if (!result.success) {
-      await this.writeSupervisorStatus(instance, 'failed', result.error ?? 'local worker deploy failed');
+      if (!await this.hasManifestContractFailure(instance)) {
+        await this.writeSupervisorStatus(
+          instance,
+          'failed',
+          result.error ?? 'local worker deploy failed',
+          'LocalWorkerDeployFailed',
+        );
+      }
       logger.warn('local worker deploy failed', { instanceId: instance.id, error: result.error });
       return;
     }
@@ -206,12 +213,27 @@ export class LocalWorkerActivationService {
     });
   }
 
-  private async writeSupervisorStatus(instance: LocalWorkerInstance, state: string, error: string): Promise<void> {
+  private async hasManifestContractFailure(instance: LocalWorkerInstance): Promise<boolean> {
+    const status = await readJsonFile<Record<string, unknown>>(
+      path.join(stateDir(this.dataDir, instance.id), 'supervisor-status.json'),
+    );
+    return status?.state === 'failed'
+      && ['WorkerManifestPlaceholderInvalid', 'RuntimeBundlePlatformUnsupported']
+        .includes(String(status.reason ?? ''));
+  }
+
+  private async writeSupervisorStatus(
+    instance: LocalWorkerInstance,
+    state: string,
+    error: string,
+    reason = 'LocalWorkerRuntimeTemplateMissing',
+  ): Promise<void> {
     const statusPath = path.join(stateDir(this.dataDir, instance.id), 'supervisor-status.json');
     await writeJsonFile(statusPath, {
       state,
       name: instance.runtime,
       agentId: `local-worker:${instance.id}`,
+      reason,
       error,
       updatedAt: new Date().toISOString(),
     });

--- a/src/local-workers/local-worker-activation-service.ts
+++ b/src/local-workers/local-worker-activation-service.ts
@@ -121,7 +121,7 @@ export class LocalWorkerActivationService {
     });
 
     if (!result.success) {
-      if (!await this.hasManifestContractFailure(instance)) {
+      if (!await this.hasSupervisorFailureToPreserve(instance)) {
         await this.writeSupervisorStatus(
           instance,
           'failed',
@@ -213,12 +213,19 @@ export class LocalWorkerActivationService {
     });
   }
 
-  private async hasManifestContractFailure(instance: LocalWorkerInstance): Promise<boolean> {
+  private async hasSupervisorFailureToPreserve(instance: LocalWorkerInstance): Promise<boolean> {
     const status = await readJsonFile<Record<string, unknown>>(
       path.join(stateDir(this.dataDir, instance.id), 'supervisor-status.json'),
     );
     return status?.state === 'failed'
-      && ['WorkerManifestPlaceholderInvalid', 'RuntimeBundlePlatformUnsupported']
+      && [
+        'WorkerManifestPlaceholderInvalid',
+        'RuntimeBundlePlatformUnsupported',
+        'WorkerProcessIdentityMissing',
+        'WorkerProcessIdentityCheckFailed',
+        'WorkerProcessTreeStopFailed',
+        'WorkerProcessIdentityUnavailable',
+      ]
         .includes(String(status.reason ?? ''));
   }
 

--- a/src/local-workers/private-directory.ts
+++ b/src/local-workers/private-directory.ts
@@ -1,0 +1,55 @@
+import { execFile } from 'node:child_process';
+import * as fs from 'node:fs/promises';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const WINDOWS_ACL_CHECK = `
+$ErrorActionPreference = "Stop"
+$target = $env:LOONGSUITE_WORKER_ACL_TARGET
+$acl = Get-Acl -LiteralPath $target
+$rules = $acl.GetAccessRules(
+  $true,
+  $true,
+  [System.Security.Principal.SecurityIdentifier]
+)
+$writeMask = [int64][System.Security.AccessControl.FileSystemRights]::Write -bor [int64][System.Security.AccessControl.FileSystemRights]::Modify -bor [int64][System.Security.AccessControl.FileSystemRights]::FullControl
+$unsafeSids = @("S-1-1-0", "S-1-5-32-545")
+$unsafe = @($rules | Where-Object {
+  ($_.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow) -and ($unsafeSids -contains $_.IdentityReference.Value) -and (([int64]$_.FileSystemRights -band $writeMask) -ne 0)
+})
+if ($unsafe.Count -gt 0) {
+  [Console]::Error.WriteLine("local worker directory grants write access to Everyone or Users")
+  exit 23
+}
+`;
+
+export async function preparePrivateLocalWorkerDirectory(
+  directory: string,
+  platform: NodeJS.Platform = process.platform,
+): Promise<void> {
+  await fs.mkdir(directory, { recursive: true, mode: 0o700 });
+
+  if (platform !== 'win32') {
+    await fs.chmod(directory, 0o700);
+    return;
+  }
+
+  try {
+    await execFileAsync('powershell.exe', [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      WINDOWS_ACL_CHECK,
+    ], {
+      env: {
+        ...process.env,
+        LOONGSUITE_WORKER_ACL_TARGET: directory,
+      },
+      windowsHide: true,
+    });
+  } catch (err) {
+    const stderr = String((err as { stderr?: unknown }).stderr ?? '').trim();
+    throw new Error(`LocalWorkerDirectoryAclUnsafe: ${stderr || 'failed to verify Windows directory ACL'}`);
+  }
+}

--- a/src/local-workers/private-directory.ts
+++ b/src/local-workers/private-directory.ts
@@ -4,23 +4,44 @@ import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 
-const WINDOWS_ACL_CHECK = `
+const WINDOWS_ACL_PROTECT = `
 $ErrorActionPreference = "Stop"
 $target = $env:LOONGSUITE_WORKER_ACL_TARGET
+if ([string]::IsNullOrWhiteSpace($target)) {
+  throw "local worker directory path is empty"
+}
+
+$currentSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+$allowedSids = @($currentSid, "S-1-5-18", "S-1-5-32-544") | Select-Object -Unique
 $acl = Get-Acl -LiteralPath $target
-$rules = $acl.GetAccessRules(
+$sddl = "D:P(A;OICI;FA;;;$currentSid)(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)"
+$acl.SetSecurityDescriptorSddlForm(
+  $sddl,
+  [System.Security.AccessControl.AccessControlSections]::Access
+)
+Set-Acl -LiteralPath $target -AclObject $acl
+
+$fullControl = [System.Security.AccessControl.FileSystemRights]::FullControl
+$verified = Get-Acl -LiteralPath $target
+$rules = $verified.GetAccessRules(
   $true,
   $true,
   [System.Security.Principal.SecurityIdentifier]
 )
-$writeMask = [int64][System.Security.AccessControl.FileSystemRights]::Write -bor [int64][System.Security.AccessControl.FileSystemRights]::Modify -bor [int64][System.Security.AccessControl.FileSystemRights]::FullControl
-$unsafeSids = @("S-1-1-0", "S-1-5-32-545")
-$unsafe = @($rules | Where-Object {
-  ($_.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow) -and ($unsafeSids -contains $_.IdentityReference.Value) -and (([int64]$_.FileSystemRights -band $writeMask) -ne 0)
+$unexpected = @($rules | Where-Object {
+  -not ($allowedSids -contains $_.IdentityReference.Value) -or
+  $_.AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Allow
 })
-if ($unsafe.Count -gt 0) {
-  [Console]::Error.WriteLine("local worker directory grants write access to Everyone or Users")
-  exit 23
+$missing = @($allowedSids | Where-Object {
+  $sid = $_
+  -not ($rules | Where-Object {
+    $_.IdentityReference.Value -eq $sid -and
+    $_.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and
+    (([int64]$_.FileSystemRights -band [int64]$fullControl) -eq [int64]$fullControl)
+  })
+})
+if (-not $verified.AreAccessRulesProtected -or $unexpected.Count -gt 0 -or $missing.Count -gt 0) {
+  throw "failed to apply private ACL to local worker directory"
 }
 `;
 
@@ -40,7 +61,7 @@ export async function preparePrivateLocalWorkerDirectory(
       '-NoProfile',
       '-NonInteractive',
       '-Command',
-      WINDOWS_ACL_CHECK,
+      WINDOWS_ACL_PROTECT,
     ], {
       env: {
         ...process.env,

--- a/src/local-workers/worker-cli.ts
+++ b/src/local-workers/worker-cli.ts
@@ -152,6 +152,8 @@ async function statusCommand(dataDir: string, args: ParsedArgs): Promise<void> {
   console.log(`ID:          ${view.id}`);
   console.log(`Runtime:     ${view.runtime}`);
   console.log(`State:       ${view.state}`);
+  if (view.reason) console.log(`Reason:      ${view.reason}`);
+  if (view.message) console.log(`Message:     ${view.message}`);
   if (view.pid) console.log(`PID:         ${view.pid}`);
   console.log(`WorkDir:     ${view.workDir}`);
   console.log(`Worker:      ${view.workerName ?? '-'}`);

--- a/tests/unit/deploy/windows-worker-cli-wrapper.test.mjs
+++ b/tests/unit/deploy/windows-worker-cli-wrapper.test.mjs
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+describe('Windows worker CLI wrapper', () => {
+  let tmpDir;
+
+  afterEach(async () => {
+    if (tmpDir) await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('pins the installer Node runtime under the cache directory', async () => {
+    const installer = await fs.readFile(path.resolve('deploy/installer-opensource.ps1'), 'utf-8');
+    const checkDeps = installer.slice(
+      installer.indexOf('function Check-Deps'),
+      installer.indexOf('function Download-AndExtract'),
+    );
+
+    expect(checkDeps).toContain('Join-Path $CACHE_DIR "node-bin"');
+    expect(checkDeps).not.toContain('Join-Path $DataDir "node-bin"');
+  });
+
+  it.runIf(process.platform === 'win32')('uses separate Unicode data/cache dirs and forwards worker argv unchanged', async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pilot-worker-cli-'));
+    const binDir = path.join(tmpDir, '命令 dir');
+    const dataDir = path.join(tmpDir, '数据 dir');
+    const cacheDir = path.join(tmpDir, '缓存 dir');
+    const versionName = 'test-version';
+    const versionDir = path.join(cacheDir, 'versions', versionName);
+    const captureEntry = path.join(versionDir, 'dist', 'index.js');
+    await fs.mkdir(path.dirname(captureEntry), { recursive: true });
+    await fs.writeFile(
+      captureEntry,
+      `console.log(JSON.stringify({
+        argv: process.argv.slice(2),
+        dataDir: process.env.LOONGSUITE_PILOT_DATA_DIR,
+        cacheDir: process.env.LOONGSUITE_PILOT_CACHE_DIR,
+      }));`,
+      'utf-8',
+    );
+    await fs.writeFile(
+      path.join(cacheDir, 'current'),
+      versionName,
+      'utf-8',
+    );
+    await fs.writeFile(
+      path.join(cacheDir, 'node-bin'),
+      process.execPath,
+      'utf-8',
+    );
+    await fs.mkdir(binDir, { recursive: true });
+    const script = path.join(binDir, 'loongsuite-pilot.ps1');
+    await fs.copyFile(path.resolve('scripts/loongsuite-pilot.ps1'), script);
+    await fs.writeFile(
+      path.join(binDir, 'loongsuite-pilot-layout.json'),
+      JSON.stringify({ dataDir, cacheDir }),
+      'utf-8',
+    );
+
+    const { stdout } = await execFileAsync('powershell.exe', [
+      '-NoProfile',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-File',
+      script,
+      'worker',
+      'connect',
+      '--runtime',
+      'fake-runtime',
+      '--json',
+      '--',
+      '--runtime-command',
+      'C:\\Program Files\\Fake Runtime\\runtime.cmd',
+    ], {
+      env: {
+        ...process.env,
+        USERPROFILE: tmpDir,
+        LOONGSUITE_PILOT_DATA_DIR: '',
+        LOONGSUITE_PILOT_CACHE_DIR: '',
+      },
+    });
+
+    expect(JSON.parse(stdout.trim())).toEqual({
+      argv: [
+        'worker',
+        'connect',
+        '--runtime',
+        'fake-runtime',
+        '--json',
+        '--',
+        '--runtime-command',
+        'C:\\Program Files\\Fake Runtime\\runtime.cmd',
+      ],
+      dataDir,
+      cacheDir,
+    });
+  });
+});

--- a/tests/unit/deployment/plugin-probe-strategy.test.ts
+++ b/tests/unit/deployment/plugin-probe-strategy.test.ts
@@ -438,6 +438,33 @@ describe('PluginProbeStrategy', () => {
       expect(result.agentId).toBe('test-plugin');
     });
 
+    it('uses the existing external tar extractor for local worker bundles', async () => {
+      const destDir = path.join(tmpDir, 'local-worker-dest');
+      const tarball = path.join(tmpDir, 'local-worker.tar.gz');
+      const sourceDir = path.join(tmpDir, 'local-worker-source');
+      await fs.mkdir(path.join(sourceDir, 'bundle'), { recursive: true });
+      await fs.writeFile(
+        path.join(sourceDir, 'bundle', 'worker.manifest.json'),
+        JSON.stringify({
+          name: 'fake-worker',
+          command: ['missing-entrypoint'],
+        }),
+        'utf-8',
+      );
+      createTarball(tarball, sourceDir);
+
+      const result = await strategy.deploy(makeDef({
+        localWorkerRuntime: 'fake-runtime',
+        pluginProbe: {
+          source: { type: 'tar', tarball, destDir },
+          mountType: 'wrapper',
+        },
+      }));
+
+      expect(result.success).toBe(true);
+      await expect(fs.stat(path.join(destDir, 'bundle', 'worker.manifest.json'))).resolves.toBeDefined();
+    });
+
     it('prefers pilot wrapper script over plugin install.sh', async () => {
       const destDir = path.join(tmpDir, 'dest');
       const tarball = path.join(tmpDir, 'plugin.tar.gz');

--- a/tests/unit/deployment/plugin-probe-strategy.test.ts
+++ b/tests/unit/deployment/plugin-probe-strategy.test.ts
@@ -416,6 +416,40 @@ describe('PluginProbeStrategy', () => {
       expect(result.error).toBe('missing pluginProbe config');
     });
 
+    it('keeps the existing local worker bundle when the worker cannot be stopped', async () => {
+      const destDir = path.join(tmpDir, 'local-worker-dest');
+      const tarball = path.join(tmpDir, 'local-worker.tar.gz');
+      const oldMarker = path.join(destDir, 'old.txt');
+
+      await fs.mkdir(destDir, { recursive: true });
+      await fs.writeFile(path.join(destDir, 'worker.manifest.json'), '{invalid-json', 'utf-8');
+      await fs.writeFile(oldMarker, 'old', 'utf-8');
+
+      const sourceDir = path.join(tmpDir, 'local-worker-source');
+      await fs.mkdir(sourceDir, { recursive: true });
+      await fs.writeFile(path.join(sourceDir, 'new.txt'), 'new', 'utf-8');
+      createTarball(tarball, sourceDir);
+
+      const result = await strategy.deploy(makeDef({
+        localWorkerRuntime: 'fake-runtime',
+        pluginProbe: {
+          source: { type: 'tar', tarball, destDir },
+          mountType: 'wrapper',
+        },
+      }), {
+        instance: {
+          id: 'lw_testinstance001',
+          stateDir: path.join(tmpDir, 'state'),
+          logDir: path.join(tmpDir, 'logs'),
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('local worker stop failed; bundle replacement aborted');
+      await expect(fs.readFile(oldMarker, 'utf-8')).resolves.toBe('old');
+      await expect(fs.stat(path.join(destDir, 'new.txt'))).rejects.toThrow();
+    });
+
     it('extracts tarball and runs convention install script', async () => {
       const destDir = path.join(tmpDir, 'dest');
       const tarball = path.join(tmpDir, 'plugin.tar.gz');

--- a/tests/unit/deployment/worker-manifest-supervisor.test.ts
+++ b/tests/unit/deployment/worker-manifest-supervisor.test.ts
@@ -198,10 +198,110 @@ describe('WorkerManifestSupervisor', () => {
       expect(childPid).toBeGreaterThan(0);
       process.kill(childPid, 0);
     });
+    await expect(readStatus()).resolves.toMatchObject({
+      state: 'running',
+      processIdentity: {
+        pid: expect.any(Number),
+        creationTime: expect.any(String),
+        executablePath: expect.any(String),
+      },
+    });
 
     expect(await supervisor.stopIfPresent('local-worker:test', bundleRoot, options())).toBe(true);
     await vi.waitFor(() => {
       expect(() => process.kill(childPid, 0)).toThrow();
     });
+  });
+
+  it.runIf(process.platform === 'win32')('does not stop a reused Windows pid with a different creation time', async () => {
+    const entry = path.join(bundleRoot, 'worker-entrypoint.mjs');
+    await fs.writeFile(entry, 'setInterval(() => {}, 1000);', 'utf-8');
+    await writeManifest(['${pilot:node}', entry]);
+
+    const supervisor = new WorkerManifestSupervisor();
+    expect(await supervisor.startIfPresent('local-worker:test', bundleRoot, {}, options())).toBe(true);
+
+    let workerPid = 0;
+    try {
+      const running = await readStatus();
+      workerPid = Number(running.pid);
+      expect(workerPid).toBeGreaterThan(0);
+      expect(running.processIdentity).toMatchObject({
+        pid: workerPid,
+        creationTime: expect.any(String),
+      });
+
+      await fs.writeFile(
+        path.join(stateDir, 'worker.pid.identity.json'),
+        JSON.stringify({
+          ...(running.processIdentity as Record<string, unknown>),
+          creationTime: '2000-01-01T00:00:00.0000000Z',
+        }),
+        'utf-8',
+      );
+
+      expect(await supervisor.stopIfPresent('local-worker:test', bundleRoot, options())).toBe(true);
+      expect(() => process.kill(workerPid, 0)).not.toThrow();
+      await expect(readStatus()).resolves.toMatchObject({
+        state: 'stopped',
+        reason: 'WorkerPidIdentityMismatch',
+        pid: workerPid,
+      });
+    } finally {
+      if (workerPid > 0) {
+        try {
+          process.kill(workerPid, 'SIGKILL');
+        } catch {
+          // The test process may already have exited.
+        }
+        await vi.waitFor(() => {
+          expect(() => process.kill(workerPid, 0)).toThrow();
+        });
+      }
+    }
+  });
+
+  it('does not force-kill a Windows pid whose identity changes during graceful stop', async () => {
+    const supervisor = new WorkerManifestSupervisor({ platform: 'win32' });
+    const internals = supervisor as unknown as {
+      stopWindowsProcessTree(
+        agentId: string,
+        pid: number,
+        rootIdentity: { pid: number; creationTime: string; executablePath: string },
+      ): Promise<number[]>;
+      listWindowsDescendantProcesses(pid: number): Promise<Array<{
+        pid: number;
+        identity?: { pid: number; creationTime: string; executablePath: string };
+      }>>;
+      readWindowsProcessIdentity(pid: number): Promise<{
+        pid: number;
+        creationTime: string;
+        executablePath: string;
+      } | undefined>;
+      runTaskkill(pid: number, force: boolean): Promise<void>;
+      waitForPidsExit(pids: number[], timeoutMs: number): Promise<void>;
+      isAlive(pid: number): boolean;
+    };
+    const expectedIdentity = {
+      pid: 4242,
+      creationTime: '2026-07-29T01:00:00.0000000Z',
+      executablePath: 'C:\\Program Files\\nodejs\\node.exe',
+    };
+    vi.spyOn(internals, 'listWindowsDescendantProcesses').mockResolvedValue([]);
+    vi.spyOn(internals, 'waitForPidsExit').mockResolvedValue();
+    vi.spyOn(internals, 'isAlive').mockReturnValue(true);
+    vi.spyOn(internals, 'readWindowsProcessIdentity').mockResolvedValue({
+      ...expectedIdentity,
+      creationTime: '2026-07-29T01:01:00.0000000Z',
+    });
+    const taskkill = vi.spyOn(internals, 'runTaskkill').mockResolvedValue();
+
+    await expect(internals.stopWindowsProcessTree(
+      'local-worker:test',
+      expectedIdentity.pid,
+      expectedIdentity,
+    )).resolves.toEqual([]);
+    expect(taskkill).toHaveBeenCalledTimes(1);
+    expect(taskkill).toHaveBeenCalledWith(expectedIdentity.pid, false);
   });
 });

--- a/tests/unit/deployment/worker-manifest-supervisor.test.ts
+++ b/tests/unit/deployment/worker-manifest-supervisor.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { WorkerManifestSupervisor } from '../../../src/deployment/worker-manifest-supervisor.js';
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+describe('WorkerManifestSupervisor', () => {
+  let tmpDir: string;
+  let bundleRoot: string;
+  let stateDir: string;
+  let logDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'worker-manifest-supervisor-'));
+    bundleRoot = path.join(tmpDir, 'bundle 测试 with spaces');
+    stateDir = path.join(tmpDir, '状态 state');
+    logDir = path.join(tmpDir, '日志 logs');
+    await fs.mkdir(bundleRoot, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeManifest(command: string[], extra: Record<string, unknown> = {}): Promise<void> {
+    await fs.writeFile(
+      path.join(bundleRoot, 'worker.manifest.json'),
+      JSON.stringify({
+        name: 'fake-worker',
+        version: '1.2.3',
+        command,
+        paths: {
+          pid: '${instance:stateDir}/worker.pid',
+          status: '${instance:stateDir}/supervisor-status.json',
+          log: '${instance:logDir}/worker.log',
+        },
+        ...extra,
+      }),
+      'utf-8',
+    );
+  }
+
+  function options() {
+    return {
+      instance: { stateDir, logDir },
+    };
+  }
+
+  async function readStatus(): Promise<Record<string, unknown>> {
+    return JSON.parse(
+      await fs.readFile(path.join(stateDir, 'supervisor-status.json'), 'utf-8'),
+    ) as Record<string, unknown>;
+  }
+
+  it('resolves the controlled pilot node placeholder to the running Pilot node', async () => {
+    const capture = path.join(tmpDir, 'capture.json');
+    const entry = path.join(bundleRoot, 'worker-entrypoint.mjs');
+    await fs.writeFile(
+      entry,
+      `import fs from 'node:fs'; fs.writeFileSync(process.argv[2], JSON.stringify({
+        execPath: process.execPath,
+        value: process.argv[3]
+      }));`,
+      'utf-8',
+    );
+    await writeManifest(['${pilot:node}', entry, capture, '保留 空格']);
+
+    const supervisor = new WorkerManifestSupervisor();
+    expect(await supervisor.startIfPresent('local-worker:test', bundleRoot, process.env as Record<string, string>, options()))
+      .toBe(true);
+
+    await vi.waitFor(async () => {
+      const captured = JSON.parse(await fs.readFile(capture, 'utf-8')) as Record<string, string>;
+      expect(captured).toEqual({ execPath: process.execPath, value: '保留 空格' });
+    }, { timeout: 20_000 });
+    await vi.waitFor(async () => {
+      expect(await readStatus()).toMatchObject({ state: 'exited', exitCode: 0 });
+    }, { timeout: 20_000 });
+  }, 30_000);
+
+  it('rejects unknown and interpolated pilot placeholders', async () => {
+    await writeManifest(['${pilot:other}']);
+    const supervisor = new WorkerManifestSupervisor();
+
+    expect(await supervisor.startIfPresent('local-worker:test', bundleRoot, {}, options())).toBe(false);
+    await expect(readStatus()).resolves.toMatchObject({
+      state: 'failed',
+      reason: 'WorkerManifestPlaceholderInvalid',
+    });
+
+    await writeManifest(['prefix-${pilot:node}']);
+    expect(await supervisor.startIfPresent('local-worker:test', bundleRoot, {}, options())).toBe(false);
+    await expect(readStatus()).resolves.toMatchObject({
+      state: 'failed',
+      reason: 'WorkerManifestPlaceholderInvalid',
+    });
+  });
+
+  it('rejects Unix shell bundle entrypoints on Windows without invoking a compatibility shell', async () => {
+    const entry = path.join(bundleRoot, 'worker-entrypoint.sh');
+    await fs.writeFile(entry, '#!/usr/bin/env bash\nexit 0\n', 'utf-8');
+    await writeManifest([entry]);
+    const supervisor = new WorkerManifestSupervisor({ platform: 'win32' });
+
+    expect(await supervisor.startIfPresent('local-worker:test', bundleRoot, {}, options())).toBe(false);
+    await expect(readStatus()).resolves.toMatchObject({
+      state: 'failed',
+      reason: 'RuntimeBundlePlatformUnsupported',
+      platform: 'win32',
+      bundleVersion: '1.2.3',
+      entryType: 'unix-shell',
+    });
+  });
+
+  it('detects a Unix shell shebang even when the Windows bundle entrypoint has no extension', async () => {
+    const entry = path.join(bundleRoot, 'worker-entrypoint');
+    await fs.writeFile(entry, '#!/usr/bin/env bash\nexit 0\n', 'utf-8');
+    await writeManifest([entry]);
+    const supervisor = new WorkerManifestSupervisor({ platform: 'win32' });
+
+    expect(await supervisor.startIfPresent('local-worker:test', bundleRoot, {}, options())).toBe(false);
+    await expect(readStatus()).resolves.toMatchObject({
+      state: 'failed',
+      reason: 'RuntimeBundlePlatformUnsupported',
+      entryType: 'unix-shell',
+    });
+  });
+
+  it('rejects pilot node resolution when Pilot is not running from an absolute executable path', async () => {
+    await writeManifest(['${pilot:node}', path.join(bundleRoot, 'worker-entrypoint.mjs')]);
+    const supervisor = new WorkerManifestSupervisor({ nodeExecutable: 'relative-node' });
+
+    expect(await supervisor.startIfPresent('local-worker:test', bundleRoot, {}, options())).toBe(false);
+    await expect(readStatus()).resolves.toMatchObject({
+      state: 'failed',
+      reason: 'WorkerManifestPlaceholderInvalid',
+    });
+  });
+
+  it('maps USERPROFILE to HOME only in the Windows worker child environment', async () => {
+    const capture = path.join(tmpDir, 'home.txt');
+    const entry = path.join(bundleRoot, 'worker-entrypoint.mjs');
+    await fs.writeFile(
+      entry,
+      `import fs from 'node:fs'; fs.writeFileSync(process.argv[2], process.env.HOME ?? '');`,
+      'utf-8',
+    );
+    await writeManifest(['${pilot:node}', entry, capture]);
+
+    const supervisor = new WorkerManifestSupervisor({ platform: 'win32' });
+    expect(await supervisor.startIfPresent(
+      'local-worker:test',
+      bundleRoot,
+      { USERPROFILE: 'C:\\Users\\测试 用户' },
+      options(),
+    )).toBe(true);
+
+    await vi.waitFor(async () => {
+      expect(await fs.readFile(capture, 'utf-8')).toBe('C:\\Users\\测试 用户');
+    }, { timeout: 20_000 });
+    await vi.waitFor(async () => {
+      expect(await readStatus()).toMatchObject({ state: 'exited', exitCode: 0 });
+    }, { timeout: 20_000 });
+  }, 30_000);
+
+  it.runIf(process.platform === 'win32')('stops the complete Windows worker process tree', async () => {
+    const childPidFile = path.join(tmpDir, 'child.pid');
+    const entry = path.join(bundleRoot, 'worker-entrypoint.mjs');
+    await fs.writeFile(
+      entry,
+      `import fs from 'node:fs';
+       import { spawn } from 'node:child_process';
+       const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+         detached: false,
+         stdio: 'ignore'
+       });
+       fs.writeFileSync(process.argv[2], String(child.pid));
+       setInterval(() => {}, 1000);`,
+      'utf-8',
+    );
+    await writeManifest(['${pilot:node}', entry, childPidFile]);
+
+    const supervisor = new WorkerManifestSupervisor();
+    expect(await supervisor.startIfPresent('local-worker:test', bundleRoot, {}, options())).toBe(true);
+
+    let childPid = 0;
+    await vi.waitFor(async () => {
+      childPid = Number.parseInt(await fs.readFile(childPidFile, 'utf-8'), 10);
+      expect(childPid).toBeGreaterThan(0);
+      process.kill(childPid, 0);
+    });
+
+    expect(await supervisor.stopIfPresent('local-worker:test', bundleRoot, options())).toBe(true);
+    await vi.waitFor(() => {
+      expect(() => process.kill(childPid, 0)).toThrow();
+    });
+  });
+});

--- a/tests/unit/local-workers/instance-store.test.ts
+++ b/tests/unit/local-workers/instance-store.test.ts
@@ -54,6 +54,10 @@ describe('local worker instance store', () => {
     expect(raw).not.toContain(token());
     expect(raw).not.toContain(workerUuid);
     expect(await fs.readFile(bootstrapTokenPath(dataDir, instance), 'utf-8')).toBe(token());
+    if (process.platform !== 'win32') {
+      const stat = await fs.stat(instanceDir(dataDir, instance.id));
+      expect(stat.mode & 0o777).toBe(0o700);
+    }
   });
 
   it('treats bootstrap token as opaque local worker data', async () => {
@@ -199,6 +203,39 @@ describe('local worker instance store', () => {
 
     expect(views).toHaveLength(1);
     expect(views[0].state).toBe('degraded');
+  });
+
+  it('surfaces a live worker Waiting phase and its recoverable reason', async () => {
+    const instance = await connectLocalWorker({
+      dataDir,
+      runtime: 'claude-code',
+      bootstrapToken: token(),
+      workDir: path.join(tmpDir, 'project'),
+    });
+    const sDir = stateDir(dataDir, instance.id);
+    await fs.writeFile(
+      path.join(sDir, 'supervisor-status.json'),
+      JSON.stringify({ state: 'running', pid: process.pid }),
+      'utf-8',
+    );
+    await fs.writeFile(
+      path.join(sDir, 'status.json'),
+      JSON.stringify({
+        phase: 'Waiting',
+        reason: 'RuntimeCommandNotFound',
+        message: 'runtime command is not installed',
+        updatedAt: new Date().toISOString(),
+      }),
+      'utf-8',
+    );
+
+    const views = await listLocalWorkerViews(dataDir);
+
+    expect(views[0]).toMatchObject({
+      state: 'waiting',
+      reason: 'RuntimeCommandNotFound',
+      message: 'runtime command is not installed',
+    });
   });
 
   it('fills list display fields from worker status and runtime snapshots', async () => {

--- a/tests/unit/local-workers/instance-store.test.ts
+++ b/tests/unit/local-workers/instance-store.test.ts
@@ -116,6 +116,52 @@ describe('local worker instance store', () => {
     expect(views[0].state).toBe('disabled');
   });
 
+  it('does not report a live or failed disconnect as disabled', async () => {
+    const instance = await connectLocalWorker({
+      dataDir,
+      runtime: 'claude-code',
+      bootstrapToken: token(),
+      workDir: path.join(tmpDir, 'project'),
+    });
+    await setLocalWorkerEnabled(dataDir, instance.id, false);
+    const sDir = stateDir(dataDir, instance.id);
+    await fs.writeFile(
+      path.join(sDir, 'supervisor-status.json'),
+      JSON.stringify({ state: 'running', pid: process.pid }),
+      'utf-8',
+    );
+
+    let views = await listLocalWorkerViews(dataDir);
+    expect(views[0].state).toBe('stopping');
+
+    await fs.writeFile(
+      path.join(sDir, 'supervisor-status.json'),
+      JSON.stringify({
+        state: 'failed',
+        pid: process.pid,
+        reason: 'WorkerProcessTreeStopFailed',
+        error: 'worker process remained alive',
+      }),
+      'utf-8',
+    );
+    await fs.writeFile(
+      path.join(sDir, 'status.json'),
+      JSON.stringify({
+        phase: 'Waiting',
+        reason: 'RuntimeCommandNotFound',
+        message: 'stale worker status',
+      }),
+      'utf-8',
+    );
+
+    views = await listLocalWorkerViews(dataDir);
+    expect(views[0]).toMatchObject({
+      state: 'failed',
+      reason: 'WorkerProcessTreeStopFailed',
+      message: 'worker process remained alive',
+    });
+  });
+
   it('reconnects a disconnected instance with the same id', async () => {
     const instance = await connectLocalWorker({
       dataDir,

--- a/tests/unit/local-workers/local-worker-activation-service.test.ts
+++ b/tests/unit/local-workers/local-worker-activation-service.test.ts
@@ -397,4 +397,29 @@ while true; do sleep 1; done
       await service.stop();
     }
   });
+
+  it.each([
+    'WorkerProcessIdentityMissing',
+    'WorkerProcessIdentityCheckFailed',
+    'WorkerProcessTreeStopFailed',
+    'WorkerProcessIdentityUnavailable',
+  ])('preserves the supervisor failure reason %s', async reason => {
+    const instance = await connectLocalWorker({
+      dataDir,
+      runtime: 'claude-code',
+      bootstrapToken: token(),
+      workDir: path.join(tmpDir, 'project'),
+    });
+    await fs.writeFile(
+      path.join(stateDir(dataDir, instance.id), 'supervisor-status.json'),
+      JSON.stringify({ state: 'failed', reason }),
+      'utf-8',
+    );
+    const service = new LocalWorkerActivationService({ dataDir, pilotDir, definitions: [] });
+    const internals = service as unknown as {
+      hasSupervisorFailureToPreserve(instance: typeof instance): Promise<boolean>;
+    };
+
+    await expect(internals.hasSupervisorFailureToPreserve(instance)).resolves.toBe(true);
+  });
 });

--- a/tests/unit/local-workers/private-directory.test.ts
+++ b/tests/unit/local-workers/private-directory.test.ts
@@ -1,0 +1,108 @@
+import { execFile } from 'node:child_process';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { preparePrivateLocalWorkerDirectory } from '../../../src/local-workers/private-directory.js';
+
+const execFileAsync = promisify(execFile);
+
+describe.runIf(process.platform === 'win32')('private local worker directory', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), '本地 worker acl '));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('removes inherited access for other users from the instance directory and token', async () => {
+    const instanceDir = path.join(tmpDir, '实例 目录');
+    const tokenPath = path.join(instanceDir, 'credentials', 'bootstrap-token');
+    await fs.mkdir(instanceDir, { recursive: true });
+
+    await runPowerShell(`
+& icacls.exe $env:ACL_TEST_TARGET /grant '*S-1-5-11:(OI)(CI)(RX)' | Out-Null
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+`, {
+      ACL_TEST_TARGET: instanceDir,
+    });
+
+    await fs.mkdir(path.dirname(tokenPath), { recursive: true });
+    await fs.writeFile(tokenPath, 'secret', 'utf-8');
+    await preparePrivateLocalWorkerDirectory(instanceDir);
+
+    const result = await runPowerShellJson<{
+      currentSid: string;
+      directory: { protected: boolean; rules: Array<{ sid: string; type: string; rights: string }> };
+      token: { rules: Array<{ sid: string; type: string; rights: string }> };
+    }>(`
+function Read-AclSummary([string]$target) {
+  $acl = Get-Acl -LiteralPath $target
+  $rules = @($acl.GetAccessRules(
+    $true,
+    $true,
+    [System.Security.Principal.SecurityIdentifier]
+  ) | ForEach-Object {
+    [ordered]@{
+      sid = $_.IdentityReference.Value
+      type = $_.AccessControlType.ToString()
+      rights = $_.FileSystemRights.ToString()
+    }
+  })
+  return [ordered]@{
+    protected = $acl.AreAccessRulesProtected
+    rules = $rules
+  }
+}
+
+$result = [ordered]@{
+  currentSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+  directory = Read-AclSummary $env:ACL_TEST_TARGET
+  token = Read-AclSummary $env:ACL_TEST_TOKEN
+}
+[Console]::Out.Write((ConvertTo-Json -InputObject $result -Depth 6 -Compress))
+`, {
+      ACL_TEST_TARGET: instanceDir,
+      ACL_TEST_TOKEN: tokenPath,
+    });
+
+    const allowedSids = new Set([result.currentSid, 'S-1-5-18', 'S-1-5-32-544']);
+    expect(result.directory.protected).toBe(true);
+    expect(result.directory.rules).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ sid: 'S-1-5-11' })]),
+    );
+    expect(result.token.rules).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ sid: 'S-1-5-11' })]),
+    );
+    expect(result.directory.rules.every(rule =>
+      rule.type === 'Allow'
+      && rule.rights.includes('FullControl')
+      && allowedSids.has(rule.sid))).toBe(true);
+    expect(result.token.rules.every(rule => allowedSids.has(rule.sid))).toBe(true);
+    await expect(fs.readFile(tokenPath, 'utf-8')).resolves.toBe('secret');
+  });
+});
+
+async function runPowerShell(script: string, env: Record<string, string>): Promise<string> {
+  const { stdout } = await execFileAsync('powershell.exe', [
+    '-NoProfile',
+    '-NonInteractive',
+    '-Command',
+    script,
+  ], {
+    env: {
+      ...process.env,
+      ...env,
+    },
+    windowsHide: true,
+  });
+  return String(stdout);
+}
+
+async function runPowerShellJson<T>(script: string, env: Record<string, string>): Promise<T> {
+  return JSON.parse(await runPowerShell(script, env)) as T;
+}

--- a/tests/unit/local-workers/worker-cli.test.ts
+++ b/tests/unit/local-workers/worker-cli.test.ts
@@ -3,7 +3,11 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { handleWorkerCli } from '../../../src/local-workers/worker-cli.js';
-import { bootstrapTokenPath, readLocalWorkerInstance } from '../../../src/local-workers/instance-store.js';
+import {
+  bootstrapTokenPath,
+  readLocalWorkerInstance,
+  stateDir,
+} from '../../../src/local-workers/instance-store.js';
 
 describe('local worker CLI', () => {
   let tmpDir: string;
@@ -135,5 +139,41 @@ describe('local worker CLI', () => {
     await handleWorkerCli(['worker', 'list', '--', '--model-config-mode', 'managed-global']);
 
     expect(process.exitCode).toBe(1);
+  });
+
+  it('prints the effective Waiting reason reported by a live runtime adapter', async () => {
+    await handleWorkerCli([
+      'worker',
+      'connect',
+      '--runtime',
+      'claude-code',
+      '--bootstrap-token',
+      token(),
+    ]);
+    const instanceId = String(logSpy.mock.calls[0]?.[0] ?? '').replace(/^connected\s+/, '');
+    const sDir = stateDir(dataDir, instanceId);
+    await fs.writeFile(
+      path.join(sDir, 'supervisor-status.json'),
+      JSON.stringify({ state: 'running', pid: process.pid }),
+      'utf-8',
+    );
+    await fs.writeFile(
+      path.join(sDir, 'status.json'),
+      JSON.stringify({
+        phase: 'Waiting',
+        reason: 'RuntimeCommandNotFound',
+        message: 'runtime command is not installed',
+      }),
+      'utf-8',
+    );
+    logSpy.mockClear();
+
+    await handleWorkerCli(['worker', 'status', instanceId]);
+
+    expect(logSpy.mock.calls.map(call => call[0])).toEqual(expect.arrayContaining([
+      'State:       waiting',
+      'Reason:      RuntimeCommandNotFound',
+      'Message:     runtime command is not installed',
+    ]));
   });
 });


### PR DESCRIPTION
## Summary

Add native Windows support for managed local workers while preserving the existing Linux and macOS behavior.

This change:

- enables `worker connect`, `list`, `status`, `disconnect`, and `delete` on Windows
- adds `${pilot:node}` manifest command resolution using Pilot's pinned Node.js runtime
- resolves Windows executables through `PATHEXT`, including `.cmd` and `.bat` entrypoints
- forwards runtime arguments without PowerShell 5.1 argument rebinding
- propagates custom `LOONGSUITE_PILOT_DATA_DIR` and `LOONGSUITE_PILOT_CACHE_DIR`
- stores the Node.js pin under `CacheDir`
- adds Windows process identity checks and process-tree termination
- prevents bundle replacement when the existing worker cannot be stopped
- protects local worker credentials with a private Windows ACL
- skips Unix-only install and uninstall scripts for Windows local worker bundles
- adds Windows CI and unit coverage for the new behavior

## Scope

The changes are limited to the managed local worker path:

- `localWorkerRuntime`
- local worker instances
- Windows Pilot CLI and installer integration

Existing collection and monitoring deployment behavior is unchanged.

Linux and macOS continue using their existing runtime commands and process-management paths. This change does not introduce a new archive extractor, global runtime injection, or symlink handling.

## Compatibility

- Existing Linux and macOS manifest behavior is preserved.
- Existing runtime bundles without `${pilot:node}` continue using their declared commands.
- `${pilot:node}` is resolved only as a controlled manifest command placeholder.
- Custom `DataDir` and `CacheDir` remain independent.
- A failed worker stop blocks bundle replacement instead of starting a second worker.

## Validation

### Automated tests

- TypeScript type checking passed.
- Local-worker-focused test suite: 77 passed, 3 skipped.
- Added coverage for:
  - PowerShell 5.1 argument forwarding
  - independent `--` handling
  - DataDir and CacheDir propagation
  - `${pilot:node}` resolution
  - Windows `PATHEXT` command discovery
  - process identity matching
  - process-tree termination
  - stop-before-replace behavior
  - private directory ACLs
  - Windows local worker activation

### Windows validation

Validated on Windows 10 with PowerShell 5.1 and Node.js 22:

- paths containing spaces and non-ASCII characters
- separated DataDir and CacheDir
- Pilot `info` and worker control commands
- local worker connect, disconnect, reconnect, and cleanup
- private bootstrap-token directory ACLs
- runtime command resolution for Claude Code, Codex, QoderCLI, and OpenClaw manifests
- plugin, AGENTS.md, Skill, and MCP configuration materialization
- real Matrix turns with Codex and QoderCLI
- managed Skill invocation through the bundled at-cli launcher

OpenClaw reached the runtime entrypoint and completed plugin materialization. Its full Matrix turn was blocked by an external agent-package fetch failure after Pilot startup, outside the Pilot lifecycle changes in this PR.