### PR TITLE
fix(qoder-cn): probe multiple SQLite candidates for token enrichment

### DIFF
--- a/src/inputs/qoder-cn-trace/qoder-cn-trace-input.ts
+++ b/src/inputs/qoder-cn-trace/qoder-cn-trace-input.ts
@@ -152,7 +152,9 @@ export class QoderCnTraceInput extends BaseInput {
     }
 
     for (const [sessionId, sessionEntries] of ideSessionGroups) {
-      const sqliteRows = await readSqliteTokensForSession(sessionId);
+      // Intentionally ignores matchedDbPath: agent.type must never be derived from
+      // which candidate DB matched. See resolveQoderCnDbPaths in sqlite-token-reader.
+      const { rows: sqliteRows } = await readSqliteTokensForSession(sessionId);
       enrichIdeTurn(sessionEntries, sqliteRows);
       // Post-processing after enrichIdeTurn:
       expandContainerTimes(sessionEntries);

--- a/src/inputs/qoder-cn-trace/sqlite-token-reader.ts
+++ b/src/inputs/qoder-cn-trace/sqlite-token-reader.ts
@@ -7,6 +7,9 @@ import { createLogger } from '../../utils/logger.js';
 
 const logger = createLogger('QoderCnSqliteTokenReader');
 
+/** Path tail shared by the standalone-app layouts, appended to an app-support dir name. */
+const DB_PATH_SEGMENTS = ['SharedClientCache', 'cache', 'db', 'local.db'] as const;
+
 export interface SqliteTokenData {
   sessionId?: string;
   requestId: string;
@@ -18,9 +21,15 @@ export interface SqliteTokenData {
   model?: string;
 }
 
-export async function readSqliteTokensForSession(sessionId: string): Promise<SqliteTokenData[]> {
-  const dbPath = resolveQoderCnDbPath();
-  if (!dbPath) return [];
+export interface SqliteTokenResult {
+  rows: SqliteTokenData[];
+  /** The candidate DB that contained this session. Debug logging only — see resolveQoderCnDbPaths. */
+  matchedDbPath: string | null;
+}
+
+export async function readSqliteTokensForSession(sessionId: string): Promise<SqliteTokenResult> {
+  const dbPaths = resolveQoderCnDbPaths();
+  if (dbPaths.length === 0) return { rows: [], matchedDbPath: null };
 
   const sql = `
     SELECT
@@ -41,57 +50,93 @@ export async function readSqliteTokensForSession(sessionId: string): Promise<Sql
     ORDER BY cm.gmt_create ASC
   `;
 
-  let rows: Array<{
-    message_id?: string;
-    session_id?: string;
-    request_id: string;
-    gmt_create: number;
-    token_info: string;
-    model_info?: string | null;
-    record_extra?: string | null;
-  }>;
-  try {
-    rows = await queryReadonly(dbPath, sql, [sessionId]);
-  } catch (err) {
-    logger.debug('sqlite query failed', { sessionId, error: String(err) });
-    return [];
+  for (const dbPath of dbPaths) {
+    let rows: Array<{
+      message_id?: string;
+      session_id?: string;
+      request_id: string;
+      gmt_create: number;
+      token_info: string;
+      model_info?: string | null;
+      record_extra?: string | null;
+    }>;
+    try {
+      rows = await queryReadonly(dbPath, sql, [sessionId]);
+    } catch (err) {
+      logger.debug('sqlite query failed', { sessionId, dbPath, error: String(err) });
+      continue;
+    }
+
+    if (rows.length === 0) continue;
+
+    const results: SqliteTokenData[] = [];
+    for (const row of rows) {
+      const info = parseTokenInfo(row.token_info);
+      if (!info) continue;
+      results.push({
+        sessionId: row.session_id ?? '',
+        requestId: row.request_id ?? '',
+        messageId: row.message_id ?? '',
+        gmtCreate: row.gmt_create,
+        inputTokens: info.promptTokens,
+        outputTokens: info.completionTokens,
+        cacheReadTokens: info.cachedTokens,
+        model: parseModelKey(row.model_info) ?? parseRecordModelKey(row.record_extra),
+      });
+    }
+    if (results.length > 0) return { rows: results, matchedDbPath: dbPath };
   }
 
-  const results: SqliteTokenData[] = [];
-  for (const row of rows) {
-    const info = parseTokenInfo(row.token_info);
-    if (!info) continue;
-    results.push({
-      sessionId: row.session_id ?? '',
-      requestId: row.request_id ?? '',
-      messageId: row.message_id ?? '',
-      gmtCreate: row.gmt_create,
-      inputTokens: info.promptTokens,
-      outputTokens: info.completionTokens,
-      cacheReadTokens: info.cachedTokens,
-      model: parseModelKey(row.model_info) ?? parseRecordModelKey(row.record_extra),
-    });
-  }
-  return results;
+  return { rows: [], matchedDbPath: null };
 }
 
-function resolveQoderCnDbPath(): string | null {
-  const appdata = process.env.APPDATA ?? path.join(os.homedir(), 'AppData', 'Roaming');
-  const candidates = process.platform === 'darwin'
-    ? [resolveHome('~/Library/Application Support/QoderCN/SharedClientCache/cache/db/local.db')]
+/**
+ * Qoder CN ships more than one data layout, and both share the same `~/.qoder-cn`
+ * config directory:
+ *
+ *   IDE plugin host  ~/.qoder-cn/shared_client/cache/db/local.db
+ *   standalone app   <app-support>/QoderCN/SharedClientCache/cache/db/local.db
+ *
+ * Config-dir presence therefore says nothing about where the DB lives, so probe every
+ * accessible candidate and let `session_id` decide ownership: a candidate that does not
+ * contain the session simply returns zero rows and we move on. Session ids are per-session
+ * UUIDs, so a wrong candidate can never mis-attribute data.
+ *
+ * `<app-support>/Qoder/SharedClientCache/...` is deliberately NOT a candidate: that is the
+ * international Qoder desktop DB. No CN build has been observed using it, and it can be
+ * hundreds of MB — opening it on every enrichment would cost real IO for no benefit.
+ *
+ * DO NOT use the matched path to derive or rewrite `gen_ai.agent.type`. Identity comes only
+ * from hook deploy location -> hook script agent id -> the hook record. `qoder-trace` does
+ * relabel qoder -> qoder-idea via `isIdeaDbPath()`, which tests
+ * `includes('.qoder/shared_client')`; `.qoder-cn/shared_client` escapes that test purely
+ * because the substring is `-cn/` rather than `/`. That is a coincidence, not a guarantee.
+ * Copying that pattern here, or loosening the test, would mislabel every Qoder CN user.
+ */
+function resolveQoderCnDbPaths(): string[] {
+  const appSupportRoot = process.platform === 'darwin'
+    ? resolveHome('~/Library/Application Support')
     : process.platform === 'win32'
-      ? [path.join(appdata, 'QoderCN', 'SharedClientCache', 'cache', 'db', 'local.db')]
-      : [resolveHome('~/.config/QoderCN/SharedClientCache/cache/db/local.db')];
+      ? (process.env.APPDATA ?? path.join(os.homedir(), 'AppData', 'Roaming'))
+      : resolveHome('~/.config');
 
+  // Ordered by observed hit rate.
+  const candidates = [
+    path.join(os.homedir(), '.qoder-cn', 'shared_client', 'cache', 'db', 'local.db'),
+    path.join(appSupportRoot, 'QoderCN', ...DB_PATH_SEGMENTS),
+    path.join(appSupportRoot, 'Qoder CN', ...DB_PATH_SEGMENTS),
+  ];
+
+  const available: string[] = [];
   for (const candidate of candidates) {
     try {
       fs.accessSync(candidate);
-      return candidate;
+      available.push(candidate);
     } catch {
       continue;
     }
   }
-  return null;
+  return available;
 }
 
 function parseTokenInfo(raw: string): { promptTokens: number; completionTokens: number; cachedTokens: number } | null {

--- a/tests/unit/inputs/qoder-cn-sqlite-reader.test.ts
+++ b/tests/unit/inputs/qoder-cn-sqlite-reader.test.ts
@@ -17,30 +17,55 @@ vi.mock('node:os', async (importOriginal) => {
 
 const { readSqliteTokensForSession } = await import('../../../src/inputs/qoder-cn-trace/sqlite-token-reader.js');
 
+/** Standalone-app layout: <app-support>/<dirName>/SharedClientCache/cache/db/local.db */
+function appSupportDbPath(dirName = 'QoderCN'): string {
+  const root = process.platform === 'darwin'
+    ? path.join(tmpHome, 'Library', 'Application Support')
+    : process.platform === 'win32'
+      ? path.join(tmpHome, 'AppData', 'Roaming')
+      : path.join(tmpHome, '.config');
+  return path.join(root, dirName, 'SharedClientCache', 'cache', 'db', 'local.db');
+}
+
+/** IDE plugin layout: ~/.qoder-cn/shared_client/cache/db/local.db (probed first) */
+function sharedClientDbPath(): string {
+  return path.join(tmpHome, '.qoder-cn', 'shared_client', 'cache', 'db', 'local.db');
+}
+
+async function createDb(p: string): Promise<string> {
+  await fs.mkdir(path.dirname(p), { recursive: true });
+  await createSchema(p);
+  return p;
+}
+
+// On Windows the reader resolves app-support from %APPDATA%; redirect it into the temp home.
+const originalAppData = process.env.APPDATA;
+
 let dbPath: string;
 
 beforeEach(async () => {
   tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'qodercn-sqlite-test-'));
-
-  // The reader resolves ~/Library/Application Support/QoderCN/SharedClientCache/cache/db/local.db on darwin.
-  // For non-darwin platforms it uses ~/.config/QoderCN/.../local.db. We always cover the darwin path
-  // (covers macOS CI / local dev); on Linux CI the readSqliteTokensForSession will probe both candidates.
-  const dbDir = process.platform === 'darwin'
-    ? path.join(tmpHome, 'Library', 'Application Support', 'QoderCN', 'SharedClientCache', 'cache', 'db')
-    : path.join(tmpHome, '.config', 'QoderCN', 'SharedClientCache', 'cache', 'db');
-  await fs.mkdir(dbDir, { recursive: true });
-  dbPath = path.join(dbDir, 'local.db');
-  await createSchema(dbPath);
+  if (process.platform === 'win32') {
+    process.env.APPDATA = path.join(tmpHome, 'AppData', 'Roaming');
+  }
+  // Default fixture uses the standalone-app layout (the layout originally supported).
+  dbPath = await createDb(appSupportDbPath());
 });
 
 afterEach(async () => {
+  if (process.platform === 'win32') {
+    if (originalAppData === undefined) delete process.env.APPDATA;
+    else process.env.APPDATA = originalAppData;
+  }
   try { await fs.rm(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
 });
 
 describe('readSqliteTokensForSession (qoder-cn)', () => {
-  it('returns empty array when DB missing', async () => {
+  it('returns an empty result when no candidate DB is accessible', async () => {
     await fs.rm(dbPath, { force: true });
-    expect(await readSqliteTokensForSession('sess-x')).toEqual([]);
+    const result = await readSqliteTokensForSession('sess-x');
+    expect(result.rows).toEqual([]);
+    expect(result.matchedDbPath).toBeNull();
   });
 
   it('maps token_info, message_id, session_id, model_info to SqliteTokenData', async () => {
@@ -51,7 +76,7 @@ describe('readSqliteTokensForSession (qoder-cn)', () => {
       gmt_create: 1_780_000_000_000,
     });
 
-    const rows = await readSqliteTokensForSession('sess-1');
+    const { rows } = await readSqliteTokensForSession('sess-1');
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({
       sessionId: 'sess-1',
@@ -78,7 +103,7 @@ describe('readSqliteTokensForSession (qoder-cn)', () => {
       gmt_create: 1_780_000_001_000,
     });
 
-    const rows = await readSqliteTokensForSession('sess-2');
+    const { rows } = await readSqliteTokensForSession('sess-2');
     expect(rows[0].model).toBe('auto');
   });
 
@@ -88,7 +113,9 @@ describe('readSqliteTokensForSession (qoder-cn)', () => {
       token_info: JSON.stringify({ prompt_tokens: 0, completion_tokens: 0, cached_tokens: 0 }),
       gmt_create: 1_780_000_002_000,
     });
-    expect(await readSqliteTokensForSession('sess-3')).toEqual([]);
+    const result = await readSqliteTokensForSession('sess-3');
+    expect(result.rows).toEqual([]);
+    expect(result.matchedDbPath).toBeNull();
   });
 
   it('ignores non-assistant rows', async () => {
@@ -97,7 +124,7 @@ describe('readSqliteTokensForSession (qoder-cn)', () => {
       token_info: JSON.stringify({ prompt_tokens: 5, completion_tokens: 5, cached_tokens: 0 }),
       gmt_create: 1_780_000_003_000,
     });
-    expect(await readSqliteTokensForSession('sess-4')).toEqual([]);
+    expect((await readSqliteTokensForSession('sess-4')).rows).toEqual([]);
   });
 
   it('orders results by gmt_create ascending', async () => {
@@ -112,8 +139,112 @@ describe('readSqliteTokensForSession (qoder-cn)', () => {
       gmt_create: 1_780_000_004_000,
     });
 
-    const rows = await readSqliteTokensForSession('sess-5');
+    const { rows } = await readSqliteTokensForSession('sess-5');
     expect(rows.map(r => r.messageId)).toEqual(['msg-5b', 'msg-5a']);
+  });
+});
+
+describe('readSqliteTokensForSession candidate probing (qoder-cn)', () => {
+  it('reads tokens from the IDE plugin layout when it is the only layout present', async () => {
+    await fs.rm(path.dirname(dbPath), { recursive: true, force: true });
+    const pluginDb = await createDb(sharedClientDbPath());
+    await insertRow(pluginDb, {
+      id: 'msg-p', session_id: 'sess-plugin', request_id: 'req-p', role: 'assistant',
+      token_info: JSON.stringify({ prompt_tokens: 11, completion_tokens: 3, cached_tokens: 0 }),
+      gmt_create: 1_780_000_010_000,
+    });
+
+    const result = await readSqliteTokensForSession('sess-plugin');
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].inputTokens).toBe(11);
+    expect(result.matchedDbPath).toBe(pluginDb);
+  });
+
+  it('reads tokens from the standalone-app layout when it is the only layout present', async () => {
+    await insertRow(dbPath, {
+      id: 'msg-s', session_id: 'sess-standalone', request_id: 'req-s', role: 'assistant',
+      token_info: JSON.stringify({ prompt_tokens: 22, completion_tokens: 4, cached_tokens: 0 }),
+      gmt_create: 1_780_000_011_000,
+    });
+
+    const result = await readSqliteTokensForSession('sess-standalone');
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].inputTokens).toBe(22);
+    expect(result.matchedDbPath).toBe(dbPath);
+  });
+
+  it('reads tokens from the spaced app-support directory variant', async () => {
+    await fs.rm(path.dirname(dbPath), { recursive: true, force: true });
+    const spacedDb = await createDb(appSupportDbPath('Qoder CN'));
+    await insertRow(spacedDb, {
+      id: 'msg-sp', session_id: 'sess-spaced', request_id: 'req-sp', role: 'assistant',
+      token_info: JSON.stringify({ prompt_tokens: 66, completion_tokens: 8, cached_tokens: 0 }),
+      gmt_create: 1_780_000_016_000,
+    });
+
+    const result = await readSqliteTokensForSession('sess-spaced');
+    expect(result.rows).toHaveLength(1);
+    expect(result.matchedDbPath).toBe(spacedDb);
+  });
+
+  it('picks the candidate that actually holds the session when both layouts exist', async () => {
+    const pluginDb = await createDb(sharedClientDbPath());
+    // Target session lives only in the standalone-app DB.
+    await insertRow(dbPath, {
+      id: 'msg-only', session_id: 'sess-only-standalone', request_id: 'req-only', role: 'assistant',
+      token_info: JSON.stringify({ prompt_tokens: 33, completion_tokens: 5, cached_tokens: 0 }),
+      gmt_create: 1_780_000_012_000,
+    });
+    // Unrelated session in the plugin DB, which is probed first.
+    await insertRow(pluginDb, {
+      id: 'msg-other', session_id: 'sess-unrelated', request_id: 'req-other', role: 'assistant',
+      token_info: JSON.stringify({ prompt_tokens: 99, completion_tokens: 9, cached_tokens: 0 }),
+      gmt_create: 1_780_000_013_000,
+    });
+
+    const result = await readSqliteTokensForSession('sess-only-standalone');
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].inputTokens).toBe(33);
+    expect(result.matchedDbPath).toBe(dbPath);
+  });
+
+  it('continues past a readable candidate that returns zero rows for the session', async () => {
+    // Plugin DB is probed first: valid schema, but no rows at all.
+    await createDb(sharedClientDbPath());
+    await insertRow(dbPath, {
+      id: 'msg-z', session_id: 'sess-zero', request_id: 'req-z', role: 'assistant',
+      token_info: JSON.stringify({ prompt_tokens: 44, completion_tokens: 6, cached_tokens: 0 }),
+      gmt_create: 1_780_000_014_000,
+    });
+
+    const result = await readSqliteTokensForSession('sess-zero');
+    expect(result.rows).toHaveLength(1);
+    expect(result.matchedDbPath).toBe(dbPath);
+  });
+
+  it('continues past a candidate whose query throws', async () => {
+    // Plugin DB exists but is not a valid SQLite file, so querying it rejects.
+    const brokenDb = sharedClientDbPath();
+    await fs.mkdir(path.dirname(brokenDb), { recursive: true });
+    await fs.writeFile(brokenDb, 'not a sqlite database');
+    await insertRow(dbPath, {
+      id: 'msg-b', session_id: 'sess-broken', request_id: 'req-b', role: 'assistant',
+      token_info: JSON.stringify({ prompt_tokens: 55, completion_tokens: 7, cached_tokens: 0 }),
+      gmt_create: 1_780_000_015_000,
+    });
+
+    const result = await readSqliteTokensForSession('sess-broken');
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].inputTokens).toBe(55);
+    expect(result.matchedDbPath).toBe(dbPath);
+  });
+
+  it('does not throw when every candidate is inaccessible', async () => {
+    await fs.rm(path.dirname(dbPath), { recursive: true, force: true });
+    await expect(readSqliteTokensForSession('sess-none')).resolves.toEqual({
+      rows: [],
+      matchedDbPath: null,
+    });
   });
 });
 

--- a/tests/unit/inputs/qoder-cn-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-cn-trace-input.test.ts
@@ -136,6 +136,37 @@ describe('QoderCnTraceInput.collect (session-level enrich)', () => {
     expect(respB['gen_ai.response.id']).toBe('msg-2');
   });
 
+  it('enriches from the IDE plugin layout without ever relabelling agent.type', async () => {
+    // Only the ~/.qoder-cn/shared_client layout exists here. Tokens must still land,
+    // and agent.type must stay 'qoder-cn': identity comes from the hook record, never
+    // from which candidate DB matched (design D3).
+    await fs.rm(path.dirname(dbPath), { recursive: true, force: true });
+    const pluginDbDir = path.join(tmpHome, '.qoder-cn', 'shared_client', 'cache', 'db');
+    await fs.mkdir(pluginDbDir, { recursive: true });
+    const pluginDbPath = path.join(pluginDbDir, 'local.db');
+    await createSchema(pluginDbPath);
+
+    const sessionId = 'sess-plugin-layout';
+    await insertRow(pluginDbPath, {
+      id: 'msg-plugin', session_id: sessionId, request_id: 'req-plugin', role: 'assistant',
+      token_info: JSON.stringify({ prompt_tokens: 300, completion_tokens: 30, cached_tokens: 0 }),
+      gmt_create: 1_780_000_021_000,
+    });
+
+    await writeHookJsonl(logDir, [
+      buildEntry({ event: 'llm.request', turn: 'turn-P', step: 'turn-P:s1', session: sessionId, ts: 1_780_000_020_000 }),
+      buildEntry({ event: 'llm.response', turn: 'turn-P', step: 'turn-P:s1', session: sessionId, ts: 1_780_000_021_000 }),
+    ]);
+
+    const entries = await collectOnce();
+
+    const response = entries.find(e => e['event.name'] === 'llm.response')!;
+    expect(response['gen_ai.usage.input_tokens']).toBe(300);
+    expect(response['gen_ai.usage.output_tokens']).toBe(30);
+    expect(response['gen_ai.response.id']).toBe('msg-plugin');
+    expect(entries.every(e => e['gen_ai.agent.type'] === 'qoder-cn')).toBe(true);
+  });
+
   it('assigns a distinct trace_id per turn even when sessionId is shared', async () => {
     const sessionId = 'sess-trace';
     await insertRow(dbPath, {


### PR DESCRIPTION
## Summary

Qoder CN ships two host forms that share the same `~/.qoder-cn` config directory but store their SQLite database in different locations:

- **Standalone desktop app** → `<app-support>/QoderCN/SharedClientCache/cache/db/local.db`
- **IDE plugin** → `~/.qoder-cn/shared_client/cache/db/local.db`

The token reader only probed the desktop path. On plugin installs (the majority of real users), `readSqliteTokensForSession()` returned empty and `enrichIdeTurn()` short-circuited, so `llm.response` events silently lost `gen_ai.usage.*`, `gen_ai.response.id` and `gen_ai.request.id`, and the model name stayed `auto`/`unknown`.

## Changes

- Resolve the SQLite source to a **candidate list** and probe each accessible DB in turn; the first one containing the session wins. Query failures or zero rows fall through to the next candidate. This mirrors the existing `qoder-trace` reader.
- Add `~/.qoder-cn/shared_client/...` (IDE plugin layout, probed first) plus the standalone-app path and a spaced `Qoder CN` variant.
- `readSqliteTokensForSession()` now returns `{ rows, matchedDbPath }`. `matchedDbPath` is for debug logging only.
- **Ownership is decided by `session_id`** (per-session UUIDs never collide across DBs), never by file path — so a machine with both Qoder and Qoder CN installed cannot mis-attribute tokens.
- `gen_ai.agent.type` remains sourced solely from the hook deploy chain. The matched DB path deliberately does **not** drive agent identity.

## Test plan

- [x] `npm run typecheck`
- [x] `qoder-cn-sqlite-reader.test.ts` — new cases for both layouts, cross-DB isolation, zero-row fall-through, query-error fall-through, and no-candidate graceful return
- [x] `qoder-cn-trace-input.test.ts` — new case: enriching from the IDE plugin layout keeps `gen_ai.agent.type` as `qoder-cn`
- [x] All 20 tests across the two files pass