### PR TITLE
fix(status-bar): incrementally aggregate current-day metrics

### DIFF
--- a/src/status-bar/jsonl-tail-reader.ts
+++ b/src/status-bar/jsonl-tail-reader.ts
@@ -1,0 +1,97 @@
+import * as fs from 'node:fs/promises';
+
+const DEFAULT_CHUNK_SIZE_BYTES = 4 * 1024 * 1024;
+
+export interface JsonlTailScanResult {
+  nextOffset: number;
+  bytesRead: number;
+}
+
+export interface JsonlTailScanOptions {
+  chunkSizeBytes?: number;
+  onRecord: (record: Record<string, unknown>) => void;
+}
+
+/**
+ * Reads a stable byte range from a JSONL file and advances only through complete
+ * newline-terminated records. A trailing partial record is deliberately left
+ * behind for the next scan.
+ */
+export async function scanJsonlTail(
+  filePath: string,
+  startOffset: number,
+  endOffset: number,
+  options: JsonlTailScanOptions,
+): Promise<JsonlTailScanResult> {
+  if (startOffset >= endOffset) {
+    return { nextOffset: startOffset, bytesRead: 0 };
+  }
+
+  const chunkSize = Math.max(1, options.chunkSizeBytes ?? DEFAULT_CHUNK_SIZE_BYTES);
+  const handle = await fs.open(filePath, 'r');
+  let readOffset = startOffset;
+  let committedOffset = startOffset;
+  let bytesReadTotal = 0;
+  let carry = Buffer.alloc(0);
+
+  try {
+    while (readOffset < endOffset) {
+      const requestedBytes = Math.min(chunkSize, endOffset - readOffset);
+      const chunk = Buffer.allocUnsafe(requestedBytes);
+      const { bytesRead } = await handle.read(chunk, 0, requestedBytes, readOffset);
+      if (bytesRead === 0) break;
+
+      const data = bytesRead === requestedBytes ? chunk : chunk.subarray(0, bytesRead);
+      const dataStartOffset = readOffset - carry.length;
+      const combined = carry.length > 0 ? Buffer.concat([carry, data]) : data;
+      let lineStart = 0;
+
+      for (let index = 0; index < combined.length; index++) {
+        if (combined[index] !== 0x0a) continue;
+
+        const line = combined.subarray(lineStart, index);
+        parseJsonlLine(line, options.onRecord);
+        lineStart = index + 1;
+        committedOffset = dataStartOffset + lineStart;
+      }
+
+      carry = lineStart < combined.length
+        ? Buffer.from(combined.subarray(lineStart))
+        : Buffer.alloc(0);
+      readOffset += bytesRead;
+      bytesReadTotal += bytesRead;
+
+      // Initial migration may need to read a large current-day file. Yield
+      // between chunks so the collector's event loop remains responsive.
+      if (readOffset < endOffset) {
+        await new Promise<void>(resolve => setImmediate(resolve));
+      }
+    }
+  } finally {
+    await handle.close();
+  }
+
+  return {
+    nextOffset: committedOffset,
+    bytesRead: bytesReadTotal,
+  };
+}
+
+function parseJsonlLine(
+  line: Buffer,
+  onRecord: (record: Record<string, unknown>) => void,
+): void {
+  let text = line.toString('utf8');
+  if (text.endsWith('\r')) text = text.slice(0, -1);
+  if (!text.trim()) return;
+
+  try {
+    const record = JSON.parse(text) as unknown;
+    if (record && typeof record === 'object' && !Array.isArray(record)) {
+      onRecord(record as Record<string, unknown>);
+    }
+  } catch {
+    // Malformed complete lines are skipped. Partial lines never reach this
+    // function because their offsets are not committed.
+  }
+}

--- a/src/status-bar/metrics-summary-writer.ts
+++ b/src/status-bar/metrics-summary-writer.ts
@@ -1,11 +1,10 @@
 import * as fs from 'node:fs/promises';
 import * as fsSync from 'node:fs';
 import * as path from 'node:path';
-import { createReadStream } from 'node:fs';
-import { createInterface } from 'node:readline';
 import type { StatusBarConfig } from '../types/index.js';
 import { writeJsonFile, readJsonFile, ensureDir, getTodayDateString } from '../utils/fs-utils.js';
 import { createLogger } from '../utils/logger.js';
+import { scanJsonlTail } from './jsonl-tail-reader.js';
 
 const logger = createLogger('MetricsSummaryWriter');
 
@@ -116,6 +115,38 @@ interface ScanState {
   files: Record<string, { offset: number; size: number; ino: number }>;
 }
 
+interface SerializedDayStats {
+  tokens: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  sessions: string[];
+  requests: number;
+  toolCalls: number;
+  events: number;
+  modelTokens: Array<[string, { total: number; input: number; cacheRead: number }]>;
+  agentStats: Array<[string, { sessions: string[]; events: number; tokens: number }]>;
+  providerTokens: Array<[string, number]>;
+  repoStats: Array<[string, { sessions: string[]; events: number }]>;
+}
+
+interface CurrentDayFileState {
+  fileName: string;
+  dev: number;
+  ino: number;
+  birthtimeMs: number;
+  offset: number;
+  size: number;
+  stats: SerializedDayStats;
+}
+
+interface CurrentDayState {
+  version: 1;
+  day: string;
+  files: CurrentDayFileState[];
+}
+
 // ── Class ──
 
 export class MetricsSummaryWriter {
@@ -125,6 +156,7 @@ export class MetricsSummaryWriter {
   private readonly summaryPath: string;
   private readonly digestPath: string;
   private readonly scanStatePath: string;
+  private readonly currentDayStatePath: string;
   private startupTimer: ReturnType<typeof setTimeout> | null = null;
   private intervalTimer: ReturnType<typeof setInterval> | null = null;
   private isRefreshing = false;
@@ -136,6 +168,7 @@ export class MetricsSummaryWriter {
     this.summaryPath = path.join(dataDir, 'logs', 'metrics-summary.json');
     this.digestPath = path.join(dataDir, 'cache', 'metrics-daily-digest.json');
     this.scanStatePath = path.join(dataDir, 'cache', 'metrics-scan-state.json');
+    this.currentDayStatePath = path.join(dataDir, 'cache', 'metrics-current-day-state.json');
   }
 
   start(): void {
@@ -186,8 +219,20 @@ export class MetricsSummaryWriter {
     const today = getTodayDateString();
     const scanState = await this.loadScanState();
     const digest = await this.loadDigest();
-
     const files = await this.listOutputFiles();
+    let currentDayState = await this.loadCurrentDayState();
+
+    // Finish the previous active day before starting a new one. The replacement
+    // write is idempotent, so a crash between digest and state persistence cannot
+    // double-count the day on restart.
+    if (currentDayState && currentDayState.day !== today) {
+      currentDayState = await this.refreshCurrentDayState(currentDayState, files);
+      const completedStats = mergeCurrentDayStats(currentDayState);
+      digest.days[currentDayState.day] = this.dayStatsToDigest(completedStats);
+      this.copyCurrentDayOffsetsToScanState(currentDayState, scanState);
+      currentDayState = null;
+    }
+
     const liveStats = new Map<string, DayStats>();
     const fullScanDays = new Set<string>();
 
@@ -195,35 +240,27 @@ export class MetricsSummaryWriter {
       const match = FILE_NAME_PATTERN.exec(path.basename(file));
       if (!match) continue;
       const day = match[2];
+      if (day === today) continue;
 
       const fileStat = await this.safeStat(file);
       if (!fileStat) continue;
 
       const baseName = path.basename(file);
-      const isToday = day === today;
-
-      // Today's files: always scan from offset 0. The file is actively written by flushers,
-      // and we need session dedup (Set) + model/provider/repo breakdowns that can't be
-      // incrementally maintained without serializing Sets. Cost is acceptable (<1MB/day typical).
-      // Past files: incremental scan using cached offset.
-      // Exception: if a past day has no digest entry yet, scan from start to ensure data is captured.
       let startOffset = 0;
-      if (!isToday) {
-        const hasDigest = !!digest.days[day];
-        const cached = scanState.files[baseName];
-        if (hasDigest && cached && cached.ino === fileStat.ino && cached.size <= fileStat.size) {
-          startOffset = cached.offset;
-        }
-        if (startOffset >= fileStat.size && hasDigest) {
-          this.ensureDayStats(liveStats, day);
-          continue;
-        }
+      const hasDigest = !!digest.days[day];
+      const cached = scanState.files[baseName];
+      if (hasDigest && cached && cached.ino === fileStat.ino && cached.size <= fileStat.size) {
+        startOffset = cached.offset;
+      }
+      if (startOffset >= fileStat.size && hasDigest) {
+        this.ensureDayStats(liveStats, day);
+        continue;
       }
 
-      if (startOffset === 0 && !isToday) fullScanDays.add(day);
+      if (startOffset === 0) fullScanDays.add(day);
 
       const dayStats = this.ensureDayStats(liveStats, day);
-      const newOffset = await this.scanFile(file, startOffset, dayStats);
+      const newOffset = await this.scanFile(file, startOffset, fileStat.size, dayStats);
 
       scanState.files[baseName] = {
         offset: newOffset,
@@ -246,8 +283,13 @@ export class MetricsSummaryWriter {
       }
     }
 
-    // Current day — merge live + any partial digest
-    const todayLive = liveStats.get(today);
+    currentDayState ??= {
+      version: 1,
+      day: today,
+      files: [],
+    };
+    currentDayState = await this.refreshCurrentDayState(currentDayState, files);
+    const todayLive = mergeCurrentDayStats(currentDayState);
 
     // Prune old digest entries
     this.pruneDigest(digest, today);
@@ -255,12 +297,14 @@ export class MetricsSummaryWriter {
     // Build summary from digest + live data
     const summary = this.buildSummary(digest, todayLive, today);
 
-    // Persist — write source-of-truth (digest, scanState) before derived output (summary)
-    // so crash recovery favors re-scanning over data loss
+    // Persist source-of-truth before the derived summary. Each state file is
+    // written atomically; after a crash, replay starts from the last committed
+    // offset and produces the same summary without double-counting.
     await ensureDir(path.dirname(this.digestPath));
     await ensureDir(path.dirname(this.summaryPath));
     await writeJsonFile(this.digestPath, digest);
     await writeJsonFile(this.scanStatePath, scanState);
+    await writeJsonFile(this.currentDayStatePath, currentDayState);
     await writeJsonFile(this.summaryPath, summary);
 
     logger.debug('metrics summary written', {
@@ -291,50 +335,100 @@ export class MetricsSummaryWriter {
   private ensureDayStats(map: Map<string, DayStats>, day: string): DayStats {
     let stats = map.get(day);
     if (!stats) {
-      stats = {
-        tokens: 0,
-        inputTokens: 0,
-        outputTokens: 0,
-        cacheReadTokens: 0,
-        cacheCreationTokens: 0,
-        sessions: new Set(),
-        requests: 0,
-        toolCalls: 0,
-        events: 0,
-        modelTokens: new Map(),
-        agentStats: new Map(),
-        providerTokens: new Map(),
-        repoStats: new Map(),
-      };
+      stats = createDayStats();
       map.set(day, stats);
     }
     return stats;
   }
 
-  private async scanFile(filePath: string, startOffset: number, stats: DayStats): Promise<number> {
-    return new Promise<number>((resolve, reject) => {
-      let currentOffset = startOffset;
-      const stream = createReadStream(filePath, {
-        start: startOffset,
-        encoding: 'utf8',
-      });
-      const rl = createInterface({ input: stream, crlfDelay: Infinity });
-
-      rl.on('line', (line) => {
-        currentOffset += Buffer.byteLength(line, 'utf8') + 1; // +1 for newline
-        if (!line.trim()) return;
-
-        try {
-          const record = JSON.parse(line) as Record<string, string>;
-          this.applyRecord(record, stats);
-        } catch {
-          // skip malformed lines
-        }
-      });
-
-      rl.on('close', () => resolve(currentOffset));
-      rl.on('error', reject);
+  private async scanFile(
+    filePath: string,
+    startOffset: number,
+    endOffset: number,
+    stats: DayStats,
+  ): Promise<number> {
+    const result = await scanJsonlTail(filePath, startOffset, endOffset, {
+      onRecord: record => {
+        this.applyRecord(record as Record<string, string>, stats);
+      },
     });
+    logger.debug('metrics summary file scanned', {
+      file: path.basename(filePath),
+      startOffset,
+      endOffset,
+      nextOffset: result.nextOffset,
+      bytesRead: result.bytesRead,
+      mode: startOffset === 0 ? 'rebuild' : 'incremental',
+    });
+    return result.nextOffset;
+  }
+
+  private async refreshCurrentDayState(
+    state: CurrentDayState,
+    files: string[],
+  ): Promise<CurrentDayState> {
+    const existingByName = new Map(state.files.map(file => [file.fileName, file]));
+    const nextByName = new Map(existingByName);
+    let totalBytesRead = 0;
+
+    for (const filePath of files) {
+      const match = FILE_NAME_PATTERN.exec(path.basename(filePath));
+      if (!match || match[2] !== state.day) continue;
+
+      const fileStat = await this.safeStat(filePath);
+      if (!fileStat) continue;
+
+      const fileName = path.basename(filePath);
+      const existing = existingByName.get(fileName);
+      const canResume = existing !== undefined
+        && sameFileIdentity(existing, fileStat)
+        && existing.offset <= fileStat.size
+        && existing.size <= fileStat.size;
+      const startOffset = canResume ? existing.offset : 0;
+      const stats = canResume ? deserializeDayStats(existing.stats) : createDayStats();
+      const result = await scanJsonlTail(filePath, startOffset, fileStat.size, {
+        onRecord: record => {
+          this.applyRecord(record as Record<string, string>, stats);
+        },
+      });
+      totalBytesRead += result.bytesRead;
+
+      nextByName.set(fileName, {
+        fileName,
+        dev: fileStat.dev,
+        ino: fileStat.ino,
+        birthtimeMs: fileStat.birthtimeMs,
+        offset: result.nextOffset,
+        size: fileStat.size,
+        stats: serializeDayStats(stats),
+      });
+    }
+
+    logger.debug('metrics current-day files refreshed', {
+      day: state.day,
+      fileCount: nextByName.size,
+      bytesRead: totalBytesRead,
+    });
+
+    return {
+      version: 1,
+      day: state.day,
+      files: Array.from(nextByName.values())
+        .sort((left, right) => left.fileName.localeCompare(right.fileName)),
+    };
+  }
+
+  private copyCurrentDayOffsetsToScanState(
+    state: CurrentDayState,
+    scanState: ScanState,
+  ): void {
+    for (const file of state.files) {
+      scanState.files[file.fileName] = {
+        offset: file.offset,
+        size: file.size,
+        ino: file.ino,
+      };
+    }
   }
 
   private applyRecord(record: Record<string, string>, stats: DayStats): void {
@@ -637,9 +731,215 @@ export class MetricsSummaryWriter {
     const data = await readJsonFile<DigestFile>(this.digestPath);
     return data && data.days ? data : { version: 1, days: {} };
   }
+
+  private async loadCurrentDayState(): Promise<CurrentDayState | null> {
+    const data = await readJsonFile<CurrentDayState>(this.currentDayStatePath);
+    if (!data
+      || data.version !== 1
+      || typeof data.day !== 'string'
+      || !Array.isArray(data.files)) {
+      return null;
+    }
+
+    try {
+      for (const file of data.files) {
+        if (!file
+          || typeof file.fileName !== 'string'
+          || !Number.isFinite(file.dev)
+          || !Number.isFinite(file.ino)
+          || !Number.isFinite(file.birthtimeMs)
+          || !Number.isFinite(file.offset)
+          || file.offset < 0
+          || !Number.isFinite(file.size)
+          || file.size < 0) {
+          return null;
+        }
+        deserializeDayStats(file.stats);
+      }
+      return data;
+    } catch {
+      logger.warn('metrics current-day state is invalid; rebuilding');
+      return null;
+    }
+  }
 }
 
 // ── Helpers ──
+
+function createDayStats(): DayStats {
+  return {
+    tokens: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    sessions: new Set(),
+    requests: 0,
+    toolCalls: 0,
+    events: 0,
+    modelTokens: new Map(),
+    agentStats: new Map(),
+    providerTokens: new Map(),
+    repoStats: new Map(),
+  };
+}
+
+function serializeDayStats(stats: DayStats): SerializedDayStats {
+  return {
+    tokens: stats.tokens,
+    inputTokens: stats.inputTokens,
+    outputTokens: stats.outputTokens,
+    cacheReadTokens: stats.cacheReadTokens,
+    cacheCreationTokens: stats.cacheCreationTokens,
+    sessions: Array.from(stats.sessions).sort(),
+    requests: stats.requests,
+    toolCalls: stats.toolCalls,
+    events: stats.events,
+    modelTokens: Array.from(stats.modelTokens.entries())
+      .sort(([left], [right]) => left.localeCompare(right)),
+    agentStats: Array.from(stats.agentStats.entries())
+      .map(([agentType, data]) => [
+        agentType,
+        {
+          sessions: Array.from(data.sessions).sort(),
+          events: data.events,
+          tokens: data.tokens,
+        },
+      ] as [string, { sessions: string[]; events: number; tokens: number }])
+      .sort(([left], [right]) => left.localeCompare(right)),
+    providerTokens: Array.from(stats.providerTokens.entries())
+      .sort(([left], [right]) => left.localeCompare(right)),
+    repoStats: Array.from(stats.repoStats.entries())
+      .map(([repo, data]) => [
+        repo,
+        {
+          sessions: Array.from(data.sessions).sort(),
+          events: data.events,
+        },
+      ] as [string, { sessions: string[]; events: number }])
+      .sort(([left], [right]) => left.localeCompare(right)),
+  };
+}
+
+function deserializeDayStats(serialized: SerializedDayStats): DayStats {
+  if (!serialized
+    || !Array.isArray(serialized.sessions)
+    || !Array.isArray(serialized.modelTokens)
+    || !Array.isArray(serialized.agentStats)
+    || !Array.isArray(serialized.providerTokens)
+    || !Array.isArray(serialized.repoStats)) {
+    throw new Error('invalid serialized day stats');
+  }
+
+  const stats = createDayStats();
+  stats.tokens = finiteNumber(serialized.tokens);
+  stats.inputTokens = finiteNumber(serialized.inputTokens);
+  stats.outputTokens = finiteNumber(serialized.outputTokens);
+  stats.cacheReadTokens = finiteNumber(serialized.cacheReadTokens);
+  stats.cacheCreationTokens = finiteNumber(serialized.cacheCreationTokens);
+  stats.sessions = new Set(serialized.sessions.filter(value => typeof value === 'string'));
+  stats.requests = finiteNumber(serialized.requests);
+  stats.toolCalls = finiteNumber(serialized.toolCalls);
+  stats.events = finiteNumber(serialized.events);
+
+  for (const item of serialized.modelTokens) {
+    if (!Array.isArray(item) || typeof item[0] !== 'string' || !item[1]) continue;
+    stats.modelTokens.set(item[0], {
+      total: finiteNumber(item[1].total),
+      input: finiteNumber(item[1].input),
+      cacheRead: finiteNumber(item[1].cacheRead),
+    });
+  }
+  for (const item of serialized.agentStats) {
+    if (!Array.isArray(item) || typeof item[0] !== 'string' || !item[1]) continue;
+    stats.agentStats.set(item[0], {
+      sessions: new Set(
+        Array.isArray(item[1].sessions)
+          ? item[1].sessions.filter(value => typeof value === 'string')
+          : [],
+      ),
+      events: finiteNumber(item[1].events),
+      tokens: finiteNumber(item[1].tokens),
+    });
+  }
+  for (const item of serialized.providerTokens) {
+    if (!Array.isArray(item) || typeof item[0] !== 'string') continue;
+    stats.providerTokens.set(item[0], finiteNumber(item[1]));
+  }
+  for (const item of serialized.repoStats) {
+    if (!Array.isArray(item) || typeof item[0] !== 'string' || !item[1]) continue;
+    stats.repoStats.set(item[0], {
+      sessions: new Set(
+        Array.isArray(item[1].sessions)
+          ? item[1].sessions.filter(value => typeof value === 'string')
+          : [],
+      ),
+      events: finiteNumber(item[1].events),
+    });
+  }
+  return stats;
+}
+
+function mergeCurrentDayStats(state: CurrentDayState): DayStats {
+  const merged = createDayStats();
+  for (const file of state.files) {
+    mergeDayStats(merged, deserializeDayStats(file.stats));
+  }
+  return merged;
+}
+
+function mergeDayStats(target: DayStats, source: DayStats): void {
+  target.tokens += source.tokens;
+  target.inputTokens += source.inputTokens;
+  target.outputTokens += source.outputTokens;
+  target.cacheReadTokens += source.cacheReadTokens;
+  target.cacheCreationTokens += source.cacheCreationTokens;
+  target.requests += source.requests;
+  target.toolCalls += source.toolCalls;
+  target.events += source.events;
+  for (const session of source.sessions) target.sessions.add(session);
+
+  for (const [model, data] of source.modelTokens) {
+    const current = target.modelTokens.get(model) ?? { total: 0, input: 0, cacheRead: 0 };
+    current.total += data.total;
+    current.input += data.input;
+    current.cacheRead += data.cacheRead;
+    target.modelTokens.set(model, current);
+  }
+  for (const [agentType, data] of source.agentStats) {
+    const current = target.agentStats.get(agentType) ?? {
+      sessions: new Set<string>(),
+      events: 0,
+      tokens: 0,
+    };
+    current.events += data.events;
+    current.tokens += data.tokens;
+    for (const session of data.sessions) current.sessions.add(session);
+    target.agentStats.set(agentType, current);
+  }
+  for (const [provider, tokens] of source.providerTokens) {
+    target.providerTokens.set(provider, (target.providerTokens.get(provider) ?? 0) + tokens);
+  }
+  for (const [repo, data] of source.repoStats) {
+    const current = target.repoStats.get(repo) ?? {
+      sessions: new Set<string>(),
+      events: 0,
+    };
+    current.events += data.events;
+    for (const session of data.sessions) current.sessions.add(session);
+    target.repoStats.set(repo, current);
+  }
+}
+
+function sameFileIdentity(file: CurrentDayFileState, stat: fsSync.Stats): boolean {
+  return file.dev === stat.dev
+    && file.ino === stat.ino
+    && file.birthtimeMs === stat.birthtimeMs;
+}
+
+function finiteNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
 
 function toNumber(value: unknown): number {
   if (typeof value === 'number') return value;

--- a/tests/unit/status-bar/jsonl-tail-reader.test.ts
+++ b/tests/unit/status-bar/jsonl-tail-reader.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { scanJsonlTail } from '../../../src/status-bar/jsonl-tail-reader.js';
+import { cleanupTempDir, createTempDir } from '../../helpers/fixture-builder.js';
+
+describe('scanJsonlTail', () => {
+  it('reads only complete records and resumes from the committed newline', async () => {
+    const tmpDir = await createTempDir('jsonl-tail-reader-');
+    try {
+      const filePath = path.join(tmpDir, 'events.jsonl');
+      const first = JSON.stringify({ id: 1, text: '你好' }) + '\n';
+      const second = JSON.stringify({ id: 2, text: 'partial' });
+      const splitAt = Math.floor(second.length / 2);
+      await fs.writeFile(filePath, first + second.slice(0, splitAt));
+
+      const records: Record<string, unknown>[] = [];
+      let stat = await fs.stat(filePath);
+      const initial = await scanJsonlTail(filePath, 0, stat.size, {
+        chunkSizeBytes: 7,
+        onRecord: record => records.push(record),
+      });
+
+      expect(records).toEqual([{ id: 1, text: '你好' }]);
+      expect(initial.nextOffset).toBe(Buffer.byteLength(first));
+      expect(initial.bytesRead).toBe(stat.size);
+
+      await fs.appendFile(filePath, second.slice(splitAt) + '\n');
+      stat = await fs.stat(filePath);
+      const resumedRecords: Record<string, unknown>[] = [];
+      const resumed = await scanJsonlTail(filePath, initial.nextOffset, stat.size, {
+        chunkSizeBytes: 5,
+        onRecord: record => resumedRecords.push(record),
+      });
+
+      expect(resumedRecords).toEqual([{ id: 2, text: 'partial' }]);
+      expect(resumed.nextOffset).toBe(stat.size);
+    } finally {
+      await cleanupTempDir(tmpDir);
+    }
+  });
+
+  it('does not open or read a file when the range is empty', async () => {
+    const records: Record<string, unknown>[] = [];
+    const result = await scanJsonlTail('/path/does/not/need/to/exist', 42, 42, {
+      onRecord: record => records.push(record),
+    });
+
+    expect(result).toEqual({ nextOffset: 42, bytesRead: 0 });
+    expect(records).toEqual([]);
+  });
+});

--- a/tests/unit/status-bar/metrics-summary-writer.test.ts
+++ b/tests/unit/status-bar/metrics-summary-writer.test.ts
@@ -5,10 +5,15 @@ import { createTempDir, cleanupTempDir } from '../../helpers/fixture-builder.js'
 import { MetricsSummaryWriter } from '../../../src/status-bar/metrics-summary-writer.js';
 import type { StatusBarConfig } from '../../../src/types/index.js';
 
+const logger = vi.hoisted(() => ({
+  info: vi.fn(),
+  debug: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
 vi.mock('../../../src/utils/logger.js', () => ({
-  createLogger: () => ({
-    info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(),
-  }),
+  createLogger: () => logger,
 }));
 
 function makeConfig(overrides: Partial<StatusBarConfig> = {}): StatusBarConfig {
@@ -23,6 +28,12 @@ function makeConfig(overrides: Partial<StatusBarConfig> = {}): StatusBarConfig {
 function today(): string {
   const d = new Date();
   return [d.getFullYear(), String(d.getMonth() + 1).padStart(2, '0'), String(d.getDate()).padStart(2, '0')].join('-');
+}
+
+function currentDayScanBytes(): number[] {
+  return logger.debug.mock.calls
+    .filter(([message]) => message === 'metrics current-day files refreshed')
+    .map(([, details]) => (details as { bytesRead: number }).bytesRead);
 }
 
 function makeLlmResponse(overrides: Record<string, string> = {}): Record<string, string> {
@@ -76,12 +87,14 @@ describe('MetricsSummaryWriter', () => {
   let tmpDir: string;
 
   beforeEach(async () => {
+    vi.clearAllMocks();
     tmpDir = await createTempDir('metrics-summary-test-');
     await fs.mkdir(path.join(tmpDir, 'logs', 'output'), { recursive: true });
     await fs.mkdir(path.join(tmpDir, 'cache'), { recursive: true });
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     await cleanupTempDir(tmpDir);
   });
 
@@ -190,6 +203,7 @@ describe('MetricsSummaryWriter', () => {
     const claude = agents.find((a: { agentType: string }) => a.agentType === 'claude-code');
     expect(cursor.events).toBe(3);
     expect(claude.events).toBe(2);
+    expect(summary.ranges.today.totalSessions).toBe(1);
   });
 
   it('incremental scan: only reads new lines on second refresh', async () => {
@@ -220,6 +234,176 @@ describe('MetricsSummaryWriter', () => {
 
     summary = JSON.parse(await fs.readFile(path.join(tmpDir, 'logs', 'metrics-summary.json'), 'utf8'));
     expect(summary.ranges.today.totalTokens).toBe(1500);
+    expect(summary.ranges.today.totalSessions).toBe(1);
+
+    await writer.refresh();
+
+    const scanBytes = currentDayScanBytes();
+    expect(scanBytes).toHaveLength(3);
+    expect(scanBytes[0]).toBeGreaterThan(0);
+    expect(scanBytes[1]).toBe(Buffer.byteLength(JSON.stringify(resp2) + '\n'));
+    expect(scanBytes[2]).toBe(0);
+  });
+
+  it('restores current-day aggregate state across writer restarts without rescanning', async () => {
+    const outputDir = path.join(tmpDir, 'logs', 'output');
+    await writeJsonlFile(outputDir, `codex-${today()}.jsonl`, [
+      makeLlmRequest({ 'gen_ai.agent.type': 'codex' }),
+      makeLlmResponse({ 'gen_ai.agent.type': 'codex' }),
+    ]);
+
+    await new MetricsSummaryWriter(tmpDir, makeConfig()).refresh();
+    await new MetricsSummaryWriter(tmpDir, makeConfig()).refresh();
+
+    const summary = JSON.parse(await fs.readFile(path.join(tmpDir, 'logs', 'metrics-summary.json'), 'utf8'));
+    expect(summary.ranges.today.totalTokens).toBe(1200);
+    expect(summary.ranges.today.totalEvents).toBe(2);
+    expect(currentDayScanBytes()).toEqual([
+      expect.any(Number),
+      0,
+    ]);
+  });
+
+  it('does not commit a trailing partial JSONL record', async () => {
+    const outputDir = path.join(tmpDir, 'logs', 'output');
+    const filePath = path.join(outputDir, `codex-${today()}.jsonl`);
+    const first = makeLlmResponse({ 'gen_ai.usage.total_tokens': '1000' });
+    const second = makeLlmResponse({ 'gen_ai.usage.total_tokens': '500' });
+    const firstLine = JSON.stringify(first) + '\n';
+    const secondLine = JSON.stringify(second);
+    const splitAt = Math.floor(secondLine.length / 2);
+    await fs.writeFile(filePath, firstLine + secondLine.slice(0, splitAt));
+
+    const writer = new MetricsSummaryWriter(tmpDir, makeConfig());
+    await writer.refresh();
+
+    let summary = JSON.parse(await fs.readFile(path.join(tmpDir, 'logs', 'metrics-summary.json'), 'utf8'));
+    expect(summary.ranges.today.totalTokens).toBe(1000);
+
+    const statePath = path.join(tmpDir, 'cache', 'metrics-current-day-state.json');
+    const state = JSON.parse(await fs.readFile(statePath, 'utf8'));
+    expect(state.files[0].offset).toBe(Buffer.byteLength(firstLine));
+
+    await fs.appendFile(filePath, secondLine.slice(splitAt) + '\n');
+    await writer.refresh();
+
+    summary = JSON.parse(await fs.readFile(path.join(tmpDir, 'logs', 'metrics-summary.json'), 'utf8'));
+    expect(summary.ranges.today.totalTokens).toBe(1500);
+    expect(summary.ranges.today.totalEvents).toBe(2);
+  });
+
+  it('rebuilds only a replaced current-day file', async () => {
+    const outputDir = path.join(tmpDir, 'logs', 'output');
+    const codexPath = path.join(outputDir, `codex-${today()}.jsonl`);
+    const claudePath = path.join(outputDir, `claude-code-${today()}.jsonl`);
+    await writeJsonlFile(outputDir, path.basename(codexPath), [
+      makeLlmResponse({
+        'gen_ai.agent.type': 'codex',
+        'gen_ai.session.id': 'codex-old',
+        'gen_ai.usage.total_tokens': '1000',
+      }),
+    ]);
+    await writeJsonlFile(outputDir, path.basename(claudePath), [
+      makeLlmResponse({
+        'gen_ai.agent.type': 'claude-code',
+        'gen_ai.session.id': 'claude-stable',
+        'gen_ai.usage.total_tokens': '2000',
+      }),
+    ]);
+
+    const writer = new MetricsSummaryWriter(tmpDir, makeConfig());
+    await writer.refresh();
+
+    const replacementPath = `${codexPath}.replacement`;
+    await fs.writeFile(replacementPath, JSON.stringify(makeLlmResponse({
+      'gen_ai.agent.type': 'codex',
+      'gen_ai.session.id': 'codex-new',
+      'gen_ai.usage.total_tokens': '500',
+    })) + '\n');
+    await fs.rename(replacementPath, codexPath);
+    await writer.refresh();
+
+    const summary = JSON.parse(await fs.readFile(path.join(tmpDir, 'logs', 'metrics-summary.json'), 'utf8'));
+    expect(summary.ranges.today.totalTokens).toBe(2500);
+    expect(summary.ranges.today.totalEvents).toBe(2);
+    expect(summary.ranges.today.totalSessions).toBe(2);
+  });
+
+  it('rebuilds a current-day file after it is truncated in place', async () => {
+    const outputDir = path.join(tmpDir, 'logs', 'output');
+    const filePath = path.join(outputDir, `codex-${today()}.jsonl`);
+    const original = makeLlmResponse({
+      'gen_ai.session.id': 'old-session',
+      'gen_ai.usage.total_tokens': '123456',
+    });
+    const replacement = makeLlmResponse({
+      'gen_ai.session.id': 'new-session',
+      'gen_ai.usage.total_tokens': '50',
+    });
+    await fs.writeFile(filePath, JSON.stringify(original) + '\n');
+
+    const writer = new MetricsSummaryWriter(tmpDir, makeConfig());
+    await writer.refresh();
+    await fs.truncate(filePath, 0);
+    await fs.writeFile(filePath, JSON.stringify(replacement) + '\n');
+    await writer.refresh();
+
+    const summary = JSON.parse(await fs.readFile(path.join(tmpDir, 'logs', 'metrics-summary.json'), 'utf8'));
+    expect(summary.ranges.today.totalTokens).toBe(50);
+    expect(summary.ranges.today.totalEvents).toBe(1);
+    expect(summary.ranges.today.totalSessions).toBe(1);
+  });
+
+  it('falls back to one full rebuild when current-day state is corrupt', async () => {
+    const outputDir = path.join(tmpDir, 'logs', 'output');
+    await writeJsonlFile(outputDir, `codex-${today()}.jsonl`, [
+      makeLlmResponse({ 'gen_ai.usage.total_tokens': '1000' }),
+    ]);
+
+    const writer = new MetricsSummaryWriter(tmpDir, makeConfig());
+    await writer.refresh();
+    await fs.writeFile(
+      path.join(tmpDir, 'cache', 'metrics-current-day-state.json'),
+      JSON.stringify({ version: 1, day: today(), files: [{ broken: true }] }),
+    );
+    await writer.refresh();
+
+    const summary = JSON.parse(await fs.readFile(path.join(tmpDir, 'logs', 'metrics-summary.json'), 'utf8'));
+    expect(summary.ranges.today.totalTokens).toBe(1000);
+    expect(summary.ranges.today.totalEvents).toBe(1);
+    expect(currentDayScanBytes().at(-1)).toBeGreaterThan(0);
+  });
+
+  it('finalizes the previous day including data appended after its last refresh', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-30T12:00:00'));
+    const outputDir = path.join(tmpDir, 'logs', 'output');
+    const previousDayPath = path.join(outputDir, 'codex-2026-07-30.jsonl');
+    const first = makeLlmResponse({ 'gen_ai.usage.total_tokens': '1000' });
+    const second = makeLlmResponse({ 'gen_ai.usage.total_tokens': '500' });
+    await fs.writeFile(previousDayPath, JSON.stringify(first) + '\n');
+
+    await new MetricsSummaryWriter(tmpDir, makeConfig()).refresh();
+    await fs.appendFile(previousDayPath, JSON.stringify(second) + '\n');
+
+    vi.setSystemTime(new Date('2026-07-31T00:01:00'));
+    await new MetricsSummaryWriter(tmpDir, makeConfig()).refresh();
+
+    const summary = JSON.parse(await fs.readFile(path.join(tmpDir, 'logs', 'metrics-summary.json'), 'utf8'));
+    expect(summary.ranges.today.totalTokens).toBe(0);
+    expect(summary.ranges.sevenDays.totalTokens).toBe(1500);
+
+    const digest = JSON.parse(await fs.readFile(
+      path.join(tmpDir, 'cache', 'metrics-daily-digest.json'),
+      'utf8',
+    ));
+    expect(digest.days['2026-07-30'].tokens).toBe(1500);
+
+    const currentState = JSON.parse(await fs.readFile(
+      path.join(tmpDir, 'cache', 'metrics-current-day-state.json'),
+      'utf8',
+    ));
+    expect(currentState.day).toBe('2026-07-31');
   });
 
   it('handles empty output directory gracefully', async () => {


### PR DESCRIPTION
## Summary

- persist per-file current-day metric aggregates and byte offsets so the status bar only scans appended JSONL data
- add a snapshot-bounded JSONL tail reader that commits only complete newline-terminated records and yields between large chunks
- recover safely across collector restarts, day rollover, file replacement/truncation, partial records, and corrupt cache state
- keep the existing `metrics-summary.json` schema and all collection/export paths unchanged

## Root cause

`MetricsSummaryWriter` intentionally ignored cached offsets for current-day files and rescanned them from byte 0 every 60 seconds. Codex output can grow to hundreds of MB per day, turning each refresh into several seconds of synchronous JSON parsing and aggregation.

The new `metrics-current-day-state.json` cache serializes the small aggregation state needed for session/repo/agent deduplication together with each file's committed offset. Steady-state refresh cost is now proportional to appended bytes rather than the full current-day file size.

## Compatibility

- no change to `metrics-summary.json` version or fields
- no change to Codex/Claude/Qoder collection
- no change to JSONL, SLS, HTTP, or OTLP output
- first refresh after upgrade performs one current-day rebuild, then all later refreshes are incremental

## Validation

- `npx vitest run tests/unit/status-bar/metrics-summary-writer.test.ts tests/unit/status-bar/jsonl-tail-reader.test.ts` — 17/17 passed
- `npm run typecheck` — passed
- 129.6 MB current-day benchmark:
  - first state build: 349.4 ms CPU
  - unchanged second refresh: 2.3 ms CPU
- full suite: 2229 tests passed; one unrelated `file-watcher` timing test failed once and passed 10/10 when rerun in isolation
