### PR TITLE
fix: avoid resetting safe Windows worker ACLs

### DIFF
--- a/src/local-workers/private-directory.ts
+++ b/src/local-workers/private-directory.ts
@@ -14,7 +14,35 @@ if ([string]::IsNullOrWhiteSpace($target)) {
 
 $currentSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
 $allowedSids = @($currentSid, "S-1-5-18", "S-1-5-32-544") | Select-Object -Unique
+$fullControl = [System.Security.AccessControl.FileSystemRights]::FullControl
+
+function Test-PrivateAcl($acl) {
+  $rules = $acl.GetAccessRules(
+    $true,
+    $true,
+    [System.Security.Principal.SecurityIdentifier]
+  )
+  $unexpected = @($rules | Where-Object {
+    -not ($allowedSids -contains $_.IdentityReference.Value) -or
+    $_.AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Allow
+  })
+  $missing = @($allowedSids | Where-Object {
+    $sid = $_
+    -not ($rules | Where-Object {
+      $_.IdentityReference.Value -eq $sid -and
+      $_.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and
+      (([int64]$_.FileSystemRights -band [int64]$fullControl) -eq [int64]$fullControl)
+    })
+  })
+  return $acl.AreAccessRulesProtected -and $unexpected.Count -eq 0 -and $missing.Count -eq 0
+}
+
 $acl = Get-Acl -LiteralPath $target
+# Avoid propagating inheritable ACLs through an already-private runtime tree.
+if (Test-PrivateAcl $acl) {
+  exit 0
+}
+
 $sddl = "D:P(A;OICI;FA;;;$currentSid)(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)"
 $acl.SetSecurityDescriptorSddlForm(
   $sddl,
@@ -22,26 +50,8 @@ $acl.SetSecurityDescriptorSddlForm(
 )
 Set-Acl -LiteralPath $target -AclObject $acl
 
-$fullControl = [System.Security.AccessControl.FileSystemRights]::FullControl
 $verified = Get-Acl -LiteralPath $target
-$rules = $verified.GetAccessRules(
-  $true,
-  $true,
-  [System.Security.Principal.SecurityIdentifier]
-)
-$unexpected = @($rules | Where-Object {
-  -not ($allowedSids -contains $_.IdentityReference.Value) -or
-  $_.AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Allow
-})
-$missing = @($allowedSids | Where-Object {
-  $sid = $_
-  -not ($rules | Where-Object {
-    $_.IdentityReference.Value -eq $sid -and
-    $_.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and
-    (([int64]$_.FileSystemRights -band [int64]$fullControl) -eq [int64]$fullControl)
-  })
-})
-if (-not $verified.AreAccessRulesProtected -or $unexpected.Count -gt 0 -or $missing.Count -gt 0) {
+if (-not (Test-PrivateAcl $verified)) {
   throw "failed to apply private ACL to local worker directory"
 }
 `;

--- a/tests/unit/local-workers/private-directory.test.ts
+++ b/tests/unit/local-workers/private-directory.test.ts
@@ -19,7 +19,7 @@ describe.runIf(process.platform === 'win32')('private local worker directory', (
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it('removes inherited access for other users from the instance directory and token', async () => {
+  it('removes inherited access and remains safe when prepared again', async () => {
     const instanceDir = path.join(tmpDir, '实例 目录');
     const tokenPath = path.join(instanceDir, 'credentials', 'bootstrap-token');
     await fs.mkdir(instanceDir, { recursive: true });
@@ -33,6 +33,7 @@ if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     await fs.mkdir(path.dirname(tokenPath), { recursive: true });
     await fs.writeFile(tokenPath, 'secret', 'utf-8');
+    await preparePrivateLocalWorkerDirectory(instanceDir);
     await preparePrivateLocalWorkerDirectory(instanceDir);
 
     const result = await runPowerShellJson<{


### PR DESCRIPTION
## Summary

- verify an existing Windows local-worker directory ACL before changing it
- skip `Set-Acl` when the directory is already private
- retain repair-and-verify behavior for unsafe ACLs
- cover repeated directory preparation in the Windows ACL test

## Why

Reconnecting a managed OpenClaw worker re-ran `Set-Acl` on an instance tree containing about 16,000 files. Because the ACL contains inheritable entries, Windows propagated it through the tree and exceeded the PowerShell timeout, causing `LocalWorkerDirectoryAclUnsafe` even though the root ACL was already private.

The fast path keeps reconnects read-only when the expected ACL is already present, while preserving fail-closed protection and remediation for unsafe ACLs.

## User impact

Windows managed workers with large runtime state can be reconnected without timing out during ACL setup. Linux and macOS behavior is unchanged.

## Validation

- `npm run typecheck`
- `npm test -- --run tests/unit/local-workers` (29 passed, 1 Windows-only test skipped on macOS)
- `npm test` (2,159 passed, 10 skipped)
- real Windows OpenClaw regression with 16,251 state files:
  - before: reconnect failed after about 19 seconds with `LocalWorkerDirectoryAclUnsafe`
  - after: reconnect completed in 4.39 seconds and the worker returned to `WorkerReady`
  - the resulting instance ACL still allowed only the current user, SYSTEM, and Administrators