### PR TITLE
fix(qoder): stabilize trace step assembly

### DIFF
--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -150,6 +150,26 @@ function timestampToUnixNanos(value) {
   return String(BigInt(Date.now()) * 1_000_000n);
 }
 
+function timestampOrderNanos(value) {
+  if (typeof value !== 'string' || !value) return null;
+
+  // Date.parse() truncates ISO fractions to milliseconds. Qoder emits
+  // microsecond timestamps, so two ordered events such as .999176 and .999890
+  // otherwise compare as equal and can collapse adjacent LLM boundaries.
+  const match = value.match(/^(.*?)(?:\.(\d+))?(Z|[+-]\d{2}:\d{2})$/);
+  if (match) {
+    const [, wholeSeconds, fraction = '', zone] = match;
+    const wholeSecondsMs = Date.parse(`${wholeSeconds}${zone}`);
+    if (!Number.isNaN(wholeSecondsMs)) {
+      const fractionNanos = BigInt((fraction + '000000000').slice(0, 9));
+      return BigInt(wholeSecondsMs) * 1_000_000n + fractionNanos;
+    }
+  }
+
+  const ms = Date.parse(value);
+  return Number.isNaN(ms) ? null : BigInt(ms) * 1_000_000n;
+}
+
 function computeDurationMs(startNanos, endNanos) {
   if (!startNanos || !endNanos || startNanos === endNanos) return 0;
   try {
@@ -720,14 +740,14 @@ export function buildLlmBoundaries(progressEvents, contentEvents) {
   let currentGroup = [];
   let currentToolIds = new Set();
   let resolvedToolIds = new Set();
-  let currentToolStartMs = null;
+  let currentToolStartNanos = null;
 
   function flushGroup() {
     if (currentGroup.length > 0) assistantGroups.push(currentGroup);
     currentGroup = [];
     currentToolIds = new Set();
     resolvedToolIds = new Set();
-    currentToolStartMs = null;
+    currentToolStartNanos = null;
   }
 
   for (const row of contentEvents) {
@@ -741,8 +761,8 @@ export function buildLlmBoundaries(progressEvents, contentEvents) {
       }
       continue;
     }
-    const ts = row.timestamp ? Date.parse(row.timestamp) : 0;
-    if (!ts) continue;
+    const ts = timestampOrderNanos(row.timestamp);
+    if (ts === null) continue;
 
     const toolCycleComplete = currentGroup.length > 0 &&
       currentToolIds.size > 0 &&
@@ -754,10 +774,10 @@ export function buildLlmBoundaries(progressEvents, contentEvents) {
     // result while preventing an unresolved tool from swallowing all later LLMs.
     const completedByHook = currentGroup.length > 0 &&
       currentToolIds.size > 0 &&
-      currentToolStartMs !== null &&
+      currentToolStartNanos !== null &&
       progressEvents.filter(pe => {
-        const peMs = Date.parse(pe.ts) || 0;
-        return peMs > currentToolStartMs && peMs < ts && (
+        const peTs = timestampOrderNanos(pe.ts);
+        return peTs !== null && peTs > currentToolStartNanos && peTs < ts && (
           pe.hookEvent === 'PostToolUse' || pe.hookEvent === 'PostToolUseFailure'
         );
       }).length >= currentToolIds.size;
@@ -767,7 +787,7 @@ export function buildLlmBoundaries(progressEvents, contentEvents) {
     for (const block of row.message?.content || []) {
       if (block?.type === 'tool_use' && block.id) {
         currentToolIds.add(block.id);
-        if (currentToolStartMs === null) currentToolStartMs = ts;
+        if (currentToolStartNanos === null) currentToolStartNanos = ts;
       }
     }
   }
@@ -777,14 +797,16 @@ export function buildLlmBoundaries(progressEvents, contentEvents) {
   const boundaries = [];
   for (let i = 0; i < assistantGroups.length; i++) {
     const group = assistantGroups[i];
-    const groupStartMs = Date.parse(group[0].timestamp) || 0;
-    const groupEndMs = Date.parse(group[group.length - 1].timestamp) || groupStartMs;
+    const groupStartNanos = timestampOrderNanos(group[0].timestamp);
+    const groupEndNanos = timestampOrderNanos(group[group.length - 1].timestamp) ?? groupStartNanos;
+    if (groupStartNanos === null || groupEndNanos === null) continue;
 
     // Find start time: last tool completion or UserPromptSubmit BEFORE this group
     let startTs = null;
     for (const pe of progressEvents) {
-      const peMs = Date.parse(pe.ts) || 0;
-      if (peMs >= groupStartMs) break;
+      const peTs = timestampOrderNanos(pe.ts);
+      if (peTs === null) continue;
+      if (peTs >= groupStartNanos) break;
       if (
         pe.hookEvent === 'PostToolUse' ||
         pe.hookEvent === 'PostToolUseFailure' ||
@@ -797,8 +819,8 @@ export function buildLlmBoundaries(progressEvents, contentEvents) {
     // Find end time: first PreToolUse or Stop AFTER this group
     let endTs = null;
     for (const pe of progressEvents) {
-      const peMs = Date.parse(pe.ts) || 0;
-      if (peMs <= groupEndMs) continue;
+      const peTs = timestampOrderNanos(pe.ts);
+      if (peTs === null || peTs <= groupEndNanos) continue;
       if (pe.hookEvent === 'PreToolUse' || pe.hookEvent === 'Stop') {
         endTs = pe.ts;
         break;
@@ -1080,19 +1102,19 @@ function assignContentToBoundaries(boundaries, contentEvents) {
     // Skip the user prompt row (already handled as user-hook outside boundaries)
     if (row.type === 'user' && !isToolResult(row)) continue;
 
-    const rowTs = row.timestamp ? Date.parse(row.timestamp) : 0;
-    if (!rowTs) continue;
+    const rowTs = timestampOrderNanos(row.timestamp);
+    if (rowTs === null) continue;
 
     // Each boundary "owns" from its startTs to the NEXT boundary's startTs (exclusive).
     // This ensures tool_result events (which occur between endTs and next startTs)
     // are assigned to the current boundary, not lost in the gap.
     let bestIdx = -1;
     for (let i = 0; i < boundaries.length; i++) {
-      const startMs = Date.parse(boundaries[i].startTs) || 0;
-      const nextStartMs = (i + 1 < boundaries.length)
-        ? Date.parse(boundaries[i + 1].startTs) || Infinity
-        : Infinity;
-      if (rowTs >= startMs && rowTs < nextStartMs) {
+      const startTs = timestampOrderNanos(boundaries[i].startTs);
+      const nextStartTs = (i + 1 < boundaries.length)
+        ? timestampOrderNanos(boundaries[i + 1].startTs)
+        : null;
+      if (startTs !== null && rowTs >= startTs && (nextStartTs === null || rowTs < nextStartTs)) {
         bestIdx = i;
         break;
       }

--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -174,9 +174,13 @@ async function main() {
     const transcriptIdx = args.indexOf('--transcript');
     const sessionIdx = args.indexOf('--session');
     const cwdIdx = args.indexOf('--cwd');
+    const triggerEndLineIdx = args.indexOf('--trigger-end-line');
     const transcriptPath = transcriptIdx >= 0 ? args[transcriptIdx + 1] : '';
     const sessionId = sessionIdx >= 0 ? args[sessionIdx + 1] : '';
     const cwd = cwdIdx >= 0 ? args[cwdIdx + 1] : undefined;
+    const triggerEndLine = triggerEndLineIdx >= 0
+      ? Number.parseInt(args[triggerEndLineIdx + 1], 10)
+      : Number.NaN;
     const { agentId, logPrefix } = parseArgs();
     if (!transcriptPath || !sessionId) return;
     logDebug(agentId, `Retry: processing ${transcriptPath} for session ${sessionId}`);
@@ -200,10 +204,57 @@ async function main() {
     try {
       const range = getLineRangeInfo(agentId, transcriptPath, sessionId);
       if (!range) return;
+
+      let targetWindow = null;
+      if (Number.isFinite(triggerEndLine)) {
+        // Stop may be appended only after the hook process receives its
+        // payload. Poll briefly for that Stop's SessionEnd, without ever
+        // falling through into a queued next prompt.
+        const maxBoundaryPolls = 3;
+        for (let poll = 0; poll < maxBoundaryPolls; poll++) {
+          targetWindow = findTriggeredTurnWindow(
+            transcriptPath,
+            triggerEndLine,
+            getTranscriptLineCount(transcriptPath),
+          );
+          if (targetWindow.status === 'complete') break;
+          if (poll + 1 < maxBoundaryPolls) {
+            await new Promise(r => setTimeout(r, 1000));
+          }
+        }
+
+        if (targetWindow?.status !== 'complete') {
+          logDebug(
+            agentId,
+            `Retry deferred: target turn is not complete (${targetWindow?.reason || 'unknown'})`,
+          );
+          return;
+        }
+        logDebug(
+          agentId,
+          `Retry target window: trigger=${triggerEndLine}, ` +
+          `range=${targetWindow.startLine}-${targetWindow.endLine}, ` +
+          `stop=${targetWindow.stopLine}, terminal=${targetWindow.reason}`,
+        );
+        if (range.startLine >= targetWindow.endLine) {
+          logDebug(
+            agentId,
+            `Retry skipped: cursor ${range.startLine} already passed target ${targetWindow.endLine}`,
+          );
+          return;
+        }
+      }
+
       await processTranscript(
         agentId, logPrefix, transcriptPath, sessionId,
-        range.startLine, range.endLine, runtimeConfig, cwd,
-        { delayApplied: true, rangeReason: range.reason },
+        targetWindow?.startLine ?? range.startLine,
+        targetWindow?.endLine ?? range.endLine,
+        runtimeConfig, cwd,
+        {
+          delayApplied: true,
+          rangeReason: range.reason,
+          fixedTurnWindow: targetWindow?.status === 'complete',
+        },
       );
     } finally {
       if (agentId === 'qoder-cn') releaseRetryLock(transcriptPath);
@@ -260,10 +311,10 @@ async function main() {
         logDebug(agentId, `Skip spawn: live retry lock held by pid ${existing.pid}`);
       } else {
         if (existing) { try { fs.unlinkSync(lockPath); } catch { /* ignore */ } }
-        spawnDelayedRetry(agentId, transcriptPath, sessionId, logPrefix, cwd);
+        spawnDelayedRetry(agentId, transcriptPath, sessionId, logPrefix, cwd, endLine);
       }
     } else {
-      spawnDelayedRetry(agentId, transcriptPath, sessionId, logPrefix, cwd);
+      spawnDelayedRetry(agentId, transcriptPath, sessionId, logPrefix, cwd, endLine);
     }
     return;
   }
@@ -293,7 +344,7 @@ async function main() {
 // NOTE: Retry subprocess won't race with normal hook because non-interactive mode (--print)
 // only fires Stop once per session (process exits after hook returns). The offset check in
 // getLineRangeInfo prevents double-processing if another hook invocation somehow occurs.
-function spawnDelayedRetry(agentId, transcriptPath, sessionId, logPrefix, cwd) {
+function spawnDelayedRetry(agentId, transcriptPath, sessionId, logPrefix, cwd, triggerEndLine) {
   const nodebin = process.argv[0];
   const script = fileURLToPath(import.meta.url);
   const spawnArgs = [
@@ -303,6 +354,7 @@ function spawnDelayedRetry(agentId, transcriptPath, sessionId, logPrefix, cwd) {
     '--retry',
     '--transcript', transcriptPath,
     '--session', sessionId,
+    '--trigger-end-line', String(triggerEndLine),
     ...(cwd ? ['--cwd', cwd] : []),
   ];
   const child = spawn(nodebin, spawnArgs, {
@@ -324,11 +376,18 @@ async function processTranscript(agentId, logPrefix, transcriptPath, sessionId, 
     }
   }
 
-  // Re-read transcript (may have grown since initial read)
+  // A Stop-anchored retry receives an exact UserPromptSubmit -> SessionEnd
+  // window. Do not expand that range to the current EOF: it may already contain
+  // the next queued prompt.
   let endLine = initialEndLine;
-  const currentCount = getTranscriptLineCount(transcriptPath);
-  if (currentCount > endLine) {
-    endLine = currentCount;
+  if (!opts?.fixedTurnWindow) {
+    const currentCount = getTranscriptLineCount(transcriptPath);
+    if (currentCount > endLine) {
+      endLine = currentCount;
+    }
+    if ((opts?.rangeReason || 'incremental') === 'incremental') {
+      endLine = findIncrementalTurnEndLine(transcriptPath, startLine, endLine);
+    }
   }
 
   let lines = readTranscriptLines(transcriptPath, startLine, endLine);
@@ -360,8 +419,13 @@ async function processTranscript(agentId, logPrefix, transcriptPath, sessionId, 
         progressEvents.push({ hookEvent, ts: row.timestamp, hookName: data.hookName || '' });
       }
       if (hookEvent) lastProgressHookEvent = hookEvent;
-    } else if (rowType === 'user' || rowType === 'assistant') {
-      contentEvents.push(row);
+    } else {
+      // Only adjacent progress rows from multiple registered commands are
+      // duplicates. Content between two equal hook events means a new cycle.
+      lastProgressHookEvent = '';
+      if (rowType === 'user' || rowType === 'assistant') {
+        contentEvents.push(row);
+      }
     }
     // session_meta, other types: ignored
   }
@@ -404,8 +468,11 @@ async function processTranscript(agentId, logPrefix, transcriptPath, sessionId, 
           progressEvents.push({ hookEvent, ts: row.timestamp, hookName: data.hookName || '' });
         }
         if (hookEvent) lastProgressHookEvent = hookEvent;
-      } else if (rowType === 'user' || rowType === 'assistant') {
-        contentEvents.push(row);
+      } else {
+        lastProgressHookEvent = '';
+        if (rowType === 'user' || rowType === 'assistant') {
+          contentEvents.push(row);
+        }
       }
     }
   }
@@ -476,59 +543,199 @@ export function selectTurnSegmentsForCollection(turnSegments, rangeReason, agent
   return turnSegments;
 }
 
+export function findIncrementalTurnEndLine(transcriptPath, startLine, scanEndLine) {
+  try {
+    if (!fs.existsSync(transcriptPath)) return scanEndLine;
+    const allLines = fs.readFileSync(transcriptPath, 'utf-8').split('\n');
+    let sawStop = false;
+
+    for (let i = startLine; i < scanEndLine && i < allLines.length; i++) {
+      const text = allLines[i].trim();
+      if (!text) continue;
+
+      let row;
+      try { row = JSON.parse(text); } catch { continue; }
+      const hookEvent = row.type === 'progress' ? row.data?.hookEvent || '' : '';
+      if (hookEvent === 'Stop') {
+        sawStop = true;
+      } else if (sawStop && (
+        hookEvent === 'UserPromptSubmit' ||
+        (row.type === 'user' && !isToolResult(row))
+      )) {
+        // `last_line_count` is the next unread zero-based line index. Returning
+        // the prompt line itself consumes the prior Stop/session metadata while
+        // preserving the queued turn's timing marker and user content.
+        return i;
+      }
+    }
+  } catch {
+    // Fail open to the caller's original scan range.
+  }
+  return scanEndLine;
+}
+
+export function findTriggeredTurnWindow(transcriptPath, triggerEndLine, scanEndLine) {
+  const waiting = reason => ({
+    status: 'waiting',
+    reason,
+    startLine: null,
+    stopLine: null,
+    endLine: null,
+  });
+
+  try {
+    if (!fs.existsSync(transcriptPath)) return waiting('transcript-missing');
+    const allLines = fs.readFileSync(transcriptPath, 'utf-8').split('\n');
+    const limit = Math.min(scanEndLine, allLines.length);
+    const rows = new Array(limit);
+
+    for (let i = 0; i < limit; i++) {
+      const text = allLines[i].trim();
+      if (!text) continue;
+      try { rows[i] = JSON.parse(text); } catch { /* skip malformed line */ }
+    }
+
+    // The trigger snapshot can end immediately before Qoder appends its Stop
+    // progress rows. Its last visible prompt identifies the active turn; the
+    // first Stop after that prompt is the Stop that launched this retry.
+    let triggerPromptLine = -1;
+    const triggerLimit = Math.min(Math.max(triggerEndLine, 0), limit);
+    for (let i = triggerLimit - 1; i >= 0; i--) {
+      if (hookEventOf(rows[i]) === 'UserPromptSubmit') {
+        triggerPromptLine = i;
+        break;
+      }
+    }
+    if (triggerPromptLine < 0) {
+      for (let i = triggerLimit - 1; i >= 0; i--) {
+        if (rows[i]?.type === 'user' && !isToolResult(rows[i])) {
+          triggerPromptLine = i;
+          break;
+        }
+      }
+    }
+    if (triggerPromptLine < 0) return waiting('prompt-not-found');
+
+    let stopLine = -1;
+    for (let i = triggerPromptLine + 1; i < limit; i++) {
+      const hookEvent = hookEventOf(rows[i]);
+      if (hookEvent === 'Stop') {
+        stopLine = i;
+        break;
+      }
+      if (i >= triggerLimit && (
+        hookEvent === 'UserPromptSubmit' ||
+        (rows[i]?.type === 'user' && !isToolResult(rows[i]))
+      )) {
+        return waiting('next-prompt-before-stop');
+      }
+    }
+    if (stopLine < 0) return waiting('stop-not-found');
+
+    // Resolve the start from the actual Stop instead of trusting a global
+    // cursor that may have been reset by redeployment.
+    let startLine = -1;
+    for (let i = stopLine - 1; i >= 0; i--) {
+      if (hookEventOf(rows[i]) === 'UserPromptSubmit') {
+        startLine = i;
+        break;
+      }
+    }
+    if (startLine < 0) {
+      for (let i = stopLine - 1; i >= 0; i--) {
+        if (rows[i]?.type === 'user' && !isToolResult(rows[i])) {
+          startLine = i;
+          break;
+        }
+      }
+    }
+    if (startLine < 0) return waiting('turn-start-not-found');
+
+    for (let i = stopLine + 1; i < limit; i++) {
+      const hookEvent = hookEventOf(rows[i]);
+      if (hookEvent === 'SessionEnd') {
+        return {
+          status: 'complete',
+          reason: 'session-end',
+          startLine,
+          stopLine,
+          endLine: i + 1,
+        };
+      }
+      if (rows[i]?.type === 'last-prompt') {
+        return {
+          status: 'complete',
+          reason: 'last-prompt',
+          startLine,
+          stopLine,
+          endLine: i + 1,
+        };
+      }
+      if (
+        hookEvent === 'UserPromptSubmit' ||
+        (rows[i]?.type === 'user' && !isToolResult(rows[i]))
+      ) {
+        return waiting('next-prompt-before-session-end');
+      }
+    }
+    return waiting('session-end-not-found');
+  } catch {
+    return waiting('read-failed');
+  }
+}
+
+function hookEventOf(row) {
+  return row?.type === 'progress' ? row.data?.hookEvent || '' : '';
+}
+
 // --- LLM Boundary Detection --------------------------------------------------
 
-function buildLlmBoundaries(progressEvents, contentEvents) {
-  // Step 1: Group assistant blocks into LLM calls.
-  // Priority: use message.id (CLI variant has it) > progress window (IDE variant)
-  // > fallback to timestamp proximity when progress events are absent.
+export function buildLlmBoundaries(progressEvents, contentEvents) {
+  // Step 1: Group assistant blocks into LLM calls. Qoder transcript assistant
+  // rows do not carry message.id, and progress windows are hook timing signals,
+  // not reliable provider-call boundaries.
+  //
+  // IDE transcript rows are content blocks, not one row per provider call. A
+  // complete response may therefore be spread over thinking, text and multiple
+  // tool_use rows, and parallel tool execution may even place an early
+  // tool_result between later tool_use rows. The deterministic boundary is:
+  // after every tool_use in the current response has a matching tool_result,
+  // the next assistant row starts a new LLM call.
   const assistantGroups = [];
   let currentGroup = [];
-  let lastTs = null;
-  let currentKey = null;
-  const hasProgressWindows = progressEvents.some(pe =>
-    pe.hookEvent === 'UserPromptSubmit' || pe.hookEvent === 'PostToolUse' ||
-    pe.hookEvent === 'PreToolUse' || pe.hookEvent === 'Stop'
-  );
+  let currentToolIds = new Set();
+  let resolvedToolIds = new Set();
 
   function flushGroup() {
     if (currentGroup.length > 0) assistantGroups.push(currentGroup);
     currentGroup = [];
-    lastTs = null;
-    currentKey = null;
+    currentToolIds = new Set();
+    resolvedToolIds = new Set();
   }
 
   for (const row of contentEvents) {
     if (row.type !== 'assistant') {
-      flushGroup();
+      if (isToolResult(row)) {
+        for (const block of row.message?.content || []) {
+          if (block?.type === 'tool_result' && block.tool_use_id) {
+            resolvedToolIds.add(block.tool_use_id);
+          }
+        }
+      }
       continue;
     }
     const ts = row.timestamp ? Date.parse(row.timestamp) : 0;
     if (!ts) continue;
 
-    const messageId = row.message?.id || null;
-    const key = messageId
-      ? `message:${messageId}`
-      : hasProgressWindows
-        ? progressWindowKey(progressEvents, ts)
-        : null;
-
-    // Determine if this row starts a new LLM call
-    let isNewCall = false;
-    if (currentGroup.length > 0 && key && currentKey) {
-      isNewCall = key !== currentKey;
-    } else if (currentGroup.length > 0 && !key && !currentKey) {
-      isNewCall = lastTs !== null && (ts - lastTs) > 200;
-    } else if (currentGroup.length > 0 && key !== currentKey) {
-      // Mixed keyed/unkeyed rows are unusual; keep the old time-gap fallback.
-      isNewCall = lastTs !== null && (ts - lastTs) > 200;
-    }
-
-    if (isNewCall) flushGroup();
+    const toolCycleComplete = currentGroup.length > 0 &&
+      currentToolIds.size > 0 &&
+      [...currentToolIds].every(id => resolvedToolIds.has(id));
+    if (toolCycleComplete) flushGroup();
 
     currentGroup.push(row);
-    currentKey = key;
-    lastTs = ts;
+    for (const block of row.message?.content || []) {
+      if (block?.type === 'tool_use' && block.id) currentToolIds.add(block.id);
+    }
   }
   flushGroup();
 
@@ -539,12 +746,16 @@ function buildLlmBoundaries(progressEvents, contentEvents) {
     const groupStartMs = Date.parse(group[0].timestamp) || 0;
     const groupEndMs = Date.parse(group[group.length - 1].timestamp) || groupStartMs;
 
-    // Find start time: last PostToolUse or UserPromptSubmit BEFORE this group
+    // Find start time: last tool completion or UserPromptSubmit BEFORE this group
     let startTs = null;
     for (const pe of progressEvents) {
       const peMs = Date.parse(pe.ts) || 0;
       if (peMs >= groupStartMs) break;
-      if (pe.hookEvent === 'PostToolUse' || pe.hookEvent === 'UserPromptSubmit') {
+      if (
+        pe.hookEvent === 'PostToolUse' ||
+        pe.hookEvent === 'PostToolUseFailure' ||
+        pe.hookEvent === 'UserPromptSubmit'
+      ) {
         startTs = pe.ts;
       }
     }
@@ -569,37 +780,9 @@ function buildLlmBoundaries(progressEvents, contentEvents) {
   return boundaries;
 }
 
-function progressWindowKey(progressEvents, rowMs) {
-  let startTs = null;
-  for (const pe of progressEvents) {
-    const peMs = Date.parse(pe.ts) || 0;
-    if (peMs >= rowMs) break;
-    if (pe.hookEvent === 'PostToolUse' || pe.hookEvent === 'UserPromptSubmit') {
-      startTs = pe.ts;
-    }
-  }
-
-  // If no start boundary found, this row appears before any progress event.
-  // Return null to let the caller fall back to time-gap grouping, avoiding
-  // incorrect merging of distinct LLM calls that precede the first progress event.
-  if (!startTs) return null;
-
-  let endTs = null;
-  for (const pe of progressEvents) {
-    const peMs = Date.parse(pe.ts) || 0;
-    if (peMs <= rowMs) continue;
-    if (pe.hookEvent === 'PreToolUse' || pe.hookEvent === 'Stop') {
-      endTs = pe.ts;
-      break;
-    }
-  }
-
-  return `progress:${startTs}->${endTs || ''}`;
-}
-
 // --- Event Builder -----------------------------------------------------------
 
-function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, turnId, sessionId, agentId, runtimeConfig, cwd) {
+export function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, turnId, sessionId, agentId, runtimeConfig, cwd) {
   const records = [];
   const observedTs = timestampToUnixNanos(Date.now());
 
@@ -709,7 +892,12 @@ function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, turnId,
             outputParts.push({ type: 'text', content: block.text || '' });
           } else if (block.type === 'tool_use') {
             outputParts.push({ type: 'tool_call', id: block.id, name: block.name, arguments: block.input });
-            toolCalls.push({ id: block.id, name: block.name, input: block.input, preToolTs: endNanos });
+            toolCalls.push({
+              id: block.id,
+              name: block.name,
+              input: block.input,
+              callTs: row.timestamp,
+            });
           }
         }
       } else if (row.type === 'user' && isToolResult(row)) {
@@ -717,7 +905,12 @@ function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, turnId,
         for (const block of blocks) {
           if (block.type === 'tool_result') {
             const resultText = typeof block.content === 'string' ? block.content : JSON.stringify(block.content);
-            toolResultsForNextStep.push({ toolId: block.tool_use_id, result: resultText });
+            toolResultsForNextStep.push({
+              toolId: block.tool_use_id,
+              result: resultText,
+              isError: block.is_error === true,
+              resultTs: row.timestamp,
+            });
           }
         }
       }
@@ -771,11 +964,17 @@ function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, turnId,
       });
     }
 
-    // tool.call + tool.result events
+    // tool.call + tool.result events. Parallel tools may finish out of order,
+    // so array position is not a valid association key.
+    const toolResultsById = new Map(
+      toolResultsForNextStep
+        .filter(result => result.toolId)
+        .map(result => [result.toolId, result]),
+    );
     for (let ti = 0; ti < toolCalls.length; ti++) {
       const tc = toolCalls[ti];
-      const tr = toolResultsForNextStep[ti];
-      const toolCallTs = endNanos;
+      const tr = toolResultsById.get(tc.id);
+      const toolCallTs = tc.callTs ? isoToUnixNanos(tc.callTs) || endNanos : endNanos;
 
       records.push({
         'event.id': crypto.randomUUID(),
@@ -795,10 +994,14 @@ function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, turnId,
       });
 
       if (tr) {
-        // Find PostToolUse timestamp for this tool
-        const postToolTs = findPostToolUseTs(boundaries, i)
-          || (BigInt(toolCallTs) + 1_000_000n).toString(); // +1ms fallback → tool span duration ≥ 1ms
-        const toolDurationMs = computeDurationMs(toolCallTs, postToolTs);
+        // tool_result carries both the tool ID and its actual completion
+        // timestamp. PostToolUse progress rows have no tool ID and may arrive
+        // out of order, so they cannot safely determine per-tool timing.
+        const toolResultTs = ensureEndAfterStart(
+          toolCallTs,
+          tr.resultTs ? isoToUnixNanos(tr.resultTs) : '',
+        );
+        const toolDurationMs = computeDurationMs(toolCallTs, toolResultTs);
         records.push({
           'event.id': crypto.randomUUID(),
           'event.name': 'tool.result',
@@ -810,11 +1013,11 @@ function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, turnId,
           'gen_ai.tool.call.id': tc.id,
           'gen_ai.tool.call.exec.id': tc.id,
           'gen_ai.tool.call.result': tr.result,
-          'tool.result.status': 'success',
+          'tool.result.status': tr.isError ? 'error' : 'success',
           ...(toolDurationMs > 0 ? { 'gen_ai.tool.call.duration': toolDurationMs } : {}),
           'user.id': userId,
           'agent.source': 'qoder-transcript-hook',
-          time_unix_nano: postToolTs,
+          time_unix_nano: toolResultTs,
           observed_time_unix_nano: observedTs,
         });
       }
@@ -894,11 +1097,16 @@ function splitContentEventsIntoTurns(contentEvents) {
   return turns;
 }
 
-function findPostToolUseTs(boundaries, currentIdx) {
-  if (currentIdx + 1 < boundaries.length) {
-    return isoToUnixNanos(boundaries[currentIdx + 1].startTs);
+function ensureEndAfterStart(startNanos, candidateEndNanos) {
+  try {
+    const start = BigInt(startNanos);
+    if (candidateEndNanos && BigInt(candidateEndNanos) > start) {
+      return candidateEndNanos;
+    }
+    return String(start + 1_000_000n);
+  } catch {
+    return candidateEndNanos || startNanos;
   }
-  return null;
 }
 
 function isToolResult(row) {

--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -18,8 +18,6 @@ import {
   parseStdinPayload,
   logDebug,
   getLineRangeInfo,
-  getTranscriptLineCount,
-  readTranscriptLines,
   appendRowsToHistory,
   updateLineRecord,
   loadHookRuntimeConfig,
@@ -202,21 +200,27 @@ async function main() {
       }
     }
     try {
-      const range = getLineRangeInfo(agentId, transcriptPath, sessionId);
-      if (!range) return;
-
       let targetWindow = null;
+      let retrySnapshot = null;
+      let range = null;
       if (Number.isFinite(triggerEndLine)) {
         // Stop may be appended only after the hook process receives its
         // payload. Poll briefly for that Stop's SessionEnd, without ever
         // falling through into a queued next prompt.
         const maxBoundaryPolls = 3;
         for (let poll = 0; poll < maxBoundaryPolls; poll++) {
-          targetWindow = findTriggeredTurnWindow(
+          // One immutable snapshot per poll supplies both EOF/cursor validation
+          // and turn-boundary discovery. The successful snapshot is passed
+          // directly to processTranscript, so it is never read again.
+          retrySnapshot = readTranscriptSnapshot(transcriptPath);
+          range = getLineRangeInfo(
+            agentId,
             transcriptPath,
-            triggerEndLine,
-            getTranscriptLineCount(transcriptPath),
+            sessionId,
+            retrySnapshot.lineCount,
           );
+          if (!range) return;
+          targetWindow = findTriggeredTurnWindow(retrySnapshot, triggerEndLine);
           if (targetWindow.status === 'complete') break;
           if (poll + 1 < maxBoundaryPolls) {
             await new Promise(r => setTimeout(r, 1000));
@@ -243,6 +247,16 @@ async function main() {
           );
           return;
         }
+      } else {
+        // Compatibility with a retry spawned by an older deployed wrapper.
+        retrySnapshot = readTranscriptSnapshot(transcriptPath);
+        range = getLineRangeInfo(
+          agentId,
+          transcriptPath,
+          sessionId,
+          retrySnapshot.lineCount,
+        );
+        if (!range) return;
       }
 
       await processTranscript(
@@ -254,6 +268,7 @@ async function main() {
           delayApplied: true,
           rangeReason: range.reason,
           fixedTurnWindow: targetWindow?.status === 'complete',
+          snapshot: retrySnapshot,
         },
       );
     } finally {
@@ -276,14 +291,17 @@ async function main() {
 
   const runtimeConfig = loadHookRuntimeConfig(path.join(HOOKS_DIR, '..'));
 
-  const range = getLineRangeInfo(agentId, transcriptPath, sessionId);
+  // Read once: this snapshot supplies EOF, incomplete detection, Turn parsing,
+  // and the eventual processor input.
+  const snapshot = readTranscriptSnapshot(transcriptPath);
+  const range = getLineRangeInfo(agentId, transcriptPath, sessionId, snapshot.lineCount);
   if (!range) return;
 
   const startLine = range.startLine;
   const endLine = range.endLine;
-  const lines = readTranscriptLines(transcriptPath, startLine, endLine);
-  logDebug(agentId, `Read ${lines.length} lines (range: ${startLine}-${endLine})`);
-  if (!lines.length) {
+  const parsed = snapshot.rows.slice(startLine, endLine).filter(Boolean);
+  logDebug(agentId, `Read ${parsed.length} lines (range: ${startLine}-${endLine})`);
+  if (!parsed.length) {
     updateLineRecord(agentId, transcriptPath, sessionId, endLine);
     return;
   }
@@ -291,11 +309,6 @@ async function main() {
   // Detect incomplete transcript (race condition in print/non-interactive mode:
   // Stop hook fires BEFORE transcript is fully written, and writes happen AFTER hook returns).
   // Solution: spawn a background retry that runs after 5s delay.
-  let parsed = [];
-  for (const line of lines) {
-    try { parsed.push(JSON.parse(line)); } catch { /* skip */ }
-  }
-
   // last-prompt is the authoritative end-of-transcript marker written by qodercli on exit.
   // If absent, the file is still being flushed (race: Stop hook fires before transcript flush).
   const hasLastPrompt = parsed.some(p => p.type === 'last-prompt');
@@ -327,7 +340,7 @@ async function main() {
     try {
       await processTranscript(
         agentId, logPrefix, transcriptPath, sessionId, startLine, endLine,
-        runtimeConfig, cwd, { rangeReason: range.reason },
+        runtimeConfig, cwd, { rangeReason: range.reason, snapshot },
       );
     } finally {
       releaseRetryLock(transcriptPath);
@@ -337,7 +350,7 @@ async function main() {
 
   await processTranscript(
     agentId, logPrefix, transcriptPath, sessionId, startLine, endLine,
-    runtimeConfig, cwd, { rangeReason: range.reason },
+    runtimeConfig, cwd, { rangeReason: range.reason, snapshot },
   );
 }
 
@@ -376,31 +389,27 @@ async function processTranscript(agentId, logPrefix, transcriptPath, sessionId, 
     }
   }
 
+  const snapshot = opts?.snapshot || readTranscriptSnapshot(transcriptPath);
+
   // A Stop-anchored retry receives an exact UserPromptSubmit -> SessionEnd
   // window. Do not expand that range to the current EOF: it may already contain
   // the next queued prompt.
   let endLine = initialEndLine;
   if (!opts?.fixedTurnWindow) {
-    const currentCount = getTranscriptLineCount(transcriptPath);
+    const currentCount = snapshot.lineCount;
     if (currentCount > endLine) {
       endLine = currentCount;
     }
     if ((opts?.rangeReason || 'incremental') === 'incremental') {
-      endLine = findIncrementalTurnEndLine(transcriptPath, startLine, endLine);
+      endLine = findIncrementalTurnEndLine(snapshot, startLine, endLine);
     }
   }
 
-  let lines = readTranscriptLines(transcriptPath, startLine, endLine);
-  logDebug(agentId, `Processing ${lines.length} lines (range: ${startLine}-${endLine})`);
-  if (!lines.length) {
+  let parsed = snapshot.rows.slice(startLine, endLine).filter(Boolean);
+  logDebug(agentId, `Processing ${parsed.length} lines (range: ${startLine}-${endLine})`);
+  if (!parsed.length) {
     updateLineRecord(agentId, transcriptPath, sessionId, endLine);
     return;
-  }
-
-  // --- Phase 1: Parse all transcript lines ---
-  let parsed = [];
-  for (const line of lines) {
-    try { parsed.push(JSON.parse(line)); } catch { /* skip */ }
   }
 
   // --- Phase 2: Extract progress timing + content events ---
@@ -443,35 +452,36 @@ async function processTranscript(agentId, logPrefix, transcriptPath, sessionId, 
       logDebug(agentId, `Transcript not yet complete (no Stop event in progress). Skipping processing.`);
       return;
     }
-    // Stop detected — reprocess the entire transcript from the beginning so
-    // splitContentEventsIntoTurns sees the complete ReAct chain (user →
-    // assistant(text+tool_use) → user(tool_result) → assistant(text)) and
-    // generates one turn with all LLM calls and correct input.messages_delta.
-    startLine = 0;
-    lines = readTranscriptLines(transcriptPath, startLine, endLine);
-    logDebug(agentId, `Reprocessing full transcript from 0-${endLine} (${lines.length} lines)`);
-    // Re-parse since we reset startLine
-    parsed = [];
-    for (const line of lines) {
-      try { parsed.push(JSON.parse(line)); } catch { /* skip */ }
-    }
-    // Re-extract progress + content events from the full transcript
-    progressEvents.length = 0;
-    contentEvents.length = 0;
-    lastProgressHookEvent = '';
-    for (const row of parsed) {
-      const rowType = row.type;
-      if (rowType === 'progress') {
-        const data = row.data || {};
-        const hookEvent = data.hookEvent || '';
-        if (hookEvent && hookEvent !== lastProgressHookEvent) {
-          progressEvents.push({ hookEvent, ts: row.timestamp, hookName: data.hookName || '' });
-        }
-        if (hookEvent) lastProgressHookEvent = hookEvent;
-      } else {
-        lastProgressHookEvent = '';
-        if (rowType === 'user' || rowType === 'assistant') {
-          contentEvents.push(row);
+    // A precise retry snapshot already contains the complete target Turn. Only
+    // legacy/non-anchored handling needs the historical full-snapshot view to
+    // recover a Turn that may have been split across multiple Stop callbacks.
+    if (opts?.fixedTurnWindow) {
+      logDebug(agentId, `Processing precise QoderCN turn window ${startLine}-${endLine}`);
+    } else {
+      // Stop detected — use the already-loaded snapshot from the beginning so
+      // splitContentEventsIntoTurns can recover a Turn that crossed multiple
+      // QoderCN Stop callbacks. This changes only the in-memory slice; it does
+      // not read the transcript again.
+      startLine = 0;
+      parsed = snapshot.rows.slice(startLine, endLine).filter(Boolean);
+      logDebug(agentId, `Reprocessing snapshot from 0-${endLine} (${parsed.length} lines)`);
+      progressEvents.length = 0;
+      contentEvents.length = 0;
+      lastProgressHookEvent = '';
+      for (const row of parsed) {
+        const rowType = row.type;
+        if (rowType === 'progress') {
+          const data = row.data || {};
+          const hookEvent = data.hookEvent || '';
+          if (hookEvent && hookEvent !== lastProgressHookEvent) {
+            progressEvents.push({ hookEvent, ts: row.timestamp, hookName: data.hookName || '' });
+          }
+          if (hookEvent) lastProgressHookEvent = hookEvent;
+        } else {
+          lastProgressHookEvent = '';
+          if (rowType === 'user' || rowType === 'assistant') {
+            contentEvents.push(row);
+          }
         }
       }
     }
@@ -483,11 +493,10 @@ async function processTranscript(agentId, logPrefix, transcriptPath, sessionId, 
   // inheriting the first prompt of the whole transcript segment.
   const allTurnSegments = splitContentEventsIntoTurns(contentEvents);
   const rangeReason = opts?.rangeReason || 'incremental';
-  // Cursor recovery always reads the full transcript to re-establish a safe
-  // checkpoint, but only the latest logical turn is new. QoderCN also rebuilds
-  // from line 0 on every completed Stop so its full ReAct chain is available;
-  // it must therefore emit only the latest logical turn even with a valid
-  // incremental cursor.
+  // Cursor recovery may inspect the full snapshot to re-establish a safe
+  // checkpoint, but only the latest logical turn is new. Legacy/non-anchored
+  // QoderCN handling may also rebuild from snapshot line 0; an exact retry
+  // window already contains one Turn. In all cases QoderCN emits only latest.
   const turnSegments = selectTurnSegmentsForCollection(allTurnSegments, rangeReason, agentId);
   const keepLatestTurnOnly = turnSegments.length < allTurnSegments.length;
   if (keepLatestTurnOnly && allTurnSegments.length > turnSegments.length) {
@@ -534,47 +543,60 @@ async function processTranscript(agentId, logPrefix, transcriptPath, sessionId, 
 }
 
 export function selectTurnSegmentsForCollection(turnSegments, rangeReason, agentId) {
-  // QoderCN intentionally reparses the complete transcript on every Stop to
-  // rebuild its ReAct chain. Other variants only do that during cursor
-  // recovery. In both cases, only the latest logical turn may be emitted.
+  // QoderCN can inspect a complete snapshot to rebuild its ReAct chain. Other
+  // variants do that only during cursor recovery. Only latest may be emitted.
   if (rangeReason !== 'incremental' || agentId === 'qoder-cn') {
     return turnSegments.slice(-1);
   }
   return turnSegments;
 }
 
-export function findIncrementalTurnEndLine(transcriptPath, startLine, scanEndLine) {
+export function readTranscriptSnapshot(transcriptPath) {
   try {
-    if (!fs.existsSync(transcriptPath)) return scanEndLine;
-    const allLines = fs.readFileSync(transcriptPath, 'utf-8').split('\n');
-    let sawStop = false;
-
-    for (let i = startLine; i < scanEndLine && i < allLines.length; i++) {
-      const text = allLines[i].trim();
-      if (!text) continue;
-
-      let row;
-      try { row = JSON.parse(text); } catch { continue; }
-      const hookEvent = row.type === 'progress' ? row.data?.hookEvent || '' : '';
-      if (hookEvent === 'Stop') {
-        sawStop = true;
-      } else if (sawStop && (
-        hookEvent === 'UserPromptSubmit' ||
-        (row.type === 'user' && !isToolResult(row))
-      )) {
-        // `last_line_count` is the next unread zero-based line index. Returning
-        // the prompt line itself consumes the prior Stop/session metadata while
-        // preserving the queued turn's timing marker and user content.
-        return i;
-      }
+    if (!fs.existsSync(transcriptPath)) {
+      return { lineCount: 0, rows: [], reason: 'transcript-missing' };
     }
+    const content = fs.readFileSync(transcriptPath, 'utf-8');
+    const lines = content.split('\n');
+    const lineCount = content.length > 0 && content[content.length - 1] !== '\n'
+      ? lines.length
+      : Math.max(0, lines.length - 1);
+    const rows = new Array(lineCount);
+    for (let i = 0; i < lineCount; i++) {
+      const text = lines[i].trim();
+      if (!text) continue;
+      try { rows[i] = JSON.parse(text); } catch { /* skip malformed line */ }
+    }
+    return { lineCount, rows, reason: 'ok' };
   } catch {
-    // Fail open to the caller's original scan range.
+    return { lineCount: 0, rows: [], reason: 'read-failed' };
+  }
+}
+
+export function findIncrementalTurnEndLine(snapshot, startLine, scanEndLine) {
+  const rows = snapshot?.rows || [];
+  let sawStop = false;
+
+  for (let i = startLine; i < scanEndLine && i < rows.length; i++) {
+    const row = rows[i];
+    if (!row) continue;
+    const hookEvent = hookEventOf(row);
+    if (hookEvent === 'Stop') {
+      sawStop = true;
+    } else if (sawStop && (
+      hookEvent === 'UserPromptSubmit' ||
+      (row.type === 'user' && !isToolResult(row))
+    )) {
+      // `last_line_count` is the next unread zero-based line index. Returning
+      // the prompt line itself consumes the prior Stop/session metadata while
+      // preserving the queued turn's timing marker and user content.
+      return i;
+    }
   }
   return scanEndLine;
 }
 
-export function findTriggeredTurnWindow(transcriptPath, triggerEndLine, scanEndLine) {
+export function findTriggeredTurnWindow(snapshot, triggerEndLine) {
   const waiting = reason => ({
     status: 'waiting',
     reason,
@@ -584,16 +606,9 @@ export function findTriggeredTurnWindow(transcriptPath, triggerEndLine, scanEndL
   });
 
   try {
-    if (!fs.existsSync(transcriptPath)) return waiting('transcript-missing');
-    const allLines = fs.readFileSync(transcriptPath, 'utf-8').split('\n');
-    const limit = Math.min(scanEndLine, allLines.length);
-    const rows = new Array(limit);
-
-    for (let i = 0; i < limit; i++) {
-      const text = allLines[i].trim();
-      if (!text) continue;
-      try { rows[i] = JSON.parse(text); } catch { /* skip malformed line */ }
-    }
+    if (snapshot?.reason !== 'ok') return waiting(snapshot?.reason || 'read-failed');
+    const rows = snapshot.rows;
+    const limit = snapshot.lineCount;
 
     // The trigger snapshot can end immediately before Qoder appends its Stop
     // progress rows. Its last visible prompt identifies the active turn; the
@@ -705,12 +720,14 @@ export function buildLlmBoundaries(progressEvents, contentEvents) {
   let currentGroup = [];
   let currentToolIds = new Set();
   let resolvedToolIds = new Set();
+  let currentToolStartMs = null;
 
   function flushGroup() {
     if (currentGroup.length > 0) assistantGroups.push(currentGroup);
     currentGroup = [];
     currentToolIds = new Set();
     resolvedToolIds = new Set();
+    currentToolStartMs = null;
   }
 
   for (const row of contentEvents) {
@@ -730,11 +747,28 @@ export function buildLlmBoundaries(progressEvents, contentEvents) {
     const toolCycleComplete = currentGroup.length > 0 &&
       currentToolIds.size > 0 &&
       [...currentToolIds].every(id => resolvedToolIds.has(id));
-    if (toolCycleComplete) flushGroup();
+    // A cancelled/interrupted tool can omit its transcript tool_result even
+    // though Qoder emitted a completion hook. Count completion signals only
+    // within this group and require enough signals to cover every tool already
+    // declared; this preserves late parallel tool_use blocks after an early
+    // result while preventing an unresolved tool from swallowing all later LLMs.
+    const completedByHook = currentGroup.length > 0 &&
+      currentToolIds.size > 0 &&
+      currentToolStartMs !== null &&
+      progressEvents.filter(pe => {
+        const peMs = Date.parse(pe.ts) || 0;
+        return peMs > currentToolStartMs && peMs < ts && (
+          pe.hookEvent === 'PostToolUse' || pe.hookEvent === 'PostToolUseFailure'
+        );
+      }).length >= currentToolIds.size;
+    if (toolCycleComplete || completedByHook) flushGroup();
 
     currentGroup.push(row);
     for (const block of row.message?.content || []) {
-      if (block?.type === 'tool_use' && block.id) currentToolIds.add(block.id);
+      if (block?.type === 'tool_use' && block.id) {
+        currentToolIds.add(block.id);
+        if (currentToolStartMs === null) currentToolStartMs = ts;
+      }
     }
   }
   flushGroup();
@@ -841,8 +875,10 @@ export function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, 
 
     // llm.request for this step
     let inputDelta;
+    let emitRequest = i > 0;
     if (i === 0 && userRow) {
       inputDelta = [{ role: 'user', parts: [{ type: 'text', content: extractUserText(userRow) }] }];
+      emitRequest = true;
     } else if (toolResultsForNextStep.length > 0) {
       inputDelta = toolResultsForNextStep.map(tr => ({
         role: 'tool',
@@ -850,7 +886,7 @@ export function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, 
       }));
     }
 
-    if (inputDelta) {
+    if (emitRequest) {
       records.push({
         'event.id': crypto.randomUUID(),
         'event.name': 'llm.request',
@@ -861,7 +897,7 @@ export function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, 
         'gen_ai.provider.name': providerName,
         'gen_ai.request.model': stepModel,
         'user.id': userId,
-        'gen_ai.input.messages_delta': inputDelta,
+        ...(inputDelta ? { 'gen_ai.input.messages_delta': inputDelta } : {}),
         'agent.source': 'qoder-transcript-hook',
         time_unix_nano: startNanos,
         observed_time_unix_nano: observedTs,

--- a/assets/hooks/shared/hook-processor-base.mjs
+++ b/assets/hooks/shared/hook-processor-base.mjs
@@ -268,7 +268,7 @@ export function getTranscriptLineCount(transcriptPath) {
   }
 }
 
-export function getLineRangeInfo(agentId, transcriptPath, sessionId) {
+export function getLineRangeInfo(agentId, transcriptPath, sessionId, knownCurrentCount) {
   const record = loadLineRecord(agentId, sessionId);
   const hasRecordedOffset = Number.isFinite(record.last_line_count)
     && record.last_line_count >= 0;
@@ -277,7 +277,11 @@ export function getLineRangeInfo(agentId, transcriptPath, sessionId) {
   const recordedTranscript = record.transcript_path || '';
   let reason = hasRecordedOffset ? 'incremental' : 'missing-cursor';
 
-  const currentCount = getTranscriptLineCount(transcriptPath);
+  // Callers that already hold a transcript snapshot can pass its line count so
+  // cursor validation does not read the complete file a second time.
+  const currentCount = Number.isFinite(knownCurrentCount)
+    ? knownCurrentCount
+    : getTranscriptLineCount(transcriptPath);
 
   if (recordedSession && recordedSession !== sessionId) {
     logDebug(agentId, `Session changed: ${recordedSession} -> ${sessionId}, reset to 0`);

--- a/src/inputs/qoder-trace/token-enricher.ts
+++ b/src/inputs/qoder-trace/token-enricher.ts
@@ -10,13 +10,6 @@ import type { SqliteTokenData } from './sqlite-token-reader.js';
 // ~1.4s; the accurate agent.qoder.match_ts (when present) matches within a few ms.
 const TIMESTAMP_THRESHOLD_MS = 5000;
 
-// Time-sanity guard for the order-based pass: reject a positional pair whose
-// response↔row time gap is implausibly large (guards against mis-alignment when a
-// row is missing in the middle). STRICT applies when the response carries the
-// accurate match_ts; LOOSE applies when only the drifted time_unix_nano is available.
-const ORDER_MATCH_STRICT_MS = 1000;
-const ORDER_MATCH_LOOSE_MS = 3000;
-
 export function enrichCliTurn(
   entries: AgentActivityEntry[],
   segments: SegmentTokenData[],
@@ -92,8 +85,8 @@ export function enrichCliTurn(
       matches[0].time_unix_nano = String(BigInt(seg.responseEndTs) * 1_000_000n);
     }
 
-    // tool.call: use segment responseEndTs (tool starts when LLM finishes)
-    // tool.result: use segment toolFinishedTs (tool ends when execution completes)
+    // Preserve per-tool hook timestamps when available. Segment timing has no
+    // tool ID, so it is only a fallback for legacy hook records.
     if (stepId && seg.toolFinishedTs > 0) {
       const toolCalls = entries.filter(e =>
         e['event.name'] === 'tool.call' && e['gen_ai.step.id'] === stepId,
@@ -106,10 +99,16 @@ export function enrichCliTurn(
       const toolDurationMs = seg.responseEndTs > 0
         ? seg.toolFinishedTs - seg.responseEndTs
         : 0;
-      for (const tc of toolCalls) tc.time_unix_nano = toolCallTs;
+      for (const tc of toolCalls) {
+        if (parseUnixNanos(tc.time_unix_nano) === undefined) {
+          tc.time_unix_nano = toolCallTs;
+        }
+      }
       for (const tr of toolResults) {
-        tr.time_unix_nano = toolResultTs;
-        if (toolDurationMs > 0) {
+        if (parseUnixNanos(tr.time_unix_nano) === undefined) {
+          tr.time_unix_nano = toolResultTs;
+        }
+        if (tr['gen_ai.tool.call.duration'] === undefined && toolDurationMs > 0) {
           (tr as Record<string, unknown>)['gen_ai.tool.call.duration'] = toolDurationMs;
         }
       }
@@ -203,8 +202,8 @@ export function enrichIdeTurn(
 
   matchIdeTurnsBySqliteOrder(entries, sortedGroups, used, tokenWritten);
 
-  // Conservative fallback for incomplete SQLite metadata or structurally unmatched responses:
-  // match by close timestamp only, preserving the previous behavior.
+  // Compatibility fallback for rows that lack the session/message metadata
+  // needed by the deterministic turn/order pass.
   for (const [requestId, group] of sortedGroups) {
     for (const row of group) {
       // Skip rows already consumed by the order-based pass so Pass B only handles
@@ -310,21 +309,44 @@ export function enrichIdeTurn(
 
     if (req) {
       if (i > 0) {
-        // Previous step's gmt_create + 1ms (accounts for tool.result buffer in prior step)
-        req.time_unix_nano = String(BigInt(matchedPairs[i - 1].gmtCreate + 1) * 1_000_000n);
+        // Start after the previous response and all of its tools. Hook records
+        // now carry per-tool result timestamps, so a fixed +1ms after the
+        // response would make the next LLM overlap a still-running tool.
+        let requestStart = BigInt(matchedPairs[i - 1].gmtCreate + 1) * 1_000_000n;
+        const previousResponseIndex = entries.indexOf(matchedPairs[i - 1].entry);
+        const currentResponseIndex = entries.indexOf(respEntry);
+        for (let j = previousResponseIndex + 1; j < currentResponseIndex; j++) {
+          if (entries[j]['event.name'] !== 'tool.result') continue;
+          const resultTime = parseUnixNanos(entries[j].time_unix_nano);
+          if (resultTime !== undefined && resultTime >= requestStart) {
+            requestStart = resultTime + 1_000_000n;
+          }
+        }
+        const hookRequestTime = parseUnixNanos(req.time_unix_nano);
+        if (hookRequestTime !== undefined && hookRequestTime > requestStart) {
+          requestStart = hookRequestTime;
+        }
+        req.time_unix_nano = String(requestStart);
       } else if (userBoundary) {
         // Use userBoundary.time + 1ms so the LLM request starts strictly after
         // the user prompt event. When both share the same timestamp the converter
         // generates a duplicate empty STEP (0ms, no LLM children) because it
         // sees two events at the same instant inside step s1.
         const ubNs = BigInt(String(userBoundary.time_unix_nano));
-        req.time_unix_nano = String(ubNs + 1_000_000n); // +1ms
+        const minimumRequestTime = ubNs + 1_000_000n;
+        const hookRequestTime = parseUnixNanos(req.time_unix_nano);
+        req.time_unix_nano = String(
+          hookRequestTime !== undefined && hookRequestTime > minimumRequestTime
+            ? hookRequestTime
+            : minimumRequestTime,
+        );
       }
     }
 
-    // IDE data has no tool-finished timestamp; place tool.call at response time
-    // and tool.result 1ms later. The next step's llm.request is offset by +1ms
-    // to match, keeping steps non-overlapping.
+    // Preserve per-tool timestamps emitted by the hook. SQLite has no tool ID
+    // or tool-finished timestamp, so it cannot improve those values. The old
+    // gmt_create/+1ms fallback is retained only for legacy records whose tool
+    // timestamps are missing or malformed.
     const toolCallTs = String(BigInt(gmtCreate) * 1_000_000n);
     const toolResultTs = String(BigInt(gmtCreate + 1) * 1_000_000n);
     const respIdx = entries.indexOf(respEntry);
@@ -332,8 +354,14 @@ export function enrichIdeTurn(
       ? entries.indexOf(matchedPairs[i + 1].entry)
       : entries.length;
     for (let j = respIdx + 1; j < rightBound; j++) {
-      if (entries[j]['event.name'] === 'tool.call') entries[j].time_unix_nano = toolCallTs;
-      if (entries[j]['event.name'] === 'tool.result') entries[j].time_unix_nano = toolResultTs;
+      if (entries[j]['event.name'] === 'tool.call' &&
+          parseUnixNanos(entries[j].time_unix_nano) === undefined) {
+        entries[j].time_unix_nano = toolCallTs;
+      }
+      if (entries[j]['event.name'] === 'tool.result' &&
+          parseUnixNanos(entries[j].time_unix_nano) === undefined) {
+        entries[j].time_unix_nano = toolResultTs;
+      }
     }
   }
 
@@ -389,44 +417,54 @@ function matchIdeTurnsBySqliteOrder(
   const turnGroups = groupEntriesByTurn(entries);
   if (turnGroups.length === 0) return;
 
-  if (sessionGroups.length < turnGroups.length) {
-    for (const [, turnEntries] of turnGroups) {
-      markLowConfidence(turnEntries, 'request_count_mismatch');
-    }
-    return;
-  }
-
-  const candidateGroups = sessionGroups.slice(sessionGroups.length - turnGroups.length);
-  for (let i = 0; i < turnGroups.length; i++) {
+  // SQLite contains the full session while hook entries normally contain only
+  // newly collected turns, so align the newest request groups with those turns.
+  // If SQLite is still persisting the newest request, enrich only the available
+  // prefix and leave later responses at zero rather than guessing by timestamp.
+  const pairCount = Math.min(sessionGroups.length, turnGroups.length);
+  const candidateGroups = sessionGroups.slice(sessionGroups.length - pairCount);
+  for (let i = 0; i < pairCount; i++) {
     const [, turnEntries] = turnGroups[i];
     const [requestId, sqliteRows] = candidateGroups[i];
     const responses = turnEntries.filter(e => e['event.name'] === 'llm.response');
+    if (responses.length === 0 || sqliteRows.length === 0) continue;
 
-    // Best-effort ordered matching. Counts often differ (sub-agent turns miss the
-    // final answer in the transcript; the latest row may not be persisted yet).
-    // Match the aligned prefix by order instead of abandoning the whole turn to the
-    // timestamp fallback. A time-sanity guard rejects positionally-aligned pairs
-    // whose times are implausibly far apart (mid-turn gap → order shifts by one →
-    // the shifted pair lands on a neighbouring call seconds away) so they fall
-    // through to the nearest-timestamp fallback (Pass B) instead of mis-attributing.
-    const n = Math.min(responses.length, sqliteRows.length);
-    // When counts match exactly, trust order fully (clock-independent) — this is the
-    // original, well-tested contract. The time-sanity guard applies only in the
-    // best-effort (unequal count) path, where a mid-turn gap would shift the pairing.
-    const countsMatch = responses.length === sqliteRows.length;
-    for (let j = 0; j < n; j++) {
-      const response = responses[j];
-      const row = sqliteRows[j];
-      if (!countsMatch) {
-        const threshold = accurateMatchMs(response) !== undefined
-          ? ORDER_MATCH_STRICT_MS
-          : ORDER_MATCH_LOOSE_MS;
-        if (Math.abs(matchMs(response) - row.gmtCreate) > threshold) {
-          markLowConfidence([response], 'order_time_gap');
-          continue;
-        }
-      }
-      applySqliteRowToIdeResponse(entries, turnEntries, response, row, requestId, used, tokenWritten);
+    // This is only a cross-Turn safety check, not a call-boundary heuristic.
+    // New hook records carry an accurate first-assistant timestamp. If the
+    // newest SQLite request group is actually a stale prior Turn (the current
+    // Turn has not been persisted yet), leave it unmatched to avoid replaying
+    // old usage. Old hook records without match_ts retain order compatibility.
+    const turnAnchor = responses
+      .map(accurateMatchMs)
+      .find((value): value is number => value !== undefined);
+    if (turnAnchor !== undefined &&
+        Math.abs(turnAnchor - sqliteRows[0].gmtCreate) > TIMESTAMP_THRESHOLD_MS) {
+      continue;
+    }
+
+    // Transcript reconstruction deliberately prefers one complete response over
+    // speculative splitting. Enrichment must therefore conserve usage when the
+    // transcript produces fewer spans than SQLite has provider calls:
+    //
+    //   response 1..N-1 <- row 1..N-1
+    //   response N      <- sum(row N..M)
+    //
+    // SQLite enriches usage only; it never changes the transcript Step boundary.
+    const oneToOneCount = Math.min(responses.length, sqliteRows.length);
+    for (let j = 0; j < oneToOneCount; j++) {
+      const isLastResponse = j === responses.length - 1;
+      const rowsForResponse = isLastResponse
+        ? sqliteRows.slice(j)
+        : [sqliteRows[j]];
+      applySqliteRowsToIdeResponse(
+        entries,
+        turnEntries,
+        responses[j],
+        rowsForResponse,
+        requestId,
+        used,
+        tokenWritten,
+      );
     }
   }
 }
@@ -443,50 +481,69 @@ function groupEntriesByTurn(entries: AgentActivityEntry[]): Array<[string, Agent
   return [...groups.entries()].filter(([, group]) => group.some(e => e['event.name'] === 'llm.response'));
 }
 
-function applySqliteRowToIdeResponse(
+function applySqliteRowsToIdeResponse(
   allEntries: AgentActivityEntry[],
   turnEntries: AgentActivityEntry[],
   response: AgentActivityEntry,
-  row: SqliteTokenData,
+  rows: SqliteTokenData[],
   requestId: string,
   used: Set<AgentActivityEntry>,
   tokenWritten: Set<string>,
 ): void {
+  if (rows.length === 0) return;
+  // The last SQLite row best represents the end of a response candidate that
+  // absorbed multiple provider calls.
+  const representative = rows[rows.length - 1];
   used.add(response);
-  (response as Record<string, unknown>).__matched_gmt_create = row.gmtCreate;
+  (response as Record<string, unknown>).__matched_gmt_create = representative.gmtCreate;
   response['gen_ai.request.id'] = requestId;
   (response as Record<string, unknown>)['agent.request_id'] = requestId;
-  response['gen_ai.response.id'] = row.messageId || requestId;
+  response['gen_ai.response.id'] = representative.messageId || requestId;
 
-  if (row.model && row.model !== 'unknown') {
-    response['gen_ai.request.model'] = row.model;
-    response['gen_ai.response.model'] = row.model;
+  if (representative.model && representative.model !== 'unknown') {
+    response['gen_ai.request.model'] = representative.model;
+    response['gen_ai.response.model'] = representative.model;
   }
 
   const request = findStepRequest(allEntries, response) ?? turnEntries.find(e => e['event.name'] === 'llm.request');
   if (request) {
     request['gen_ai.request.id'] = requestId;
     (request as Record<string, unknown>)['agent.request_id'] = requestId;
-    if (row.model && row.model !== 'unknown') request['gen_ai.request.model'] = row.model;
+    if (representative.model && representative.model !== 'unknown') {
+      request['gen_ai.request.model'] = representative.model;
+    }
   }
 
-  const dedupeKey = sqliteDedupeKey(row);
-  if (tokenWritten.has(dedupeKey)) return;
-  response['gen_ai.usage.input_tokens'] = row.inputTokens;
-  response['gen_ai.usage.output_tokens'] = row.outputTokens;
-  response['gen_ai.usage.total_tokens'] = row.inputTokens + row.outputTokens;
-  response['gen_ai.usage.cache_read.input_tokens'] = row.cacheReadTokens;
-  tokenWritten.add(dedupeKey);
+  const unusedRows = rows.filter(row => !tokenWritten.has(sqliteDedupeKey(row)));
+  if (unusedRows.length === 0) return;
+
+  const inputTokens = unusedRows.reduce((sum, row) => sum + row.inputTokens, 0);
+  const outputTokens = unusedRows.reduce((sum, row) => sum + row.outputTokens, 0);
+  const cacheReadTokens = unusedRows.reduce((sum, row) => sum + row.cacheReadTokens, 0);
+  response['gen_ai.usage.input_tokens'] = inputTokens;
+  response['gen_ai.usage.output_tokens'] = outputTokens;
+  response['gen_ai.usage.total_tokens'] = inputTokens + outputTokens;
+  response['gen_ai.usage.cache_read.input_tokens'] = cacheReadTokens;
+
+  if (unusedRows.length > 1) {
+    (response as Record<string, unknown>)['agent.qoder.usage_match_mode'] = 'aggregated_tail';
+    (response as Record<string, unknown>)['agent.qoder.sqlite_row_count'] = unusedRows.length;
+  }
+  for (const row of unusedRows) tokenWritten.add(sqliteDedupeKey(row));
+}
+
+function parseUnixNanos(value: unknown): bigint | undefined {
+  if (typeof value !== 'string' || !/^\d+$/.test(value)) return undefined;
+  try {
+    return BigInt(value);
+  } catch {
+    return undefined;
+  }
 }
 
 function findStepRequest(entries: AgentActivityEntry[], response: AgentActivityEntry): AgentActivityEntry | undefined {
   const stepId = response['gen_ai.step.id'];
   return entries.find(e => e['event.name'] === 'llm.request' && e['gen_ai.step.id'] === stepId);
-}
-
-function markLowConfidence(entries: AgentActivityEntry[], _warning: string): void {
-  // Low-confidence match: no additional fields written to avoid polluting output.
-  void entries;
 }
 
 function sqliteDedupeKey(row: SqliteTokenData): string {

--- a/tests/unit/hooks/qoder-hook-processor-cold-start.test.mjs
+++ b/tests/unit/hooks/qoder-hook-processor-cold-start.test.mjs
@@ -63,6 +63,27 @@ function runProcessor(sessionId = 'session-old') {
   });
 }
 
+function runRetry(triggerEndLine, sessionId = 'session-old') {
+  return spawnSync('node', [
+    PROCESSOR,
+    '--agent-id', 'qoder',
+    '--log-prefix', 'qoder',
+    '--retry',
+    '--transcript', transcriptPath,
+    '--session', sessionId,
+    '--trigger-end-line', String(triggerEndLine),
+    '--cwd', '/tmp/qoder-project',
+  ], {
+    env: {
+      ...process.env,
+      LOONGSUITE_PILOT_DATA_DIR: dataDir,
+      HOOK_RETRY_DELAY: '0',
+    },
+    encoding: 'utf-8',
+    timeout: 30_000,
+  });
+}
+
 function readHistory() {
   const historyDir = path.join(dataDir, 'logs', 'qoder', 'history');
   if (!fs.existsSync(historyDir)) return [];
@@ -143,5 +164,125 @@ describe('qoder-hook-processor cold-start recovery', () => {
     expect(new Set(persistedSessionIds)).toEqual(
       new Set(['session-old', 'session-second-old']),
     );
+  });
+
+  it('collects the Stop-anchored turn on cold retry and leaves a queued prompt unread', () => {
+    const progress = hookEvent => ({
+      type: 'progress',
+      timestamp: '2026-07-31T04:33:41.000Z',
+      data: { hookEvent, hookName: hookEvent },
+    });
+    const targetTurn = [
+      progress('UserPromptSubmit'),
+      ...turnRows(2, 'target prompt'),
+    ];
+    const triggerEndLine = 2 + targetTurn.length;
+    const queuedPrompt = {
+      type: 'user',
+      uuid: 'queued-user',
+      timestamp: '2026-07-31T04:33:46.000Z',
+      sessionId: 'session-old',
+      message: { role: 'user', content: 'queued prompt' },
+    };
+    const initialRows = [
+      ...turnRows(1, 'historical prompt'),
+      ...targetTurn,
+      progress('Stop'),
+      progress('Stop'),
+      progress('SessionEnd'),
+      { type: 'session_meta', sessionId: 'session-old' },
+      progress('UserPromptSubmit'),
+      queuedPrompt,
+    ];
+    fs.writeFileSync(
+      transcriptPath,
+      `${initialRows.map(row => JSON.stringify(row)).join('\n')}\n`,
+    );
+
+    const first = runRetry(triggerEndLine);
+    expect(first.status).toBe(0);
+    expect(userBoundaryPrompts(readHistory())).toEqual(['target prompt']);
+
+    const cursorDir = path.join(dataDir, 'state', 'hooks', 'qoder-line-records');
+    const cursorFile = path.join(cursorDir, fs.readdirSync(cursorDir)[0]);
+    const firstCursor = JSON.parse(fs.readFileSync(cursorFile, 'utf-8'));
+    expect(firstCursor.last_line_count).toBe(8);
+
+    const secondTriggerEndLine = initialRows.length + 1;
+    fs.appendFileSync(transcriptPath, [
+      {
+        type: 'assistant',
+        uuid: 'queued-assistant',
+        timestamp: '2026-07-31T04:33:49.000Z',
+        sessionId: 'session-old',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'queued answer' }],
+          stop_reason: 'end_turn',
+        },
+      },
+      progress('Stop'),
+      progress('SessionEnd'),
+    ].map(row => JSON.stringify(row)).join('\n') + '\n');
+
+    const second = runRetry(secondTriggerEndLine);
+    expect(second.status).toBe(0);
+    expect(userBoundaryPrompts(readHistory())).toEqual(['target prompt', 'queued prompt']);
+  });
+
+  it('keeps equal PostToolUse events from separate tool cycles', () => {
+    const ts = second => `2026-07-30T11:48:${second}`;
+    const progress = (hookEvent, second, hookName = hookEvent) => ({
+      type: 'progress',
+      timestamp: ts(second),
+      data: { hookEvent, hookName },
+    });
+    const assistant = (second, content) => ({
+      type: 'assistant',
+      timestamp: ts(second),
+      message: { role: 'assistant', content },
+    });
+    const toolResult = (second, id) => ({
+      type: 'user',
+      timestamp: ts(second),
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: id, content: `result-${id}` }],
+      },
+    });
+
+    fs.writeFileSync(transcriptPath, [
+      progress('UserPromptSubmit', '01.000Z'),
+      {
+        type: 'user',
+        timestamp: ts('01.001Z'),
+        message: { role: 'user', content: 'run dependent tools' },
+      },
+      assistant('04.000Z', [{ type: 'thinking', thinking: 'step one' }]),
+      assistant('04.001Z', [{ type: 'tool_use', id: 'read-1', name: 'Read', input: {} }]),
+      toolResult('04.002Z', 'read-1'),
+      progress('PostToolUse', '04.100Z', 'PostToolUse:Read'),
+      progress('PostToolUse', '04.101Z', 'PostToolUse:Read'),
+      assistant('13.000Z', [{ type: 'thinking', thinking: 'step two' }]),
+      assistant('13.001Z', [{ type: 'tool_use', id: 'grep-1', name: 'Grep', input: {} }]),
+      toolResult('13.002Z', 'grep-1'),
+      progress('PostToolUse', '13.100Z', 'PostToolUse:Grep'),
+      progress('PostToolUse', '13.101Z', 'PostToolUse:Grep'),
+      assistant('49.000Z', [{ type: 'thinking', thinking: 'final' }]),
+      assistant('49.001Z', [{ type: 'text', text: 'done' }]),
+      progress('Stop', '50.000Z'),
+      lastPrompt(1),
+    ].map(row => JSON.stringify(row)).join('\n') + '\n');
+
+    const result = runProcessor();
+    expect(result.status).toBe(0);
+    const responses = readHistory().filter(record => record['event.name'] === 'llm.response');
+
+    expect(responses.map(record => record['gen_ai.step.id'].split(':').at(-1))).toEqual([
+      's1', 's2', 's3',
+    ]);
+    expect(responses.map(record => record['gen_ai.response.finish_reasons'])).toEqual([
+      ['tool_call'], ['tool_call'], ['end_turn'],
+    ]);
   });
 });

--- a/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
+++ b/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
@@ -202,6 +202,50 @@ describe('buildLlmBoundaries complete-response priority', () => {
     expect(buildLlmBoundaries(progress, rows)).toHaveLength(2);
   });
 
+  it('preserves microsecond ordering between tool completion and the next assistant response', () => {
+    const rows = [
+      {
+        type: 'user',
+        timestamp: '2026-08-03T09:22:25.100000Z',
+        message: { role: 'user', content: 'run two tools in sequence' },
+      },
+      assistant('2026-08-03T09:22:25.555446Z', [
+        { type: 'tool_use', id: 'tool-b', name: 'Read', input: {} },
+      ]),
+      toolResult('2026-08-03T09:22:26.668419Z', 'tool-b'),
+      assistant('2026-08-03T09:22:26.999890Z', [
+        { type: 'tool_use', id: 'tool-c', name: 'Read', input: {} },
+      ]),
+      toolResult('2026-08-03T09:22:27.500000Z', 'tool-c'),
+    ];
+    const progress = [
+      { hookEvent: 'UserPromptSubmit', ts: '2026-08-03T09:22:25.000000Z' },
+      { hookEvent: 'PreToolUse', ts: '2026-08-03T09:22:25.996439Z' },
+      { hookEvent: 'PostToolUse', ts: '2026-08-03T09:22:26.999176Z' },
+      { hookEvent: 'PreToolUse', ts: '2026-08-03T09:22:27.281923Z' },
+      { hookEvent: 'Stop', ts: '2026-08-03T09:22:28.000000Z' },
+    ];
+
+    const boundaries = buildLlmBoundaries(progress, rows);
+    expect(boundaries.map(boundary => boundary.startTs)).toEqual([
+      '2026-08-03T09:22:25.000000Z',
+      '2026-08-03T09:22:26.999176Z',
+    ]);
+
+    const records = buildEventsFromBoundaries(
+      boundaries, rows, rows, 'turn-microseconds', 'session-1', 'qoder', {}, undefined,
+    );
+    expect(records
+      .filter(record => record['event.name'] === 'llm.request' || record['event.name'] === 'llm.response')
+      .map(record => [record['event.name'], record['gen_ai.step.id']]))
+      .toEqual([
+        ['llm.request', 'turn-microseconds:s1'],
+        ['llm.response', 'turn-microseconds:s1'],
+        ['llm.request', 'turn-microseconds:s2'],
+        ['llm.response', 'turn-microseconds:s2'],
+      ]);
+  });
+
   it('starts a complete next step after PostToolUseFailure', () => {
     const rows = [
       {

--- a/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
+++ b/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
@@ -3,6 +3,10 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
+  buildLlmBoundaries,
+  buildEventsFromBoundaries,
+  findIncrementalTurnEndLine,
+  findTriggeredTurnWindow,
   isRetryLockStale,
   readRetryLock,
   releaseRetryLock,
@@ -129,6 +133,337 @@ describe('selectTurnSegmentsForCollection', () => {
   it('keeps only the latest QoderCN turn after its intentional full reparse', () => {
     expect(selectTurnSegmentsForCollection(turns, 'incremental', 'qoder-cn')).toEqual([
       ['turn-3'],
+    ]);
+  });
+});
+
+describe('buildLlmBoundaries complete-response priority', () => {
+  const assistant = (timestamp, content) => ({
+    type: 'assistant',
+    timestamp,
+    message: { role: 'assistant', content },
+  });
+  const toolResult = (timestamp, id) => ({
+    type: 'user',
+    timestamp,
+    message: {
+      role: 'user',
+      content: [{ type: 'tool_result', tool_use_id: id, content: 'ok' }],
+    },
+  });
+
+  it('keeps thinking + text + multiple tool_use blocks as one response', () => {
+    const rows = [
+      assistant('2026-07-30T01:00:00.000Z', [{ type: 'thinking', thinking: 'reason' }]),
+      assistant('2026-07-30T01:00:05.000Z', [{ type: 'text', text: 'summary' }]),
+      assistant('2026-07-30T01:00:06.000Z', [{ type: 'tool_use', id: 'tool-a', name: 'Read', input: {} }]),
+      assistant('2026-07-30T01:00:06.001Z', [{ type: 'tool_use', id: 'tool-b', name: 'Read', input: {} }]),
+    ];
+
+    expect(buildLlmBoundaries([], rows)).toHaveLength(1);
+  });
+
+  it('does not split parallel tool_use blocks when an early tool_result is interleaved', () => {
+    const rows = [
+      assistant('2026-07-30T01:00:00.000Z', [{ type: 'tool_use', id: 'tool-a', name: 'Read', input: {} }]),
+      assistant('2026-07-30T01:00:00.001Z', [{ type: 'tool_use', id: 'tool-b', name: 'Read', input: {} }]),
+      toolResult('2026-07-30T01:00:00.002Z', 'tool-a'),
+      assistant('2026-07-30T01:00:00.003Z', [{ type: 'tool_use', id: 'tool-c', name: 'Read', input: {} }]),
+    ];
+
+    expect(buildLlmBoundaries([], rows)).toHaveLength(1);
+  });
+
+  it('starts the next response after all tools in the prior response resolve', () => {
+    const rows = [
+      assistant('2026-07-30T01:00:00.000Z', [{ type: 'tool_use', id: 'tool-a', name: 'Read', input: {} }]),
+      toolResult('2026-07-30T01:00:01.000Z', 'tool-a'),
+      assistant('2026-07-30T01:00:02.000Z', [{ type: 'tool_use', id: 'tool-b', name: 'Read', input: {} }]),
+    ];
+
+    expect(buildLlmBoundaries([], rows)).toHaveLength(2);
+  });
+
+  it('uses a completed tool cycle even when progress events place both responses in one window', () => {
+    const rows = [
+      assistant('2026-07-30T01:00:00.000Z', [{ type: 'thinking', thinking: 'read' }]),
+      assistant('2026-07-30T01:00:00.001Z', [{ type: 'tool_use', id: 'tool-a', name: 'Read', input: {} }]),
+      toolResult('2026-07-30T01:00:01.000Z', 'tool-a'),
+      assistant('2026-07-30T01:00:02.000Z', [{ type: 'thinking', thinking: 'summarize' }]),
+      assistant('2026-07-30T01:00:02.001Z', [{ type: 'text', text: 'done' }]),
+    ];
+    const progress = [
+      { hookEvent: 'UserPromptSubmit', ts: '2026-07-30T00:59:59.000Z' },
+      { hookEvent: 'PostToolUse', ts: '2026-07-30T01:00:01.500Z' },
+      { hookEvent: 'Stop', ts: '2026-07-30T01:00:03.000Z' },
+    ];
+
+    expect(buildLlmBoundaries(progress, rows)).toHaveLength(2);
+  });
+
+  it('starts a complete next step after PostToolUseFailure', () => {
+    const rows = [
+      {
+        type: 'user',
+        timestamp: '2026-07-30T00:59:59.100Z',
+        message: { role: 'user', content: 'read the missing file' },
+      },
+      assistant('2026-07-30T01:00:00.000Z', [
+        { type: 'thinking', thinking: 'read it' },
+        { type: 'tool_use', id: 'tool-a', name: 'Read', input: { path: 'missing' } },
+      ]),
+      {
+        type: 'user',
+        timestamp: '2026-07-30T01:00:01.000Z',
+        message: {
+          role: 'user',
+          content: [{
+            type: 'tool_result',
+            tool_use_id: 'tool-a',
+            content: 'file not found',
+            is_error: true,
+          }],
+        },
+      },
+      assistant('2026-07-30T01:00:02.000Z', [
+        { type: 'text', text: 'the file does not exist' },
+      ]),
+    ];
+    const progress = [
+      { hookEvent: 'UserPromptSubmit', ts: '2026-07-30T00:59:59.000Z' },
+      { hookEvent: 'PreToolUse', ts: '2026-07-30T01:00:00.500Z' },
+      { hookEvent: 'PostToolUseFailure', ts: '2026-07-30T01:00:01.500Z' },
+      { hookEvent: 'Stop', ts: '2026-07-30T01:00:03.000Z' },
+    ];
+
+    const boundaries = buildLlmBoundaries(progress, rows);
+    expect(boundaries.map(boundary => boundary.startTs)).toEqual([
+      '2026-07-30T00:59:59.000Z',
+      '2026-07-30T01:00:01.500Z',
+    ]);
+
+    const records = buildEventsFromBoundaries(
+      boundaries, rows, rows, 'turn-1', 'session-1', 'qoder', {}, undefined,
+    );
+    expect(records
+      .filter(record => record['event.name'] === 'llm.request' || record['event.name'] === 'llm.response')
+      .map(record => [record['event.name'], record['gen_ai.step.id']]))
+      .toEqual([
+        ['llm.request', 'turn-1:s1'],
+        ['llm.response', 'turn-1:s1'],
+        ['llm.request', 'turn-1:s2'],
+        ['llm.response', 'turn-1:s2'],
+      ]);
+  });
+
+  it('does not invent a boundary without a completed tool cycle', () => {
+    const rows = [
+      assistant('2026-07-30T01:00:00.000Z', [{ type: 'thinking', thinking: 'first' }]),
+      assistant('2026-07-30T01:00:14.000Z', [{ type: 'thinking', thinking: 'second' }]),
+      assistant('2026-07-30T01:00:20.000Z', [{ type: 'text', text: 'done' }]),
+    ];
+
+    expect(buildLlmBoundaries([], rows)).toHaveLength(1);
+  });
+});
+
+describe('findIncrementalTurnEndLine', () => {
+  it('commits the completed turn but preserves the next queued prompt', () => {
+    const transcript = path.join(lockDir, 'queued.jsonl');
+    const rows = [
+      { type: 'progress', data: { hookEvent: 'UserPromptSubmit' } },
+      { type: 'user', message: { content: 'turn one' } },
+      { type: 'assistant', timestamp: '2026-07-30T01:00:00.000Z', message: { content: [{ type: 'text', text: 'done' }] } },
+      { type: 'progress', data: { hookEvent: 'Stop' } },
+      { type: 'progress', data: { hookEvent: 'SessionEnd' } },
+      { type: 'progress', data: { hookEvent: 'UserPromptSubmit' } },
+      { type: 'user', message: { content: 'turn two' } },
+    ];
+    fs.writeFileSync(transcript, `${rows.map(row => JSON.stringify(row)).join('\n')}\n`);
+
+    expect(findIncrementalTurnEndLine(transcript, 0, rows.length)).toBe(5);
+  });
+
+  it('uses the scan end when no next prompt has appeared', () => {
+    const transcript = path.join(lockDir, 'single.jsonl');
+    const rows = [
+      { type: 'progress', data: { hookEvent: 'UserPromptSubmit' } },
+      { type: 'user', message: { content: 'turn one' } },
+      { type: 'assistant', timestamp: '2026-07-30T01:00:00.000Z', message: { content: [{ type: 'text', text: 'done' }] } },
+      { type: 'progress', data: { hookEvent: 'Stop' } },
+    ];
+    fs.writeFileSync(transcript, `${rows.map(row => JSON.stringify(row)).join('\n')}\n`);
+
+    expect(findIncrementalTurnEndLine(transcript, 0, rows.length)).toBe(rows.length);
+  });
+
+  it('preserves the next real user row when its progress marker is absent', () => {
+    const transcript = path.join(lockDir, 'queued-without-progress.jsonl');
+    const rows = [
+      { type: 'user', message: { content: 'turn one' } },
+      { type: 'assistant', timestamp: '2026-07-30T01:00:00.000Z', message: { content: [{ type: 'text', text: 'done' }] } },
+      { type: 'progress', data: { hookEvent: 'Stop' } },
+      { type: 'user', message: { content: 'turn two' } },
+    ];
+    fs.writeFileSync(transcript, `${rows.map(row => JSON.stringify(row)).join('\n')}\n`);
+
+    expect(findIncrementalTurnEndLine(transcript, 0, rows.length)).toBe(3);
+  });
+});
+
+describe('findTriggeredTurnWindow', () => {
+  const progress = hookEvent => ({ type: 'progress', data: { hookEvent } });
+  const user = content => ({ type: 'user', message: { content } });
+  const assistant = content => ({
+    type: 'assistant',
+    timestamp: '2026-07-31T04:33:41.000Z',
+    message: { content: [{ type: 'text', text: content }] },
+  });
+
+  function writeTranscript(name, rows) {
+    const transcript = path.join(lockDir, name);
+    fs.writeFileSync(transcript, `${rows.map(row => JSON.stringify(row)).join('\n')}\n`);
+    return transcript;
+  }
+
+  it('anchors the current Stop turn and excludes a queued next prompt', () => {
+    const rows = [
+      progress('UserPromptSubmit'),
+      user('historical'),
+      assistant('old answer'),
+      progress('Stop'),
+      progress('SessionEnd'),
+      progress('UserPromptSubmit'),
+      user('target prompt'),
+      assistant('target answer'),
+      // The Stop hook snapshot ends here. Stop/SessionEnd are appended while
+      // the detached retry is sleeping.
+      progress('Stop'),
+      progress('Stop'),
+      progress('SessionEnd'),
+      { type: 'session_meta' },
+      progress('UserPromptSubmit'),
+      user('queued prompt'),
+    ];
+    const transcript = writeTranscript('cold-queued.jsonl', rows);
+
+    expect(findTriggeredTurnWindow(transcript, 8, rows.length)).toEqual({
+      status: 'complete',
+      reason: 'session-end',
+      startLine: 5,
+      stopLine: 8,
+      endLine: 11,
+    });
+  });
+
+  it('waits instead of consuming the next prompt when SessionEnd is missing', () => {
+    const rows = [
+      progress('UserPromptSubmit'),
+      user('target prompt'),
+      assistant('target answer'),
+      progress('Stop'),
+      progress('UserPromptSubmit'),
+      user('queued prompt'),
+    ];
+    const transcript = writeTranscript('missing-session-end.jsonl', rows);
+
+    expect(findTriggeredTurnWindow(transcript, 3, rows.length)).toMatchObject({
+      status: 'waiting',
+      reason: 'next-prompt-before-session-end',
+    });
+  });
+
+  it('uses last-prompt as the terminal marker for Qoder CLI', () => {
+    const rows = [
+      progress('UserPromptSubmit'),
+      user('target prompt'),
+      assistant('target answer'),
+      progress('Stop'),
+      { type: 'last-prompt', lastPrompt: 'target prompt' },
+    ];
+    const transcript = writeTranscript('cli-last-prompt.jsonl', rows);
+
+    expect(findTriggeredTurnWindow(transcript, 3, rows.length)).toEqual({
+      status: 'complete',
+      reason: 'last-prompt',
+      startLine: 0,
+      stopLine: 3,
+      endLine: 5,
+    });
+  });
+});
+
+describe('buildEventsFromBoundaries tool result matching', () => {
+  it('matches parallel tool results by tool_use_id instead of return order', () => {
+    const makeToolResult = (timestamp, id, content, isError = false) => ({
+      type: 'user',
+      timestamp,
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: id, content, is_error: isError }],
+      },
+    });
+    const grepResult = makeToolResult('2026-07-30T01:00:02.000Z', 'grep', 'grep-result');
+    const readResult = makeToolResult('2026-07-30T01:00:02.001Z', 'read', 'read-result');
+    const problemsResult = makeToolResult(
+      '2026-07-30T01:00:05.002Z',
+      'problems',
+      'file not found',
+      true,
+    );
+    const content = [
+      {
+        type: 'user',
+        timestamp: '2026-07-30T01:00:00.000Z',
+        message: { content: 'read files' },
+      },
+      {
+        type: 'assistant',
+        timestamp: '2026-07-30T01:00:01.000Z',
+        message: {
+          content: [
+            { type: 'tool_use', id: 'problems', name: 'GetProblems', input: {} },
+            { type: 'tool_use', id: 'read', name: 'Read', input: { path: 'a' } },
+            { type: 'tool_use', id: 'grep', name: 'Grep', input: { pattern: 'x' } },
+          ],
+        },
+      },
+      grepResult,
+      readResult,
+      problemsResult,
+    ];
+    const boundaries = [{
+      startTs: '2026-07-30T01:00:00.000Z',
+      endTs: '2026-07-30T01:00:03.000Z',
+    }];
+
+    const records = buildEventsFromBoundaries(
+      boundaries, content, content, 'turn-1', 'session-1', 'qoder', {}, undefined,
+    );
+    const results = records.filter(record => record['event.name'] === 'tool.result');
+    const calls = records.filter(record => record['event.name'] === 'tool.call');
+
+    expect(results.map(record => [
+      record['gen_ai.tool.call.id'],
+      record['gen_ai.tool.call.result'],
+      record['tool.result.status'],
+    ])).toEqual([
+      ['problems', 'file not found', 'error'],
+      ['read', 'read-result', 'success'],
+      ['grep', 'grep-result', 'success'],
+    ]);
+    const callNanos = String(
+      BigInt(Date.parse('2026-07-30T01:00:01.000Z')) * 1_000_000n,
+    );
+    expect(calls.map(record => record.time_unix_nano)).toEqual([
+      callNanos,
+      callNanos,
+      callNanos,
+    ]);
+    expect(results.map(record => record['gen_ai.tool.call.duration'])).toEqual([
+      4002,
+      1001,
+      1000,
     ]);
   });
 });

--- a/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
+++ b/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
@@ -11,6 +11,7 @@ import {
   readRetryLock,
   releaseRetryLock,
   retryLockPath,
+  readTranscriptSnapshot,
   selectTurnSegmentsForCollection,
   tryAcquireRetryLock,
 } from '../../../assets/hooks/qoder-hook-processor.mjs';
@@ -256,6 +257,63 @@ describe('buildLlmBoundaries complete-response priority', () => {
       ]);
   });
 
+  it('uses PostToolUseFailure to close a tool cycle whose result is missing', () => {
+    const rows = [
+      {
+        type: 'user',
+        timestamp: '2026-07-30T00:59:59.100Z',
+        message: { role: 'user', content: 'read the missing file' },
+      },
+      assistant('2026-07-30T01:00:00.000Z', [
+        { type: 'tool_use', id: 'tool-a', name: 'Read', input: { path: 'missing' } },
+      ]),
+      assistant('2026-07-30T01:00:02.000Z', [
+        { type: 'text', text: 'the tool was cancelled' },
+      ]),
+    ];
+    const progress = [
+      { hookEvent: 'UserPromptSubmit', ts: '2026-07-30T00:59:59.000Z' },
+      { hookEvent: 'PreToolUse', ts: '2026-07-30T01:00:00.500Z' },
+      { hookEvent: 'PostToolUseFailure', ts: '2026-07-30T01:00:01.500Z' },
+      { hookEvent: 'Stop', ts: '2026-07-30T01:00:03.000Z' },
+    ];
+
+    const boundaries = buildLlmBoundaries(progress, rows);
+    expect(boundaries).toHaveLength(2);
+    const records = buildEventsFromBoundaries(
+      boundaries, rows, rows, 'turn-missing-result', 'session-1', 'qoder', {}, undefined,
+    );
+    expect(records
+      .filter(record => record['event.name'] === 'llm.request' || record['event.name'] === 'llm.response')
+      .map(record => [record['event.name'], record['gen_ai.step.id']]))
+      .toEqual([
+        ['llm.request', 'turn-missing-result:s1'],
+        ['llm.response', 'turn-missing-result:s1'],
+        ['llm.request', 'turn-missing-result:s2'],
+        ['llm.response', 'turn-missing-result:s2'],
+      ]);
+  });
+
+  it('does not close a parallel response until completion signals cover its declared tools', () => {
+    const rows = [
+      assistant('2026-07-30T01:00:00.000Z', [
+        { type: 'tool_use', id: 'tool-a', name: 'Read', input: {} },
+      ]),
+      assistant('2026-07-30T01:00:00.001Z', [
+        { type: 'tool_use', id: 'tool-b', name: 'Read', input: {} },
+      ]),
+      toolResult('2026-07-30T01:00:00.500Z', 'tool-a'),
+      assistant('2026-07-30T01:00:02.000Z', [
+        { type: 'tool_use', id: 'tool-c', name: 'Read', input: {} },
+      ]),
+    ];
+    const progress = [
+      { hookEvent: 'PostToolUse', ts: '2026-07-30T01:00:01.000Z' },
+    ];
+
+    expect(buildLlmBoundaries(progress, rows)).toHaveLength(1);
+  });
+
   it('does not invent a boundary without a completed tool cycle', () => {
     const rows = [
       assistant('2026-07-30T01:00:00.000Z', [{ type: 'thinking', thinking: 'first' }]),
@@ -281,7 +339,7 @@ describe('findIncrementalTurnEndLine', () => {
     ];
     fs.writeFileSync(transcript, `${rows.map(row => JSON.stringify(row)).join('\n')}\n`);
 
-    expect(findIncrementalTurnEndLine(transcript, 0, rows.length)).toBe(5);
+    expect(findIncrementalTurnEndLine(readTranscriptSnapshot(transcript), 0, rows.length)).toBe(5);
   });
 
   it('uses the scan end when no next prompt has appeared', () => {
@@ -294,7 +352,9 @@ describe('findIncrementalTurnEndLine', () => {
     ];
     fs.writeFileSync(transcript, `${rows.map(row => JSON.stringify(row)).join('\n')}\n`);
 
-    expect(findIncrementalTurnEndLine(transcript, 0, rows.length)).toBe(rows.length);
+    expect(findIncrementalTurnEndLine(
+      readTranscriptSnapshot(transcript), 0, rows.length,
+    )).toBe(rows.length);
   });
 
   it('preserves the next real user row when its progress marker is absent', () => {
@@ -307,7 +367,7 @@ describe('findIncrementalTurnEndLine', () => {
     ];
     fs.writeFileSync(transcript, `${rows.map(row => JSON.stringify(row)).join('\n')}\n`);
 
-    expect(findIncrementalTurnEndLine(transcript, 0, rows.length)).toBe(3);
+    expect(findIncrementalTurnEndLine(readTranscriptSnapshot(transcript), 0, rows.length)).toBe(3);
   });
 });
 
@@ -347,7 +407,7 @@ describe('findTriggeredTurnWindow', () => {
     ];
     const transcript = writeTranscript('cold-queued.jsonl', rows);
 
-    expect(findTriggeredTurnWindow(transcript, 8, rows.length)).toEqual({
+    expect(findTriggeredTurnWindow(readTranscriptSnapshot(transcript), 8)).toEqual({
       status: 'complete',
       reason: 'session-end',
       startLine: 5,
@@ -367,7 +427,7 @@ describe('findTriggeredTurnWindow', () => {
     ];
     const transcript = writeTranscript('missing-session-end.jsonl', rows);
 
-    expect(findTriggeredTurnWindow(transcript, 3, rows.length)).toMatchObject({
+    expect(findTriggeredTurnWindow(readTranscriptSnapshot(transcript), 3)).toMatchObject({
       status: 'waiting',
       reason: 'next-prompt-before-session-end',
     });
@@ -383,7 +443,7 @@ describe('findTriggeredTurnWindow', () => {
     ];
     const transcript = writeTranscript('cli-last-prompt.jsonl', rows);
 
-    expect(findTriggeredTurnWindow(transcript, 3, rows.length)).toEqual({
+    expect(findTriggeredTurnWindow(readTranscriptSnapshot(transcript), 3)).toEqual({
       status: 'complete',
       reason: 'last-prompt',
       startLine: 0,

--- a/tests/unit/inputs/qoder-ide-lag-repro.test.ts
+++ b/tests/unit/inputs/qoder-ide-lag-repro.test.ts
@@ -108,9 +108,8 @@ describe('qoder IDE enrichment — production lag symptom', () => {
   });
 });
 
-// Fix behaviour (Option 1): order-first best-effort matching + time-sanity guard +
-// nearest-timestamp fallback. All in the qoder IDE variant (no response.id / model 'auto'
-// in the hook JSONL; everything comes from SQLite).
+// Deterministic policy: transcript owns Step boundaries; SQLite usage is attached
+// by turn/order, with extra rows aggregated into the last response.
 const B = 1783308010000; // base ms
 
 function makeTurn(
@@ -148,8 +147,8 @@ function makeRows(specs: { gmt: number; id: string; in?: number; out?: number }[
   }));
 }
 
-describe('qoder IDE enrichment — Option 1 robustness', () => {
-  it('tail gap JSONL=3 < SQLite=4 → first 3 matched by order (no collapse to fallback)', () => {
+describe('qoder IDE enrichment — deterministic usage conservation', () => {
+  it('JSONL=3 < SQLite=4 → aggregates the tail rows into the last response', () => {
     const entries = makeTurn([B + 200, B + 10200, B + 20200]);
     const rows = makeRows([
       { gmt: B, id: 'm1' },
@@ -162,8 +161,10 @@ describe('qoder IDE enrichment — Option 1 robustness', () => {
 
     expect(entries[0]['gen_ai.response.id']).toBe('m1');
     expect(entries[1]['gen_ai.response.id']).toBe('m2');
-    expect(entries[2]['gen_ai.response.id']).toBe('m3');
-    expect(entries[2]['gen_ai.usage.total_tokens']).toBe(110);
+    expect(entries[2]['gen_ai.response.id']).toBe('m4');
+    expect(entries[2]['gen_ai.usage.total_tokens']).toBe(220);
+    expect((entries[2] as any)['agent.qoder.usage_match_mode']).toBe('aggregated_tail');
+    expect((entries[2] as any)['agent.qoder.sqlite_row_count']).toBe(2);
     expect(entries.every(e => e['gen_ai.response.model'] === 'ultimate')).toBe(true);
   });
 
@@ -185,9 +186,8 @@ describe('qoder IDE enrichment — Option 1 robustness', () => {
     expect(entries[3]['gen_ai.usage.total_tokens']).toBe(0);
   });
 
-  it('middle gap → guard rejects the shifted pair; nearest fallback attaches the correct row (no mis-attribution)', () => {
+  it('SQLite fewer than responses → applies the available prefix without timestamp guessing', () => {
     const entries = makeTurn([B + 200, B + 10200, B + 20200]);
-    // SQLite missing the MIDDLE call: only rows for t1 and t3.
     const rows = makeRows([
       { gmt: B, id: 'm1' },
       { gmt: B + 20000, id: 'm3' },
@@ -196,25 +196,28 @@ describe('qoder IDE enrichment — Option 1 robustness', () => {
     enrichIdeTurn(entries, rows);
 
     expect(entries[0]['gen_ai.response.id']).toBe('m1');
-    // Without the guard, order would pair resp#2 (t2) with row m3 (t3) — wrong.
-    // With guard + nearest fallback, m3 attaches to resp#3 (t3), resp#2 stays empty.
-    expect(entries[2]['gen_ai.response.id']).toBe('m3');
-    expect(entries[1]['gen_ai.response.id']).toBeUndefined();
+    expect(entries[1]['gen_ai.response.id']).toBe('m3');
+    expect(entries[2]['gen_ai.response.id']).toBeUndefined();
   });
 
-  it('accurate match_ts rescues a drifted response in the best-effort (unequal count) path', () => {
-    // Unequal counts (2 responses, 1 row) → the time-sanity guard runs. Response #1's
-    // time_unix_nano is drifted +6s (beyond the 3s loose guard and 5s fallback), but its
-    // match_ts is exact. Response #2 is far later and has no row.
+  it('ordered structural matching does not depend on response timestamp drift', () => {
     const withMatchTs = makeTurn([B + 6000, B + 60000], { matchTs: [B, undefined] });
     enrichIdeTurn(withMatchTs, makeRows([{ gmt: B, id: 'm1' }]));
-    expect(withMatchTs[0]['gen_ai.response.id']).toBe('m1'); // strict guard uses accurate ts
+    expect(withMatchTs[0]['gen_ai.response.id']).toBe('m1');
     expect(withMatchTs[0]['gen_ai.usage.total_tokens']).toBe(110);
 
-    // Same shape WITHOUT match_ts → loose guard on drifted clock rejects, fallback out of
-    // window → response #1 unmatched (demonstrates the value of the accurate timestamp).
     const noMatchTs = makeTurn([B + 6000, B + 60000]);
     enrichIdeTurn(noMatchTs, makeRows([{ gmt: B, id: 'm1' }]));
-    expect(noMatchTs[0]['gen_ai.response.id']).toBeUndefined();
+    expect(noMatchTs[0]['gen_ai.response.id']).toBe('m1');
+  });
+
+  it('does not attach a stale prior-Turn SQLite group when the current hook has an accurate timestamp', () => {
+    const entries = makeTurn([B + 60000], { matchTs: [B + 60000] });
+    const staleRows = makeRows([{ gmt: B, id: 'old-turn-row', in: 999, out: 99 }]);
+
+    enrichIdeTurn(entries, staleRows);
+
+    expect(entries[0]['gen_ai.response.id']).toBeUndefined();
+    expect(entries[0]['gen_ai.usage.total_tokens']).toBe(0);
   });
 });

--- a/tests/unit/inputs/qoder-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-trace-input.test.ts
@@ -281,6 +281,50 @@ describe('QoderTraceInput token-enricher', () => {
       expect(entries[0]['gen_ai.usage.output_tokens']).toBe(20);
       expect(entries[0]['gen_ai.usage.total_tokens']).toBe(170);
     });
+
+    it('preserves per-tool hook timing when CLI segment timing has no tool ID', () => {
+      const ms = (value: number) => String(BigInt(value) * 1_000_000n);
+      const base = 1_780_000_000_000;
+      const entries: AgentActivityEntry[] = [
+        makeEntry({
+          'event.name': 'llm.response',
+          'gen_ai.response.id': 'req-tools',
+          'gen_ai.step.id': 'turn-tools:s1',
+          time_unix_nano: ms(base + 200),
+        }),
+        makeEntry({
+          'event.name': 'tool.call',
+          'gen_ai.step.id': 'turn-tools:s1',
+          'gen_ai.tool.call.id': 'slow-tool',
+          time_unix_nano: ms(base + 201),
+        } as any),
+        makeEntry({
+          'event.name': 'tool.result',
+          'gen_ai.step.id': 'turn-tools:s1',
+          'gen_ai.tool.call.id': 'slow-tool',
+          'gen_ai.tool.call.duration': 4000,
+          time_unix_nano: ms(base + 4201),
+        } as any),
+      ];
+      const segments: SegmentTokenData[] = [{
+        requestId: 'req-tools',
+        inputTokens: 10,
+        outputTokens: 2,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        requestStartTs: base + 100,
+        responseEndTs: base + 200,
+        toolFinishedTs: base + 5000,
+        stopReason: 'tool_call',
+        model: 'qmodel',
+      }];
+
+      enrichCliTurn(entries, segments);
+
+      expect(entries[1].time_unix_nano).toBe(ms(base + 201));
+      expect(entries[2].time_unix_nano).toBe(ms(base + 4201));
+      expect(entries[2]['gen_ai.tool.call.duration']).toBe(4000);
+    });
   });
 
   describe('enrichIdeTurn (SQLite structure match)', () => {
@@ -366,7 +410,7 @@ describe('QoderTraceInput token-enricher', () => {
       expect(entries[3]['gen_ai.usage.input_tokens']).toBe(200);
     });
 
-    it('marks low confidence and avoids structural assignment when assistant counts differ', () => {
+    it('aggregates extra SQLite calls into the last response when assistant counts differ', () => {
       const entries: AgentActivityEntry[] = [
         makeEntry({
           'event.name': 'llm.request',
@@ -413,8 +457,103 @@ describe('QoderTraceInput token-enricher', () => {
 
       enrichIdeTurn(entries, sqliteRows);
 
-      expect(entries[1]['gen_ai.response.id']).toBeUndefined();
-      expect(entries[1]['gen_ai.response.model']).toBe('auto');
+      expect(entries[1]['gen_ai.response.id']).toBe('message-a-2');
+      expect(entries[1]['gen_ai.response.model']).toBe('gm51model');
+      expect(entries[1]['gen_ai.usage.input_tokens']).toBe(300);
+      expect(entries[1]['gen_ai.usage.output_tokens']).toBe(30);
+      expect(entries[1]['gen_ai.usage.total_tokens']).toBe(330);
+      expect(entries[1]['gen_ai.usage.cache_read.input_tokens']).toBe(7);
+      expect((entries[1] as any)['agent.qoder.usage_match_mode']).toBe('aggregated_tail');
+      expect((entries[1] as any)['agent.qoder.sqlite_row_count']).toBe(2);
+    });
+
+    it('preserves hook tool status and per-ID timing during SQLite enrichment', () => {
+      const ms = (value: number) => String(BigInt(value) * 1_000_000n);
+      const base = 1_780_000_000_000;
+      const entries: AgentActivityEntry[] = [
+        makeEntry({
+          'event.name': 'other',
+          'gen_ai.session.id': 'sess-tools',
+          'gen_ai.turn.id': 'turn-tools',
+          time_unix_nano: ms(base),
+        } as any),
+        makeEntry({
+          'event.name': 'llm.request',
+          'gen_ai.session.id': 'sess-tools',
+          'gen_ai.turn.id': 'turn-tools',
+          'gen_ai.step.id': 'turn-tools:s1',
+          time_unix_nano: ms(base + 100),
+        } as any),
+        makeEntry({
+          'event.name': 'llm.response',
+          'gen_ai.session.id': 'sess-tools',
+          'gen_ai.turn.id': 'turn-tools',
+          'gen_ai.step.id': 'turn-tools:s1',
+          time_unix_nano: ms(base + 200),
+        } as any),
+        makeEntry({
+          'event.name': 'tool.call',
+          'gen_ai.session.id': 'sess-tools',
+          'gen_ai.turn.id': 'turn-tools',
+          'gen_ai.step.id': 'turn-tools:s1',
+          'gen_ai.tool.call.id': 'slow-tool',
+          time_unix_nano: ms(base + 201),
+        } as any),
+        makeEntry({
+          'event.name': 'tool.result',
+          'gen_ai.session.id': 'sess-tools',
+          'gen_ai.turn.id': 'turn-tools',
+          'gen_ai.step.id': 'turn-tools:s1',
+          'gen_ai.tool.call.id': 'slow-tool',
+          'tool.result.status': 'failure',
+          'gen_ai.tool.call.duration': 4000,
+          time_unix_nano: ms(base + 4201),
+        } as any),
+        makeEntry({
+          'event.name': 'llm.request',
+          'gen_ai.session.id': 'sess-tools',
+          'gen_ai.turn.id': 'turn-tools',
+          'gen_ai.step.id': 'turn-tools:s2',
+          time_unix_nano: ms(base + 4202),
+        } as any),
+        makeEntry({
+          'event.name': 'llm.response',
+          'gen_ai.session.id': 'sess-tools',
+          'gen_ai.turn.id': 'turn-tools',
+          'gen_ai.step.id': 'turn-tools:s2',
+          time_unix_nano: ms(base + 5000),
+        } as any),
+      ];
+      const sqliteRows: SqliteTokenData[] = [
+        {
+          sessionId: 'sess-tools',
+          requestId: 'request-tools',
+          messageId: 'message-tools-1',
+          gmtCreate: base + 200,
+          inputTokens: 100,
+          outputTokens: 10,
+          cacheReadTokens: 0,
+          model: 'gm51model',
+        },
+        {
+          sessionId: 'sess-tools',
+          requestId: 'request-tools',
+          messageId: 'message-tools-2',
+          gmtCreate: base + 5000,
+          inputTokens: 200,
+          outputTokens: 20,
+          cacheReadTokens: 0,
+          model: 'gm51model',
+        },
+      ];
+
+      enrichIdeTurn(entries, sqliteRows);
+
+      expect(entries[3].time_unix_nano).toBe(ms(base + 201));
+      expect(entries[4].time_unix_nano).toBe(ms(base + 4201));
+      expect(entries[4]['gen_ai.tool.call.duration']).toBe(4000);
+      expect(entries[4]['tool.result.status']).toBe('failure');
+      expect(entries[5].time_unix_nano).toBe(ms(base + 4202));
     });
   });
 

--- a/tests/unit/normalization/build-entry.test.ts
+++ b/tests/unit/normalization/build-entry.test.ts
@@ -124,4 +124,15 @@ describe('buildAgentActivityEntry', () => {
     expect(entry['agent.content']).toBeUndefined();
     expect(entry['agent.inline_diff_message']).toBeUndefined();
   });
+
+  it('normalizes a hook tool error to failure and marks the event as erroneous', () => {
+    const entry = buildAgentActivityEntry({
+      'event.name': 'tool.result',
+      'gen_ai.agent.type': ClientType.Qoder,
+      'tool.result.status': 'error',
+    });
+
+    expect(entry['tool.result.status']).toBe('failure');
+    expect(entry['error.type']).toBe('_OTHER');
+  });
 });


### PR DESCRIPTION
## Summary

- group transcript assistant blocks by completed tool cycles and treat both `PostToolUse` and `PostToolUseFailure` as the next LLM Step boundary
- anchor delayed retries to the triggering Stop turn so queued prompts are not consumed by the previous turn
- associate tool results by tool ID while preserving failure status and per-tool timing
- align SQLite usage by turn and aggregate unmatched tail rows into the final response so total token usage is conserved

## Verification

- `npx vitest run tests/unit/hooks/qoder-hook-processor-cold-start.test.mjs tests/unit/hooks/qoder-hook-processor-retry.test.mjs tests/unit/inputs/qoder-ide-lag-repro.test.ts tests/unit/inputs/qoder-trace-input.test.ts tests/unit/inputs/qoder-cn-trace-input.test.ts tests/unit/normalization/build-entry.test.ts` — 81 tests passed
- `npm run typecheck`
- replayed 10 real Qoder turns containing `PostToolUseFailure`: 48/48 LLM Steps paired, 0 tool-ID mismatches, and 15/15 failed tool results retained as errors