### PR TITLE
fix(otlp-trace): isolate Signal B by session

### DIFF
--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -46,6 +46,7 @@ interface TurnBuffer {
   keySource: 'turn_id' | 'trace_id' | 'session_id' | 'ephemeral';
   keyValue: string;
   agentType: string;
+  sessionId?: string;
   records: AgentActivityEntry[];
   completed: boolean;
   lastActivityMs: number;
@@ -224,31 +225,15 @@ export class OtlpTraceFlusher extends BaseFlusher {
       return;
     }
 
-    // Signal B: check if there's an active buffer for same agentType with different key.
-    // Same session (or one side missing session info): treat as sequential user flow —
-    // preempt the older buffer so it converts and frees. This includes abandoned
-    // turns that never emit a terminal llm.response (e.g. MiMo crashed mid-stream,
-    // user moved on, turnIdleTimeoutMs=0). For same-session buffers we preempt
-    // even without llm.response; for missing-session-info buffers we keep the
-    // original hasLlmResponse safety check to avoid splitting in-progress turns
-    // on every sibling arrival.
-    // Different non-empty sessions → concurrent subagent (e.g. mimo-code's
-    // checkpoint-writer / distill), never preempt — flushing mid-stream would
-    // split the parent turn's records and produce duplicate ENTRY/AGENT spans
-    // in the same trace_id (observed 2026-07-16 with concurrent subagent spawns).
-    const incomingSessionId = (entry['gen_ai.session.id'] as string | undefined) ?? '';
+    // Signal B: a different turn from the same agent type is a boundary only
+    // when it belongs to the same session, or when session identity is unknown.
+    // Explicitly different sessions may run concurrently; preempting one would
+    // split its records and synthesize duplicate ENTRY/AGENT spans.
+    // Missing session identity preserves the legacy preempt behavior.
+    const incomingSessionId = (entry['gen_ai.session.id'] as string | undefined) || undefined;
     for (const [bufKey, buf] of this.turnBuffers) {
       if (buf.agentType !== agentType || bufKey === key || buf.completed) continue;
-      const bufSessionId = (buf.records[0]?.['gen_ai.session.id'] as string | undefined) ?? '';
-      const differentSessions = !!incomingSessionId && !!bufSessionId && incomingSessionId !== bufSessionId;
-      if (differentSessions) continue;
-      const sameSessionConfirmed = !!incomingSessionId && !!bufSessionId && incomingSessionId === bufSessionId;
-      if (!sameSessionConfirmed) {
-        const hasLlmResponse = buf.records.some(
-          (r) => r['event.name'] === 'llm.response',
-        );
-        if (!hasLlmResponse) continue;
-      }
+      if (incomingSessionId && buf.sessionId && incomingSessionId !== buf.sessionId) continue;
       buf.completed = true;
       this.triggerFlush(buf, false);
     }
@@ -275,11 +260,14 @@ export class OtlpTraceFlusher extends BaseFlusher {
         keySource: source,
         keyValue: value,
         agentType,
+        sessionId: incomingSessionId,
         records: [],
         completed: false,
         lastActivityMs: Date.now(),
       };
       this.turnBuffers.set(key, buf);
+    } else if (!buf.sessionId && incomingSessionId) {
+      buf.sessionId = incomingSessionId;
     }
     buf.records.push(entry);
     buf.lastActivityMs = Date.now();

--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -226,14 +226,13 @@ export class OtlpTraceFlusher extends BaseFlusher {
     }
 
     // Signal B: a different turn from the same agent type is a boundary only
-    // when it belongs to the same session, or when session identity is unknown.
-    // Explicitly different sessions may run concurrently; preempting one would
+    // when both turns are confirmed to belong to the same session.
+    // Different or unknown sessions may be concurrent; preempting one would
     // split its records and synthesize duplicate ENTRY/AGENT spans.
-    // Missing session identity preserves the legacy preempt behavior.
     const incomingSessionId = (entry['gen_ai.session.id'] as string | undefined) || undefined;
     for (const [bufKey, buf] of this.turnBuffers) {
       if (buf.agentType !== agentType || bufKey === key || buf.completed) continue;
-      if (incomingSessionId && buf.sessionId && incomingSessionId !== buf.sessionId) continue;
+      if (!incomingSessionId || !buf.sessionId || incomingSessionId !== buf.sessionId) continue;
       buf.completed = true;
       this.triggerFlush(buf, false);
     }

--- a/tests/unit/flushers/otlp-trace-flusher/concurrent-subagent.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/concurrent-subagent.test.ts
@@ -251,10 +251,9 @@ describe('OtlpTraceFlusher - concurrent subagent regression', () => {
     expect((abandonedRecords[0] as Record<string, unknown>)['gen_ai.turn.id']).toBe('s1:t1');
   });
 
-  it('preserves legacy preemption when session info is missing', async () => {
-    // The concurrency guard applies only when both sessions are known and
-    // different. Agents that do not emit gen_ai.session.id retain the
-    // original same-agent/different-key Signal B behavior.
+  it('does NOT preempt when both session ids are missing', async () => {
+    // Without two known session ids, Signal B cannot prove that the turns
+    // are sequential rather than concurrent.
     const { convertEventLogToTrace } = await import('@loongsuite/otel-util-genai');
     const mockConvert = vi.mocked(convertEventLogToTrace);
     mockConvert.mockClear();
@@ -268,16 +267,54 @@ describe('OtlpTraceFlusher - concurrent subagent regression', () => {
       'trace_id': trace1,
       'event.name': 'other',
     }));
-    // New turn arrives, also without gen_ai.session.id — legacy Signal B
-    // preempts the old buffer even though it has no llm.response.
+    // New turn arrives, also without gen_ai.session.id — keep both buffers
+    // open until their own terminal/idle/cap/shutdown signal.
     await flusher.send(makeEntry({
       'gen_ai.turn.id': 'no-ses:t2',
       'trace_id': trace2,
       'event.name': 'other',
     }));
-    expect(mockConvert).toHaveBeenCalledTimes(1);
-    expect(mockConvert.mock.calls[0][0]).toHaveLength(1);
-    expect((mockConvert.mock.calls[0][0][0] as Record<string, unknown>)['gen_ai.turn.id']).toBe('no-ses:t1');
+    expect(mockConvert).not.toHaveBeenCalled();
+  });
+
+  it('does NOT preempt a known-session buffer when the incoming session is missing', async () => {
+    const { convertEventLogToTrace } = await import('@loongsuite/otel-util-genai');
+    const mockConvert = vi.mocked(convertEventLogToTrace);
+    mockConvert.mockClear();
+
+    await flusher.send(makeEntry({
+      'gen_ai.turn.id': 'known-session:t1',
+      'gen_ai.session.id': 'known-session',
+      'trace_id': '99992f3577b34da6a3ce929d0e0e4736',
+      'event.name': 'other',
+    }));
+    await flusher.send(makeEntry({
+      'gen_ai.turn.id': 'unknown-session:t1',
+      'trace_id': 'aaaa3f3577b34da6a3ce929d0e0e4736',
+      'event.name': 'other',
+    }));
+
+    expect(mockConvert).not.toHaveBeenCalled();
+  });
+
+  it('does NOT preempt an unknown-session buffer when the incoming session is known', async () => {
+    const { convertEventLogToTrace } = await import('@loongsuite/otel-util-genai');
+    const mockConvert = vi.mocked(convertEventLogToTrace);
+    mockConvert.mockClear();
+
+    await flusher.send(makeEntry({
+      'gen_ai.turn.id': 'unknown-session:t1',
+      'trace_id': 'bbbb3f3577b34da6a3ce929d0e0e4736',
+      'event.name': 'other',
+    }));
+    await flusher.send(makeEntry({
+      'gen_ai.turn.id': 'known-session:t1',
+      'gen_ai.session.id': 'known-session',
+      'trace_id': 'cccc3f3577b34da6a3ce929d0e0e4736',
+      'event.name': 'other',
+    }));
+
+    expect(mockConvert).not.toHaveBeenCalled();
   });
 
   it('learns a session id from later records before applying Signal B', async () => {

--- a/tests/unit/flushers/otlp-trace-flusher/concurrent-subagent.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/concurrent-subagent.test.ts
@@ -156,6 +156,57 @@ describe('OtlpTraceFlusher - concurrent subagent regression', () => {
     }
   });
 
+  it('keeps interleaved Codex sessions isolated until their own stop signals', async () => {
+    const { convertEventLogToTrace } = await import('@loongsuite/otel-util-genai');
+    const mockConvert = vi.mocked(convertEventLogToTrace);
+    mockConvert.mockClear();
+
+    const a = {
+      'gen_ai.agent.type': 'codex',
+      'gen_ai.turn.id': 'codex-session-a:t1',
+      'gen_ai.session.id': 'codex-session-a',
+      'trace_id': '77772f3577b34da6a3ce929d0e0e4736',
+    };
+    const b = {
+      'gen_ai.agent.type': 'codex',
+      'gen_ai.turn.id': 'codex-session-b:t1',
+      'gen_ai.session.id': 'codex-session-b',
+      'trace_id': '88882f3577b34da6a3ce929d0e0e4736',
+    };
+
+    await flusher.send(makeEntry({ ...a, 'event.name': 'other' }));
+    await flusher.send(makeEntry({
+      ...a,
+      'event.name': 'llm.response',
+      'gen_ai.response.finish_reasons': ['tool_call'],
+    }));
+    await flusher.send(makeEntry({ ...b, 'event.name': 'other' }));
+    await flusher.send(makeEntry({ ...a, 'event.name': 'llm.request' }));
+    expect(mockConvert).not.toHaveBeenCalled();
+
+    await flusher.send(makeEntry({
+      ...b,
+      'event.name': 'llm.response',
+      'gen_ai.response.finish_reasons': ['stop'],
+    }));
+    await flusher.send(makeEntry({
+      ...a,
+      'event.name': 'llm.response',
+      'gen_ai.response.finish_reasons': ['stop'],
+    }));
+    await flusher.flush();
+
+    expect(mockConvert).toHaveBeenCalledTimes(2);
+    const recordsByTurn = new Map(
+      mockConvert.mock.calls.map(([records]) => [
+        (records[0] as Record<string, unknown>)['gen_ai.turn.id'],
+        records,
+      ]),
+    );
+    expect(recordsByTurn.get(a['gen_ai.turn.id'])).toHaveLength(4);
+    expect(recordsByTurn.get(b['gen_ai.turn.id'])).toHaveLength(2);
+  });
+
   it('preempts an abandoned same-session buffer with no llm.response when a new same-session turn arrives', async () => {
     // PR #115 review issue 3: an abandoned same-session turn that only has
     // llm.request / tool.call records (the user moved on or MiMo crashed
@@ -200,12 +251,10 @@ describe('OtlpTraceFlusher - concurrent subagent regression', () => {
     expect((abandonedRecords[0] as Record<string, unknown>)['gen_ai.turn.id']).toBe('s1:t1');
   });
 
-  it('does NOT preempt an abandoned buffer with no llm.response when session info is missing', async () => {
-    // When gen_ai.session.id is missing on either side, we can't tell
-    // same-session (sequential, safe to preempt) from different-session
-    // (concurrent subagent, must not preempt). Fall back to the original
-    // hasLlmResponse safety check so an in-progress turn isn't split on
-    // every sibling arrival.
+  it('preserves legacy preemption when session info is missing', async () => {
+    // The concurrency guard applies only when both sessions are known and
+    // different. Agents that do not emit gen_ai.session.id retain the
+    // original same-agent/different-key Signal B behavior.
     const { convertEventLogToTrace } = await import('@loongsuite/otel-util-genai');
     const mockConvert = vi.mocked(convertEventLogToTrace);
     mockConvert.mockClear();
@@ -219,14 +268,48 @@ describe('OtlpTraceFlusher - concurrent subagent regression', () => {
       'trace_id': trace1,
       'event.name': 'other',
     }));
-    // New turn arrives, also without gen_ai.session.id — must NOT preempt
-    // (hasLlmResponse guard still applies when session info is missing).
+    // New turn arrives, also without gen_ai.session.id — legacy Signal B
+    // preempts the old buffer even though it has no llm.response.
     await flusher.send(makeEntry({
       'gen_ai.turn.id': 'no-ses:t2',
       'trace_id': trace2,
       'event.name': 'other',
     }));
-    // No preemption should have fired before shutdown flush.
+    expect(mockConvert).toHaveBeenCalledTimes(1);
+    expect(mockConvert.mock.calls[0][0]).toHaveLength(1);
+    expect((mockConvert.mock.calls[0][0][0] as Record<string, unknown>)['gen_ai.turn.id']).toBe('no-ses:t1');
+  });
+
+  it('learns a session id from later records before applying Signal B', async () => {
+    const { convertEventLogToTrace } = await import('@loongsuite/otel-util-genai');
+    const mockConvert = vi.mocked(convertEventLogToTrace);
+    mockConvert.mockClear();
+
+    const mainTurnId = 'late-session:t1';
+    const mainTraceId = '55552f3577b34da6a3ce929d0e0e4736';
+
+    // The first record has no session id, but a later record for the same
+    // turn supplies it. The buffer should retain that identity.
+    await flusher.send(makeEntry({
+      'gen_ai.turn.id': mainTurnId,
+      'trace_id': mainTraceId,
+      'event.name': 'other',
+    }));
+    await flusher.send(makeEntry({
+      'gen_ai.turn.id': mainTurnId,
+      'gen_ai.session.id': 'late-session',
+      'trace_id': mainTraceId,
+      'event.name': 'llm.response',
+      'gen_ai.response.finish_reasons': ['tool_call'],
+    }));
+
+    // A different known session must not preempt the first turn.
+    await flusher.send(makeEntry({
+      'gen_ai.turn.id': 'parallel-session:t1',
+      'gen_ai.session.id': 'parallel-session',
+      'trace_id': '66662f3577b34da6a3ce929d0e0e4736',
+      'event.name': 'other',
+    }));
     expect(mockConvert).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/flushers/otlp-trace-flusher/turn-boundary.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/turn-boundary.test.ts
@@ -108,41 +108,27 @@ describe('OtlpTraceFlusher - turn boundary detection', () => {
     expect(records).toHaveLength(1);
   });
 
-  it('Signal B: does NOT flush old buffer that has no llm.response (still in progress)', async () => {
-    // Regression test for the multi-ENTRY/AGENT bug observed with mimo-code
-    // when a sibling turn (e.g. auto-triggered distill agent) starts while
-    // the build turn is still streaming records. The old buffer has only
-    // llm.request / tool.call events — flushing it on the sibling's arrival
-    // would split the turn's records across buffers and produce duplicate
-    // ENTRY/AGENT spans in the same trace.
+  it('Signal B: preserves legacy preemption when session identity is unavailable', async () => {
+    // The concurrency guard is intentionally limited to two known, different
+    // sessions. Agents without gen_ai.session.id keep the original behavior:
+    // a different group key from the same agent type preempts the old buffer.
     const { convertEventLogToTrace } = await import('@loongsuite/otel-util-genai');
     const mockConvert = vi.mocked(convertEventLogToTrace);
     mockConvert.mockClear();
 
-    // First turn — only llm.request, no llm.response yet (still in progress).
+    // First turn — only llm.request, no llm.response and no session id.
     await flusher.send(makeEntry({
       'event.name': 'llm.request',
       'trace_id': 'aaaa2f3577b34da6a3ce929d0e0e4736',
     }));
     expect(mockConvert).not.toHaveBeenCalled();
 
-    // Sibling turn arrives — old buffer must NOT be flushed (no llm.response).
+    // A different group key retains the pre-session-aware Signal B behavior.
     await flusher.send(makeEntry({
       'event.name': 'llm.request',
       'trace_id': 'bbbb2f3577b34da6a3ce929d0e0e4736',
     }));
-    expect(mockConvert).not.toHaveBeenCalled();
-
-    // Old turn now completes (llm.response arrives) — Signal A should fire
-    // and flush the OLD buffer with both its records (request + response).
-    await flusher.send(makeEntry({
-      'event.name': 'llm.response',
-      'trace_id': 'aaaa2f3577b34da6a3ce929d0e0e4736',
-      'gen_ai.response.finish_reasons': ['stop'],
-    }));
     expect(mockConvert).toHaveBeenCalledTimes(1);
-    const records = mockConvert.mock.calls[0][0];
-    expect(records).toHaveLength(2);
   });
 
   it('Signal C: shutdown drains all pending buffers', async () => {

--- a/tests/unit/flushers/otlp-trace-flusher/turn-boundary.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/turn-boundary.test.ts
@@ -92,15 +92,16 @@ describe('OtlpTraceFlusher - turn boundary detection', () => {
     const mockConvert = vi.mocked(convertEventLogToTrace);
     mockConvert.mockClear();
 
-    // First turn — makeEntry() defaults to event.name=llm.response, so the
-    // old buffer is considered "complete enough" for Signal B to flush it.
+    // A confirmed same session makes the new group key a turn boundary.
     await flusher.send(makeEntry({
+      'gen_ai.session.id': 'session-a',
       'trace_id': 'aaaa2f3577b34da6a3ce929d0e0e4736',
     }));
     expect(mockConvert).not.toHaveBeenCalled();
 
     // New trace_id → old turn should flush
     await flusher.send(makeEntry({
+      'gen_ai.session.id': 'session-a',
       'trace_id': 'bbbb2f3577b34da6a3ce929d0e0e4736',
     }));
     expect(mockConvert).toHaveBeenCalledTimes(1);
@@ -108,10 +109,9 @@ describe('OtlpTraceFlusher - turn boundary detection', () => {
     expect(records).toHaveLength(1);
   });
 
-  it('Signal B: preserves legacy preemption when session identity is unavailable', async () => {
-    // The concurrency guard is intentionally limited to two known, different
-    // sessions. Agents without gen_ai.session.id keep the original behavior:
-    // a different group key from the same agent type preempts the old buffer.
+  it('Signal B: does NOT preempt when session identity is unavailable', async () => {
+    // An unknown session cannot prove that a different group key represents
+    // sequential user flow rather than a concurrent turn.
     const { convertEventLogToTrace } = await import('@loongsuite/otel-util-genai');
     const mockConvert = vi.mocked(convertEventLogToTrace);
     mockConvert.mockClear();
@@ -123,12 +123,21 @@ describe('OtlpTraceFlusher - turn boundary detection', () => {
     }));
     expect(mockConvert).not.toHaveBeenCalled();
 
-    // A different group key retains the pre-session-aware Signal B behavior.
+    // A different group key must not preempt the unknown-session buffer.
     await flusher.send(makeEntry({
       'event.name': 'llm.request',
       'trace_id': 'bbbb2f3577b34da6a3ce929d0e0e4736',
     }));
+    expect(mockConvert).not.toHaveBeenCalled();
+
+    // The old turn still flushes normally on its own terminal Signal A.
+    await flusher.send(makeEntry({
+      'event.name': 'llm.response',
+      'trace_id': 'aaaa2f3577b34da6a3ce929d0e0e4736',
+      'gen_ai.response.finish_reasons': ['stop'],
+    }));
     expect(mockConvert).toHaveBeenCalledTimes(1);
+    expect(mockConvert.mock.calls[0][0]).toHaveLength(2);
   });
 
   it('Signal C: shutdown drains all pending buffers', async () => {


### PR DESCRIPTION
## Summary

- persist session identity on each OTLP turn buffer and learn it from later records when necessary
- allow Signal B preemption only when both turns have known, matching `gen_ai.session.id` values
- keep different-session and unknown-session buffers isolated until their own terminal, idle timeout, buffer cap, or shutdown signal
- add Codex A/B/A interleaving and known/missing session regressions so each turn converts exactly once

This is a focused follow-up to #115. Signal A terminal handling, transcript extraction, and synthetic `other` events are unchanged.

## Verification

- targeted Signal B/grouping tests — 25 passed
- all flusher tests — 134 passed
- `npm run typecheck` — passed
- replayed 7/28 Codex JSONL: 7,623 records, 0 missing session IDs, 77 terminal events, 0 confirmed-same-session preemptions, 0 buffers left open