### PR TITLE
feat(claude-code): propagate trace context to Bash tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,12 +138,15 @@ Link collected agent spans to an **upstream** trace so each turn's span tree rep
 | Setting | Values | Default |
 | ------- | ------ | ------- |
 | `LOONGSUITE_PILOT_UPSTREAM_LINK` (env) · `upstreamLink.enabled` (config.json) | `true` / `1` to enable; unset, `false`, or `0` to disable | disabled |
+| `LOONGSUITE_PILOT_UPSTREAM_LINK_PROPAGATE_TO_TOOLS` (env) · `upstreamLink.propagateToTools` (config.json) | propagate the first-turn upstream context to supported CLI tool calls | disabled |
 | `LOONGSUITE_PILOT_UPSTREAM_LINK_TTL_MS` (env) · `upstreamLink.ttlMs` (config.json) | cleanup TTL in ms for `acp-correlate` files | `86400000` (24h) |
 
 When enabled, the upstream `traceparent` reaches Pilot via one of two schemes and is stamped onto collected records (`trace_id` on the turn, `parent_span_id` on the user-input event):
 
 - **Correlation file** (per-turn): the caller writes `{sessionId, contentHash, contentPrefix, traceparent}` to `~/.loongsuite-pilot/acp-correlate/<sessionId>.jsonl` when it sends a prompt. Linking is protocol-agnostic — the only requirement is that `sessionId` matches the `gen_ai.session.id` Pilot collects for that turn, and the content (hash or prefix) matches the collected user text. ACP clients satisfy this naturally (the `session/new` id flows into collection), so ACP is the primary case.
 - **Environment** (`TRACEPARENT` on the agent process): applied to the session's first turn, via the agent's hook. Use this when the caller cannot obtain a per-turn `sessionId` up front.
+
+For Claude Code, enabling both upstream linking and `propagateToTools` also passes the first turn's context into main-agent `Bash` calls. Pilot's `PreToolUse(Bash)` hook reserves the TOOL span id, prepends `TRACEPARENT` (and valid `TRACESTATE`, when present) to the Bash command, then reuses that id when the Stop hook builds the TOOL span. The downstream CLI must read these environment variables and configure its own trace exporter. This initial scope is fail-open and does not cover subagents, PowerShell, MCP tools, later turns, or resumed sessions with a newly supplied context.
 
 
 ## Output Data

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -110,6 +110,7 @@ loongsuite-pilot info
 | 写入本地 JSONL 日志 | [本地 JSONL 输出](docs/zh-CN/local-jsonl-output.md) |
 | 上报日志到 SLS | [SLS 输出](docs/zh-CN/sls-output.md) |
 | 上报 OTLP Trace | [Trace 输出](docs/zh-CN/trace-output.md) |
+| 将上游 Trace 继续传给 Claude Code 调用的 CLI | [Claude Code 下游 CLI Trace 传播](docs/zh-CN/claude-code-downstream-trace-propagation.md) |
 | POST 到 HTTP 接口 | [HTTP 输出](docs/zh-CN/http-output.md) |
 | 输出前进行密钥脱敏 | [数据脱敏](docs/zh-CN/masking.md) |
 | 查看全局配置加载顺序和保留策略 | [配置总览](docs/zh-CN/configuration.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -121,12 +121,15 @@ loongsuite-pilot info
 | 配置项 | 取值 | 默认 |
 | ------ | ---- | ---- |
 | `LOONGSUITE_PILOT_UPSTREAM_LINK`(环境变量)· `upstreamLink.enabled`(config.json) | `true` / `1` 开启;不设、`false` 或 `0` 关闭 | 关闭 |
+| `LOONGSUITE_PILOT_UPSTREAM_LINK_PROPAGATE_TO_TOOLS`(环境变量)· `upstreamLink.propagateToTools`(config.json) | 将首轮上游上下文传给受支持的下游 CLI 工具调用 | 关闭 |
 | `LOONGSUITE_PILOT_UPSTREAM_LINK_TTL_MS`(环境变量)· `upstreamLink.ttlMs`(config.json) | `acp-correlate` 文件清理 TTL(毫秒) | `86400000`(24 小时) |
 
 开启后,上游 `traceparent` 经以下两种方案之一到达 Pilot,并在采集时 stamp 到记录(turn 打 `trace_id`、用户输入事件打 `parent_span_id`):
 
 - **关联文件**(per-turn):调用方在发送 prompt 时,把 `{sessionId, contentHash, contentPrefix, traceparent}` 写入 `~/.loongsuite-pilot/acp-correlate/<sessionId>.jsonl`。串联与协议无关——唯一要求是 `sessionId` 等于 Pilot 采集该 turn 时的 `gen_ai.session.id`,且内容(hash 或前缀)能匹配采集到的用户文本。ACP client 天然满足(`session/new` 的 id 会贯穿采集),故 ACP 是主要场景。
 - **环境变量**(agent 进程上的 `TRACEPARENT`):经 agent 的 hook 作用于该会话的第一个 turn。适用于调用方无法预先拿到 per-turn `sessionId` 的情况。
+
+对于 Claude Code，同时开启上游串联和 `propagateToTools` 后，Pilot 还会把首轮上下文传给主 agent 的 `Bash` 调用。`PreToolUse(Bash)` hook 会预留 TOOL span id，在 Bash 命令前注入 `TRACEPARENT`（存在有效值时也注入 `TRACESTATE`），Stop hook 构建 TOOL span 时再复用同一个 id。下游 CLI 需要自行读取这些环境变量并配置 trace exporter。首版全程 fail-open，暂不覆盖 subagent、PowerShell、MCP 工具、后续 turn，以及带新上下文恢复的会话。
 
 ## 输出数据
 

--- a/agents.d/claude-code.json
+++ b/agents.d/claude-code.json
@@ -9,6 +9,7 @@
   "hook": {
     "settingsPath": "~/.claude/settings.json",
     "events": [
+      "PreToolUse",
       "Stop",
       "SubagentStart",
       "SubagentStop"
@@ -16,6 +17,9 @@
     "hookCommand": "$PILOT_DATA/hooks/claude-code-loongsuite-pilot-hook.sh",
     "format": "nested",
     "matcher": "*",
+    "eventMatchers": {
+      "PreToolUse": "Bash"
+    },
     "eventSubcommand": "kebab-case",
     "replaceHookCommands": [
       "otel-claude-hook",

--- a/assets/hooks/agent-event-normalizer.mjs
+++ b/assets/hooks/agent-event-normalizer.mjs
@@ -226,12 +226,31 @@ export function loadHookRuntimeConfig(dataDir) {
     file = {};
   }
 
+  const envBool = (name, fallback) => {
+    const raw = process.env[name];
+    if (raw === undefined || raw === '') return fallback;
+    return raw === '1' || raw.toLowerCase() === 'true';
+  };
+  const upstreamLink = file.upstreamLink && typeof file.upstreamLink === 'object'
+    ? file.upstreamLink
+    : {};
+
   return {
     userId: process.env.LOONGSUITE_PILOT_USER_ID
       || file.userId
       || file['user.id']
       || os.hostname(),
     agents: file.agents && typeof file.agents === 'object' ? file.agents : {},
+    upstreamLink: {
+      enabled: envBool(
+        'LOONGSUITE_PILOT_UPSTREAM_LINK',
+        upstreamLink.enabled === true,
+      ),
+      propagateToTools: envBool(
+        'LOONGSUITE_PILOT_UPSTREAM_LINK_PROPAGATE_TO_TOOLS',
+        upstreamLink.propagateToTools === true,
+      ),
+    },
   };
 }
 

--- a/assets/hooks/claude-code-hook-processor.mjs
+++ b/assets/hooks/claude-code-hook-processor.mjs
@@ -300,11 +300,6 @@ function cmdPreToolUse() {
   // v1 policy: only propagate from the main agent's Bash calls.
   if (event.agent_id || event.agent_type) return;
   if (event.tool_name !== 'Bash') return;
-  // A background Bash produces no paired tool.result in this turn's Stop
-  // records, so its TOOL span is dropped by dropOrphanPairs and the reserved
-  // parent span id is never emitted. Skip propagation to avoid leaving the
-  // downstream process with a dangling (nonexistent) parent span.
-  if (event.tool_input?.run_in_background === true) return;
   const toolUseId = typeof event.tool_use_id === 'string' ? event.tool_use_id : '';
   if (!toolUseId) return;
 

--- a/assets/hooks/claude-code-hook-processor.mjs
+++ b/assets/hooks/claude-code-hook-processor.mjs
@@ -300,6 +300,11 @@ function cmdPreToolUse() {
   // v1 policy: only propagate from the main agent's Bash calls.
   if (event.agent_id || event.agent_type) return;
   if (event.tool_name !== 'Bash') return;
+  // A background Bash produces no paired tool.result in this turn's Stop
+  // records, so its TOOL span is dropped by dropOrphanPairs and the reserved
+  // parent span id is never emitted. Skip propagation to avoid leaving the
+  // downstream process with a dangling (nonexistent) parent span.
+  if (event.tool_input?.run_in_background === true) return;
   const toolUseId = typeof event.tool_use_id === 'string' ? event.tool_use_id : '';
   if (!toolUseId) return;
 

--- a/assets/hooks/claude-code-hook-processor.mjs
+++ b/assets/hooks/claude-code-hook-processor.mjs
@@ -9,7 +9,7 @@
  *   $ node claude-code-hook-processor.mjs <subcommand>
  *
  * v2 重构:
- *   - 只处理 3 个 subcommand: stop / subagent-start / subagent-stop
+ *   - 只处理 4 个 subcommand: pre-tool-use / stop / subagent-start / subagent-stop
  *   - 纯 transcript 驱动: 时间戳从 transcript record.timestamp 获取
  *   - tool→step 归属: 通过 tool_use_id 从 LLM output_content 匹配到声明方 step
  *   - 不再依赖 alignWithHookEvents / hook 事件累积
@@ -49,6 +49,12 @@ import {
   withStateLock,
 } from './claude-code/state.mjs';
 import {
+  buildBashUpdatedInput,
+  consumeToolContext,
+  markToolPropagationConsumed,
+  reserveToolContext,
+} from './claude-code/tool-context.mjs';
+import {
   parseClaudeTranscript,
 } from './claude-code/transcript-parser.mjs';
 import {
@@ -74,6 +80,7 @@ const SPAN_ATTRIBUTES = parseSpanAttributesFromEnv(process.env, { agentId: AGENT
 // Retain recent completion tombstones to ignore delayed duplicate SubagentStop
 // events while keeping the persisted session state bounded.
 const FINALIZED_SUBAGENT_LIMIT = 128;
+let emittedHookResponse = false;
 
 // ─── utilities ───
 
@@ -279,6 +286,45 @@ function deterministicSkillLoadId(sessionId, promptId, metaUuid, rootPath) {
   return `toolu_skillload_${h}`;
 }
 
+function toolPropagationEnabled(runtimeConfig) {
+  return runtimeConfig?.upstreamLink?.enabled === true
+    && runtimeConfig?.upstreamLink?.propagateToTools === true;
+}
+
+function cmdPreToolUse() {
+  const event = tryReadStdin();
+  if (isCursorCaller(event)) return;
+  const sessionId = requireSessionId(event, 'pre_tool_use');
+  if (!sessionId) return;
+
+  // v1 policy: only propagate from the main agent's Bash calls.
+  if (event.agent_id || event.agent_type) return;
+  if (event.tool_name !== 'Bash') return;
+  const toolUseId = typeof event.tool_use_id === 'string' ? event.tool_use_id : '';
+  if (!toolUseId) return;
+
+  const runtimeConfig = loadHookRuntimeConfig(pilotDataDir());
+  if (!toolPropagationEnabled(runtimeConfig)) return;
+
+  const context = reserveToolContext({
+    dataDir: pilotDataDir(),
+    sessionId,
+    toolUseId,
+    traceparent: process.env.TRACEPARENT,
+    tracestate: process.env.TRACESTATE,
+  });
+  const updatedInput = buildBashUpdatedInput(event.tool_input, context);
+  if (!updatedInput) return;
+
+  emittedHookResponse = true;
+  process.stdout.write(`${JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      updatedInput,
+    },
+  })}\n`);
+}
+
 function skillAttributes(skillLoad, fallbackName) {
   const name = skillLoad?.name
     || (typeof fallbackName === 'string' ? fallbackName.trim().replace(/^\/+/, '') : null);
@@ -391,8 +437,13 @@ async function cmdStop() {
   const sessionId = requireSessionId(event, 'cmd');
   if (!sessionId) return;
 
+  const runtimeConfig = loadHookRuntimeConfig(pilotDataDir());
+
   // 方案1(env):首个 turn 读 TRACEPARENT 写 session 级关联记录(fail-open, 每 session 一次)
   recordUpstreamContextOnce({ agentId: AGENT_ID, sessionId, dataDir: pilotDataDir() });
+  if (toolPropagationEnabled(runtimeConfig)) {
+    markToolPropagationConsumed(pilotDataDir(), sessionId);
+  }
 
   await withStateLock(sessionId, async () => {
     const state = loadState(sessionId);
@@ -948,7 +999,8 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
 
       const toolName = toolBlock.name || 'unknown';
 
-      const toolSpanId = generateSpanId();
+      const reservedContext = consumeToolContext(pilotDataDir(), sessionId, toolId);
+      const toolSpanId = reservedContext?.spanId || generateSpanId();
       const skillLoad = toolName === 'Skill' ? skillLoadsByToolId.get(toolId) : null;
       const skillFields = toolName === 'Skill'
         ? skillAttributes(skillLoad, toolBlock.input?.skill || toolBlock.input?.name)
@@ -1070,6 +1122,7 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
 // ─── dispatcher ───
 
 const DISPATCH = {
+  'pre-tool-use': cmdPreToolUse,
   'stop': cmdStop,
   'subagent-start': cmdSubagentStart,
   'subagent-stop': cmdSubagentStop,
@@ -1086,7 +1139,7 @@ if (fn) {
       errorMessage: err?.message || String(err),
     });
   }).finally(() => {
-    process.stdout.write('{}\n');
+    if (!emittedHookResponse) process.stdout.write('{}\n');
   });
 } else {
   process.stdout.write('{}\n');

--- a/assets/hooks/claude-code-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/claude-code-loongsuite-pilot-hook.ps1
@@ -3,7 +3,7 @@
 # Usage (registered in ~/.claude/settings.json by pilot HookStrategy):
 #   powershell -File $PILOT_DATA/hooks/claude-code-loongsuite-pilot-hook.ps1 <subcommand>
 #
-# Subcommand: stop / subagent-start / subagent-stop
+# Subcommand: pre-tool-use / stop / subagent-start / subagent-stop
 #
 # Fail-open: any error outputs "{}" and exits 0.
 
@@ -15,7 +15,7 @@ $Processor = Join-Path $ScriptDir "claude-code-hook-processor.mjs"
 $Subcommand = if ($args.Count -gt 0) { $args[0] } else { "unknown" }
 
 # Only process registered subcommands
-if ($Subcommand -notin @("stop", "subagent-start", "subagent-stop")) {
+if ($Subcommand -notin @("pre-tool-use", "stop", "subagent-start", "subagent-stop")) {
     Write-Output $EMPTY_RESULT
     exit 0
 }

--- a/assets/hooks/claude-code-loongsuite-pilot-hook.sh
+++ b/assets/hooks/claude-code-loongsuite-pilot-hook.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 # Usage (registered in ~/.claude/settings.json by pilot HookStrategy):
 #   $PILOT_DATA/hooks/claude-code-loongsuite-pilot-hook.sh <subcommand>
 #
-# Subcommand (v2: 只处理 3 个):
-#   stop / subagent-start / subagent-stop
+# Subcommand:
+#   pre-tool-use / stop / subagent-start / subagent-stop
 #
 # Fail-open 原则: 任何错误都输出 "{}" 并 exit 0,不阻塞宿主 agent。
 
@@ -18,7 +18,7 @@ SUBCOMMAND="${1:-unknown}"
 
 # Only process registered subcommands; early-return for legacy/unregistered ones.
 case "$SUBCOMMAND" in
-  stop|subagent-start|subagent-stop)
+  pre-tool-use|stop|subagent-start|subagent-stop)
     ;;
   *)
     printf '%s\n' "$EMPTY_RESULT"

--- a/assets/hooks/claude-code/tool-context.mjs
+++ b/assets/hooks/claude-code/tool-context.mjs
@@ -166,18 +166,26 @@ export function consumeToolContext(dataDir, sessionId, toolUseId) {
  */
 export function markToolPropagationConsumed(dataDir, sessionId) {
   if (!dataDir || !sessionId) return;
+  const file = consumedPath(dataDir, sessionId);
   try {
     const dir = correlateDir(dataDir);
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(
-      consumedPath(dataDir, sessionId),
+      file,
       JSON.stringify({ sessionId, ts: new Date().toISOString() }),
       { encoding: 'utf-8', flag: 'wx' },
     );
   } catch (err) {
-    if (err?.code !== 'EEXIST') {
-      // fail-open
+    // The marker already exists from an earlier turn. Refresh its mtime so the
+    // mtime-based acp-correlate retention TTL does not reclaim the first-turn
+    // marker of a session that is still active past the TTL window (which would
+    // reset first-turn-only propagation and re-inject on later turns). Only a
+    // truly idle session — no Stop for a full TTL — is then reclaimed.
+    if (err?.code === 'EEXIST') {
+      const now = new Date();
+      try { fs.utimesSync(file, now, now); } catch {}
     }
+    // Any other error is a fail-open miss.
   }
 }
 

--- a/assets/hooks/claude-code/tool-context.mjs
+++ b/assets/hooks/claude-code/tool-context.mjs
@@ -1,0 +1,201 @@
+// Copyright 2026 Alibaba Group Holding Limited
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Per-Bash-tool upstream trace context reservation for Claude Code.
+ *
+ * PreToolUse runs before the Bash subprocess exists. It reserves the span id
+ * that Pilot will later use for the synthetic TOOL span and returns a
+ * traceparent whose parent id is that reserved span id. The Stop processor
+ * consumes the same record by tool_use_id while building tool.call/result.
+ *
+ * Files are intentionally one-per-tool so parallel PreToolUse hook processes
+ * never contend on a shared session JSON document. Orphans live under
+ * acp-correlate and are removed by the existing upstream-link retention job.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+const TRACEPARENT_RE = /^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/i;
+const ZERO_TRACE = '0'.repeat(32);
+const ZERO_SPAN = '0'.repeat(16);
+const TRACESTATE_MAX_LENGTH = 512;
+
+function safeName(value) {
+  return path.basename(String(value)).replace(/[^a-zA-Z0-9_-]/g, '_') || 'unknown';
+}
+
+function correlateDir(dataDir) {
+  return path.join(dataDir, 'acp-correlate');
+}
+
+function contextPath(dataDir, sessionId, toolUseId) {
+  return path.join(
+    correlateDir(dataDir),
+    `${safeName(sessionId)}.${safeName(toolUseId)}.tool-context.json`,
+  );
+}
+
+function consumedPath(dataDir, sessionId) {
+  return path.join(correlateDir(dataDir), `${safeName(sessionId)}.tool-propagation.done`);
+}
+
+function parseTraceparent(value) {
+  if (typeof value !== 'string') return null;
+  const match = TRACEPARENT_RE.exec(value.trim());
+  if (!match) return null;
+  const traceId = match[1].toLowerCase();
+  const parentSpanId = match[2].toLowerCase();
+  const flags = match[3].toLowerCase();
+  if (traceId === ZERO_TRACE || parentSpanId === ZERO_SPAN) return null;
+  return { traceId, parentSpanId, flags };
+}
+
+function sanitizeTracestate(value) {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > TRACESTATE_MAX_LENGTH) return undefined;
+  // Environment values must not contain control bytes. Shell quoting handles
+  // printable punctuation (including single quotes) below.
+  if (/[\x00-\x1f\x7f]/.test(trimmed)) return undefined;
+  return trimmed;
+}
+
+function readRecord(file) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    if (
+      parsed
+      && typeof parsed === 'object'
+      && typeof parsed.spanId === 'string'
+      && /^[0-9a-f]{16}$/i.test(parsed.spanId)
+      && parsed.spanId.toLowerCase() !== ZERO_SPAN
+      && typeof parsed.traceparent === 'string'
+      && parseTraceparent(parsed.traceparent)
+    ) {
+      return {
+        ...parsed,
+        spanId: parsed.spanId.toLowerCase(),
+        tracestate: sanitizeTracestate(parsed.tracestate),
+      };
+    }
+  } catch {
+    // Missing, partial, or corrupt state is a fail-open miss.
+  }
+  return null;
+}
+
+function shellSingleQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+export function isToolPropagationConsumed(dataDir, sessionId) {
+  try {
+    return fs.statSync(consumedPath(dataDir, sessionId)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Reserve (or idempotently reload) the TOOL span context for one tool_use_id.
+ */
+export function reserveToolContext({
+  dataDir,
+  sessionId,
+  toolUseId,
+  traceparent,
+  tracestate,
+}) {
+  if (!dataDir || !sessionId || !toolUseId) return null;
+  if (isToolPropagationConsumed(dataDir, sessionId)) return null;
+
+  const parsed = parseTraceparent(traceparent);
+  if (!parsed) return null;
+
+  const dir = correlateDir(dataDir);
+  const file = contextPath(dataDir, sessionId, toolUseId);
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    const existing = readRecord(file);
+    if (existing) return existing;
+
+    const spanId = crypto.randomBytes(8).toString('hex');
+    const downstreamTraceparent = `00-${parsed.traceId}-${spanId}-${parsed.flags}`;
+    const record = {
+      type: 'tool',
+      sessionId,
+      toolUseId,
+      traceId: parsed.traceId,
+      spanId,
+      traceparent: downstreamTraceparent,
+      tracestate: sanitizeTracestate(tracestate),
+      ts: new Date().toISOString(),
+    };
+
+    try {
+      fs.writeFileSync(file, JSON.stringify(record), { encoding: 'utf-8', flag: 'wx' });
+      return record;
+    } catch (err) {
+      // Duplicate hook invocation: the process that won O_EXCL owns the
+      // record; reuse it so both invocations return the same context.
+      if (err?.code === 'EEXIST') return readRecord(file);
+      throw err;
+    }
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read and remove a reserved context after Stop has attached it to TOOL.
+ */
+export function consumeToolContext(dataDir, sessionId, toolUseId) {
+  const file = contextPath(dataDir, sessionId, toolUseId);
+  const record = readRecord(file);
+  if (!record) return null;
+  try { fs.unlinkSync(file); } catch {}
+  return record;
+}
+
+/**
+ * Mark the environment-supplied context consumed after the first Stop, keeping
+ * downstream propagation aligned with TraceLinker's first-turn-only behavior.
+ */
+export function markToolPropagationConsumed(dataDir, sessionId) {
+  if (!dataDir || !sessionId) return;
+  try {
+    const dir = correlateDir(dataDir);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      consumedPath(dataDir, sessionId),
+      JSON.stringify({ sessionId, ts: new Date().toISOString() }),
+      { encoding: 'utf-8', flag: 'wx' },
+    );
+  } catch (err) {
+    if (err?.code !== 'EEXIST') {
+      // fail-open
+    }
+  }
+}
+
+/**
+ * Return a full Bash tool input replacement. No permission decision is
+ * included: Claude Code must continue applying the user's existing policy.
+ */
+export function buildBashUpdatedInput(toolInput, context) {
+  if (!toolInput || typeof toolInput !== 'object' || Array.isArray(toolInput)) return null;
+  if (typeof toolInput.command !== 'string' || toolInput.command.length === 0) return null;
+  if (!context || typeof context.traceparent !== 'string') return null;
+
+  const exports = [`export TRACEPARENT=${shellSingleQuote(context.traceparent)}`];
+  if (context.tracestate) {
+    exports.push(`export TRACESTATE=${shellSingleQuote(context.tracestate)}`);
+  }
+  return {
+    ...toolInput,
+    command: `${exports.join('; ')};\n${toolInput.command}`,
+  };
+}

--- a/assets/hooks/shared/qoder-db-utils.mjs
+++ b/assets/hooks/shared/qoder-db-utils.mjs
@@ -1,13 +1,25 @@
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import { homedir } from 'node:os';
 
-// node:sqlite is available in Node 22+. Load once at module init.
-// On Node 18 (repo minimum), this fails gracefully and isQoderIdeaSession
-// returns null — callers fall back to 'qoder' (Desktop IDE) as safe default.
-let DatabaseSync = null;
-try {
-  ({ DatabaseSync } = await import('node:sqlite'));
-} catch { /* Node < 22: DB detection unavailable, fallback to qoder */ }
+const require = createRequire(import.meta.url);
+
+// node:sqlite is available in Node 22+. Load it only when Qoder session
+// detection is actually requested: this module is also imported by the shared
+// event normalizer used by other agents, and eager loading would emit Node's
+// SQLite ExperimentalWarning in unrelated hooks such as Claude Code.
+// On Node 18 (repo minimum), loading fails gracefully and callers fall back to
+// 'qoder' (Desktop IDE) as the safe default.
+let DatabaseSync;
+function loadDatabaseSync() {
+  if (DatabaseSync !== undefined) return DatabaseSync;
+  try {
+    ({ DatabaseSync } = require('node:sqlite'));
+  } catch {
+    DatabaseSync = null;
+  }
+  return DatabaseSync;
+}
 
 // Per-session cache to avoid repeated DB open/close within the same process.
 const _cache = new Map();
@@ -21,12 +33,13 @@ const _cache = new Map();
  * Results are cached per sessionId for the lifetime of the process.
  */
 export function isQoderIdeaSession(sessionId) {
-  if (!DatabaseSync) return null;
+  const Database = loadDatabaseSync();
+  if (!Database) return null;
   if (_cache.has(sessionId)) return _cache.get(sessionId);
 
   const dbPath = homedir() + '/.qoder/shared_client/cache/db/local.db';
   if (!fs.existsSync(dbPath)) return null;
-  const db = new DatabaseSync(dbPath, { readonly: true });
+  const db = new Database(dbPath, { readonly: true });
   try {
     const row = db.prepare('SELECT 1 FROM chat_session WHERE session_id = ? LIMIT 1').get(sessionId);
     const result = row !== undefined;

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -19,6 +19,7 @@
 | [本地 JSONL 输出](local-jsonl-output.md) | 将规范化事件写入本地文件，并验证采集是否生效。 |
 | [SLS 输出](sls-output.md) | 将日志上报到阿里云日志服务。 |
 | [Trace 输出](trace-output.md) | 将 GenAI 活动导出为 OTLP Trace。 |
+| [Claude Code 下游 CLI Trace 传播](claude-code-downstream-trace-propagation.md) | 将上游 Trace 上下文继续传给 Claude Code 通过 Bash 调用的用户 CLI。 |
 | [HTTP 输出](http-output.md) | 将规范化事件 POST 到自定义接口。 |
 
 ## 配置采集与隐私

--- a/docs/zh-CN/claude-code-downstream-trace-propagation.md
+++ b/docs/zh-CN/claude-code-downstream-trace-propagation.md
@@ -309,7 +309,7 @@ span ID，不影响其他 Trace 数据采集。
 - Claude Code。
 - 主 Agent。
 - 通过环境变量传入的会话首轮上游上下文。
-- Claude Code `Bash` 工具调用。
+- Claude Code `Bash` 工具调用，包括设置 `run_in_background: true` 的后台命令。
 - W3C `TRACEPARENT`。
 - 可选的 `TRACESTATE`。
 
@@ -323,6 +323,20 @@ span ID，不影响其他 Trace 数据采集。
 - 恢复已有会话时注入一份新的环境变量上下文。
 - 仅通过 ACP per-turn 关联文件提供、但未出现在 Claude Code 进程环境中的
   下游上下文。
+
+## 已知限制
+
+Pilot 必须在下游进程启动前通过 `PreToolUse(Bash)` 注入上下文，因此 TOOL
+span ID 的预留早于工具执行结果。Claude Code 成功启动后台 Bash 后会立即
+产生包含后台任务 ID 的 `tool_result`，Pilot 可以正常生成与其配对的 TOOL
+span；后台进程是否已经运行结束不影响这次配对。
+
+如果 Claude Code 在写入工具结果和执行 Stop hook 之前被强制终止（例如进程
+被操作系统直接杀死或主机崩溃），下游进程可能已经收到上下文，但 Pilot 没有
+机会导出预留的 TOOL span。此时下游 span 会暂时引用一个后端不存在的父 span。
+预留状态会在 TTL 到期后被清理，但无法在 Claude Code 没有留下完整 transcript
+和 Stop 事件的情况下补建 TOOL span。正常完成、正常失败或能够写入
+`tool_result` 的中断不受此限制。
 
 ## 如何验证链路
 

--- a/docs/zh-CN/claude-code-downstream-trace-propagation.md
+++ b/docs/zh-CN/claude-code-downstream-trace-propagation.md
@@ -1,0 +1,380 @@
+# Claude Code 下游 CLI Trace 上下文传播
+
+本文介绍 LoongSuite Pilot 如何把上游 Trace 上下文继续传递给 Claude Code
+通过 `Bash` 调用的下游 CLI，使上游应用、Claude Code、Bash TOOL span 和用户
+CLI 的 Trace 串联成一条完整链路。
+
+## 适用场景
+
+假设业务系统通过环境变量启动 Claude Code：
+
+```bash
+TRACEPARENT='00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01' \
+TRACESTATE='vendor=value' \
+claude
+```
+
+Claude Code 在执行任务时可能通过 `Bash` 调用用户自己的 CLI。开启本功能后，
+Pilot 会把同一个 Trace 上下文传给该 CLI，并保证下游收到的 parent span ID
+就是 Pilot 最终生成的 Bash TOOL span ID。
+
+最终链路关系如下：
+
+```text
+上游应用 Span
+└── Claude Code ENTRY Span
+    └── Claude Code AGENT / STEP / LLM Span
+        └── Bash TOOL Span
+            └── 用户 CLI Span
+                └── 用户 CLI 的更多下游 Span
+```
+
+其中：
+
+- 上游 `traceparent` 的 trace ID 会贯穿整条链路。
+- Claude Code ENTRY span 的 parent span ID 指向上游应用 span。
+- Pilot 为 Bash TOOL span 预留一个 span ID。
+- 传给用户 CLI 的 `TRACEPARENT` 使用这个 TOOL span ID 作为 parent span ID。
+- 用户 CLI 应提取该上下文并创建自己的子 span。
+
+## 功能概述
+
+本功能以 Claude Code 的 `PreToolUse(Bash)` hook 为注入点。
+
+当 Claude Code 准备执行主 Agent 的 Bash 工具时，Pilot 会：
+
+1. 校验 Claude Code 进程继承的 `TRACEPARENT`。
+2. 为本次 Bash TOOL span 预留一个新的 span ID。
+3. 使用原 trace ID、预留 span ID 和原 trace flags 构造新的
+   `TRACEPARENT`。
+4. 保留有效的 `TRACESTATE`。
+5. 在原 Bash 命令前增加 `export TRACEPARENT=...` 和可选的
+   `export TRACESTATE=...`。
+6. 在处理 Claude Code Stop hook 时，用同一个预留 span ID 生成
+   TOOL span。
+
+例如，上游传给 Claude Code 的上下文是：
+
+```text
+00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
+```
+
+Pilot 为 Bash TOOL span 预留 `d41591ac92dd2cec` 后，下游 CLI 收到：
+
+```text
+00-4bf92f3577b34da6a3ce929d0e0e4736-d41591ac92dd2cec-01
+```
+
+各字段的对应关系：
+
+| 字段 | 上游传给 Claude Code | Pilot 传给下游 CLI |
+|------|----------------------|---------------------|
+| Version | `00` | 保持 `00` |
+| Trace ID | `4bf92f...4736` | 保持不变 |
+| Parent span ID | 上游应用 span ID | Pilot 的 Bash TOOL span ID |
+| Trace flags | `01` | 保持不变 |
+| `TRACESTATE` | 可选 | 有效时保持不变 |
+
+## 前置条件
+
+使用本功能前，需要满足以下条件：
+
+1. 已安装并启动 LoongSuite Pilot。
+2. Pilot 已启用 Claude Code 采集。
+3. Claude Code 的 `PreToolUse(Bash)` 和 `Stop` hook 已由 Pilot 部署。
+4. 上游在启动 Claude Code 时提供有效的 `TRACEPARENT`。
+5. Pilot 已开启上游 Trace 串联和下游工具传播。
+6. 用户 CLI 能读取 W3C Trace Context，并配置自己的 Trace exporter。
+
+可以通过以下命令检查 Pilot：
+
+```bash
+loongsuite-pilot status
+loongsuite-pilot info
+```
+
+## 开启功能
+
+### 推荐：通过配置文件开启
+
+编辑 `~/.loongsuite-pilot/config.json`：
+
+```json
+{
+  "upstreamLink": {
+    "enabled": true,
+    "propagateToTools": true
+  }
+}
+```
+
+修改后重启 Pilot：
+
+```bash
+loongsuite-pilot restart
+```
+
+配置项说明：
+
+| 配置项 | 环境变量 | 默认值 | 说明 |
+|--------|----------|--------|------|
+| `upstreamLink.enabled` | `LOONGSUITE_PILOT_UPSTREAM_LINK` | `false` | 将 Claude Code span 挂载到上游 Trace |
+| `upstreamLink.propagateToTools` | `LOONGSUITE_PILOT_UPSTREAM_LINK_PROPAGATE_TO_TOOLS` | `false` | 将上下文继续传给支持的 CLI 工具 |
+| `upstreamLink.ttlMs` | `LOONGSUITE_PILOT_UPSTREAM_LINK_TTL_MS` | `86400000` | 关联状态文件的清理 TTL |
+
+配置优先级为：环境变量 > `config.json` > 内置默认值。
+
+### 通过环境变量开启
+
+如果使用环境变量配置 Pilot，需要确保 Pilot collector 和 Claude Code
+进程都能读取对应开关。对于长期使用，推荐写入 `config.json`。
+
+```bash
+export LOONGSUITE_PILOT_UPSTREAM_LINK=true
+export LOONGSUITE_PILOT_UPSTREAM_LINK_PROPAGATE_TO_TOOLS=true
+
+loongsuite-pilot restart
+```
+
+## 启动 Claude Code
+
+必须在启动 Claude Code 时设置上下文；在 Claude Code 已经启动后再修改当前
+终端的环境变量不会影响已有进程。
+
+```bash
+TRACEPARENT='00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01' \
+TRACESTATE='vendor=value' \
+claude
+```
+
+`TRACEPARENT` 必须符合以下格式：
+
+```text
+00-<32 位非零 trace ID>-<16 位非零 parent span ID>-<2 位 flags>
+```
+
+`TRACESTATE` 是可选项。Pilot 只传播非空、长度不超过 512 且不包含控制字符
+的值。
+
+## 下游 CLI 如何接收
+
+Pilot 负责把上下文注入下游进程，但不会替用户 CLI 自动创建或上报 span。
+用户 CLI 至少需要完成以下步骤：
+
+1. 读取 `TRACEPARENT` 和可选的 `TRACESTATE`。
+2. 使用 W3C Trace Context propagator 提取父上下文。
+3. 基于该父上下文创建 CLI 自己的 span。
+4. 配置 exporter，将 span 上报到能够与 Pilot Trace 汇聚的后端。
+5. CLI 如需调用更下游的服务，应继续注入当前 span 的上下文。
+
+### Node.js 示例
+
+下面的示例只展示上下文提取和创建子 span。SDK、资源属性和 exporter 应按
+用户 CLI 的实际环境配置。
+
+```js
+import { context, propagation, trace } from '@opentelemetry/api';
+
+const carrier = {
+  traceparent: process.env.TRACEPARENT,
+  tracestate: process.env.TRACESTATE,
+};
+
+const parentContext = propagation.extract(context.active(), carrier);
+const tracer = trace.getTracer('my-cli');
+
+await tracer.startActiveSpan(
+  'my-cli.operation',
+  {},
+  parentContext,
+  async (span) => {
+    try {
+      // 执行 CLI 的实际业务逻辑。
+    } catch (error) {
+      span.recordException(error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  },
+);
+```
+
+注意：环境变量名称是大写的，而 OpenTelemetry carrier 通常使用小写
+`traceparent` 和 `tracestate`，因此示例中显式进行了字段映射。
+
+### 最小接收验证
+
+可以先让下游 CLI 打印它实际收到的上下文：
+
+```bash
+node -e 'console.log(JSON.stringify({
+  traceparent: process.env.TRACEPARENT,
+  tracestate: process.env.TRACESTATE
+}))'
+```
+
+让 Claude Code 通过 Bash 执行该命令。如果功能正常，输出中的 trace ID
+应与启动 Claude Code 时提供的 trace ID 相同，但 parent span ID 应变为一个
+新的值。
+
+打印环境变量只适合测试。生产 CLI 应提取上下文并创建 span，不建议把
+Trace Context 当作业务日志长期输出。
+
+## 安全注意事项
+
+- `TRACEPARENT` 和 `TRACESTATE` 是链路关联数据，不是身份认证凭证。
+- 不要在 `TRACESTATE` 中放入 AccessKey、API Key、Cookie、用户输入或其他
+  敏感数据。
+- 用户 CLI 应校验收到的上下文，并在上下文无效时安全地创建新 Trace 或按
+  自身策略 fail-open。
+- Pilot 会校验 `TRACEPARENT`、过滤含控制字符的 `TRACESTATE`，并对注入值
+  做 shell 单引号转义，但下游 CLI 仍应把环境变量视为外部输入。
+
+## 实现原理
+
+### 1. Hook 注册
+
+Pilot 为 Claude Code 注册以下相关 hook：
+
+- `PreToolUse`，matcher 为 `Bash`。
+- `Stop`。
+
+`PreToolUse` 负责在命令执行前预留上下文并返回
+`hookSpecificOutput.updatedInput`。Pilot 只替换 `tool_input.command`，保留
+`description`、`timeout`、`run_in_background` 等原字段，也不会改变用户
+已有的工具权限策略。
+
+### 2. 每个工具调用独立预留
+
+Pilot 使用 `session_id + tool_use_id` 标识一次 Bash 工具调用，并在
+`~/.loongsuite-pilot/acp-correlate/` 中保存独立的临时预留记录。
+
+记录采用“每个工具调用一个文件”的方式，并通过独占创建保证：
+
+- 并行 Bash 调用不会争用同一个会话状态文件。
+- 重复执行同一个 PreToolUse hook 时会复用相同的预留 span ID。
+- 部分写入、文件缺失或状态损坏时能够 fail-open。
+
+过期的预留文件由现有 upstream-link retention 任务清理。
+
+### 3. 安全修改 Bash 命令
+
+Pilot 返回给 Claude Code 的命令结构类似：
+
+```bash
+export TRACEPARENT='<downstream-traceparent>';
+export TRACESTATE='<tracestate>';
+<原始 Bash 命令>
+```
+
+注入值使用 shell 单引号转义，能够安全处理 `TRACESTATE` 中的普通标点和
+单引号。原始 Bash 命令内容保持不变。
+
+### 4. Stop 阶段复用 TOOL span ID
+
+Stop hook 解析 Claude Code transcript 时，会按 `tool_use_id` 读取并删除预留
+记录，然后为对应的 `tool.call` 和 `tool.result` 写入相同的 `span_id`。
+
+OTLP Trace flusher 在创建真实 TOOL span 前，会再次按 tool call ID 找到该
+预留 ID，并通过一次性的 span ID generator 让 OpenTelemetry SDK 使用这个
+ID。无效、重复冲突或缺失的预留都会回退到 SDK 正常生成的随机 span ID。
+
+### 5. 首轮约束
+
+通过环境变量提供的上游上下文只用于会话首个 turn。首个 Stop hook 完成后，
+Pilot 会写入已消费标记，后续 turn 的 Bash 调用不再传播该上下文。这与
+现有 TraceLinker 的“环境变量上下文只关联首轮”语义保持一致。
+
+## Fail-open 行为
+
+该能力不会阻断 Claude Code 的正常工具执行。出现以下情况时，Pilot 会跳过
+注入并让原 Bash 命令继续执行：
+
+- 功能开关未开启。
+- `TRACEPARENT` 缺失、格式错误或包含全零 ID。
+- 当前工具不是主 Agent 的 `Bash`。
+- 缺少 `session_id` 或 `tool_use_id`。
+- 命令为空或工具输入格式不受支持。
+- 预留状态文件无法创建、读取或校验。
+- 当前会话的环境变量上下文已经消费。
+
+如果预留 ID 无法在 Stop 或 OTLP 转换阶段复用，Pilot 会回退到普通 TOOL
+span ID，不影响其他 Trace 数据采集。
+
+## 当前支持范围
+
+首版支持：
+
+- Claude Code。
+- 主 Agent。
+- 通过环境变量传入的会话首轮上游上下文。
+- Claude Code `Bash` 工具调用。
+- W3C `TRACEPARENT`。
+- 可选的 `TRACESTATE`。
+
+暂不支持：
+
+- Claude Code subagent 的工具调用。
+- PowerShell 工具命令。
+- MCP 工具。
+- 非 Bash 工具。
+- 后续 turn 继续使用首轮环境变量上下文。
+- 恢复已有会话时注入一份新的环境变量上下文。
+- 仅通过 ACP per-turn 关联文件提供、但未出现在 Claude Code 进程环境中的
+  下游上下文。
+
+## 如何验证链路
+
+建议同时验证进程侧和 Trace 后端：
+
+1. 下游 CLI 收到了格式正确的 `TRACEPARENT`。
+2. 下游 `TRACEPARENT` 的 trace ID 与上游一致。
+3. 下游 `TRACEPARENT` 的 parent span ID 等于 Pilot Bash TOOL span ID。
+4. Claude Code ENTRY span 的 parent span ID 等于上游 span ID。
+5. `TRACESTATE` 在需要时保持一致。
+6. 用户 CLI 创建的 span 位于 Bash TOOL span 之下。
+
+只看到环境变量并不代表完整链路已经建立；还需要确认用户 CLI 正确提取
+上下文、创建 span，并成功上报。
+
+## 常见问题
+
+### Claude Code 已串到上游，但下游 CLI 没有收到上下文
+
+检查：
+
+- `upstreamLink.propagateToTools` 是否为 `true`。
+- 修改配置后是否重启了 Pilot。
+- `TRACEPARENT` 是否在启动 Claude Code 时设置。
+- Claude Code 调用的是否是主 Agent 的 `Bash`。
+- 当前是否已经超过会话首个 turn。
+
+### 下游 CLI 收到了 TRACEPARENT，但后端仍显示为两条 Trace
+
+通常是用户 CLI 没有把环境变量作为 W3C carrier 提取，或者创建 span 时没有
+显式使用提取到的 parent context。还应检查 CLI 和 Pilot 是否上报到同一个
+可关联的 Trace 后端。
+
+### TRACESTATE 没有传递
+
+检查该值是否为空、超过 512 字符或包含换行等控制字符。无效
+`TRACESTATE` 会被忽略，但有效的 `TRACEPARENT` 仍可继续传播。
+
+### 后续 turn 不再注入
+
+这是首版的预期行为。环境变量提供的是会话级启动上下文，为避免错误地把
+后续 turn 重挂到首轮上游 span，Pilot 只在首个 turn 中使用和传播它。
+
+### Hook 配置被其他工具覆盖
+
+重新启动 Pilot 并检查状态：
+
+```bash
+loongsuite-pilot restart
+loongsuite-pilot status
+loongsuite-pilot info
+```
+
+Pilot 的 hook watchdog 会持续检查受管 hook，但仍应避免手工删除 Pilot
+注册的 Claude Code hook。

--- a/src/core/config-loader.ts
+++ b/src/core/config-loader.ts
@@ -118,6 +118,7 @@ export interface ConfigFile {
 
   upstreamLink?: {
     enabled?: boolean;
+    propagateToTools?: boolean;
     ttlMs?: number;
   };
 
@@ -261,6 +262,10 @@ function buildUpstreamLinkConfig(file: ConfigFile | null): UpstreamLinkConfig {
   const ttlMs = envInt('LOONGSUITE_PILOT_UPSTREAM_LINK_TTL_MS', file?.upstreamLink?.ttlMs ?? 86_400_000); // 24h
   return {
     enabled: envBool('LOONGSUITE_PILOT_UPSTREAM_LINK', file?.upstreamLink?.enabled ?? false),
+    propagateToTools: envBool(
+      'LOONGSUITE_PILOT_UPSTREAM_LINK_PROPAGATE_TO_TOOLS',
+      file?.upstreamLink?.propagateToTools ?? false,
+    ),
     // Clamp: ttlMs <= 0 would make the retention cutoff Date.now() (or the future),
     // deleting all freshly-written correlation files and silently breaking linking.
     ttlMs: ttlMs > 0 ? ttlMs : 86_400_000,

--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -29,6 +29,11 @@ import { appendLine, ensureDir, getTodayDateString, readInstalledVersion } from 
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
+import {
+  attachReservedToolSpanIds,
+  ReservedToolSpanIdGenerator,
+  type ToolSpanIdReservations,
+} from './tool-span-id-reservation.js';
 
 const logger = createLogger('otlp-trace-flusher');
 
@@ -56,6 +61,7 @@ interface AgentConvertState {
   provider: BasicTracerProvider;
   handler: ExtendedTelemetryHandler;
   inMem: InMemorySpanExporter;
+  toolSpanIds: ToolSpanIdReservations;
   active: number;
 }
 
@@ -453,7 +459,7 @@ export class OtlpTraceFlusher extends BaseFlusher {
     convertKey: string,
   ): Promise<void> {
     const convertState = this.getOrCreateConvertState(agentType, serviceName, projectedResourceAttributes, convertKey);
-    const { handler, provider, inMem } = convertState;
+    const { handler, provider, inMem, toolSpanIds } = convertState;
     convertState.active += 1;
 
     try {
@@ -503,10 +509,16 @@ export class OtlpTraceFlusher extends BaseFlusher {
         // user Ctrl+C, agent errored mid-step). The converter library would
         // otherwise still emit a span for the orphan request/call.
         const sanitized = dropOrphanPairs(recordsForConversion);
-        const result = convertEventLogToTrace(
-          sanitized as unknown as EventLogRecord[],
-          { handler, strict: false, passthroughKeys },
-        );
+        toolSpanIds.prepare(sanitized);
+        let result;
+        try {
+          result = convertEventLogToTrace(
+            sanitized as unknown as EventLogRecord[],
+            { handler, strict: false, passthroughKeys },
+          );
+        } finally {
+          toolSpanIds.clear();
+        }
         if (result.warnings.length > 0) {
           logger.warn(`Conversion warnings for ${agentType}`, { warnings: result.warnings.join('; ') });
         }
@@ -620,13 +632,16 @@ export class OtlpTraceFlusher extends BaseFlusher {
 
     const resource = this.buildResource(agentType, serviceName, projectedResourceAttributes);
     const inMem = new InMemorySpanExporter();
+    const idGenerator = new ReservedToolSpanIdGenerator();
     const provider = new BasicTracerProvider({
       resource,
+      idGenerator,
       spanProcessors: [new SimpleSpanProcessor(inMem)],
     });
     const handler = new ExtendedTelemetryHandler({ tracerProvider: provider });
+    const toolSpanIds = attachReservedToolSpanIds(handler, idGenerator);
 
-    state = { provider, handler, inMem, active: 0 };
+    state = { provider, handler, inMem, toolSpanIds, active: 0 };
     this.agentConvertStates.set(key, state);
     this.evictConvertStates();
     return state;

--- a/src/flushers/tool-span-id-reservation.ts
+++ b/src/flushers/tool-span-id-reservation.ts
@@ -1,0 +1,121 @@
+import type { Context } from '@opentelemetry/api';
+import {
+  RandomIdGenerator,
+  type IdGenerator,
+} from '@opentelemetry/sdk-trace-base';
+import type {
+  ExecuteToolInvocation,
+  ExtendedTelemetryHandler,
+} from '@loongsuite/otel-util-genai';
+import type { AgentActivityEntry } from '../types/index.js';
+
+const VALID_SPAN_ID_RE = /^[0-9a-f]{16}$/;
+const ZERO_SPAN_ID = '0'.repeat(16);
+
+function validSpanId(value: unknown): value is string {
+  return typeof value === 'string'
+    && VALID_SPAN_ID_RE.test(value)
+    && value !== ZERO_SPAN_ID;
+}
+
+/**
+ * OTel's public startSpan API cannot accept a caller-selected span id. This
+ * generator provides one reserved id for the immediately following span and
+ * otherwise delegates to the SDK's cryptographically random generator.
+ */
+export class ReservedToolSpanIdGenerator implements IdGenerator {
+  private readonly fallback = new RandomIdGenerator();
+  private reserved?: string;
+
+  generateTraceId = (): string => this.fallback.generateTraceId();
+
+  generateSpanId = (): string => {
+    const reserved = this.reserved;
+    this.reserved = undefined;
+    return reserved ?? this.fallback.generateSpanId();
+  };
+
+  reserve(spanId: unknown): boolean {
+    if (!validSpanId(spanId)) return false;
+    this.reserved = spanId;
+    return true;
+  }
+
+  clear(): void {
+    this.reserved = undefined;
+  }
+}
+
+/**
+ * Maps converter tool invocations back to their canonical event span_id.
+ * Duplicate/conflicting ids fail open instead of selecting an ambiguous id.
+ */
+export class ToolSpanIdReservations {
+  private readonly byToolCallId = new Map<string, string>();
+
+  prepare(records: AgentActivityEntry[]): void {
+    this.byToolCallId.clear();
+    const conflicts = new Set<string>();
+
+    for (const record of records) {
+      const eventName = record['event.name'];
+      if (eventName !== 'tool.call' && eventName !== 'tool.result') continue;
+
+      const toolCallId = record['gen_ai.tool.call.id'];
+      const spanId = record.span_id;
+      if (typeof toolCallId !== 'string' || !toolCallId || !validSpanId(spanId)) continue;
+
+      const existing = this.byToolCallId.get(toolCallId);
+      if (existing && existing !== spanId) {
+        conflicts.add(toolCallId);
+        this.byToolCallId.delete(toolCallId);
+      } else if (!conflicts.has(toolCallId)) {
+        this.byToolCallId.set(toolCallId, spanId);
+      }
+    }
+  }
+
+  take(toolCallId: string | null | undefined): string | undefined {
+    if (!toolCallId) return undefined;
+    const spanId = this.byToolCallId.get(toolCallId);
+    this.byToolCallId.delete(toolCallId);
+    return spanId;
+  }
+
+  clear(): void {
+    this.byToolCallId.clear();
+  }
+}
+
+/**
+ * Decorate the converter handler so the generator reservation is active only
+ * for the synchronous startExecuteTool -> startSpan call.
+ */
+export function attachReservedToolSpanIds(
+  handler: ExtendedTelemetryHandler,
+  idGenerator: ReservedToolSpanIdGenerator,
+): ToolSpanIdReservations {
+  const reservations = new ToolSpanIdReservations();
+  const original = handler.startExecuteTool;
+
+  // Unit tests mock the third-party handler with a minimal object.
+  if (typeof original !== 'function') return reservations;
+
+  handler.startExecuteTool = function startExecuteToolWithReservedId(
+    invocation: ExecuteToolInvocation,
+    parentContext?: Context,
+    startTime?: number,
+  ): ExecuteToolInvocation {
+    const spanId = reservations.take(invocation.toolCallId);
+    if (spanId) idGenerator.reserve(spanId);
+    try {
+      return original.call(handler, invocation, parentContext, startTime);
+    } finally {
+      // Prevent a converter/SDK exception from leaking the reservation to the
+      // next unrelated span.
+      idGenerator.clear();
+    }
+  };
+
+  return reservations;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -132,6 +132,8 @@ export interface AnalyticsConfig {
  */
 export interface UpstreamLinkConfig {
   enabled: boolean;
+  /** Propagate the linked context into supported downstream CLI tool calls. */
+  propagateToTools: boolean;
   /** TTL (ms) after which acp-correlate files/locks are cleaned up. */
   ttlMs: number;
 }

--- a/tests/fixtures/trace-context-demo-cli.mjs
+++ b/tests/fixtures/trace-context-demo-cli.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// Copyright 2026 Alibaba Group Holding Limited
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Minimal downstream CLI used by trace-context propagation tests.
+ *
+ * It behaves like a user-owned CLI: read W3C context from the environment,
+ * validate TRACEPARENT, and persist what the process actually received.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const TRACEPARENT_RE = /^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/i;
+const ZERO_TRACE_ID = '0'.repeat(32);
+const ZERO_SPAN_ID = '0'.repeat(16);
+
+function option(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+const outputPath = option('--output');
+const allowMissing = process.argv.includes('--allow-missing');
+const requestedExitCode = Number.parseInt(option('--exit-code') ?? '0', 10);
+const traceparent = process.env.TRACEPARENT ?? null;
+const tracestate = process.env.TRACESTATE ?? null;
+const match = typeof traceparent === 'string' ? TRACEPARENT_RE.exec(traceparent.trim()) : null;
+const valid = Boolean(
+  match
+  && match[1].toLowerCase() !== ZERO_TRACE_ID
+  && match[2].toLowerCase() !== ZERO_SPAN_ID,
+);
+
+const result = {
+  traceparent,
+  tracestate,
+  valid,
+  traceId: valid ? match[1].toLowerCase() : null,
+  parentSpanId: valid ? match[2].toLowerCase() : null,
+  traceFlags: valid ? match[3].toLowerCase() : null,
+  argv: process.argv.slice(2),
+};
+
+if (outputPath) {
+  fs.mkdirSync(path.dirname(path.resolve(outputPath)), { recursive: true });
+  fs.writeFileSync(outputPath, `${JSON.stringify(result)}\n`, 'utf-8');
+}
+
+process.stdout.write(`${JSON.stringify(result)}\n`);
+
+if (!valid && !allowMissing) {
+  process.exitCode = 2;
+} else if (Number.isInteger(requestedExitCode) && requestedExitCode >= 0) {
+  process.exitCode = requestedExitCode;
+}

--- a/tests/helpers/claude-code-hook-simulator.mjs
+++ b/tests/helpers/claude-code-hook-simulator.mjs
@@ -1,0 +1,84 @@
+// Copyright 2026 Alibaba Group Holding Limited
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * A small Claude Code hook protocol simulator.
+ *
+ * It invokes the real Pilot hook wrapper with a Claude-shaped JSON payload,
+ * applies hookSpecificOutput.updatedInput like Claude Code would, and executes
+ * the resulting Bash command in a fresh process.
+ */
+
+import { spawnSync } from 'node:child_process';
+
+function parseHookResponse(stdout) {
+  const lines = stdout.split('\n').map((line) => line.trim()).filter(Boolean);
+  if (lines.length !== 1) {
+    throw new Error(`expected one hook response line, received ${lines.length}: ${stdout}`);
+  }
+  return JSON.parse(lines[0]);
+}
+
+export function invokeClaudeHook({
+  hookPath,
+  subcommand,
+  payload,
+  env = {},
+  timeout = 15_000,
+}) {
+  const result = spawnSync('bash', [hookPath, subcommand], {
+    input: JSON.stringify(payload),
+    env: { ...process.env, ...env },
+    encoding: 'utf-8',
+    timeout,
+  });
+
+  return {
+    ...result,
+    response: parseHookResponse(result.stdout),
+  };
+}
+
+export function simulateClaudeBashTool({
+  hookPath,
+  payload,
+  hookEnv = {},
+  executionEnv = {},
+  timeout = 15_000,
+  isolateInheritedTraceContext = true,
+}) {
+  const hook = invokeClaudeHook({
+    hookPath,
+    subcommand: 'pre-tool-use',
+    payload,
+    env: hookEnv,
+    timeout,
+  });
+  const updatedInput = hook.response?.hookSpecificOutput?.updatedInput;
+  const effectiveInput = updatedInput ?? payload.tool_input;
+
+  if (!effectiveInput || typeof effectiveInput.command !== 'string') {
+    throw new Error('PreToolUse simulation did not produce an executable Bash command');
+  }
+
+  const childEnv = { ...process.env, ...executionEnv };
+  if (isolateInheritedTraceContext) {
+    delete childEnv.TRACEPARENT;
+    delete childEnv.TRACESTATE;
+  }
+
+  const tool = spawnSync('bash', ['-c', effectiveInput.command], {
+    cwd: payload.cwd,
+    env: childEnv,
+    encoding: 'utf-8',
+    timeout,
+  });
+
+  return {
+    hook,
+    tool,
+    originalInput: payload.tool_input,
+    effectiveInput,
+    wasUpdated: Boolean(updatedInput),
+  };
+}

--- a/tests/integration/claude-code-tool-context-flow.test.mjs
+++ b/tests/integration/claude-code-tool-context-flow.test.mjs
@@ -1,0 +1,297 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { CorrelationStore } from '../../src/core/upstream-link/correlation-store.ts';
+import { TraceLinker } from '../../src/core/upstream-link/trace-linker.ts';
+import { OtlpTraceFlusher } from '../../src/flushers/otlp-trace-flusher.ts';
+import {
+  invokeClaudeHook,
+  simulateClaudeBashTool,
+} from '../helpers/claude-code-hook-simulator.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const HOOK = path.resolve(
+  __dirname,
+  '../../assets/hooks/claude-code-loongsuite-pilot-hook.sh',
+);
+const DEMO_CLI = path.resolve(__dirname, '../fixtures/trace-context-demo-cli.mjs');
+
+function shellSingleQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+function readClaudeRecords(dataDir) {
+  const logDir = path.join(dataDir, 'logs', 'claude-code');
+  if (!fs.existsSync(logDir)) return [];
+  return fs.readdirSync(logDir)
+    .filter((name) => name.endsWith('.jsonl'))
+    .flatMap((name) => fs.readFileSync(path.join(logDir, name), 'utf-8')
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line)));
+}
+
+describe('Claude Code PreToolUse(Bash) downstream propagation flow', () => {
+  let dataDir;
+
+  beforeEach(() => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-hook-simulator-'));
+    fs.writeFileSync(
+      path.join(dataDir, 'config.json'),
+      JSON.stringify({
+        upstreamLink: {
+          enabled: true,
+          propagateToTools: true,
+        },
+      }),
+      'utf-8',
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  test('real wrapper injects context into a real downstream CLI and reuses its parent id for TOOL', async () => {
+    const sessionId = 'simulated-claude-session';
+    const toolUseId = 'toolu_demo_cli';
+    const upstreamTraceId = '4bf92f3577b34da6a3ce929d0e0e4736';
+    const upstreamSpanId = '00f067aa0ba902b7';
+    const traceparent = `00-${upstreamTraceId}-${upstreamSpanId}-01`;
+    const tracestate = "vendor=value,tenant=O'Reilly";
+    const receiverOutput = path.join(dataDir, 'demo output', 'received-context.json');
+    const originalCommand = [
+      shellSingleQuote(process.execPath),
+      shellSingleQuote(DEMO_CLI),
+      '--output',
+      shellSingleQuote(receiverOutput),
+    ].join(' ');
+    const payload = {
+      session_id: sessionId,
+      prompt_id: 'prompt-1',
+      cwd: dataDir,
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_use_id: toolUseId,
+      tool_input: {
+        command: originalCommand,
+        description: 'run downstream trace receiver',
+        timeout: 5000,
+        run_in_background: false,
+      },
+    };
+
+    const simulation = simulateClaudeBashTool({
+      hookPath: HOOK,
+      payload,
+      hookEnv: {
+        LOONGSUITE_PILOT_DATA_DIR: dataDir,
+        TRACEPARENT: traceparent,
+        TRACESTATE: tracestate,
+      },
+      // A wrong inherited value would make this test pass accidentally if the
+      // simulator did not remove it before executing the updated command.
+      executionEnv: {
+        TRACEPARENT: 'not-the-injected-context',
+        TRACESTATE: 'not-the-injected-state',
+      },
+    });
+
+    expect(simulation.hook.status).toBe(0);
+    expect(simulation.hook.stderr).toBe('');
+    expect(simulation.wasUpdated).toBe(true);
+    expect(simulation.effectiveInput).toMatchObject({
+      description: payload.tool_input.description,
+      timeout: 5000,
+      run_in_background: false,
+    });
+    expect(simulation.tool.status).toBe(0);
+    expect(simulation.tool.stderr).toBe('');
+
+    const received = JSON.parse(fs.readFileSync(receiverOutput, 'utf-8'));
+    expect(received).toMatchObject({
+      valid: true,
+      traceId: upstreamTraceId,
+      traceFlags: '01',
+      tracestate,
+    });
+    expect(received.parentSpanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(received.parentSpanId).not.toBe(upstreamSpanId);
+
+    const transcriptPath = path.join(dataDir, 'transcript.jsonl');
+    const transcript = [
+      {
+        type: 'user',
+        timestamp: '2026-07-31T02:00:00.000Z',
+        promptId: 'prompt-1',
+        message: { content: [{ type: 'text', text: 'run the downstream demo cli' }] },
+      },
+      {
+        type: 'assistant',
+        timestamp: '2026-07-31T02:00:01.000Z',
+        message: {
+          id: 'msg_demo_1',
+          content: [{
+            type: 'tool_use',
+            id: toolUseId,
+            name: 'Bash',
+            input: payload.tool_input,
+          }],
+          usage: { input_tokens: 10, output_tokens: 5 },
+          stop_reason: 'tool_use',
+        },
+      },
+      {
+        type: 'user',
+        timestamp: '2026-07-31T02:00:01.100Z',
+        promptId: 'prompt-1',
+        message: {
+          content: [{
+            type: 'tool_result',
+            tool_use_id: toolUseId,
+            content: simulation.tool.stdout.trim(),
+          }],
+        },
+      },
+      {
+        type: 'assistant',
+        timestamp: '2026-07-31T02:00:02.000Z',
+        message: {
+          id: 'msg_demo_2',
+          content: [{ type: 'text', text: 'done' }],
+          usage: { input_tokens: 12, output_tokens: 2 },
+          stop_reason: 'end_turn',
+        },
+      },
+    ];
+    fs.writeFileSync(
+      transcriptPath,
+      `${transcript.map((record) => JSON.stringify(record)).join('\n')}\n`,
+      'utf-8',
+    );
+
+    const stop = invokeClaudeHook({
+      hookPath: HOOK,
+      subcommand: 'stop',
+      payload: {
+        session_id: sessionId,
+        prompt_id: 'prompt-1',
+        stop_reason: 'end_turn',
+        transcript_path: transcriptPath,
+      },
+      env: {
+        LOONGSUITE_PILOT_DATA_DIR: dataDir,
+        TRACEPARENT: traceparent,
+        TRACESTATE: tracestate,
+      },
+    });
+    expect(stop.status).toBe(0);
+    expect(stop.response).toEqual({});
+
+    const records = readClaudeRecords(dataDir);
+    const toolCall = records.find((record) =>
+      record['event.name'] === 'tool.call'
+      && record['gen_ai.tool.call.id'] === toolUseId);
+    const toolResult = records.find((record) =>
+      record['event.name'] === 'tool.result'
+      && record['gen_ai.tool.call.id'] === toolUseId);
+    expect(toolCall?.span_id).toBe(received.parentSpanId);
+    expect(toolResult?.span_id).toBe(received.parentSpanId);
+
+    // InputManager performs this step between reading hook JSONL and flushing.
+    // Keep the simulator aligned with that production pipeline boundary.
+    const linker = new TraceLinker(
+      new CorrelationStore(path.join(dataDir, 'acp-correlate')),
+      { retries: 0 },
+    );
+    await linker.stamp(records);
+    expect(records.map((record) => ({
+      event: record['event.name'],
+      turn: record['gen_ai.turn.id'],
+      traceId: record.trace_id,
+      parentSpanId: record.parent_span_id,
+    }))).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        event: 'tool.call',
+        traceId: upstreamTraceId,
+      }),
+    ]));
+
+    const exportedSpans = [];
+    const flusher = new OtlpTraceFlusher({
+      enabled: true,
+      endpoints: [{ name: 'test', endpoint: 'http://localhost:4318' }],
+      protocol: 'http/protobuf',
+      serviceName: 'test-pilot',
+      dataDir,
+    }, undefined, () => ({
+      export: (spans, callback) => {
+        exportedSpans.push(...spans);
+        callback({ code: 0 });
+      },
+      shutdown: async () => {},
+    }));
+    try {
+      await flusher.sendBatch(records);
+      await flusher.flush();
+    } finally {
+      await flusher.shutdown();
+    }
+
+    const toolSpan = exportedSpans.find((span) =>
+      span.name === 'execute_tool Bash'
+      && span.attributes['gen_ai.tool.call.id'] === toolUseId);
+    expect(toolSpan).toBeDefined();
+    expect(toolSpan.spanContext().traceId).toBe(upstreamTraceId);
+    expect(toolSpan.spanContext().spanId).toBe(received.parentSpanId);
+  });
+
+  test('disabled propagation leaves the downstream process without hidden inherited context', () => {
+    fs.writeFileSync(
+      path.join(dataDir, 'config.json'),
+      JSON.stringify({
+        upstreamLink: {
+          enabled: true,
+          propagateToTools: false,
+        },
+      }),
+      'utf-8',
+    );
+    const receiverOutput = path.join(dataDir, 'disabled-context.json');
+    const command = [
+      shellSingleQuote(process.execPath),
+      shellSingleQuote(DEMO_CLI),
+      '--allow-missing',
+      '--output',
+      shellSingleQuote(receiverOutput),
+    ].join(' ');
+
+    const simulation = simulateClaudeBashTool({
+      hookPath: HOOK,
+      payload: {
+        session_id: 'disabled-session',
+        cwd: dataDir,
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_use_id: 'toolu_disabled',
+        tool_input: { command },
+      },
+      hookEnv: {
+        LOONGSUITE_PILOT_DATA_DIR: dataDir,
+        TRACEPARENT: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+      },
+    });
+
+    expect(simulation.hook.status).toBe(0);
+    expect(simulation.hook.response).toEqual({});
+    expect(simulation.wasUpdated).toBe(false);
+    expect(simulation.tool.status).toBe(0);
+    expect(JSON.parse(fs.readFileSync(receiverOutput, 'utf-8'))).toMatchObject({
+      traceparent: null,
+      tracestate: null,
+      valid: false,
+    });
+  });
+});

--- a/tests/unit/core/config-loader.test.ts
+++ b/tests/unit/core/config-loader.test.ts
@@ -1125,6 +1125,7 @@ describe('ConfigLoader', () => {
       mockReadJsonFile.mockResolvedValueOnce(null);
       const config = await loadConfig();
       expect(config.upstreamLink.enabled).toBe(false);
+      expect(config.upstreamLink.propagateToTools).toBe(false);
       expect(config.upstreamLink.ttlMs).toBe(86_400_000);
     });
 
@@ -1134,6 +1135,19 @@ describe('ConfigLoader', () => {
       const config = await loadConfig();
       expect(config.upstreamLink.enabled).toBe(true);
       expect(config.upstreamLink.ttlMs).toBe(3_600_000);
+    });
+
+    it('enables downstream tool propagation from config or env', async () => {
+      mockReadJsonFile.mockResolvedValueOnce({
+        upstreamLink: { enabled: true, propagateToTools: true },
+      });
+      let config = await loadConfig();
+      expect(config.upstreamLink.propagateToTools).toBe(true);
+
+      mockReadJsonFile.mockResolvedValueOnce({ upstreamLink: { enabled: true } });
+      vi.stubEnv('LOONGSUITE_PILOT_UPSTREAM_LINK_PROPAGATE_TO_TOOLS', '1');
+      config = await loadConfig();
+      expect(config.upstreamLink.propagateToTools).toBe(true);
     });
 
     it('treats an empty-string enable env as unset (not "true")', async () => {

--- a/tests/unit/hooks/claude-code/hook-processor.test.mjs
+++ b/tests/unit/hooks/claude-code/hook-processor.test.mjs
@@ -287,6 +287,21 @@ describe('claude-code-hook-processor v2 端到端', () => {
     }, { TRACEPARENT: traceparent }).stdout.trim()).toBe('{}');
   });
 
+  test('PreToolUse 跳过后台 Bash（run_in_background）以避免下游悬挂父 span', () => {
+    enableToolPropagation();
+    const traceparent = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01';
+    // 后台 Bash 的 tool.call 在本轮 Stop 记录中没有配对的 tool.result，
+    // 会被 dropOrphanPairs 丢弃、预留的 parent span 永不 emit，因此不得注入。
+    const out = runHook('pre-tool-use', {
+      session_id: 's-bg',
+      tool_name: 'Bash',
+      tool_use_id: 'tu-bg',
+      tool_input: { command: 'my-cli --serve', run_in_background: true },
+    }, { TRACEPARENT: traceparent });
+    expect(out.status).toBe(0);
+    expect(out.stdout.trim()).toBe('{}');
+  });
+
   test('AgentTeams 环境变量会进入 hook record resourceAttributes', () => {
     const transcriptPath = writeTranscript('sat1', [
       { type: 'user', timestamp: '2026-06-04T02:57:32.000Z', message: { content: [{ type: 'text', text: 'hello' }] } },

--- a/tests/unit/hooks/claude-code/hook-processor.test.mjs
+++ b/tests/unit/hooks/claude-code/hook-processor.test.mjs
@@ -182,7 +182,111 @@ function parentTranscriptWithBackgroundAgents(sessionId, agents) {
   ]);
 }
 
+function enableToolPropagation() {
+  fs.writeFileSync(
+    path.join(DATA_DIR, 'config.json'),
+    JSON.stringify({
+      upstreamLink: {
+        enabled: true,
+        propagateToTools: true,
+      },
+    }),
+  );
+}
+
 describe('claude-code-hook-processor v2 端到端', () => {
+  test('PreToolUse 注入 per-tool traceparent，Stop 复用其 span id', () => {
+    enableToolPropagation();
+    const upstreamTraceId = '4bf92f3577b34da6a3ce929d0e0e4736';
+    const upstreamSpanId = '00f067aa0ba902b7';
+    const traceparent = `00-${upstreamTraceId}-${upstreamSpanId}-01`;
+
+    const pre = runHook('pre-tool-use', {
+      session_id: 's-propagate',
+      prompt_id: 'prompt-1',
+      tool_name: 'Bash',
+      tool_use_id: 'tu-propagate',
+      tool_input: {
+        command: 'my-cli --work',
+        description: 'run user cli',
+        timeout: 5000,
+        run_in_background: false,
+      },
+    }, {
+      TRACEPARENT: traceparent,
+      TRACESTATE: 'vendor=value',
+    });
+
+    expect(pre.status).toBe(0);
+    const lines = pre.stdout.trim().split('\n');
+    expect(lines).toHaveLength(1);
+    const hookOutput = JSON.parse(lines[0]);
+    expect(hookOutput.hookSpecificOutput.permissionDecision).toBeUndefined();
+    const updated = hookOutput.hookSpecificOutput.updatedInput;
+    expect(updated.description).toBe('run user cli');
+    expect(updated.timeout).toBe(5000);
+    expect(updated.run_in_background).toBe(false);
+    const injected = /TRACEPARENT='00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})'/.exec(updated.command);
+    expect(injected).not.toBeNull();
+    expect(injected[1]).toBe(upstreamTraceId);
+    expect(injected[3]).toBe('01');
+    const reservedToolSpanId = injected[2];
+
+    const transcriptPath = writeTranscript('s-propagate', [
+      { type: 'user', timestamp: '2026-06-04T02:57:32.000Z', message: { content: [{ type: 'text', text: 'run my cli' }] } },
+      { type: 'assistant', timestamp: '2026-06-04T02:57:49.000Z', message: { id: 'msg_1', content: [{ type: 'tool_use', id: 'tu-propagate', name: 'Bash', input: { command: 'my-cli --work' } }], usage: { input_tokens: 100, output_tokens: 50 }, stop_reason: 'tool_use' } },
+      { type: 'user', timestamp: '2026-06-04T02:57:49.200Z', message: { content: [{ type: 'tool_result', tool_use_id: 'tu-propagate', content: 'done' }] } },
+      { type: 'assistant', timestamp: '2026-06-04T02:57:52.000Z', message: { id: 'msg_2', content: [{ type: 'text', text: 'complete' }], usage: { input_tokens: 200, output_tokens: 20 }, stop_reason: 'end_turn' } },
+    ]);
+    const stop = runHook('stop', {
+      session_id: 's-propagate',
+      prompt_id: 'prompt-1',
+      stop_reason: 'end_turn',
+      transcript_path: transcriptPath,
+    }, {
+      TRACEPARENT: traceparent,
+      TRACESTATE: 'vendor=value',
+    });
+    expect(stop.status).toBe(0);
+
+    const records = readJsonlRecords();
+    const toolCall = records.find((r) =>
+      r['event.name'] === 'tool.call' && r['gen_ai.tool.call.id'] === 'tu-propagate');
+    const toolResult = records.find((r) =>
+      r['event.name'] === 'tool.result' && r['gen_ai.tool.call.id'] === 'tu-propagate');
+    expect(toolCall.span_id).toBe(reservedToolSpanId);
+    expect(toolResult.span_id).toBe(reservedToolSpanId);
+
+    const later = runHook('pre-tool-use', {
+      session_id: 's-propagate',
+      prompt_id: 'prompt-2',
+      tool_name: 'Bash',
+      tool_use_id: 'tu-later',
+      tool_input: { command: 'my-cli --again' },
+    }, { TRACEPARENT: traceparent });
+    expect(later.stdout.trim()).toBe('{}');
+  });
+
+  test('PreToolUse 默认关闭，并跳过子 Agent Bash', () => {
+    const traceparent = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01';
+    const payload = {
+      session_id: 's-disabled',
+      tool_name: 'Bash',
+      tool_use_id: 'tu-disabled',
+      tool_input: { command: 'my-cli' },
+    };
+    expect(runHook('pre-tool-use', payload, { TRACEPARENT: traceparent }).stdout.trim()).toBe('{}');
+
+    enableToolPropagation();
+    expect(runHook('pre-tool-use', {
+      ...payload,
+      session_id: 's-subagent',
+      tool_use_id: 'tu-subagent',
+      agent_id: 'agent-child',
+      agent_type: 'Explore',
+    }, { TRACEPARENT: traceparent }).stdout.trim()).toBe('{}');
+  });
+
   test('AgentTeams 环境变量会进入 hook record resourceAttributes', () => {
     const transcriptPath = writeTranscript('sat1', [
       { type: 'user', timestamp: '2026-06-04T02:57:32.000Z', message: { content: [{ type: 'text', text: 'hello' }] } },

--- a/tests/unit/hooks/claude-code/hook-processor.test.mjs
+++ b/tests/unit/hooks/claude-code/hook-processor.test.mjs
@@ -287,19 +287,52 @@ describe('claude-code-hook-processor v2 端到端', () => {
     }, { TRACEPARENT: traceparent }).stdout.trim()).toBe('{}');
   });
 
-  test('PreToolUse 跳过后台 Bash（run_in_background）以避免下游悬挂父 span', () => {
+  test('PreToolUse 为后台 Bash 注入上下文，并复用即时 tool_result 的 TOOL span id', () => {
     enableToolPropagation();
     const traceparent = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01';
-    // 后台 Bash 的 tool.call 在本轮 Stop 记录中没有配对的 tool.result，
-    // 会被 dropOrphanPairs 丢弃、预留的 parent span 永不 emit，因此不得注入。
-    const out = runHook('pre-tool-use', {
+    const pre = runHook('pre-tool-use', {
       session_id: 's-bg',
       tool_name: 'Bash',
       tool_use_id: 'tu-bg',
       tool_input: { command: 'my-cli --serve', run_in_background: true },
     }, { TRACEPARENT: traceparent });
-    expect(out.status).toBe(0);
-    expect(out.stdout.trim()).toBe('{}');
+    expect(pre.status).toBe(0);
+
+    const hookOutput = JSON.parse(pre.stdout.trim());
+    const updated = hookOutput.hookSpecificOutput.updatedInput;
+    expect(updated.run_in_background).toBe(true);
+    const injected = /TRACEPARENT='00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})'/.exec(
+      updated.command,
+    );
+    expect(injected).not.toBeNull();
+    const reservedToolSpanId = injected[2];
+
+    // Claude Code returns a tool_result as soon as the background process is
+    // launched. The result contains the task id while the process keeps running.
+    const transcriptPath = writeTranscript('s-bg', [
+      { type: 'user', timestamp: '2026-06-04T02:57:32.000Z', message: { content: [{ type: 'text', text: 'start my cli in background' }] } },
+      { type: 'assistant', timestamp: '2026-06-04T02:57:49.000Z', message: { id: 'msg-bg-1', content: [{ type: 'tool_use', id: 'tu-bg', name: 'Bash', input: { command: 'my-cli --serve', run_in_background: true } }], usage: { input_tokens: 100, output_tokens: 50 }, stop_reason: 'tool_use' } },
+      { type: 'user', timestamp: '2026-06-04T02:57:49.200Z', toolUseResult: { backgroundTaskId: 'bg-task-1' }, message: { content: [{ type: 'tool_result', tool_use_id: 'tu-bg', content: 'Command running in background with ID: bg-task-1' }] } },
+      { type: 'assistant', timestamp: '2026-06-04T02:57:52.000Z', message: { id: 'msg-bg-2', content: [{ type: 'text', text: 'background task started' }], usage: { input_tokens: 200, output_tokens: 20 }, stop_reason: 'end_turn' } },
+    ]);
+    const stop = runHook('stop', {
+      session_id: 's-bg',
+      stop_reason: 'end_turn',
+      transcript_path: transcriptPath,
+    }, { TRACEPARENT: traceparent });
+    expect(stop.status).toBe(0);
+
+    const records = readJsonlRecords();
+    const toolCall = records.find((r) =>
+      r['event.name'] === 'tool.call' && r['gen_ai.tool.call.id'] === 'tu-bg');
+    const toolResult = records.find((r) =>
+      r['event.name'] === 'tool.result' && r['gen_ai.tool.call.id'] === 'tu-bg');
+    expect(toolCall).toBeDefined();
+    expect(toolResult).toBeDefined();
+    expect(toolCall.span_id).toBe(reservedToolSpanId);
+    expect(toolResult.span_id).toBe(reservedToolSpanId);
+    expect(toolCall['gen_ai.tool.call.arguments']).toMatchObject({ run_in_background: true });
+    expect(toolResult['gen_ai.tool.call.result']).toContain('bg-task-1');
   });
 
   test('AgentTeams 环境变量会进入 hook record resourceAttributes', () => {

--- a/tests/unit/hooks/claude-code/tool-context.test.mjs
+++ b/tests/unit/hooks/claude-code/tool-context.test.mjs
@@ -90,6 +90,23 @@ describe('claude-code per-tool context', () => {
     })).toBeNull();
   });
 
+  it('refreshes the consumed marker mtime on later turns so active sessions survive TTL cleanup', () => {
+    markToolPropagationConsumed(dataDir, 'sid-ttl');
+    const markerPath = path.join(dataDir, 'acp-correlate', 'sid-ttl.tool-propagation.done');
+    expect(fs.existsSync(markerPath)).toBe(true);
+
+    // Age the marker past the mtime-based retention TTL window.
+    const stale = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    fs.utimesSync(markerPath, stale, stale);
+    const staleMtime = fs.statSync(markerPath).mtimeMs;
+
+    // A later Stop must bump the mtime forward (wx write -> EEXIST -> utimes),
+    // so an active long session is not reaped and first-turn-only is preserved.
+    markToolPropagationConsumed(dataDir, 'sid-ttl');
+    expect(fs.statSync(markerPath).mtimeMs).toBeGreaterThan(staleMtime);
+    expect(isToolPropagationConsumed(dataDir, 'sid-ttl')).toBe(true);
+  });
+
   it('fails open for invalid traceparent and malformed input', () => {
     expect(reserveToolContext({
       dataDir,

--- a/tests/unit/hooks/claude-code/tool-context.test.mjs
+++ b/tests/unit/hooks/claude-code/tool-context.test.mjs
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  buildBashUpdatedInput,
+  consumeToolContext,
+  isToolPropagationConsumed,
+  markToolPropagationConsumed,
+  reserveToolContext,
+} from '../../../../assets/hooks/claude-code/tool-context.mjs';
+
+const TRACE_ID = '4bf92f3577b34da6a3ce929d0e0e4736';
+const UPSTREAM_SPAN_ID = '00f067aa0ba902b7';
+const TRACEPARENT = `00-${TRACE_ID}-${UPSTREAM_SPAN_ID}-00`;
+
+describe('claude-code per-tool context', () => {
+  let dataDir;
+
+  beforeEach(() => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-tool-context-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it('reserves idempotently and preserves trace flags', () => {
+    const first = reserveToolContext({
+      dataDir,
+      sessionId: 'sid-1',
+      toolUseId: 'tool-1',
+      traceparent: TRACEPARENT,
+      tracestate: 'vendor=value',
+    });
+    const second = reserveToolContext({
+      dataDir,
+      sessionId: 'sid-1',
+      toolUseId: 'tool-1',
+      traceparent: TRACEPARENT,
+      tracestate: 'vendor=value',
+    });
+
+    expect(first.spanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(first.traceparent).toBe(`00-${TRACE_ID}-${first.spanId}-00`);
+    expect(first.tracestate).toBe('vendor=value');
+    expect(second.spanId).toBe(first.spanId);
+  });
+
+  it('returns a full Bash input replacement without changing other fields', () => {
+    const context = reserveToolContext({
+      dataDir,
+      sessionId: 'sid-2',
+      toolUseId: 'tool-2',
+      traceparent: TRACEPARENT,
+      tracestate: "vendor=value'quoted",
+    });
+    const updated = buildBashUpdatedInput({
+      command: 'printf hello | sed s/h/H/',
+      description: 'pipeline',
+      timeout: 1234,
+      run_in_background: true,
+    }, context);
+
+    expect(updated.description).toBe('pipeline');
+    expect(updated.timeout).toBe(1234);
+    expect(updated.run_in_background).toBe(true);
+    expect(updated.command).toContain(`export TRACEPARENT='${context.traceparent}'`);
+    expect(updated.command).toContain("export TRACESTATE='vendor=value'\\''quoted'");
+    expect(updated.command.endsWith('printf hello | sed s/h/H/')).toBe(true);
+  });
+
+  it('consumes the context once and rejects later turns after Stop', () => {
+    const context = reserveToolContext({
+      dataDir,
+      sessionId: 'sid-3',
+      toolUseId: 'tool-3',
+      traceparent: TRACEPARENT,
+    });
+    expect(consumeToolContext(dataDir, 'sid-3', 'tool-3').spanId).toBe(context.spanId);
+    expect(consumeToolContext(dataDir, 'sid-3', 'tool-3')).toBeNull();
+
+    markToolPropagationConsumed(dataDir, 'sid-3');
+    expect(isToolPropagationConsumed(dataDir, 'sid-3')).toBe(true);
+    expect(reserveToolContext({
+      dataDir,
+      sessionId: 'sid-3',
+      toolUseId: 'tool-next-turn',
+      traceparent: TRACEPARENT,
+    })).toBeNull();
+  });
+
+  it('fails open for invalid traceparent and malformed input', () => {
+    expect(reserveToolContext({
+      dataDir,
+      sessionId: 'sid-4',
+      toolUseId: 'tool-4',
+      traceparent: 'invalid',
+    })).toBeNull();
+    expect(buildBashUpdatedInput({ command: '' }, { traceparent: TRACEPARENT })).toBeNull();
+  });
+});

--- a/tests/unit/upstream-link/acp-correlate-retention-service.test.ts
+++ b/tests/unit/upstream-link/acp-correlate-retention-service.test.ts
@@ -30,7 +30,11 @@ describe('AcpCorrelateRetentionService', () => {
     const staleLock = writeFile('old.env.lock', 48 * 3600_000);
     const fresh = writeFile('new.jsonl', 60_000); // 1min
 
-    const svc = new AcpCorrelateRetentionService(dataDir, { enabled: true, ttlMs: 24 * 3600_000 });
+    const svc = new AcpCorrelateRetentionService(dataDir, {
+      enabled: true,
+      propagateToTools: false,
+      ttlMs: 24 * 3600_000,
+    });
     const result = await svc.runCleanup();
 
     expect(result.deleted).toBe(2);
@@ -41,7 +45,11 @@ describe('AcpCorrelateRetentionService', () => {
 
   it('no-ops when the directory is absent', async () => {
     fs.rmSync(dir, { recursive: true, force: true });
-    const svc = new AcpCorrelateRetentionService(dataDir, { enabled: true, ttlMs: 1000 });
+    const svc = new AcpCorrelateRetentionService(dataDir, {
+      enabled: true,
+      propagateToTools: false,
+      ttlMs: 1000,
+    });
     const result = await svc.runCleanup();
     expect(result).toEqual({ deleted: 0, errors: 0 });
   });

--- a/tests/unit/upstream-link/e2e-reparent.test.ts
+++ b/tests/unit/upstream-link/e2e-reparent.test.ts
@@ -13,12 +13,17 @@ import { CorrelationStore } from '../../../src/core/upstream-link/correlation-st
 import { TraceLinker } from '../../../src/core/upstream-link/trace-linker.js';
 import { contentHash } from '../../../src/utils/content-hash.js';
 import type { AgentActivityEntry } from '../../../src/types/index.js';
+import {
+  attachReservedToolSpanIds,
+  ReservedToolSpanIdGenerator,
+} from '../../../src/flushers/tool-span-id-reservation.js';
 
 const SID = 'ses_e2e';
 const UP_TRACE = '4bf92f3577b34da6a3ce929d0e0e4736';
 const UP_SPAN = '00f067aa0ba902b7';
 const TP = `00-${UP_TRACE}-${UP_SPAN}-01`;
 const PROMPT = '场景检查里的野图怪物检查,需要在主页面加个配置';
+const RESERVED_TOOL_SPAN = 'd4d4d4d4d4d4d4d4';
 
 // A synthetic opencode-style turn: other (user input) + llm.request + llm.response.
 function buildTurn(localTrace: string): AgentActivityEntry[] {
@@ -52,6 +57,31 @@ function buildTurn(localTrace: string): AgentActivityEntry[] {
     {
       ...base,
       time_unix_nano: String(t0 + 2e6),
+      'event.id': 'e-tool-call',
+      'event.name': 'tool.call',
+      'gen_ai.step.id': `${SID}:t1:s1`,
+      'gen_ai.tool.name': 'Bash',
+      'gen_ai.tool.call.id': 'tool-reserved',
+      'gen_ai.tool.call.arguments': { command: 'my-cli' },
+      span_id: RESERVED_TOOL_SPAN,
+      parent_span_id: 'c3c3c3c3c3c3c3c3',
+    },
+    {
+      ...base,
+      time_unix_nano: String(t0 + 3e6),
+      'event.id': 'e-tool-result',
+      'event.name': 'tool.result',
+      'gen_ai.step.id': `${SID}:t1:s1`,
+      'gen_ai.tool.name': 'Bash',
+      'gen_ai.tool.call.id': 'tool-reserved',
+      'gen_ai.tool.call.result': 'ok',
+      'tool.result.status': 'success',
+      span_id: RESERVED_TOOL_SPAN,
+      parent_span_id: 'c3c3c3c3c3c3c3c3',
+    },
+    {
+      ...base,
+      time_unix_nano: String(t0 + 4e6),
       'event.id': 'e-resp',
       'event.name': 'llm.response',
       'gen_ai.step.id': `${SID}:t1:s1`,
@@ -92,9 +122,16 @@ describe('upstream-link e2e: stamp -> real converter reparents to upstream span'
 
     // 4. run the REAL converter
     const inMem = new InMemorySpanExporter();
-    const provider = new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(inMem)] });
+    const idGenerator = new ReservedToolSpanIdGenerator();
+    const provider = new BasicTracerProvider({
+      idGenerator,
+      spanProcessors: [new SimpleSpanProcessor(inMem)],
+    });
     const handler = new ExtendedTelemetryHandler({ tracerProvider: provider });
+    const toolSpanIds = attachReservedToolSpanIds(handler, idGenerator);
+    toolSpanIds.prepare(records);
     const result = convertEventLogToTrace(records as unknown as EventLogRecord[], { handler, strict: false });
+    toolSpanIds.clear();
     await provider.forceFlush();
     const spans = inMem.getFinishedSpans();
 
@@ -105,5 +142,7 @@ describe('upstream-link e2e: stamp -> real converter reparents to upstream span'
     expect(spans.every((s) => s.spanContext().traceId !== localTrace)).toBe(true);
     // ENTRY span's parent is the upstream span
     expect(spans.some((s) => s.parentSpanId === UP_SPAN)).toBe(true);
+    // The converter preserves the TOOL span id reserved before Bash execution.
+    expect(spans.some((s) => s.spanContext().spanId === RESERVED_TOOL_SPAN)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- propagate W3C `TRACEPARENT` and `TRACESTATE` into downstream CLI processes launched by Claude Code's `PreToolUse(Bash)` hook
- reserve the Bash TOOL span ID before execution and reuse it as the downstream `traceparent` parent-span ID
- add feature-flag configuration, cross-platform hook support, documentation, and stale-reservation cleanup
- add a Claude Code hook simulator, demo downstream CLI, and automated unit/integration coverage

## Configuration

The propagation behavior is controlled by:

- `LOONGSUITE_PILOT_UPSTREAM_LINK=true`
- `LOONGSUITE_PILOT_UPSTREAM_LINK_PROPAGATE_TO_TOOLS=true`

## Validation

- repository test suite: 196 files, 2,279 passing, 11 skipped
- focused simulator/integration suite: 9 files, 185 passing
- type checking and syntax validation passed
- real interactive Claude Code `2.1.220` E2E in ACK passed without test-side preload
- SLS trace validation: 1 ENTRY, 1 AGENT, 2 STEP, 2 LLM, 1 TOOL; 0 errors
- downstream CLI received the upstream trace ID and `TRACESTATE`
- downstream `traceparent` parent-span ID exactly matched the Bash TOOL span ID
- ENTRY span remained attached to the original upstream parent span
