### PR TITLE
fix(windows): CLM/WDAC compatibility, plus duplicate-collection & uninstall-residue fixes

### DIFF
--- a/agents.d/qoder-cn.json
+++ b/agents.d/qoder-cn.json
@@ -11,7 +11,8 @@
     "events": ["Stop", "PreToolUse", "PostToolUse", "UserPromptSubmit"],
     "hookCommand": "$PILOT_DATA/hooks/qodercn-loongsuite-pilot-hook.sh",
     "format": "nested",
-    "matcher": "*"
+    "matcher": "*",
+    "winShell": "powershell"
   },
   "input": {
     "type": "hook-jsonl",

--- a/agents.d/qoder-work-cn.json
+++ b/agents.d/qoder-work-cn.json
@@ -12,6 +12,7 @@
     "hookCommand": "$PILOT_DATA/hooks/qoderworkcn-loongsuite-pilot-hook.sh",
     "format": "nested",
     "matcher": "*",
+    "winShell": "powershell",
     "replaceHookCommands": ["$PILOT_DATA/hooks/qoder-loongsuite-pilot-hook.sh qoder-work-cn"]
   },
   "input": {

--- a/agents.d/qoder-work.json
+++ b/agents.d/qoder-work.json
@@ -12,6 +12,7 @@
     "hookCommand": "$PILOT_DATA/hooks/qoderwork-loongsuite-pilot-hook.sh",
     "format": "nested",
     "matcher": "*",
+    "winShell": "powershell",
     "replaceHookCommands": ["$PILOT_DATA/hooks/qoder-loongsuite-pilot-hook.sh qoder-work"]
   },
   "input": {

--- a/agents.d/qoder.json
+++ b/agents.d/qoder.json
@@ -12,6 +12,7 @@
     "hookCommand": "$PILOT_DATA/hooks/qoder-loongsuite-pilot-hook.sh",
     "format": "nested",
     "matcher": "*",
+    "winShell": "powershell",
     "replaceHookCommands": ["$PILOT_DATA/hooks/qoder-loongsuite-pilot-hook.sh qoder-cli", "$PILOT_DATA/hooks/qoder-loongsuite-pilot-hook.sh qoder"]
   },
   "input": {

--- a/assets/hooks/claude-code-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/claude-code-loongsuite-pilot-hook.ps1
@@ -1,4 +1,4 @@
-# Claude Code hook entrypoint (Windows) — delegates to claude-code-hook-processor.mjs.
+# Claude Code hook entrypoint (Windows) - delegates to claude-code-hook-processor.mjs.
 #
 # Usage (registered in ~/.claude/settings.json by pilot HookStrategy):
 #   powershell -File $PILOT_DATA/hooks/claude-code-loongsuite-pilot-hook.ps1 <subcommand>
@@ -100,51 +100,16 @@ if (-not [Console]::IsInputRedirected) {
 }
 
 try {
-    # Read stdin as raw bytes to avoid PowerShell encoding issues (GB2312/ASCII mangles UTF-8)
-    $stdinStream = [Console]::OpenStandardInput()
-    $ms = New-Object System.IO.MemoryStream
-    $stdinStream.CopyTo($ms)
-    $rawBytes = $ms.ToArray()
-    $ms.Dispose()
-
-    # Strip UTF-8 BOM (EF BB BF) before any encoding fixup
-    if ($rawBytes.Length -ge 3 -and $rawBytes[0] -eq 0xEF -and $rawBytes[1] -eq 0xBB -and $rawBytes[2] -eq 0xBF) {
-        $rawBytes = $rawBytes[3..($rawBytes.Length - 1)]
-    }
-
-    # Fix Cursor's UTF-8→GBK double-encoding on Chinese Windows.
-    if ($rawBytes.Length -gt 2) {
-        try {
-            $utf8    = [System.Text.Encoding]::UTF8
-            $gbk     = [System.Text.Encoding]::GetEncoding(936)
-            $garbled = $utf8.GetString($rawBytes)
-            $recovered = $gbk.GetBytes($garbled)
-
-            $strictUtf8 = [System.Text.UTF8Encoding]::new($false, $true)
-            [void]$strictUtf8.GetString($recovered)
-
-            $rawBytes = $recovered
-        } catch {}
-    }
-
-    if ($rawBytes.Length -eq 0) {
-        $result = & $nodeBin $Processor $Subcommand 2>$null
-    } else {
-        $psi = New-Object System.Diagnostics.ProcessStartInfo
-        $psi.FileName = $nodeBin
-        $psi.Arguments = "`"$Processor`" $Subcommand"
-        $psi.UseShellExecute = $false
-        $psi.RedirectStandardInput = $true
-        $psi.RedirectStandardOutput = $true
-        $psi.RedirectStandardError = $false
-        $psi.CreateNoWindow = $true
-
-        $proc = [System.Diagnostics.Process]::Start($psi)
-        $proc.StandardInput.BaseStream.Write($rawBytes, 0, $rawBytes.Length)
-        $proc.StandardInput.Close()
-        $result = $proc.StandardOutput.ReadToEnd()
-        $proc.WaitForExit()
-    }
+    # CLM/WDAC-safe passthrough: node inherits this process's stdin (fd0) and
+    # reads it directly; PowerShell never touches the bytes. The old code used
+    # [Console]::OpenStandardInput / MemoryStream / ProcessStartInfo, whose .NET
+    # calls throw under Constrained Language Mode (WDAC/Device Guard) and silently
+    # drop telemetry. BOM stripping and the Chinese UTF-8->GBK fixup now live in
+    # node (shared/decode-payload.mjs).
+    # NOTE: keep this file ASCII-only. Windows PowerShell 5.1 parses a BOM-less
+    # script using the system ANSI code page (GBK/936 on Chinese Windows); any
+    # non-ASCII byte here can corrupt parsing and abort the whole script.
+    $result = & $nodeBin $Processor $Subcommand 2>$null
     if ($result) { Write-Output $result } else { Write-Output $EMPTY_RESULT }
 } catch {
     Write-Error "[claude-code-hook] processor failed (subcommand=$Subcommand)"

--- a/assets/hooks/codex-hook-processor.mjs
+++ b/assets/hooks/codex-hook-processor.mjs
@@ -15,6 +15,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import crypto from 'node:crypto';
+import { decodePayload } from './shared/decode-payload.mjs';
 import { logHookError } from './shared/error-logger.mjs';
 import { recordUpstreamContextOnce } from './shared/upstream-context.mjs';
 import {
@@ -34,7 +35,8 @@ function pilotDataDir() {
 
 function tryReadStdin() {
   try {
-    const input = fs.readFileSync(0, 'utf8').trim();
+    // decodePayload 去 BOM 并修复中文 UTF-8->GBK 双重编码(纠偏已从 PS 侧移入 node)。
+    const input = decodePayload(fs.readFileSync(0)).trim();
     if (!input) return {};
     const value = JSON.parse(input);
     return value && typeof value === 'object' && !Array.isArray(value) ? value : {};

--- a/assets/hooks/codex-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/codex-loongsuite-pilot-hook.ps1
@@ -48,7 +48,7 @@ function Log-Error {
 }
 
 function Write-EmptyResult {
-    [Console]::Out.WriteLine($EMPTY_RESULT)
+    Write-Output $EMPTY_RESULT
 }
 
 function Convert-NodePath {
@@ -144,56 +144,23 @@ try {
         exit 0
     }
 
-    # Preserve Codex's UTF-8 JSON exactly; PowerShell 5.1 text pipelines can
-    # otherwise reinterpret non-ASCII prompts using a legacy code page.
-    $stdinStream = [Console]::OpenStandardInput()
-    $memory = New-Object System.IO.MemoryStream
-    $stdinStream.CopyTo($memory)
-    [byte[]]$rawBytes = $memory.ToArray()
-    $memory.Dispose()
-
-    if (
-        $rawBytes.Length -ge 3 -and
-        $rawBytes[0] -eq 0xEF -and
-        $rawBytes[1] -eq 0xBB -and
-        $rawBytes[2] -eq 0xBF
-    ) {
-        if ($rawBytes.Length -eq 3) {
-            $rawBytes = [byte[]]@()
-        } else {
-            $rawBytes = $rawBytes[3..($rawBytes.Length - 1)]
-        }
+    # CLM/WDAC-safe passthrough: node inherits this process's stdin (fd0) and
+    # reads Codex's UTF-8 JSON directly; PowerShell never touches the bytes. The
+    # old code used [Console]::OpenStandardInput / MemoryStream / ProcessStartInfo,
+    # whose .NET calls throw under Constrained Language Mode (WDAC/Device Guard)
+    # and silently drop telemetry. BOM stripping and the Chinese UTF-8->GBK fixup
+    # now live in node (shared/decode-payload.mjs).
+    # NOTE: keep this file ASCII-only. Windows PowerShell 5.1 parses a BOM-less
+    # script using the system ANSI code page (GBK/936 on Chinese Windows); any
+    # non-ASCII byte here can corrupt parsing and abort the whole script.
+    $result = & $nodeBin $Processor $Subcommand 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        throw "processor exited with code $LASTEXITCODE"
     }
+    $result = ($result | Out-String).Trim()
 
-    if ($rawBytes.Length -eq 0) {
-        $result = & $nodeBin $Processor $Subcommand 2>$null
-        if ($LASTEXITCODE -ne 0) {
-            throw "processor exited with code $LASTEXITCODE"
-        }
-        $result = $result -join [Environment]::NewLine
-    } else {
-        $startInfo = New-Object System.Diagnostics.ProcessStartInfo
-        $startInfo.FileName = $nodeBin
-        $startInfo.Arguments = "`"$Processor`" `"$Subcommand`""
-        $startInfo.UseShellExecute = $false
-        $startInfo.RedirectStandardInput = $true
-        $startInfo.RedirectStandardOutput = $true
-        $startInfo.RedirectStandardError = $true
-        $startInfo.CreateNoWindow = $true
-
-        $process = [System.Diagnostics.Process]::Start($startInfo)
-        $process.StandardInput.BaseStream.Write($rawBytes, 0, $rawBytes.Length)
-        $process.StandardInput.Close()
-        $result = $process.StandardOutput.ReadToEnd()
-        $stderr = $process.StandardError.ReadToEnd()
-        $process.WaitForExit()
-        if ($process.ExitCode -ne 0) {
-            throw "processor exited with code $($process.ExitCode): $stderr"
-        }
-    }
-
-    if ($result -and $result.Trim()) {
-        [Console]::Out.WriteLine($result.Trim())
+    if ($result) {
+        Write-Output $result
     } else {
         Write-EmptyResult
     }

--- a/assets/hooks/cursor-hook-processor.mjs
+++ b/assets/hooks/cursor-hook-processor.mjs
@@ -15,6 +15,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { decodePayload } from './shared/decode-payload.mjs';
 import {
   applyHookContentPolicy,
   hashJson,
@@ -66,9 +67,8 @@ async function readStdin() {
   for await (const chunk of process.stdin) {
     chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
   }
-  let str = Buffer.concat(chunks).toString('utf-8');
-  if (str.charCodeAt(0) === 0xFEFF) str = str.slice(1);
-  return str;
+  // decodePayload 去 BOM 并修复中文 UTF-8->GBK 双重编码(纠偏已从 PS 侧移入 node)。
+  return decodePayload(Buffer.concat(chunks));
 }
 
 async function appendJsonl(filePath, record) {

--- a/assets/hooks/cursor-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/cursor-loongsuite-pilot-hook.ps1
@@ -1,4 +1,4 @@
-# Cursor hook entrypoint (Windows) — delegates to cursor-hook-processor.mjs.
+# Cursor hook entrypoint (Windows) - delegates to cursor-hook-processor.mjs.
 #
 # Fail-open: any error outputs "{}" and exits 0.
 
@@ -86,36 +86,16 @@ if (-not $nodeBin) {
 }
 
 try {
-    # Read stdin as raw bytes to avoid PowerShell encoding issues (GB2312/ASCII mangles UTF-8)
-    $stdinStream = [Console]::OpenStandardInput()
-    $ms = New-Object System.IO.MemoryStream
-    $stdinStream.CopyTo($ms)
-    $rawBytes = $ms.ToArray()
-    $ms.Dispose()
-
-    # Strip UTF-8 BOM (EF BB BF) before passing to Node.
-    if ($rawBytes.Length -ge 3 -and $rawBytes[0] -eq 0xEF -and $rawBytes[1] -eq 0xBB -and $rawBytes[2] -eq 0xBF) {
-        $rawBytes = $rawBytes[3..($rawBytes.Length - 1)]
-    }
-
-    if ($rawBytes.Length -eq 0) {
-        $result = & $nodeBin $Processor 2>$null
-    } else {
-        $psi = New-Object System.Diagnostics.ProcessStartInfo
-        $psi.FileName = $nodeBin
-        $psi.Arguments = "`"$Processor`""
-        $psi.UseShellExecute = $false
-        $psi.RedirectStandardInput = $true
-        $psi.RedirectStandardOutput = $true
-        $psi.RedirectStandardError = $false
-        $psi.CreateNoWindow = $true
-
-        $proc = [System.Diagnostics.Process]::Start($psi)
-        $proc.StandardInput.BaseStream.Write($rawBytes, 0, $rawBytes.Length)
-        $proc.StandardInput.Close()
-        $result = $proc.StandardOutput.ReadToEnd()
-        $proc.WaitForExit()
-    }
+    # CLM/WDAC-safe passthrough: node inherits this process's stdin (fd0) and
+    # reads it directly; PowerShell never touches the bytes. The old code used
+    # [Console]::OpenStandardInput / MemoryStream / ProcessStartInfo, whose .NET
+    # calls throw under Constrained Language Mode (WDAC/Device Guard) and silently
+    # drop telemetry. BOM stripping and the Chinese UTF-8->GBK fixup now live in
+    # node (shared/decode-payload.mjs).
+    # NOTE: keep this file ASCII-only. Windows PowerShell 5.1 parses a BOM-less
+    # script using the system ANSI code page (GBK/936 on Chinese Windows); any
+    # non-ASCII byte here can corrupt parsing and abort the whole script.
+    $result = & $nodeBin $Processor 2>$null
     if ($result) { Write-Output $result } else { Write-Output $EMPTY_RESULT }
 } catch {
     Write-Error "[loongsuite-pilot] hook processor failed"

--- a/assets/hooks/qoder-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/qoder-loongsuite-pilot-hook.ps1
@@ -1,4 +1,4 @@
-# Qoder hook entrypoint (Windows) — delegates to qoder-hook-processor.mjs.
+# Qoder hook entrypoint (Windows) - delegates to qoder-hook-processor.mjs.
 # Usage: powershell -File qoder-loongsuite-pilot-hook.ps1 [agent-id]
 
 $ErrorActionPreference = "Continue"
@@ -58,57 +58,18 @@ if (-not $nodeBin) {
 }
 
 try {
-    # Read stdin as raw bytes to avoid PowerShell encoding issues (GB2312/ASCII mangles UTF-8)
-    $stdinStream = [Console]::OpenStandardInput()
-    $ms = New-Object System.IO.MemoryStream
-    $stdinStream.CopyTo($ms)
-    $rawBytes = $ms.ToArray()
-    $ms.Dispose()
-
-    # Strip UTF-8 BOM (EF BB BF) before any encoding fixup
-    if ($rawBytes.Length -ge 3 -and $rawBytes[0] -eq 0xEF -and $rawBytes[1] -eq 0xBB -and $rawBytes[2] -eq 0xBF) {
-        $rawBytes = $rawBytes[3..($rawBytes.Length - 1)]
-    }
-
-    # Fix Cursor's UTF-8→GBK double-encoding on Chinese Windows.
-    # Cursor encodes hook payloads through the system codepage (GBK/CP936), garbling
-    # all non-ASCII text.  Reversal: decode the garbled bytes as UTF-8, encode the
-    # resulting string as GBK — this recovers the ORIGINAL UTF-8 bytes.  We validate
-    # by checking that the recovered bytes are valid UTF-8; if not, keep the originals.
-    if ($rawBytes.Length -gt 2) {
-        try {
-            $utf8    = [System.Text.Encoding]::UTF8
-            $gbk     = [System.Text.Encoding]::GetEncoding(936)
-            $garbled = $utf8.GetString($rawBytes)
-            $recovered = $gbk.GetBytes($garbled)
-
-            $strictUtf8 = [System.Text.UTF8Encoding]::new($false, $true)
-            [void]$strictUtf8.GetString($recovered)
-
-            $rawBytes = $recovered
-        } catch {
-            # Validation failed — original bytes are already correct UTF-8, keep them
-        }
-    }
-
-    if ($rawBytes.Length -eq 0) {
-        & $nodeBin $Processor --agent-id $AgentId 2>$null
-    } else {
-        $psi = New-Object System.Diagnostics.ProcessStartInfo
-        $psi.FileName = $nodeBin
-        $psi.Arguments = "`"$Processor`" --agent-id $AgentId"
-        $psi.UseShellExecute = $false
-        $psi.RedirectStandardInput = $true
-        $psi.RedirectStandardOutput = $true
-        $psi.RedirectStandardError = $false
-        $psi.CreateNoWindow = $true
-
-        $proc = [System.Diagnostics.Process]::Start($psi)
-        $proc.StandardInput.BaseStream.Write($rawBytes, 0, $rawBytes.Length)
-        $proc.StandardInput.Close()
-        $null = $proc.StandardOutput.ReadToEnd()
-        $proc.WaitForExit()
-    }
+    # CLM/WDAC-safe: let node inherit this process's stdin (fd0) and read it
+    # directly; PowerShell never touches the bytes. The old implementation used
+    # [Console]::OpenStandardInput / MemoryStream / ProcessStartInfo to spawn
+    # node -- those .NET calls throw under Constrained Language Mode (enforced by
+    # Device Guard/WDAC), crashing the hook and silently dropping telemetry. BOM
+    # stripping and the Chinese UTF-8->GBK double-encoding fixup now live in node
+    # (shared/decode-payload.mjs), so here we only pass through, which works in
+    # both language modes.
+    # NOTE: keep this file ASCII-only. Windows PowerShell 5.1 parses a BOM-less
+    # script using the system ANSI code page (GBK/936 on Chinese Windows); any
+    # non-ASCII byte here can corrupt parsing and abort the whole script.
+    & $nodeBin $Processor --agent-id $AgentId 2>$null | Out-Null
 } catch {}
 
 exit 0

--- a/assets/hooks/qodercn-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/qodercn-loongsuite-pilot-hook.ps1
@@ -1,4 +1,4 @@
-# QoderCN hook entrypoint (Windows) — delegates to qoder-hook-processor.mjs.
+# QoderCN hook entrypoint (Windows) - delegates to qoder-hook-processor.mjs.
 # Usage: powershell -File qodercn-loongsuite-pilot-hook.ps1 [agent-id]
 
 $ErrorActionPreference = "Continue"
@@ -58,51 +58,18 @@ if (-not $nodeBin) {
 }
 
 try {
-    # Read stdin as raw bytes to avoid PowerShell encoding issues (GB2312/ASCII mangles UTF-8)
-    $stdinStream = [Console]::OpenStandardInput()
-    $ms = New-Object System.IO.MemoryStream
-    $stdinStream.CopyTo($ms)
-    $rawBytes = $ms.ToArray()
-    $ms.Dispose()
-
-    # Strip UTF-8 BOM (EF BB BF) before any encoding fixup
-    if ($rawBytes.Length -ge 3 -and $rawBytes[0] -eq 0xEF -and $rawBytes[1] -eq 0xBB -and $rawBytes[2] -eq 0xBF) {
-        $rawBytes = $rawBytes[3..($rawBytes.Length - 1)]
-    }
-
-    # Fix Cursor's UTF-8→GBK double-encoding on Chinese Windows.
-    if ($rawBytes.Length -gt 2) {
-        try {
-            $utf8    = [System.Text.Encoding]::UTF8
-            $gbk     = [System.Text.Encoding]::GetEncoding(936)
-            $garbled = $utf8.GetString($rawBytes)
-            $recovered = $gbk.GetBytes($garbled)
-
-            $strictUtf8 = [System.Text.UTF8Encoding]::new($false, $true)
-            [void]$strictUtf8.GetString($recovered)
-
-            $rawBytes = $recovered
-        } catch {}
-    }
-
-    if ($rawBytes.Length -eq 0) {
-        & $nodeBin $Processor --agent-id $AgentId 2>$null
-    } else {
-        $psi = New-Object System.Diagnostics.ProcessStartInfo
-        $psi.FileName = $nodeBin
-        $psi.Arguments = "`"$Processor`" --agent-id $AgentId"
-        $psi.UseShellExecute = $false
-        $psi.RedirectStandardInput = $true
-        $psi.RedirectStandardOutput = $true
-        $psi.RedirectStandardError = $false
-        $psi.CreateNoWindow = $true
-
-        $proc = [System.Diagnostics.Process]::Start($psi)
-        $proc.StandardInput.BaseStream.Write($rawBytes, 0, $rawBytes.Length)
-        $proc.StandardInput.Close()
-        $null = $proc.StandardOutput.ReadToEnd()
-        $proc.WaitForExit()
-    }
+    # CLM/WDAC-safe: let node inherit this process's stdin (fd0) and read it
+    # directly; PowerShell never touches the bytes. The old implementation used
+    # [Console]::OpenStandardInput / MemoryStream / ProcessStartInfo to spawn
+    # node -- those .NET calls throw under Constrained Language Mode (enforced by
+    # Device Guard/WDAC), crashing the hook and silently dropping telemetry. BOM
+    # stripping and the Chinese UTF-8->GBK double-encoding fixup now live in node
+    # (shared/decode-payload.mjs), so here we only pass through, which works in
+    # both language modes.
+    # NOTE: keep this file ASCII-only. Windows PowerShell 5.1 parses a BOM-less
+    # script using the system ANSI code page (GBK/936 on Chinese Windows); any
+    # non-ASCII byte here can corrupt parsing and abort the whole script.
+    & $nodeBin $Processor --agent-id $AgentId 2>$null | Out-Null
 } catch {}
 
 exit 0

--- a/assets/hooks/qoderwork-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/qoderwork-loongsuite-pilot-hook.ps1
@@ -1,4 +1,4 @@
-# Qoder Work hook entrypoint (Windows) — delegates to qoderwork-hook-processor.mjs.
+# Qoder Work hook entrypoint (Windows) - delegates to qoderwork-hook-processor.mjs.
 # Usage: powershell -File qoderwork-loongsuite-pilot-hook.ps1
 
 $ErrorActionPreference = "Continue"
@@ -58,51 +58,18 @@ if (-not $nodeBin) {
 }
 
 try {
-    # Read stdin as raw bytes to avoid PowerShell encoding issues (GB2312/ASCII mangles UTF-8)
-    $stdinStream = [Console]::OpenStandardInput()
-    $ms = New-Object System.IO.MemoryStream
-    $stdinStream.CopyTo($ms)
-    $rawBytes = $ms.ToArray()
-    $ms.Dispose()
-
-    # Strip UTF-8 BOM (EF BB BF) before any encoding fixup
-    if ($rawBytes.Length -ge 3 -and $rawBytes[0] -eq 0xEF -and $rawBytes[1] -eq 0xBB -and $rawBytes[2] -eq 0xBF) {
-        $rawBytes = $rawBytes[3..($rawBytes.Length - 1)]
-    }
-
-    # Fix Cursor's UTF-8→GBK double-encoding on Chinese Windows.
-    if ($rawBytes.Length -gt 2) {
-        try {
-            $utf8    = [System.Text.Encoding]::UTF8
-            $gbk     = [System.Text.Encoding]::GetEncoding(936)
-            $garbled = $utf8.GetString($rawBytes)
-            $recovered = $gbk.GetBytes($garbled)
-
-            $strictUtf8 = [System.Text.UTF8Encoding]::new($false, $true)
-            [void]$strictUtf8.GetString($recovered)
-
-            $rawBytes = $recovered
-        } catch {}
-    }
-
-    if ($rawBytes.Length -eq 0) {
-        & $nodeBin $Processor --agent-id $AgentId 2>$null
-    } else {
-        $psi = New-Object System.Diagnostics.ProcessStartInfo
-        $psi.FileName = $nodeBin
-        $psi.Arguments = "`"$Processor`" --agent-id $AgentId"
-        $psi.UseShellExecute = $false
-        $psi.RedirectStandardInput = $true
-        $psi.RedirectStandardOutput = $true
-        $psi.RedirectStandardError = $false
-        $psi.CreateNoWindow = $true
-
-        $proc = [System.Diagnostics.Process]::Start($psi)
-        $proc.StandardInput.BaseStream.Write($rawBytes, 0, $rawBytes.Length)
-        $proc.StandardInput.Close()
-        $null = $proc.StandardOutput.ReadToEnd()
-        $proc.WaitForExit()
-    }
+    # CLM/WDAC-safe: let node inherit this process's stdin (fd0) and read it
+    # directly; PowerShell never touches the bytes. The old implementation used
+    # [Console]::OpenStandardInput / MemoryStream / ProcessStartInfo to spawn
+    # node -- those .NET calls throw under Constrained Language Mode (enforced by
+    # Device Guard/WDAC), crashing the hook and silently dropping telemetry. BOM
+    # stripping and the Chinese UTF-8->GBK double-encoding fixup now live in node
+    # (shared/decode-payload.mjs), so here we only pass through, which works in
+    # both language modes.
+    # NOTE: keep this file ASCII-only. Windows PowerShell 5.1 parses a BOM-less
+    # script using the system ANSI code page (GBK/936 on Chinese Windows); any
+    # non-ASCII byte here can corrupt parsing and abort the whole script.
+    & $nodeBin $Processor --agent-id $AgentId 2>$null | Out-Null
 } catch {}
 
 exit 0

--- a/assets/hooks/qoderworkcn-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/qoderworkcn-loongsuite-pilot-hook.ps1
@@ -1,4 +1,4 @@
-# Qoder Work CN hook entrypoint (Windows) — delegates to qoderwork-hook-processor.mjs.
+# Qoder Work CN hook entrypoint (Windows) - delegates to qoderwork-hook-processor.mjs.
 # Usage: powershell -File qoderworkcn-loongsuite-pilot-hook.ps1
 
 $ErrorActionPreference = "Continue"
@@ -58,51 +58,18 @@ if (-not $nodeBin) {
 }
 
 try {
-    # Read stdin as raw bytes to avoid PowerShell encoding issues (GB2312/ASCII mangles UTF-8)
-    $stdinStream = [Console]::OpenStandardInput()
-    $ms = New-Object System.IO.MemoryStream
-    $stdinStream.CopyTo($ms)
-    $rawBytes = $ms.ToArray()
-    $ms.Dispose()
-
-    # Strip UTF-8 BOM (EF BB BF) before any encoding fixup
-    if ($rawBytes.Length -ge 3 -and $rawBytes[0] -eq 0xEF -and $rawBytes[1] -eq 0xBB -and $rawBytes[2] -eq 0xBF) {
-        $rawBytes = $rawBytes[3..($rawBytes.Length - 1)]
-    }
-
-    # Fix Cursor's UTF-8→GBK double-encoding on Chinese Windows.
-    if ($rawBytes.Length -gt 2) {
-        try {
-            $utf8    = [System.Text.Encoding]::UTF8
-            $gbk     = [System.Text.Encoding]::GetEncoding(936)
-            $garbled = $utf8.GetString($rawBytes)
-            $recovered = $gbk.GetBytes($garbled)
-
-            $strictUtf8 = [System.Text.UTF8Encoding]::new($false, $true)
-            [void]$strictUtf8.GetString($recovered)
-
-            $rawBytes = $recovered
-        } catch {}
-    }
-
-    if ($rawBytes.Length -eq 0) {
-        & $nodeBin $Processor --agent-id $AgentId 2>$null
-    } else {
-        $psi = New-Object System.Diagnostics.ProcessStartInfo
-        $psi.FileName = $nodeBin
-        $psi.Arguments = "`"$Processor`" --agent-id $AgentId"
-        $psi.UseShellExecute = $false
-        $psi.RedirectStandardInput = $true
-        $psi.RedirectStandardOutput = $true
-        $psi.RedirectStandardError = $false
-        $psi.CreateNoWindow = $true
-
-        $proc = [System.Diagnostics.Process]::Start($psi)
-        $proc.StandardInput.BaseStream.Write($rawBytes, 0, $rawBytes.Length)
-        $proc.StandardInput.Close()
-        $null = $proc.StandardOutput.ReadToEnd()
-        $proc.WaitForExit()
-    }
+    # CLM/WDAC-safe: let node inherit this process's stdin (fd0) and read it
+    # directly; PowerShell never touches the bytes. The old implementation used
+    # [Console]::OpenStandardInput / MemoryStream / ProcessStartInfo to spawn
+    # node -- those .NET calls throw under Constrained Language Mode (enforced by
+    # Device Guard/WDAC), crashing the hook and silently dropping telemetry. BOM
+    # stripping and the Chinese UTF-8->GBK double-encoding fixup now live in node
+    # (shared/decode-payload.mjs), so here we only pass through, which works in
+    # both language modes.
+    # NOTE: keep this file ASCII-only. Windows PowerShell 5.1 parses a BOM-less
+    # script using the system ANSI code page (GBK/936 on Chinese Windows); any
+    # non-ASCII byte here can corrupt parsing and abort the whole script.
+    & $nodeBin $Processor --agent-id $AgentId 2>$null | Out-Null
 } catch {}
 
 exit 0

--- a/assets/hooks/qwen-code-cli-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/qwen-code-cli-loongsuite-pilot-hook.ps1
@@ -1,4 +1,4 @@
-# Qwen Code CLI hook entrypoint (Windows) — delegates to qwen-code-cli-hook-processor.mjs.
+# Qwen Code CLI hook entrypoint (Windows) - delegates to qwen-code-cli-hook-processor.mjs.
 #
 # Usage (registered in ~/.qwen/settings.json by pilot HookStrategy):
 #   powershell -File $PILOT_DATA/hooks/qwen-code-cli-loongsuite-pilot-hook.ps1 <subcommand>
@@ -100,51 +100,16 @@ if (-not [Console]::IsInputRedirected) {
 }
 
 try {
-    # Read stdin as raw bytes to avoid PowerShell encoding issues (GB2312/ASCII mangles UTF-8)
-    $stdinStream = [Console]::OpenStandardInput()
-    $ms = New-Object System.IO.MemoryStream
-    $stdinStream.CopyTo($ms)
-    $rawBytes = $ms.ToArray()
-    $ms.Dispose()
-
-    # Strip UTF-8 BOM (EF BB BF) before any encoding fixup
-    if ($rawBytes.Length -ge 3 -and $rawBytes[0] -eq 0xEF -and $rawBytes[1] -eq 0xBB -and $rawBytes[2] -eq 0xBF) {
-        $rawBytes = $rawBytes[3..($rawBytes.Length - 1)]
-    }
-
-    # Fix Cursor's UTF-8→GBK double-encoding on Chinese Windows.
-    if ($rawBytes.Length -gt 2) {
-        try {
-            $utf8    = [System.Text.Encoding]::UTF8
-            $gbk     = [System.Text.Encoding]::GetEncoding(936)
-            $garbled = $utf8.GetString($rawBytes)
-            $recovered = $gbk.GetBytes($garbled)
-
-            $strictUtf8 = [System.Text.UTF8Encoding]::new($false, $true)
-            [void]$strictUtf8.GetString($recovered)
-
-            $rawBytes = $recovered
-        } catch {}
-    }
-
-    if ($rawBytes.Length -eq 0) {
-        $result = & $nodeBin $Processor $Subcommand 2>$null
-    } else {
-        $psi = New-Object System.Diagnostics.ProcessStartInfo
-        $psi.FileName = $nodeBin
-        $psi.Arguments = "`"$Processor`" $Subcommand"
-        $psi.UseShellExecute = $false
-        $psi.RedirectStandardInput = $true
-        $psi.RedirectStandardOutput = $true
-        $psi.RedirectStandardError = $false
-        $psi.CreateNoWindow = $true
-
-        $proc = [System.Diagnostics.Process]::Start($psi)
-        $proc.StandardInput.BaseStream.Write($rawBytes, 0, $rawBytes.Length)
-        $proc.StandardInput.Close()
-        $result = $proc.StandardOutput.ReadToEnd()
-        $proc.WaitForExit()
-    }
+    # CLM/WDAC-safe passthrough: node inherits this process's stdin (fd0) and
+    # reads it directly; PowerShell never touches the bytes. The old code used
+    # [Console]::OpenStandardInput / MemoryStream / ProcessStartInfo, whose .NET
+    # calls throw under Constrained Language Mode (WDAC/Device Guard) and silently
+    # drop telemetry. BOM stripping and the Chinese UTF-8->GBK fixup now live in
+    # node (shared/decode-payload.mjs).
+    # NOTE: keep this file ASCII-only. Windows PowerShell 5.1 parses a BOM-less
+    # script using the system ANSI code page (GBK/936 on Chinese Windows); any
+    # non-ASCII byte here can corrupt parsing and abort the whole script.
+    $result = & $nodeBin $Processor $Subcommand 2>$null
     if ($result) { Write-Output $result } else { Write-Output $EMPTY_RESULT }
 } catch {
     Write-Error "[qwen-code-cli-hook] processor failed (subcommand=$Subcommand)"

--- a/assets/hooks/shared/common.ps1
+++ b/assets/hooks/shared/common.ps1
@@ -42,66 +42,23 @@ function Resolve-NodeBin {
     return $null
 }
 
-function Read-StdinRawBytes {
-    $stdinStream = [Console]::OpenStandardInput()
-    $ms = New-Object System.IO.MemoryStream
-    $stdinStream.CopyTo($ms)
-    $rawBytes = $ms.ToArray()
-    $ms.Dispose()
-
-    # Strip UTF-8 BOM (EF BB BF)
-    if ($rawBytes.Length -ge 3 -and $rawBytes[0] -eq 0xEF -and $rawBytes[1] -eq 0xBB -and $rawBytes[2] -eq 0xBF) {
-        $rawBytes = $rawBytes[3..($rawBytes.Length - 1)]
-    }
-
-    # Fix UTF-8->GBK double-encoding on Chinese Windows
-    if ($rawBytes.Length -gt 2) {
-        try {
-            $utf8    = [System.Text.Encoding]::UTF8
-            $gbk     = [System.Text.Encoding]::GetEncoding(936)
-            $garbled = $utf8.GetString($rawBytes)
-            $recovered = $gbk.GetBytes($garbled)
-
-            $strictUtf8 = [System.Text.UTF8Encoding]::new($false, $true)
-            [void]$strictUtf8.GetString($recovered)
-
-            $rawBytes = $recovered
-        } catch {}
-    }
-
-    return ,$rawBytes
-}
-
+# CLM/WDAC-safe node invocation: node inherits this process's stdin (fd0) and
+# reads it directly; PowerShell never touches the bytes. The old helper pair
+# (Read-StdinRawBytes + a ProcessStartInfo-based spawn) used .NET calls that throw
+# under Constrained Language Mode (WDAC/Device Guard), crashing hooks and silently
+# dropping telemetry. BOM stripping and the Chinese UTF-8->GBK double-encoding
+# fixup now live in node (shared/decode-payload.mjs), so this helper only passes
+# stdin through -- which works in both FullLanguage and ConstrainedLanguage.
 function Invoke-NodeProcessor {
     param(
         [string]$NodeBin,
         [string]$ProcessorPath,
-        [string]$ExtraArgs,
-        [byte[]]$StdinBytes
+        [string]$ExtraArgs
     )
-    if ($StdinBytes.Length -eq 0) {
-        if ($ExtraArgs) {
-            return & $NodeBin $ProcessorPath $ExtraArgs.Split(' ') 2>$null
-        } else {
-            return & $NodeBin $ProcessorPath 2>$null
-        }
+    if ($ExtraArgs) {
+        return & $NodeBin $ProcessorPath $ExtraArgs.Split(' ') 2>$null
     }
-
-    $psi = New-Object System.Diagnostics.ProcessStartInfo
-    $psi.FileName = $NodeBin
-    $psi.Arguments = if ($ExtraArgs) { "`"$ProcessorPath`" $ExtraArgs" } else { "`"$ProcessorPath`"" }
-    $psi.UseShellExecute = $false
-    $psi.RedirectStandardInput = $true
-    $psi.RedirectStandardOutput = $true
-    $psi.RedirectStandardError = $false
-    $psi.CreateNoWindow = $true
-
-    $proc = [System.Diagnostics.Process]::Start($psi)
-    $proc.StandardInput.BaseStream.Write($StdinBytes, 0, $StdinBytes.Length)
-    $proc.StandardInput.Close()
-    $result = $proc.StandardOutput.ReadToEnd()
-    $proc.WaitForExit()
-    return $result
+    return & $NodeBin $ProcessorPath 2>$null
 }
 
 function Log-HookError {

--- a/assets/hooks/shared/decode-payload.mjs
+++ b/assets/hooks/shared/decode-payload.mjs
@@ -1,0 +1,80 @@
+// Copyright 2026 Alibaba Group Holding Limited
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * decode-payload.mjs — 把 hook stdin 的原始字节解码为字符串,并修复
+ * Cursor/Qoder 在中文 Windows 上的 UTF-8→GBK 双重编码。
+ *
+ * 背景:部分 host agent 会先把 UTF-8 的 hook 负载按系统代码页(GBK/CP936)解码成字符串,
+ * 再以 UTF-8 重新编码后经 stdin 传入,导致中文乱码(ASCII/JSON 结构不受影响)。
+ * 还原:对收到的字节做 gbkEncode(utf8Decode(bytes)),若结果是严格合法的 UTF-8 则采用,
+ * 否则保留原始 UTF-8(正确输入天然走后者,无副作用)。
+ *
+ * 该纠偏原先在 PowerShell hook wrapper 里用 .NET 完成,但 WDAC 受限语言模式(CLM)禁止
+ * .NET 静态调用,故整体移入 node —— node 不受 CLM 约束,PS 侧从此无需触碰字节。
+ */
+
+// char code point -> [lead, trail],首次使用时用内置 TextDecoder('gbk') 运行时反建,模块级缓存。
+let GBK_ENCODE_MAP = null;
+
+function buildGbkEncodeMap() {
+  const map = new Map();
+  // fatal:false → 无法映射的字节对解码为 U+FFFD,据此跳过。
+  // 若当前 node 为 small-ICU 构建、不支持 'gbk',TextDecoder 构造会抛错 → 上层放弃纠偏。
+  const dec = new TextDecoder('gbk', { fatal: false });
+  const pair = new Uint8Array(2);
+  for (let lead = 0x81; lead <= 0xfe; lead++) {
+    for (let trail = 0x40; trail <= 0xfe; trail++) {
+      if (trail === 0x7f) continue; // 0x7F 不是合法 GBK 尾字节
+      pair[0] = lead;
+      pair[1] = trail;
+      const ch = dec.decode(pair);
+      if (ch.length !== 1 || ch.charCodeAt(0) === 0xfffd) continue; // 未映射
+      const cp = ch.charCodeAt(0);
+      if (!map.has(cp)) map.set(cp, [lead, trail]);
+    }
+  }
+  return map;
+}
+
+// 把字符串编码为 GBK 字节;遇到无法映射的非 ASCII 字符则抛错(上层据此放弃纠偏)。
+function gbkEncode(str) {
+  if (!GBK_ENCODE_MAP) GBK_ENCODE_MAP = buildGbkEncodeMap();
+  const out = [];
+  for (const ch of str) {
+    const cp = ch.codePointAt(0);
+    if (cp < 0x80) {
+      out.push(cp);
+      continue;
+    }
+    const pair = GBK_ENCODE_MAP.get(cp);
+    if (!pair) throw new Error('char not mappable to GBK: U+' + cp.toString(16));
+    out.push(pair[0], pair[1]);
+  }
+  return Buffer.from(out);
+}
+
+/**
+ * 把 hook stdin 原始字节解码为字符串:去 UTF-8 BOM + 修复 GBK 双重编码。
+ * @param {Buffer} buf 原始 stdin 字节
+ * @returns {string}
+ */
+export function decodePayload(buf) {
+  if (!buf || buf.length === 0) return '';
+  // 去 UTF-8 BOM (EF BB BF)
+  if (buf.length >= 3 && buf[0] === 0xef && buf[1] === 0xbb && buf[2] === 0xbf) {
+    buf = buf.subarray(3);
+  }
+  const utf8 = buf.toString('utf-8');
+  if (buf.length > 2) {
+    try {
+      const recovered = gbkEncode(utf8);
+      // 严格 UTF-8 校验:仅当还原结果是合法 UTF-8 才采用(排除正确输入被误纠)。
+      new TextDecoder('utf-8', { fatal: true }).decode(recovered);
+      return recovered.toString('utf-8');
+    } catch {
+      // 非双重编码(或 gbk 不可用)——保留原始 UTF-8
+    }
+  }
+  return utf8;
+}

--- a/assets/hooks/shared/decode-payload.mjs
+++ b/assets/hooks/shared/decode-payload.mjs
@@ -13,6 +13,9 @@
  * .NET 静态调用,故整体移入 node —— node 不受 CLM 约束,PS 侧从此无需触碰字节。
  * 注意:原 PowerShell 版本是 .ps1、只在 Windows 运行,纠偏只作用于 Windows;移入 node 后必须显式限定
  * process.platform === 'win32',否则在 macOS/Linux 上会误纠合法 UTF-8(严格 UTF-8 校验无法排除孤立 CJK 误纠)。
+ * 即便限定 win32,严格 UTF-8 校验仍不足以排除干净单 CJK 的误纠(如「业」的 GBK 字节 D2 B5 恰是合法
+ * UTF-8 的 U+04B5),故再加一道"膨胀判据":真正的双重编码必然使收到的中间串 code point 数 > 还原串
+ * (UTF-8 的 CJK 占 3 字节,被误当 GBK 每字符 2 字节解码后字符数变多),仅当膨胀时才采纳,消除假阳性。
  */
 
 // char code point -> [lead, trail],首次使用时用内置 TextDecoder('gbk') 运行时反建,模块级缓存。
@@ -75,9 +78,14 @@ export function decodePayload(buf) {
   if (process.platform === 'win32' && buf.length > 2 && /[^\x00-\x7f]/.test(utf8)) {
     try {
       const recovered = gbkEncode(utf8);
-      // 严格 UTF-8 校验:仅当还原结果是合法 UTF-8 才采用(排除正确输入被误纠)。
-      new TextDecoder('utf-8', { fatal: true }).decode(recovered);
-      return recovered.toString('utf-8');
+      // 严格 UTF-8 校验:还原结果必须是合法 UTF-8(排除大部分正确输入被误纠)。
+      const recoveredStr = new TextDecoder('utf-8', { fatal: true }).decode(recovered);
+      // 膨胀判据:真正的 UTF-8→GBK 双重编码必然使收到的中间串 code point 数 > 还原串
+      // ——UTF-8 的 CJK 占 3 字节,被误当 GBK(每字符 2 字节)解码后字符数变多。反之干净单 CJK
+      // (如「业」→ GBK D2 B5 恰是合法 UTF-8 U+04B5「ҵ」)长度不变,严格校验放行却是误纠。仅当膨胀时才采纳。
+      if ([...utf8].length > [...recoveredStr].length) {
+        return recoveredStr;
+      }
     } catch {
       // 非双重编码(或 gbk 不可用)——保留原始 UTF-8
     }

--- a/assets/hooks/shared/decode-payload.mjs
+++ b/assets/hooks/shared/decode-payload.mjs
@@ -5,13 +5,14 @@
  * decode-payload.mjs — 把 hook stdin 的原始字节解码为字符串,并修复
  * Cursor/Qoder 在中文 Windows 上的 UTF-8→GBK 双重编码。
  *
- * 背景:部分 host agent 会先把 UTF-8 的 hook 负载按系统代码页(GBK/CP936)解码成字符串,
- * 再以 UTF-8 重新编码后经 stdin 传入,导致中文乱码(ASCII/JSON 结构不受影响)。
- * 还原:对收到的字节做 gbkEncode(utf8Decode(bytes)),若结果是严格合法的 UTF-8 则采用,
- * 否则保留原始 UTF-8(正确输入天然走后者,无副作用)。
+ * 背景:中文 Windows 上部分 host agent(Cursor/Qoder)会先把 UTF-8 的 hook 负载按系统代码页
+ * (GBK/CP936)解码成字符串,再以 UTF-8 重新编码后经 stdin 传入,导致中文乱码(ASCII/JSON 结构不受影响)。
+ * 还原:对收到的字节做 gbkEncode(utf8Decode(bytes)),若结果是严格合法的 UTF-8 则采用,否则保留原始 UTF-8。
  *
  * 该纠偏原先在 PowerShell hook wrapper 里用 .NET 完成,但 WDAC 受限语言模式(CLM)禁止
  * .NET 静态调用,故整体移入 node —— node 不受 CLM 约束,PS 侧从此无需触碰字节。
+ * 注意:原 PowerShell 版本是 .ps1、只在 Windows 运行,纠偏只作用于 Windows;移入 node 后必须显式限定
+ * process.platform === 'win32',否则在 macOS/Linux 上会误纠合法 UTF-8(严格 UTF-8 校验无法排除孤立 CJK 误纠)。
  */
 
 // char code point -> [lead, trail],首次使用时用内置 TextDecoder('gbk') 运行时反建,模块级缓存。
@@ -66,7 +67,12 @@ export function decodePayload(buf) {
     buf = buf.subarray(3);
   }
   const utf8 = buf.toString('utf-8');
-  if (buf.length > 2) {
+  // GBK 双重编码纠偏仅在 Windows 上进行。该乱码只源于中文 Windows 上的 host agent(Cursor/Qoder)
+  // 先按系统代码页(CP936)解码 UTF-8 负载再重新编码;原 PowerShell 版本本就是 .ps1、只在 Windows 运行。
+  // 移入 node 后若不加平台判断,会在 macOS/Linux 上对本就合法的 UTF-8(如孤立中文字符)误纠而损坏遥测——
+  // 因为孤立 CJK 字符的 GBK 编码字节本身也可能是合法 UTF-8,严格校验无法排除这种误纠。
+  // 额外要求负载含非 ASCII 字节:纯 ASCII 不可能是该乱码,借此跳过绝大多数负载,也避免无谓构建 GBK 编码表。
+  if (process.platform === 'win32' && buf.length > 2 && /[^\x00-\x7f]/.test(utf8)) {
     try {
       const recovered = gbkEncode(utf8);
       // 严格 UTF-8 校验:仅当还原结果是合法 UTF-8 才采用(排除正确输入被误纠)。

--- a/assets/hooks/shared/hook-processor-base.mjs
+++ b/assets/hooks/shared/hook-processor-base.mjs
@@ -13,6 +13,7 @@ import {
   buildQoderHookRecord,
   loadHookRuntimeConfig,
 } from '../agent-event-normalizer.mjs';
+import { decodePayload } from './decode-payload.mjs';
 
 const ENABLE_LOGGING = true;
 export const HOOKS_DIR = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
@@ -382,10 +383,9 @@ export async function readStdin() {
   for await (const chunk of process.stdin) {
     chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
   }
-  let str = Buffer.concat(chunks).toString('utf-8');
-  // Strip UTF-8 BOM — PowerShell 5.x adds BOM when piping strings to native commands
-  if (str.charCodeAt(0) === 0xFEFF) str = str.slice(1);
-  return str;
+  // decodePayload 负责去 UTF-8 BOM + 修复 Cursor/Qoder 中文 UTF-8→GBK 双重编码。
+  // (原先由 PowerShell hook wrapper 用 .NET 完成,已移入 node 以兼容 WDAC 受限语言模式)
+  return decodePayload(Buffer.concat(chunks));
 }
 
 export async function parseStdinPayload(agentId) {

--- a/assets/hooks/shared/stdin-reader.mjs
+++ b/assets/hooks/shared/stdin-reader.mjs
@@ -12,6 +12,8 @@
 
 import fs from 'node:fs';
 
+import { decodePayload } from './decode-payload.mjs';
+
 export function readStdinJson() {
   try {
     const chunks = [];
@@ -29,8 +31,8 @@ export function readStdinJson() {
     if (fd !== 0) {
       try { fs.closeSync(fd); } catch {}
     }
-    let raw = Buffer.concat(chunks).toString('utf-8');
-    if (raw.charCodeAt(0) === 0xFEFF) raw = raw.slice(1);
+    // decodePayload 去 BOM 并修复中文 UTF-8->GBK 双重编码(纠偏已从 PS 侧移入 node)。
+    const raw = decodePayload(Buffer.concat(chunks));
     if (!raw.trim()) return {};
     return JSON.parse(raw);
   } catch {

--- a/assets/hooks/workbuddy-hook-event-writer.mjs
+++ b/assets/hooks/workbuddy-hook-event-writer.mjs
@@ -6,6 +6,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import { fileURLToPath } from 'node:url';
+import { decodePayload } from './shared/decode-payload.mjs';
 
 const EVENT_NAMES = new Map([
   ['session-start', 'SessionStart'],
@@ -16,7 +17,9 @@ const EVENT_NAMES = new Map([
 ]);
 
 function readStdin() {
-  return fs.readFileSync(0, 'utf8');
+  // 读原始字节后交给 decodePayload:去 UTF-8 BOM,并在中文 Windows 上修复 Cursor/Qoder 的
+  // UTF-8->GBK 双重编码。与其它 host processor 一致,也让 .ps1 里"BOM 剥离与 GBK 纠偏已移入 node"的注释成立。
+  return decodePayload(fs.readFileSync(0));
 }
 
 function stringField(value) {

--- a/assets/hooks/workbuddy-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/workbuddy-loongsuite-pilot-hook.ps1
@@ -24,7 +24,7 @@ if (-not $env:LOONGSUITE_PILOT_DATA_DIR) {
 }
 
 function Write-EmptyResult {
-    [Console]::Out.WriteLine($EMPTY_RESULT)
+    Write-Output $EMPTY_RESULT
 }
 
 function Convert-NodePath {
@@ -111,50 +111,24 @@ try {
         exit 0
     }
 
-    $stdinStream = [Console]::OpenStandardInput()
-    $memory = New-Object System.IO.MemoryStream
-    $stdinStream.CopyTo($memory)
-    [byte[]]$rawBytes = $memory.ToArray()
-    $memory.Dispose()
-
-    if (
-        $rawBytes.Length -ge 3 -and
-        $rawBytes[0] -eq 0xEF -and
-        $rawBytes[1] -eq 0xBB -and
-        $rawBytes[2] -eq 0xBF
-    ) {
-        if ($rawBytes.Length -eq 3) {
-            $rawBytes = [byte[]]@()
-        } else {
-            $rawBytes = $rawBytes[3..($rawBytes.Length - 1)]
-        }
-    }
-
-    $startInfo = New-Object System.Diagnostics.ProcessStartInfo
-    $startInfo.FileName = $nodeBin
-    $startInfo.Arguments = "`"$Processor`" `"$Subcommand`""
-    $startInfo.UseShellExecute = $false
-    $startInfo.RedirectStandardInput = $true
-    $startInfo.RedirectStandardOutput = $true
-    $startInfo.RedirectStandardError = $true
-    $startInfo.CreateNoWindow = $true
-
-    $process = [System.Diagnostics.Process]::Start($startInfo)
-    if ($rawBytes.Length -gt 0) {
-        $process.StandardInput.BaseStream.Write($rawBytes, 0, $rawBytes.Length)
-    }
-    $process.StandardInput.Close()
-    $result = $process.StandardOutput.ReadToEnd()
-    $process.StandardError.ReadToEnd() | Out-Null
-    $process.WaitForExit()
-
-    if ($process.ExitCode -ne 0) {
+    # CLM/WDAC-safe passthrough: node inherits this process's stdin (fd0) and
+    # reads it directly; PowerShell never touches the bytes. The old code used
+    # [Console]::OpenStandardInput / MemoryStream / ProcessStartInfo, whose .NET
+    # calls throw under Constrained Language Mode (WDAC/Device Guard) and silently
+    # drop telemetry. BOM stripping and the Chinese UTF-8->GBK fixup now live in
+    # node (shared/decode-payload.mjs).
+    # NOTE: keep this file ASCII-only. Windows PowerShell 5.1 parses a BOM-less
+    # script using the system ANSI code page (GBK/936 on Chinese Windows); any
+    # non-ASCII byte here can corrupt parsing and abort the whole script.
+    $result = & $nodeBin $Processor $Subcommand 2>$null
+    if ($LASTEXITCODE -ne 0) {
         Write-EmptyResult
         exit 0
     }
+    $result = ($result | Out-String).Trim()
 
-    if ($result -and $result.Trim()) {
-        [Console]::Out.WriteLine($result.Trim())
+    if ($result) {
+        Write-Output $result
     } else {
         Write-EmptyResult
     }

--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -56,7 +56,10 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+# Wrap in try/catch: setting a static property on [Console] throws under Constrained
+# Language Mode (WDAC), and with $ErrorActionPreference=Stop that would abort the whole
+# script at load. Console encoding is cosmetic, so degrade silently.
+try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch {}
 
 # ============================================================
 # Constants
@@ -128,10 +131,9 @@ if (-not $PackageUrl) {
 function Detect-Lang {
     if ($Lang) { return $Lang }
     if ($env:LOONGSUITE_PILOT_LANG) { return $env:LOONGSUITE_PILOT_LANG }
-    try {
-        $culture = [System.Globalization.CultureInfo]::CurrentUICulture.Name
-        if ($culture -match "zh") { return "zh" }
-    } catch {}
+    # $PSUICulture is an automatic variable (no .NET static call), so it works under
+    # Constrained Language Mode where [CultureInfo]::CurrentUICulture would throw.
+    if ($PSUICulture -match "zh") { return "zh" }
     return "en"
 }
 
@@ -143,12 +145,18 @@ function Msg {
 }
 
 function Test-CanPrompt {
-    $processArgs = [Environment]::GetCommandLineArgs()
-    if ($processArgs -contains "-NonInteractive") { return $false }
+    # Each .NET call below throws under Constrained Language Mode (WDAC); guard every one
+    # and default to non-interactive (the safe degrade — irm|iex installs are non-interactive).
+    try {
+        $processArgs = [Environment]::GetCommandLineArgs()
+        if ($processArgs -contains "-NonInteractive") { return $false }
+    } catch {}
     try {
         if ([Console]::IsInputRedirected) { return $false }
     } catch {}
-    return [Environment]::UserInteractive -and $null -ne $Host.UI.RawUI
+    try {
+        return [Environment]::UserInteractive -and $null -ne $Host.UI.RawUI
+    } catch { return $false }
 }
 
 # ============================================================
@@ -287,10 +295,15 @@ function Download-AndExtract {
         if (Test-Path -LiteralPath $PackageUrl) {
             Copy-Item -LiteralPath $PackageUrl -Destination $archivePath -Force
         } elseif ($PackageUrl -match '^file://') {
-            $localPackagePath = ([Uri]$PackageUrl).LocalPath
+            # Strip the file:// scheme with string ops instead of casting to [Uri], which is
+            # forbidden under Constrained Language Mode (WDAC). Handles file:///C:/x and
+            # file://C:/x; forward slashes are normalized to backslashes.
+            $localPackagePath = ($PackageUrl -replace '^file:/{2,3}', '') -replace '/', '\'
             Copy-Item -LiteralPath $localPackagePath -Destination $archivePath -Force
         } else {
-            [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+            # Best-effort TLS1.2 bump; setting this static property throws under Constrained
+            # Language Mode (WDAC), so swallow it (modern Windows defaults to TLS1.2 anyway).
+            try { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 } catch {}
             Invoke-WebRequest -Uri $PackageUrl -OutFile $archivePath -UseBasicParsing
         }
     } catch {
@@ -740,13 +753,14 @@ function Write-Config {
         probeResult       = "$($script:PROBE_RESULT)"
     }
     $cfgJson = $cfgArgs | ConvertTo-Json -Compress
-    $cfgTmp = Join-Path $env:TEMP "lp-config-args.json"
-    [System.IO.File]::WriteAllText($cfgTmp, $cfgJson, [System.Text.UTF8Encoding]::new($false))
 
+    # Pipe the JSON through stdin instead of a temp file: writing UTF-8 *without BOM*
+    # requires .NET calls that Constrained Language Mode (WDAC) forbids, and a BOM would
+    # break node's JSON.parse. node reads fd 0, so no file — and no CLM-blocked APIs.
     $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
-    & $script:NODE_BIN -e @'
+    $cfgJson | & $script:NODE_BIN -e @'
 const fs = require('fs');
-const opts = JSON.parse(fs.readFileSync(process.argv[1], 'utf-8'));
+const opts = JSON.parse(fs.readFileSync(0, 'utf-8'));
 
 let existing = {};
 try { existing = JSON.parse(fs.readFileSync(opts.configPath, 'utf-8')); } catch {}
@@ -817,10 +831,8 @@ if (opts.selectedAgents) {
 }
 
 fs.writeFileSync(opts.configPath, JSON.stringify(config, null, 2) + '\n');
-'@ $cfgTmp
+'@
     $ErrorActionPreference = $prevEAP
-
-    Remove-Item $cfgTmp -Force -ErrorAction SilentlyContinue
 
     Msg "    ✅ 配置已写入" "    ✅ Config written"
     Write-Host ""
@@ -834,36 +846,51 @@ function Install-Command {
     $binDir = Join-Path $env:USERPROFILE ".local\bin"
     if (-not (Test-Path $binDir)) { New-Item -ItemType Directory -Path $binDir -Force | Out-Null }
 
-    # Copy the PowerShell service management script
-    $ps1File = Join-Path $binDir "loongsuite-pilot.ps1"
+    # Copy the PowerShell service management script. Deploy it as loongsuite-pilot-service.ps1,
+    # NOT loongsuite-pilot.ps1: in PowerShell a bare `loongsuite-pilot` resolves an on-PATH .ps1
+    # (ExternalScript) BEFORE the .cmd shim, and a directly-run .ps1 obeys the session
+    # ExecutionPolicy (often Restricted) instead of the shim's -ExecutionPolicy Bypass. A
+    # non-colliding name keeps the .cmd the only match for the bare command name.
+    $ps1File = Join-Path $binDir "loongsuite-pilot-service.ps1"
     $ps1Src = Join-Path $script:PERMANENT_DIR "scripts\loongsuite-pilot.ps1"
     if (Test-Path $ps1Src) {
         Copy-Item $ps1Src $ps1File -Force
     }
+    # Remove any stale same-name script from older installs that would shadow the .cmd shim.
+    $legacyPs1 = Join-Path $binDir "loongsuite-pilot.ps1"
+    if (Test-Path $legacyPs1) { Remove-Item $legacyPs1 -Force -ErrorAction SilentlyContinue }
     $layoutFile = Join-Path $binDir "loongsuite-pilot-layout.json"
     $layout = [ordered]@{
         dataDir = $DataDir
         cacheDir = $CACHE_DIR
     } | ConvertTo-Json
-    [System.IO.File]::WriteAllText(
-        $layoutFile,
-        "$layout$([Environment]::NewLine)",
-        (New-Object System.Text.UTF8Encoding($false))
-    )
+    # loongsuite-pilot.ps1 reads this back with Get-Content -Encoding UTF8 | ConvertFrom-Json,
+    # which tolerates a BOM, so Set-Content is fine here (and CLM-safe, unlike WriteAllText).
+    Set-Content -LiteralPath $layoutFile -Value $layout -Encoding UTF8
 
     # Create a .cmd shim that forwards to the PowerShell script
     $cmdFile = Join-Path $binDir "loongsuite-pilot.cmd"
     $cmdContent = @'
 @echo off
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0loongsuite-pilot.ps1" %*
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0loongsuite-pilot-service.ps1" %*
 '@
     Set-Content -Path $cmdFile -Value $cmdContent -Encoding ASCII
     Msg "    ✅ 已安装: $cmdFile" "    ✅ Installed: $cmdFile"
 
-    # Add to user PATH if not already there
-    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    # Add to user PATH if not already there. Use the HKCU:\Environment registry key via
+    # cmdlets instead of [Environment]::Get/SetEnvironmentVariable, which are .NET static
+    # calls that Constrained Language Mode (WDAC) forbids.
+    $userPath = (Get-ItemProperty -Path 'HKCU:\Environment' -Name Path -ErrorAction SilentlyContinue).Path
     if ($userPath -notlike "*$binDir*") {
-        [Environment]::SetEnvironmentVariable("Path", "$binDir;$userPath", "User")
+        $newPath = if ($userPath) { "$binDir;$userPath" } else { $binDir }
+        Set-ItemProperty -Path 'HKCU:\Environment' -Name Path -Value $newPath
+        # Best-effort broadcast so already-open Explorer-spawned terminals refresh their PATH
+        # without a re-login. [Environment]::SetEnvironmentVariable persists AND sends
+        # WM_SETTINGCHANGE, but is a .NET static call that Constrained Language Mode (WDAC)
+        # forbids — the registry write above already persisted the value, so we just swallow
+        # the failure there (a new logon picks it up regardless). Get-ItemProperty returned the
+        # value already expanded, so this never re-introduces %VAR% tokens as a plain REG_SZ.
+        try { [Environment]::SetEnvironmentVariable('Path', $newPath, 'User') } catch {}
         Msg "    已将 $binDir 添加到用户 PATH" "    Added $binDir to user PATH"
         $env:Path = "$binDir;$env:Path"
     }
@@ -967,6 +994,9 @@ function Print-Summary {
     Msg "命令:" "Commands:"
     Write-Host "   loongsuite-pilot          # 查看状态 / Status"
     Write-Host "   loongsuite-pilot info     # 版本与配置 / Version & config"
+    Write-Host ""
+    Msg "提示: 请新开一个终端后再使用 loongsuite-pilot 命令 (WDAC/受限环境可能需注销重登)。" `
+        "Tip: open a NEW terminal before using the loongsuite-pilot command (a WDAC/locked-down environment may require signing out and back in)."
     Write-Host "============================================================"
 }
 
@@ -997,7 +1027,7 @@ function Stop-PilotService {
     }
 
     # Also try the loongsuite-pilot command (use .ps1 directly to avoid cmd.exe popup)
-    $ps1Path = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot.ps1"
+    $ps1Path = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot-service.ps1"
     if (Test-Path $ps1Path) {
         $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
         & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $ps1Path stop 2>$null
@@ -1045,7 +1075,7 @@ function Remove-HookConfigs {
 
     foreach ($cfg in $configs) {
         if (-not (Test-Path $cfg)) { continue }
-        $short = $cfg -replace [regex]::Escape($env:USERPROFILE), "~"
+        $short = $cfg.Replace($env:USERPROFILE, "~")
 
         try {
             $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
@@ -1102,7 +1132,7 @@ function Remove-OpenCodePlugin {
 
     foreach ($cfg in $configs) {
         if (-not (Test-Path $cfg)) { continue }
-        $short = $cfg -replace [regex]::Escape($env:USERPROFILE), "~"
+        $short = $cfg.Replace($env:USERPROFILE, "~")
 
         if (-not $script:NODE_BIN) {
             Msg "    ⚠️  跳过: $short (无 node,需手动清理)" "    ⚠️  Skipped: $short (node unavailable, manual cleanup needed)"
@@ -1194,7 +1224,7 @@ function Remove-HermesPlugin {
 function Remove-PiCodingAgentExtension {
     $cfg = Join-Path $env:USERPROFILE ".pi\agent\settings.json"
     if (-not (Test-Path $cfg)) { return }
-    $short = $cfg -replace [regex]::Escape($env:USERPROFILE), "~"
+    $short = $cfg.Replace($env:USERPROFILE, "~")
 
     if (-not $script:NODE_BIN) {
         Msg "    ⚠️  跳过: $short (无 node,需手动清理)" "    ⚠️  Skipped: $short (node unavailable, manual cleanup needed)"
@@ -1241,7 +1271,7 @@ function Remove-MimoCodePlugin {
 
     foreach ($cfg in $configs) {
         if (-not (Test-Path $cfg)) { continue }
-        $short = $cfg -replace [regex]::Escape($env:USERPROFILE), "~"
+        $short = $cfg.Replace($env:USERPROFILE, "~")
 
         if (-not $script:NODE_BIN) {
             Msg "    ⚠️  跳过: $short (无 node,需手动清理)" "    ⚠️  Skipped: $short (node unavailable, manual cleanup needed)"
@@ -1398,7 +1428,7 @@ function Cmd-Install {
         Install-Command
 
         Msg "==> 启动服务..." "==> Starting service..."
-        $ps1Path = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot.ps1"
+        $ps1Path = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot-service.ps1"
         $started = Start-PilotAndWait -ScriptPath $ps1Path
         if (-not $started) {
             if ($curVer -and (Test-Path (Join-Path $CACHE_DIR "previous"))) {
@@ -1466,7 +1496,7 @@ function Cmd-Upgrade {
         Install-Command
 
         Msg "==> 启动新版本..." "==> Starting new version..."
-        $ps1Path = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot.ps1"
+        $ps1Path = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot-service.ps1"
         $started = Start-PilotAndWait -ScriptPath $ps1Path
         if ($started) {
             Msg "    ✅ 新版本启动成功" "    ✅ New version started successfully"
@@ -1495,21 +1525,37 @@ function Cmd-Upgrade {
     }
 }
 
+# Write UTF-8 *without BOM* in a way that works under Constrained Language Mode (WDAC),
+# where [System.IO.File]::WriteAllText / New-Object UTF8Encoding are forbidden. We stage the
+# content through a temp file (Set-Content prepends a BOM) and let node rewrite it BOM-free,
+# because these files (.codex/hooks.json, config.toml) are read by node/Codex, which choke
+# on a BOM. Falls back to Set-Content (with BOM) only if node is somehow unavailable.
+function Write-FileUtf8NoBom {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Content
+    )
+    if (-not $script:NODE_BIN) {
+        Set-Content -LiteralPath $Path -Value $Content -Encoding UTF8 -NoNewline
+        return
+    }
+    $tmp = Join-Path $env:TEMP ("lp-write-" + (Get-Random) + ".tmp")
+    Set-Content -LiteralPath $tmp -Value $Content -Encoding UTF8 -NoNewline
+    & $script:NODE_BIN -e 'const fs=require("fs");let s=fs.readFileSync(process.argv[1],"utf-8");if(s.charCodeAt(0)===0xFEFF)s=s.slice(1);fs.writeFileSync(process.argv[2],s);' $tmp $Path
+    Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+}
+
 function Remove-CodexTrustState {
     $configPath = Join-Path $env:USERPROFILE ".codex\config.toml"
     if (-not (Test-Path -LiteralPath $configPath)) { return }
 
     $content = Get-Content -LiteralPath $configPath -Raw
     $pattern = '(?ms)^[ \t]*# BEGIN otel-codex-hook trust[ \t]*\r?\n.*?^[ \t]*# END otel-codex-hook trust[ \t]*(?:\r?\n)?'
-    $updated = [regex]::Replace($content, $pattern, "")
+    $updated = $content -replace $pattern, ""
     if ($updated -eq $content) { return }
 
-    $updated = [regex]::Replace($updated, '(\r?\n){3,}', "$([Environment]::NewLine)$([Environment]::NewLine)")
-    [System.IO.File]::WriteAllText(
-        $configPath,
-        $updated,
-        (New-Object System.Text.UTF8Encoding($false))
-    )
+    $updated = $updated -replace '(\r?\n){3,}', "`r`n`r`n"
+    Write-FileUtf8NoBom -Path $configPath -Content $updated
     Msg "    ✅ Codex trust 状态已清理" "    ✅ Codex trust state cleaned"
 }
 
@@ -1524,10 +1570,9 @@ function Remove-CodexHookConfig {
     if (-not (Test-Path -LiteralPath $configPath)) { return }
 
     try {
-        $raw = [System.IO.File]::ReadAllText(
-            $configPath,
-            [System.Text.Encoding]::UTF8
-        )
+        # Get-Content -Encoding UTF8 handles both BOM and no-BOM files and is CLM-safe,
+        # unlike [System.IO.File]::ReadAllText.
+        $raw = Get-Content -LiteralPath $configPath -Raw -Encoding UTF8
         $data = $raw | ConvertFrom-Json
         if (-not $data.hooks -or
             $null -eq $data.hooks.PSObject -or
@@ -1599,18 +1644,14 @@ function Remove-CodexHookConfig {
         }
 
         if ($changed) {
-            $updated = ($data | ConvertTo-Json -Depth 100) + [Environment]::NewLine
-            [System.IO.File]::WriteAllText(
-                $configPath,
-                $updated,
-                (New-Object System.Text.UTF8Encoding($false))
-            )
+            $updated = ($data | ConvertTo-Json -Depth 100) + "`r`n"
+            Write-FileUtf8NoBom -Path $configPath -Content $updated
         }
 
         # Do not report success until the resulting config is independently
         # checked for both direct and nested Pilot commands.
         $verifyData = (
-            [System.IO.File]::ReadAllText($configPath, [System.Text.Encoding]::UTF8) |
+            Get-Content -LiteralPath $configPath -Raw -Encoding UTF8 |
                 ConvertFrom-Json
         )
         if ($verifyData.hooks) {
@@ -1706,7 +1747,7 @@ function Remove-OnePilotScheduledTask {
 function Remove-PilotScheduledTasks {
     $taskFolder = "\LoongsuitePilot"
     $currentIdentity = (whoami).Trim()
-    $currentUser = [Environment]::UserName
+    $currentUser = $env:USERNAME
     $userTag = ($currentIdentity -replace '[^A-Za-z0-9._-]', '_')
     $currentUserTasks = @(
         "LoongsuitePilot-$userTag",
@@ -1727,7 +1768,7 @@ function Remove-PilotScheduledTasks {
                 -not $taskOwner -or
                 $taskOwner -ieq $currentIdentity -or
                 $taskOwner -ieq $currentUser -or
-                $taskOwner.EndsWith("\$currentUser", [System.StringComparison]::OrdinalIgnoreCase)
+                $taskOwner.ToLower().EndsWith("\$currentUser".ToLower())
             )
             if (-not $isCurrentOwner) { continue }
         }
@@ -1746,10 +1787,15 @@ function Assert-SafePilotDirectory {
         [string]$Purpose
     )
 
-    $fullPath = [System.IO.Path]::GetFullPath($Path).TrimEnd('\')
-    $rootPath = [System.IO.Path]::GetPathRoot($fullPath).TrimEnd('\')
-    $profilePath = [System.IO.Path]::GetFullPath($env:USERPROFILE).TrimEnd('\')
-    if (-not $fullPath -or $fullPath -ieq $rootPath -or $fullPath -ieq $profilePath) {
+    # CLM-safe path normalization: Convert-Path resolves the absolute path without the
+    # forbidden [System.IO.Path]::GetFullPath; fall back to the raw path if it can't be
+    # resolved (e.g. it no longer exists). Split-Path -Qualifier gives the drive root ("C:").
+    $fullPath = $Path
+    try { $fullPath = (Convert-Path -LiteralPath $Path -ErrorAction Stop) } catch { $fullPath = $Path }
+    $fullPath = $fullPath.TrimEnd('\')
+    $rootPath = (Split-Path -Qualifier $fullPath -ErrorAction SilentlyContinue)
+    $profilePath = $env:USERPROFILE.TrimEnd('\')
+    if (-not $fullPath -or $fullPath -ieq $rootPath -or $fullPath -ieq "$rootPath\" -or $fullPath -ieq $profilePath) {
         throw "Refusing to use unsafe $Purpose directory: $Path"
     }
     return $fullPath
@@ -1761,7 +1807,8 @@ function ConvertTo-ExtendedLengthPath {
         [string]$Path
     )
 
-    $fullPath = [System.IO.Path]::GetFullPath($Path)
+    $fullPath = $Path
+    try { $fullPath = (Convert-Path -LiteralPath $Path -ErrorAction Stop) } catch { $fullPath = $Path }
     if ($fullPath.StartsWith("\\?\")) { return $fullPath }
     if ($fullPath.StartsWith("\\")) {
         return "\\?\UNC\$($fullPath.Substring(2))"
@@ -1778,13 +1825,23 @@ function Remove-PilotPath {
     if (-not (Test-Path -LiteralPath $Path)) { return }
     $extendedPath = ConvertTo-ExtendedLengthPath -Path $Path
     $lastError = $null
+    $isFullLanguage = $ExecutionContext.SessionState.LanguageMode -eq 'FullLanguage'
     for ($attempt = 1; $attempt -le 3; $attempt++) {
         try {
-            if ([System.IO.Directory]::Exists($extendedPath)) {
-                [System.IO.Directory]::Delete($extendedPath, $true)
-            } elseif ([System.IO.File]::Exists($extendedPath)) {
-                [System.IO.File]::SetAttributes($extendedPath, [System.IO.FileAttributes]::Normal)
-                [System.IO.File]::Delete($extendedPath)
+            if ($isFullLanguage) {
+                # Fast path: .NET calls handle the \\?\ extended-length path (deep node_modules
+                # trees that exceed MAX_PATH). Available only under Full Language Mode.
+                if ([System.IO.Directory]::Exists($extendedPath)) {
+                    [System.IO.Directory]::Delete($extendedPath, $true)
+                } elseif ([System.IO.File]::Exists($extendedPath)) {
+                    [System.IO.File]::SetAttributes($extendedPath, [System.IO.FileAttributes]::Normal)
+                    [System.IO.File]::Delete($extendedPath)
+                }
+            } else {
+                # Constrained Language Mode (WDAC): the .NET calls above are forbidden. Fall
+                # back to Remove-Item on the original path — covers all but pathological >260-char
+                # paths, which are rare and can be cleaned manually if they ever surface.
+                Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction Stop
             }
             return
         } catch {
@@ -1798,11 +1855,8 @@ function Remove-PilotPath {
 function Remove-PilotInstallationFiles {
     $cachePath = Assert-SafePilotDirectory -Path $CACHE_DIR -Purpose "cache"
     $dataPath = Assert-SafePilotDirectory -Path $DataDir -Purpose "data"
-    $cachePrefix = $cachePath + [System.IO.Path]::DirectorySeparatorChar
-    $cacheContainsData = $dataPath.StartsWith(
-        $cachePrefix,
-        [System.StringComparison]::OrdinalIgnoreCase
-    )
+    $cachePrefix = $cachePath + '\'
+    $cacheContainsData = $dataPath.ToLower().StartsWith($cachePrefix.ToLower())
 
     if ($cachePath -ine $dataPath -and -not $cacheContainsData) {
         if (Test-Path -LiteralPath $cachePath) {
@@ -1862,10 +1916,12 @@ function Cmd-Uninstall {
 
     Msg "==> 删除 loongsuite-pilot 命令..." "==> Removing loongsuite-pilot command..."
     $cmdFile = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot.cmd"
-    $ps1File = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot.ps1"
+    $ps1File = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot-service.ps1"
+    $legacyPs1File = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot.ps1"
     $layoutFile = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot-layout.json"
     if (Test-Path $cmdFile) { Remove-Item $cmdFile -Force }
     if (Test-Path $ps1File) { Remove-Item $ps1File -Force }
+    if (Test-Path $legacyPs1File) { Remove-Item $legacyPs1File -Force }
     if (Test-Path $layoutFile) { Remove-Item $layoutFile -Force }
     Msg "    ✅ loongsuite-pilot 命令已删除" "    ✅ loongsuite-pilot command removed"
     Write-Host ""

--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -754,13 +754,20 @@ function Write-Config {
     }
     $cfgJson = $cfgArgs | ConvertTo-Json -Compress
 
-    # Pipe the JSON through stdin instead of a temp file: writing UTF-8 *without BOM*
-    # requires .NET calls that Constrained Language Mode (WDAC) forbids, and a BOM would
-    # break node's JSON.parse. node reads fd 0, so no file — and no CLM-blocked APIs.
+    # Stage the JSON through a temp file rather than piping it to node's stdin. Under Windows
+    # PowerShell 5.1 a string piped to a native command is encoded with $OutputEncoding (default
+    # ASCII), so any non-ASCII value (Chinese serviceNamePrefix/userId, a Chinese username in the
+    # path, custom mask types...) would be mangled to "?" before node ever sees it. Set-Content
+    # -Encoding UTF8 is CLM-safe (no forbidden .NET calls) and encodes UTF-8 correctly regardless
+    # of $OutputEncoding; it prepends a BOM in PS5.1, which node strips below before JSON.parse.
+    $cfgTmp = Join-Path $env:TEMP ("lp-config-" + (Get-Random) + ".json")
+    Set-Content -LiteralPath $cfgTmp -Value $cfgJson -Encoding UTF8 -NoNewline
     $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
-    $cfgJson | & $script:NODE_BIN -e @'
+    & $script:NODE_BIN -e @'
 const fs = require('fs');
-const opts = JSON.parse(fs.readFileSync(0, 'utf-8'));
+let raw = fs.readFileSync(process.argv[1], 'utf-8');
+if (raw.charCodeAt(0) === 0xFEFF) raw = raw.slice(1);
+const opts = JSON.parse(raw);
 
 let existing = {};
 try { existing = JSON.parse(fs.readFileSync(opts.configPath, 'utf-8')); } catch {}
@@ -831,8 +838,9 @@ if (opts.selectedAgents) {
 }
 
 fs.writeFileSync(opts.configPath, JSON.stringify(config, null, 2) + '\n');
-'@
+'@ $cfgTmp
     $ErrorActionPreference = $prevEAP
+    Remove-Item -LiteralPath $cfgTmp -Force -ErrorAction SilentlyContinue
 
     Msg "    ✅ 配置已写入" "    ✅ Config written"
     Write-Host ""
@@ -877,19 +885,39 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0loongsuite-pilot-s
     Set-Content -Path $cmdFile -Value $cmdContent -Encoding ASCII
     Msg "    ✅ 已安装: $cmdFile" "    ✅ Installed: $cmdFile"
 
-    # Add to user PATH if not already there. Use the HKCU:\Environment registry key via
-    # cmdlets instead of [Environment]::Get/SetEnvironmentVariable, which are .NET static
-    # calls that Constrained Language Mode (WDAC) forbids.
-    $userPath = (Get-ItemProperty -Path 'HKCU:\Environment' -Name Path -ErrorAction SilentlyContinue).Path
-    if ($userPath -notlike "*$binDir*") {
-        $newPath = if ($userPath) { "$binDir;$userPath" } else { $binDir }
-        Set-ItemProperty -Path 'HKCU:\Environment' -Name Path -Value $newPath
+    # Add to user PATH if not already there. The persistent write uses reg.exe (a native command,
+    # CLM-safe) rather than [Environment]::SetEnvironmentVariable (a .NET static call WDAC forbids)
+    # or Set-ItemProperty. Two hazards this avoids:
+    #   1. Set-ItemProperty writes plain REG_SZ by default, DOWNGRADING a REG_EXPAND_SZ Path.
+    #   2. Get-ItemProperty returns Path already EXPANDED; writing that back FREEZES
+    #      %USERPROFILE%/%SystemRoot% tokens into literal paths.
+    # So we read the RAW (unexpanded) value and its type via `reg query`, then write it back with
+    # `reg add /t <type>` to preserve REG_EXPAND_SZ and the tokens. The presence check still uses
+    # the EXPANDED value so a bin dir already present via a %VAR% token is not added twice.
+    $expandedPath = (Get-ItemProperty -Path 'HKCU:\Environment' -Name Path -ErrorAction SilentlyContinue).Path
+    if ($expandedPath -notlike "*$binDir*") {
+        $pathType = 'REG_EXPAND_SZ'
+        $rawUserPath = ''
+        $regOut = reg query "HKCU\Environment" /v Path 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            foreach ($line in $regOut) {
+                if ($line -match '^\s*Path\s+(REG_(?:EXPAND_)?SZ)\s+(.*)$') {
+                    $pathType = $Matches[1]
+                    $rawUserPath = $Matches[2]
+                    break
+                }
+            }
+        }
+        # Never drop the existing PATH: if reg query yielded nothing usable, fall back to the
+        # expanded value (worst case re-freezes tokens, but preserves all entries).
+        if (-not $rawUserPath -and $expandedPath) { $rawUserPath = $expandedPath }
+        $newPath = if ($rawUserPath) { "$binDir;$rawUserPath" } else { $binDir }
+        reg add "HKCU\Environment" /v Path /t $pathType /d "$newPath" /f | Out-Null
         # Best-effort broadcast so already-open Explorer-spawned terminals refresh their PATH
-        # without a re-login. [Environment]::SetEnvironmentVariable persists AND sends
-        # WM_SETTINGCHANGE, but is a .NET static call that Constrained Language Mode (WDAC)
-        # forbids — the registry write above already persisted the value, so we just swallow
-        # the failure there (a new logon picks it up regardless). Get-ItemProperty returned the
-        # value already expanded, so this never re-introduces %VAR% tokens as a plain REG_SZ.
+        # without a re-login: [Environment]::SetEnvironmentVariable persists AND sends
+        # WM_SETTINGCHANGE. It is a .NET static call CLM forbids, so swallow failures — the reg add
+        # above already persisted the typed value. $newPath still carries raw %VAR% tokens, so on
+        # non-CLM hosts .NET also writes REG_EXPAND_SZ (no downgrade).
         try { [Environment]::SetEnvironmentVariable('Path', $newPath, 'User') } catch {}
         Msg "    已将 $binDir 添加到用户 PATH" "    Added $binDir to user PATH"
         $env:Path = "$binDir;$env:Path"

--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -237,21 +237,23 @@ function Test-PidRunning {
 }
 
 function Get-CollectorRuntime {
-    param([datetimeoffset]$NotBefore = [datetimeoffset]::MinValue)
+    # Use [datetime] (a Constrained-Language core type) instead of [datetimeoffset],
+    # which is not a core type and throws under CLM (WDAC). Comparisons stay correct
+    # because every value below is a local-time [datetime].
+    param([datetime]$NotBefore = [datetime]::MinValue)
     if (-not (Test-Path -LiteralPath $RUNTIME_FILE)) { return $null }
     try {
         $runtime = Get-Content -LiteralPath $RUNTIME_FILE -Raw -Encoding UTF8 | ConvertFrom-Json
-        $updatedAt = [datetimeoffset]::Parse(
-            [string]$runtime.updatedAt,
-            [System.Globalization.CultureInfo]::InvariantCulture,
-            [System.Globalization.DateTimeStyles]::RoundtripKind
-        )
+        # Get-Date (a cmdlet) parses the ISO-8601 timestamp without the CLM-forbidden
+        # [datetimeoffset]::Parse / [CultureInfo]::InvariantCulture / [DateTimeStyles],
+        # normalizing any offset to local time to match (Get-Date) below.
+        $updatedAt = Get-Date -Date ([string]$runtime.updatedAt)
         $pidValue = [int]$runtime.pid
         if (
             $runtime.status -ne "active" -or
             $pidValue -le 0 -or
             $updatedAt -lt $NotBefore -or
-            $updatedAt -lt [datetimeoffset]::Now.AddMinutes(-2) -or
+            $updatedAt -lt (Get-Date).AddMinutes(-2) -or
             -not (Get-Process -Id $pidValue -ErrorAction SilentlyContinue)
         ) {
             return $null
@@ -287,11 +289,15 @@ function Stop-PidFile {
 }
 
 function Stop-OrphanProcesses {
+    # $Match limits which daemons are terminated; the default kills both. Callers that
+    # re-register a single task (Install-CollectorTask / Install-UpdaterTask) pass a
+    # narrow pattern so they only reap the daemon they are about to re-launch.
+    param([string]$Match = "collector-daemon|updater-daemon")
     Get-Process -Name "node" -ErrorAction SilentlyContinue |
         Where-Object {
             try {
                 $cmdLine = (Get-CimInstance Win32_Process -Filter "ProcessId = $($_.Id)" -ErrorAction SilentlyContinue).CommandLine
-                $cmdLine -match "collector-daemon" -or $cmdLine -match "updater-daemon"
+                $cmdLine -match $Match
             } catch { $false }
         } | ForEach-Object {
             Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
@@ -316,7 +322,7 @@ function Get-TaskRunning {
 
 function Wait-ForCollectorHeartbeat {
     param([int]$TimeoutSeconds = 15)
-    $notBefore = [datetimeoffset]::Now.AddSeconds(-2)
+    $notBefore = (Get-Date).AddSeconds(-2)
     $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
     do {
         if (
@@ -345,11 +351,12 @@ function Start-CompatibleExistingCollectorTask {
     $action = $task.Actions | Select-Object -First 1
     $actionArgs = if ($action) { [string]$action.Arguments } else { "" }
     $actionExe = if ($action) { [string]$action.Execute } else { "" }
-    $isWscript = [System.IO.Path]::GetFileName($actionExe) -ieq "wscript.exe"
-    $usesExpectedLauncher = $actionArgs.IndexOf(
-        $expectedLauncher,
-        [System.StringComparison]::OrdinalIgnoreCase
-    ) -ge 0
+    # Split-Path -Leaf and case-folded string ops instead of [System.IO.Path]::GetFileName
+    # and String.IndexOf(StringComparison), which are forbidden under Constrained Language
+    # Mode (WDAC). $actionExe is typically the bare "wscript.exe".
+    $exeLeaf = if ($actionExe) { Split-Path -Leaf $actionExe } else { "" }
+    $isWscript = $exeLeaf -ieq "wscript.exe"
+    $usesExpectedLauncher = $actionArgs.ToLower().Contains($expectedLauncher.ToLower())
     if (-not $isWscript -or -not $usesExpectedLauncher) {
         Write-Host "Existing collector task uses an incompatible action; refusing to reuse it." -ForegroundColor Yellow
         return $false
@@ -494,6 +501,13 @@ function Install-CollectorTask {
         -RestartInterval (New-TimeSpan -Minutes 1) `
         -ExecutionTimeLimit ([TimeSpan]::Zero)
 
+    # Kill any collector daemon left running under the OLD task registration BEFORE we
+    # delete/re-create the task. Deleting a task does not stop its running child, and the
+    # freshly registered task's MultipleInstances=IgnoreNew only counts instances under the
+    # new registration — so without this reap the orphan keeps running alongside the new
+    # instance and both write the same output (duplicate-collection incident root cause).
+    Stop-OrphanProcesses -Match "collector-daemon"
+
     # Remove existing task first (schtasks is more reliable than Unregister-ScheduledTask)
     # Use try/catch because schtasks stderr + $ErrorActionPreference=Stop can throw
     try { schtasks.exe /Delete /TN "$TASK_FOLDER\$TASK_NAME_COLLECTOR" /F 2>$null | Out-Null } catch {}
@@ -527,6 +541,10 @@ function Install-UpdaterTask {
         -RestartCount 3 `
         -RestartInterval (New-TimeSpan -Minutes 5) `
         -ExecutionTimeLimit ([TimeSpan]::Zero)
+
+    # Reap any orphaned updater daemon from the old registration before re-creating
+    # the task (same rationale as Install-CollectorTask above).
+    Stop-OrphanProcesses -Match "updater-daemon"
 
     try { schtasks.exe /Delete /TN "$TASK_FOLDER\$TASK_NAME_UPDATER" /F 2>$null | Out-Null } catch {}
     try { schtasks.exe /Delete /TN "$TASK_NAME_UPDATER" /F 2>$null | Out-Null } catch {}

--- a/src/deployment/hook-strategy.ts
+++ b/src/deployment/hook-strategy.ts
@@ -411,6 +411,7 @@ export class HookStrategy implements DeployStrategy {
       ),
       matcher: hookConfig.eventMatchers?.[event] ?? hookConfig.matcher,
       useNestedFormat: hookConfig.format === 'nested',
+      shell: process.platform === 'win32' ? hookConfig.winShell : undefined,
       replaceHookCommands: [
         ...(hookConfig.replaceHookCommands ?? []),
         ...legacyCodexHookCommands(

--- a/src/hooks/hook-manager.ts
+++ b/src/hooks/hook-manager.ts
@@ -47,6 +47,13 @@ export interface HookDefinition {
    *   { command, type, matcher }
    */
   useNestedFormat?: boolean;
+  /**
+   * Optional shell declared on the nested hook entry's inner object
+   * (`{ command, type, shell }`). Set for hosts (Qoder family on Windows) that
+   * need `"shell": "powershell"` to run the `.ps1` command through PowerShell.
+   * Only emitted when set, so agents that omit it (e.g. codex) are unaffected.
+   */
+  shell?: string;
 }
 
 /**
@@ -121,7 +128,11 @@ export class HookManager {
       const hookEntry = def.useNestedFormat
         ? {
             matcher: def.matcher ?? '*',
-            hooks: [{ command: def.hookCommand, type: 'command' }],
+            hooks: [{
+              command: def.hookCommand,
+              type: 'command',
+              ...(def.shell ? { shell: def.shell } : {}),
+            }],
           }
         : {
             type: 'command',
@@ -363,7 +374,11 @@ export class HookManager {
     return def.useNestedFormat
       ? {
           matcher: def.matcher ?? '*',
-          hooks: [{ command: def.hookCommand, type: 'command' }],
+          hooks: [{
+            command: def.hookCommand,
+            type: 'command',
+            ...(def.shell ? { shell: def.shell } : {}),
+          }],
         }
       : {
           type: 'command',

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import { createLogger, initFileLogging } from './utils/logger.js';
 import { resolveHome, readInstalledVersion } from './utils/fs-utils.js';
 import { writeStartupCrash, clearStartupCrash, resolveBreadcrumbDataDir } from './utils/crash-breadcrumb.js';
 import { handleWorkerCli } from './local-workers/worker-cli.js';
+import { acquireSingleInstanceLock } from './utils/single-instance-lock.js';
+import { COLLECTOR_PROCESS_PATTERNS } from './utils/pid-utils.js';
 
 const logger = createLogger('Main');
 
@@ -36,11 +38,33 @@ async function main(): Promise<void> {
     return;
   }
 
+  // Cross-process single-instance guard. Multiple collector daemons on one machine
+  // tail the same source and append to the same output, duplicating every record
+  // (see logs/output duplicate-collection incident). The scheduled-task
+  // `MultipleInstances=IgnoreNew` policy is bypassed whenever the task is
+  // re-registered while an instance is still running, so this pid lock — acquired
+  // before any pipeline is wired up — is the daemon's own last line of defense.
+  const lockPath = path.join(logDir, 'collector.lock');
+  const { lock, holderPid } = acquireSingleInstanceLock(lockPath, COLLECTOR_PROCESS_PATTERNS);
+  if (!lock) {
+    logger.warn('another collector instance already holds the lock; exiting', {
+      pid: process.pid,
+      holderPid,
+      lockPath,
+    });
+    return;
+  }
+  logger.info('single-instance lock acquired', { pid: process.pid, lockPath });
+  // Fires for normal completion, signal-driven shutdown (via process.exit below),
+  // and the fatal-error path in main().catch — covering every exit route.
+  process.on('exit', () => lock.release());
+
   const orchestrator = new Orchestrator(config);
 
   const shutdown = async () => {
     logger.info('shutdown signal received');
     await orchestrator.stop();
+    lock.release();
     process.exit(0);
   };
   process.on('SIGINT', () => void shutdown());

--- a/src/types/deployment.ts
+++ b/src/types/deployment.ts
@@ -79,6 +79,15 @@ export interface AgentHookConfig {
    */
   rawCommand?: boolean;
   /**
+   * Windows-only: shell to declare on the nested hook entry
+   * (`{ command, type, shell }`). Some hosts (Qoder family) require an explicit
+   * `"shell": "powershell"` so the host runs the `.ps1` command through
+   * PowerShell instead of its default shell. Ignored on non-Windows platforms
+   * (where the command is a `.sh`), and only emitted for agents that set it —
+   * codex must never set it (its settings use serde deny_unknown_fields).
+   */
+  winShell?: string;
+  /**
    * Optional env block to merge into the agent's settings.json on deploy.
    *
    * Each value may contain the `$PILOT_DATA` token; AgentDefLoader resolves

--- a/src/updater/index.ts
+++ b/src/updater/index.ts
@@ -5,6 +5,8 @@ import { UpdaterMetrics } from './updater-metrics.js';
 import { buildAutoUpdateConfig, type ConfigFile } from '../core/config-loader.js';
 import { createLogger, initFileLogging } from '../utils/logger.js';
 import { readJsonFile, resolveHome, readInstalledVersion } from '../utils/fs-utils.js';
+import { acquireSingleInstanceLock } from '../utils/single-instance-lock.js';
+import { UPDATER_PROCESS_PATTERNS } from '../utils/pid-utils.js';
 
 const logger = createLogger('UpdaterMain');
 
@@ -29,6 +31,22 @@ async function main(): Promise<void> {
     logger.info('auto-update disabled via config, exiting');
     process.exit(0);
   }
+
+  // Same single-instance guard as the collector: a re-registered scheduled task
+  // can leave a previous updater daemon orphaned, and duplicate updaters race on
+  // version pointers and rollout state. Acquire before starting any work.
+  const lockPath = path.join(dataDir, 'logs', 'updater.lock');
+  const { lock, holderPid } = acquireSingleInstanceLock(lockPath, UPDATER_PROCESS_PATTERNS);
+  if (!lock) {
+    logger.warn('another updater instance already holds the lock; exiting', {
+      pid: process.pid,
+      holderPid,
+      lockPath,
+    });
+    process.exit(0);
+  }
+  logger.info('single-instance lock acquired', { pid: process.pid, lockPath });
+  process.on('exit', () => lock.release());
 
   const userId = process.env.LOONGSUITE_PILOT_USER_ID
     ?? file?.userId ?? file?.['user.id'] ?? os.hostname();

--- a/src/utils/pid-utils.ts
+++ b/src/utils/pid-utils.ts
@@ -123,7 +123,7 @@ export function checkProcessLiveness(pidFile: string, patterns: readonly Process
   };
 }
 
-function readProcessCommand(pid: number): string {
+export function readProcessCommand(pid: number): string {
   try {
     if (process.platform === 'win32') {
       return execFileSync('powershell.exe', [

--- a/src/utils/single-instance-lock.ts
+++ b/src/utils/single-instance-lock.ts
@@ -1,0 +1,158 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  isProcessAlive,
+  readProcessCommand,
+  isCommandMatch,
+  type ProcessCommandPattern,
+} from './pid-utils.js';
+
+// Cross-process single-instance guard backed by a pid lockfile.
+//
+// Motivation: the collector/updater daemons can be launched more than once on a
+// single machine — e.g. the install flow re-registers the scheduled task while a
+// previous instance is still running, so `MultipleInstances=IgnoreNew` no longer
+// constrains the orphaned one. Multiple daemons then tail the same source and
+// append to the same output, duplicating every record. This lock is the process's
+// own last line of defense: it must be acquired before the daemon wires up any
+// input/output pipeline.
+//
+// The lockfile lives at a caller-chosen path (e.g. <dataDir>/logs/collector.lock)
+// and holds JSON `{ pid, startedAt }`. Creation is atomic via `fs.openSync(..,'wx')`.
+
+export interface SingleInstanceLock {
+  /** Absolute path of the lockfile this handle owns. */
+  readonly path: string;
+  /**
+   * Release the lock. Idempotent, and only removes the file when this process is
+   * still the recorded owner — so a crash-recovery peer that already took over is
+   * never clobbered.
+   */
+  release(): void;
+}
+
+export interface LockAcquireResult {
+  /** The acquired lock, or null when a live peer already holds it (or on fs error). */
+  lock: SingleInstanceLock | null;
+  /** pid of the live holder when acquisition failed because one exists. */
+  holderPid?: number;
+}
+
+interface LockPayload {
+  pid: number;
+  startedAt: number;
+}
+
+function readLock(lockPath: string): LockPayload | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(lockPath, 'utf-8'));
+    if (parsed && typeof parsed === 'object' && typeof (parsed as LockPayload).pid === 'number') {
+      return parsed as LockPayload;
+    }
+  } catch {
+    // Missing or malformed lockfile — treat as no lock.
+  }
+  return null;
+}
+
+// Stale = the recorded holder is no longer the daemon we expect. Age is deliberately
+// NOT part of the check: these are long-running daemons, so any age threshold would
+// eventually evict a perfectly healthy holder and reopen the very duplication window
+// this lock exists to close.
+//
+// Two conditions make a lock stale:
+//  1. The recorded pid is not alive. `isProcessAlive` treats EPERM as alive (matters
+//     on Windows, where a foreign-owned process still means "occupied").
+//  2. The pid IS alive but its command line is not one of our daemons. On Unix a pid
+//     can be recycled after the holder crashes without releasing; the recycled pid
+//     would otherwise be misread as a live holder and block every future start. When
+//     `patterns` are supplied we verify process identity, so a reused pid running some
+//     unrelated program is correctly treated as stale. A pid whose command line still
+//     matches is a genuine second daemon — exactly what we want to keep out.
+// If the command line can't be read we fail conservative (treat as held, not stale).
+function isStale(lock: LockPayload | null, patterns?: readonly ProcessCommandPattern[]): boolean {
+  if (!lock) return true;
+  if (!isProcessAlive(lock.pid)) return true;
+  if (!patterns || patterns.length === 0) return false;
+  const command = readProcessCommand(lock.pid);
+  if (!command) return false;
+  return !isCommandMatch(command, patterns);
+}
+
+function writeOwnLock(lockPath: string): void {
+  const payload = JSON.stringify({ pid: process.pid, startedAt: Date.now() });
+  const handle = fs.openSync(lockPath, 'wx');
+  try {
+    fs.writeSync(handle, payload);
+  } finally {
+    fs.closeSync(handle);
+  }
+}
+
+function makeHandle(lockPath: string): SingleInstanceLock {
+  let released = false;
+  return {
+    path: lockPath,
+    release(): void {
+      if (released) return;
+      released = true;
+      try {
+        const existing = readLock(lockPath);
+        if (existing && existing.pid === process.pid) {
+          fs.unlinkSync(lockPath);
+        }
+      } catch {
+        // Best-effort: never let lock release crash shutdown.
+      }
+    },
+  };
+}
+
+/**
+ * Attempt to acquire the single-instance lock at `lockPath`.
+ *
+ * - No live holder → creates the lockfile atomically and returns a handle.
+ * - Live holder → returns `{ lock: null, holderPid }`; the caller should log and exit.
+ * - Stale lockfile (dead holder, or a reused pid running a different program) → the
+ *   stale file is removed and the lock is taken.
+ *
+ * When `patterns` are supplied, a lockfile whose pid is alive is only honored if that
+ * process's command line matches one of the patterns — closing the Unix pid-reuse
+ * window. Omit `patterns` to fall back to a pid-liveness-only check.
+ */
+export function acquireSingleInstanceLock(
+  lockPath: string,
+  patterns?: readonly ProcessCommandPattern[],
+): LockAcquireResult {
+  try {
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  } catch {
+    // If the dir can't be created the openSync below will surface the failure.
+  }
+
+  const attempt = (): LockAcquireResult | 'retry' => {
+    try {
+      writeOwnLock(lockPath);
+      return { lock: makeHandle(lockPath) };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== 'EEXIST') {
+        // Unexpected fs error: fail closed (do not run) but report no holder.
+        return { lock: null };
+      }
+      const existing = readLock(lockPath);
+      if (isStale(existing, patterns)) {
+        // Holder is gone — drop the stale file and try once more to take over.
+        try { fs.unlinkSync(lockPath); } catch { /* ignore */ }
+        return 'retry';
+      }
+      return { lock: null, holderPid: existing?.pid };
+    }
+  };
+
+  const first = attempt();
+  if (first !== 'retry') return first;
+  // A single retry is enough: if a peer wins the race between our unlink and
+  // re-create we simply report it as the holder rather than spinning.
+  const second = attempt();
+  return second === 'retry' ? { lock: null } : second;
+}

--- a/src/utils/single-instance-lock.ts
+++ b/src/utils/single-instance-lock.ts
@@ -18,7 +18,8 @@ import {
 // input/output pipeline.
 //
 // The lockfile lives at a caller-chosen path (e.g. <dataDir>/logs/collector.lock)
-// and holds JSON `{ pid, startedAt }`. Creation is atomic via `fs.openSync(..,'wx')`.
+// and holds JSON `{ pid, startedAt }`. It is published atomically (temp file + hardlink)
+// so a peer never observes a created-but-empty lockfile — see `writeOwnLock`.
 
 export interface SingleInstanceLock {
   /** Absolute path of the lockfile this handle owns. */
@@ -55,37 +56,65 @@ function readLock(lockPath: string): LockPayload | null {
   return null;
 }
 
-// Stale = the recorded holder is no longer the daemon we expect. Age is deliberately
-// NOT part of the check: these are long-running daemons, so any age threshold would
-// eventually evict a perfectly healthy holder and reopen the very duplication window
-// this lock exists to close.
+// A lock is stale when its recorded holder is no longer a daemon we expect. For a *healthy*
+// holder age is deliberately NOT part of the check: these are long-running daemons, so any age
+// threshold on a matching holder would eventually evict a perfectly healthy one and reopen the
+// very duplication window this lock exists to close.
 //
-// Two conditions make a lock stale:
-//  1. The recorded pid is not alive. `isProcessAlive` treats EPERM as alive (matters
-//     on Windows, where a foreign-owned process still means "occupied").
-//  2. The pid IS alive but its command line is not one of our daemons. On Unix a pid
-//     can be recycled after the holder crashes without releasing; the recycled pid
-//     would otherwise be misread as a live holder and block every future start. When
-//     `patterns` are supplied we verify process identity, so a reused pid running some
-//     unrelated program is correctly treated as stale. A pid whose command line still
-//     matches is a genuine second daemon — exactly what we want to keep out.
-// If the command line can't be read we fail conservative (treat as held, not stale).
+// Conditions that make a lock stale:
+//  1. The recorded pid is not alive. `isProcessAlive` treats EPERM as alive (matters on
+//     Windows, where a foreign-owned process still means "occupied").
+//  2. The pid IS alive but its command line is readable and is not one of our daemons. On Unix a
+//     pid can be recycled after the holder crashes without releasing; the recycled pid would
+//     otherwise be misread as a live holder and block every future start. A readable command line
+//     that still matches is a genuine second daemon — exactly what we want to keep out.
+//  3. The pid is alive but its command line is UNREADABLE (foreign-owned / permission-denied /
+//     transient) AND the lock is implausibly old. We can't confirm identity, so we stay
+//     conservative (held) for a fresh lock; but an unreadable holder older than
+//     UNREADABLE_HOLDER_MAX_AGE_MS is almost certainly a crashed daemon whose pid was reused by an
+//     uninspectable process — without this escape valve such a lock would deadlock every future
+//     start forever. Healthy daemons of ours expose a readable, matching command line and take
+//     branch 2, so they are never aged out here.
+const UNREADABLE_HOLDER_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24h — generous; only breaks true deadlocks
+
 function isStale(lock: LockPayload | null, patterns?: readonly ProcessCommandPattern[]): boolean {
   if (!lock) return true;
   if (!isProcessAlive(lock.pid)) return true;
   if (!patterns || patterns.length === 0) return false;
   const command = readProcessCommand(lock.pid);
-  if (!command) return false;
+  if (!command) {
+    return (
+      typeof lock.startedAt === 'number' &&
+      Date.now() - lock.startedAt > UNREADABLE_HOLDER_MAX_AGE_MS
+    );
+  }
   return !isCommandMatch(command, patterns);
 }
 
 function writeOwnLock(lockPath: string): void {
   const payload = JSON.stringify({ pid: process.pid, startedAt: Date.now() });
-  const handle = fs.openSync(lockPath, 'wx');
+  // Atomic publish: write the full payload to a temp file, then hardlink it into place.
+  // link(2) is atomic and fails with EEXIST when a holder already exists, so a concurrent
+  // reader never observes a created-but-empty lockfile. `openSync(..,'wx')` + `writeSync`
+  // is NOT atomic that way: the file exists empty for a window between create and write, and
+  // a peer that reads it during that window parses no pid, treats the lock as stale, unlinks
+  // it, and both processes end up "holding" it — the exact double-acquire this guard prevents.
+  const tmp = `${lockPath}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, payload);
   try {
-    fs.writeSync(handle, payload);
+    fs.linkSync(tmp, lockPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === 'EEXIST') throw err; // a live holder exists
+    // Filesystem without hardlink support (some network/FAT mounts): fall back to exclusive
+    // create. Narrow non-atomic window, but preserves correctness on such mounts.
+    const handle = fs.openSync(lockPath, 'wx');
+    try {
+      fs.writeSync(handle, payload);
+    } finally {
+      fs.closeSync(handle);
+    }
   } finally {
-    fs.closeSync(handle);
+    try { fs.unlinkSync(tmp); } catch { /* best-effort temp cleanup */ }
   }
 }
 

--- a/tests/integration/hook-jsonl-flow.test.ts
+++ b/tests/integration/hook-jsonl-flow.test.ts
@@ -219,6 +219,10 @@ describe('Hook JSONL integration flow', () => {
       path.join(sharedDir, 'hook-processor-base.mjs'),
     );
     await fs.copyFile(
+      path.resolve(process.cwd(), 'assets/hooks/shared/decode-payload.mjs'),
+      path.join(sharedDir, 'decode-payload.mjs'),
+    );
+    await fs.copyFile(
       path.resolve(process.cwd(), 'assets/hooks/shared/qoder-db-utils.mjs'),
       path.join(sharedDir, 'qoder-db-utils.mjs'),
     );
@@ -343,6 +347,10 @@ describe('Hook JSONL integration flow', () => {
     await fs.copyFile(
       path.resolve(process.cwd(), 'assets/hooks/shared/hook-processor-base.mjs'),
       path.join(sharedDir, 'hook-processor-base.mjs'),
+    );
+    await fs.copyFile(
+      path.resolve(process.cwd(), 'assets/hooks/shared/decode-payload.mjs'),
+      path.join(sharedDir, 'decode-payload.mjs'),
     );
     await fs.copyFile(
       path.resolve(process.cwd(), 'assets/hooks/shared/qoder-db-utils.mjs'),
@@ -687,6 +695,10 @@ describe('Hook JSONL integration flow', () => {
     await fs.copyFile(
       path.resolve(process.cwd(), 'assets/hooks/shared/hook-processor-base.mjs'),
       path.join(sharedDir, 'hook-processor-base.mjs'),
+    );
+    await fs.copyFile(
+      path.resolve(process.cwd(), 'assets/hooks/shared/decode-payload.mjs'),
+      path.join(sharedDir, 'decode-payload.mjs'),
     );
     await fs.copyFile(
       path.resolve(process.cwd(), 'assets/hooks/shared/qoder-db-utils.mjs'),

--- a/tests/unit/deployment/hook-strategy.test.ts
+++ b/tests/unit/deployment/hook-strategy.test.ts
@@ -256,6 +256,77 @@ describe('HookStrategy', () => {
       expect(call.replaceHookCommands).toEqual(['/old/hook.sh']);
     });
 
+    it('emits winShell as def.shell on Windows', async () => {
+      const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      try {
+        mockHookManager.isHookInstalled.mockResolvedValue(true);
+        const def = makeDef({
+          id: 'qoder',
+          hook: {
+            settingsPath: 'C:/Users/test/.qoder/settings.json',
+            events: ['Stop'],
+            hookCommand: 'C:/Users/test/.loongsuite-pilot/hooks/qoder-loongsuite-pilot-hook.ps1',
+            format: 'nested',
+            matcher: '*',
+            winShell: 'powershell',
+          },
+        });
+
+        await strategy.needsDeploy(def);
+        expect(mockHookManager.isHookInstalled.mock.calls[0][0].shell).toBe('powershell');
+      } finally {
+        if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+      }
+    });
+
+    it('ignores winShell on non-Windows platforms', async () => {
+      const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+      try {
+        mockHookManager.isHookInstalled.mockResolvedValue(true);
+        const def = makeDef({
+          id: 'qoder',
+          hook: {
+            settingsPath: '/home/.qoder/settings.json',
+            events: ['Stop'],
+            hookCommand: '/opt/pilot/hooks/qoder-loongsuite-pilot-hook.sh',
+            format: 'nested',
+            matcher: '*',
+            winShell: 'powershell',
+          },
+        });
+
+        await strategy.needsDeploy(def);
+        expect(mockHookManager.isHookInstalled.mock.calls[0][0].shell).toBeUndefined();
+      } finally {
+        if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+      }
+    });
+
+    it('leaves def.shell undefined when winShell is not set (e.g. codex)', async () => {
+      const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      try {
+        mockHookManager.isHookInstalled.mockResolvedValue(true);
+        const def = makeDef({
+          id: 'codex',
+          hook: {
+            settingsPath: 'C:/Users/test/.codex/hooks.json',
+            events: ['Stop'],
+            hookCommand: 'C:/Users/test/.loongsuite-pilot/hooks/codex-loongsuite-pilot-hook.ps1',
+            format: 'nested',
+            matcher: '*',
+          },
+        });
+
+        await strategy.needsDeploy(def);
+        expect(mockHookManager.isHookInstalled.mock.calls[0][0].shell).toBeUndefined();
+      } finally {
+        if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+      }
+    });
+
     it('uses per-event matchers when configured', async () => {
       mockHookManager.isHookInstalled.mockResolvedValue(true);
       await strategy.needsDeploy(makeDef({

--- a/tests/unit/hooks/shared/decode-payload.test.mjs
+++ b/tests/unit/hooks/shared/decode-payload.test.mjs
@@ -1,0 +1,81 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { decodePayload } from '../../../../assets/hooks/shared/decode-payload.mjs';
+
+// decodePayload reads process.platform at call time, so overriding the property before a call
+// is enough — no module re-import required.
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+
+function setPlatform(platform) {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+}
+
+// Simulate a host that mis-decoded UTF-8 bytes as GBK (CP936) and re-encoded them as UTF-8 —
+// the exact double-encoding decodePayload is meant to repair on Chinese Windows.
+function doubleEncode(text) {
+  const utf8Bytes = Buffer.from(text, 'utf-8');
+  const asGbk = new TextDecoder('gbk').decode(utf8Bytes);
+  return Buffer.from(asGbk, 'utf-8');
+}
+
+describe('decodePayload', () => {
+  afterEach(() => {
+    if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+  });
+
+  it('returns empty string for empty or nullish input', () => {
+    expect(decodePayload(Buffer.alloc(0))).toBe('');
+    expect(decodePayload(undefined)).toBe('');
+    expect(decodePayload(null)).toBe('');
+  });
+
+  it('strips a UTF-8 BOM regardless of platform', () => {
+    const withBom = Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from('{"a":1}', 'utf-8')]);
+    setPlatform('linux');
+    expect(decodePayload(withBom)).toBe('{"a":1}');
+    setPlatform('win32');
+    expect(decodePayload(withBom)).toBe('{"a":1}');
+  });
+
+  it('leaves clean ASCII untouched on every platform', () => {
+    const buf = Buffer.from('{"tool":"Read","ok":true}', 'utf-8');
+    for (const platform of ['darwin', 'linux', 'win32']) {
+      setPlatform(platform);
+      expect(decodePayload(buf)).toBe('{"tool":"Read","ok":true}');
+    }
+  });
+
+  // --- C1 regression: the GBK correction must NOT run off Windows -------------------------
+  // The correction lived in a Windows-only PowerShell wrapper; porting it to node dropped the
+  // implicit platform scope, so clean isolated CJK (whose GBK bytes happen to be valid UTF-8)
+  // was silently corrupted on macOS/Linux.
+  it('preserves clean UTF-8 CJK on non-Windows platforms', () => {
+    const cases = ['业', '中文', '{"serviceNamePrefix":"支付网关"}', '测试'];
+    for (const platform of ['darwin', 'linux']) {
+      setPlatform(platform);
+      for (const text of cases) {
+        expect(decodePayload(Buffer.from(text, 'utf-8'))).toBe(text);
+      }
+    }
+  });
+
+  it('never rewrites bytes on non-Windows (platform gate short-circuits before gbkEncode)', () => {
+    // A buffer that WOULD be rewritten on win32 must pass through verbatim off Windows.
+    const mojibake = doubleEncode('测试日志');
+    setPlatform('darwin');
+    expect(decodePayload(mojibake)).toBe(mojibake.toString('utf-8'));
+  });
+
+  // --- Windows behaviour: the intended correction still works --------------------------------
+  it('repairs UTF-8→GBK double-encoded multi-char CJK on Windows', () => {
+    setPlatform('win32');
+    for (const text of ['中文', '测试日志', '中文abc123']) {
+      expect(decodePayload(doubleEncode(text))).toBe(text);
+    }
+  });
+
+  it('leaves clean ASCII untouched on Windows (non-ASCII precheck skips correction)', () => {
+    setPlatform('win32');
+    const buf = Buffer.from('{"session_id":"abc-123","n":42}', 'utf-8');
+    expect(decodePayload(buf)).toBe('{"session_id":"abc-123","n":42}');
+  });
+});

--- a/tests/unit/hooks/shared/decode-payload.test.mjs
+++ b/tests/unit/hooks/shared/decode-payload.test.mjs
@@ -78,4 +78,36 @@ describe('decodePayload', () => {
     const buf = Buffer.from('{"session_id":"abc-123","n":42}', 'utf-8');
     expect(decodePayload(buf)).toBe('{"session_id":"abc-123","n":42}');
   });
+
+  // --- Regression: clean UTF-8 CJK must NOT be corrupted on Windows either -------------------
+  // The win32 gate stopped the false-correction on macOS/Linux, but the strict-UTF-8 check alone
+  // still misfires on Windows for isolated CJK whose GBK bytes happen to be valid UTF-8 — notably
+  // '业' (GBK D2 B5 == UTF-8 U+04B5 'ҵ'). The inflation criterion (mojibake code points must
+  // exceed the recovered string's) closes this: clean input never inflates, so it is preserved.
+  it('preserves clean UTF-8 CJK on Windows (inflation criterion rejects false correction)', () => {
+    setPlatform('win32');
+    const cases = [
+      '业',
+      '{"user":"业"}',
+      '{"cwd":"C:/Users/业/proj"}',
+      '{"a":"业","b":1}',
+      '{"serviceNamePrefix":"支付网关"}',
+      '中文',
+      '测试日志',
+      '你好world',
+    ];
+    for (const text of cases) {
+      expect(decodePayload(Buffer.from(text, 'utf-8'))).toBe(text);
+    }
+  });
+
+  // The inflation criterion must not weaken any genuine repair: every multi-char mojibake the
+  // prior code recovered still recovers (the double-encoded intermediate has more code points
+  // than the clean original). Clean-input preservation above is the only added behavior.
+  it('still repairs genuine multi-char double-encoded CJK on Windows', () => {
+    setPlatform('win32');
+    for (const text of ['中文', '测试日志', '中文abc123']) {
+      expect(decodePayload(doubleEncode(text))).toBe(text);
+    }
+  });
 });

--- a/tests/unit/hooks/workbuddy-hook-event-writer.test.ts
+++ b/tests/unit/hooks/workbuddy-hook-event-writer.test.ts
@@ -69,6 +69,12 @@ describe('workbuddy hook event writer', () => {
     const installedProcessor = path.join(hooksDir, 'workbuddy-hook-event-writer.mjs');
     await mkdir(hooksDir, { recursive: true });
     await copyFile(processor, installedProcessor);
+    // The processor imports ./shared/decode-payload.mjs; a real install ships it alongside.
+    await mkdir(path.join(hooksDir, 'shared'), { recursive: true });
+    await copyFile(
+      path.resolve('assets/hooks/shared/decode-payload.mjs'),
+      path.join(hooksDir, 'shared', 'decode-payload.mjs'),
+    );
 
     execFileSync(process.execPath, [installedProcessor, 'session-start'], {
       input: JSON.stringify({

--- a/tests/unit/utils/single-instance-lock.test.ts
+++ b/tests/unit/utils/single-instance-lock.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { acquireSingleInstanceLock } from '../../../src/utils/single-instance-lock.js';
+import { readProcessCommand } from '../../../src/utils/pid-utils.js';
+
+describe('acquireSingleInstanceLock', () => {
+  let dir: string;
+  let lockPath: string;
+
+  beforeEach(async () => {
+    dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'single-instance-lock-'));
+    lockPath = path.join(dir, 'nested', 'collector.lock');
+  });
+  afterEach(async () => {
+    await fsp.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('acquires when no lock exists, creating parent dirs and recording our pid', () => {
+    const { lock, holderPid } = acquireSingleInstanceLock(lockPath);
+    expect(lock).not.toBeNull();
+    expect(holderPid).toBeUndefined();
+    expect(fs.existsSync(lockPath)).toBe(true);
+    const payload = JSON.parse(fs.readFileSync(lockPath, 'utf-8'));
+    expect(payload.pid).toBe(process.pid);
+    expect(typeof payload.startedAt).toBe('number');
+  });
+
+  it('refuses a second acquisition while a live holder exists', () => {
+    // Our own pid is alive, so a lockfile pointing at it must block a peer.
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid, startedAt: Date.now() }));
+
+    const { lock, holderPid } = acquireSingleInstanceLock(lockPath);
+    expect(lock).toBeNull();
+    expect(holderPid).toBe(process.pid);
+  });
+
+  it('takes over a stale lock left by a dead process', () => {
+    // pid 1 is init/launchd and never owned by us; process.kill(1, 0) throws
+    // ESRCH/EPERM appropriately, but we use an obviously-dead high pid instead to
+    // guarantee staleness across platforms.
+    const deadPid = 2 ** 22; // far above any real live pid on the test host
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: deadPid, startedAt: 1 }));
+
+    const { lock } = acquireSingleInstanceLock(lockPath);
+    expect(lock).not.toBeNull();
+    const payload = JSON.parse(fs.readFileSync(lockPath, 'utf-8'));
+    expect(payload.pid).toBe(process.pid);
+  });
+
+  it('treats a malformed lockfile as stale and takes over', () => {
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, 'not json');
+
+    const { lock } = acquireSingleInstanceLock(lockPath);
+    expect(lock).not.toBeNull();
+    expect(JSON.parse(fs.readFileSync(lockPath, 'utf-8')).pid).toBe(process.pid);
+  });
+
+  it('release removes the lockfile only when we still own it', () => {
+    const { lock } = acquireSingleInstanceLock(lockPath);
+    expect(lock).not.toBeNull();
+
+    // A peer takes over the lockfile (simulating crash recovery after our exit).
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid + 1, startedAt: Date.now() }));
+    lock!.release();
+
+    // Our release must NOT wipe the peer's lock.
+    expect(fs.existsSync(lockPath)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(lockPath, 'utf-8')).pid).toBe(process.pid + 1);
+  });
+
+  it('with patterns, takes over a lock whose live pid runs a non-matching command (pid reuse)', () => {
+    // Our own pid is alive, but its command line is the test runner — not a
+    // collector. This simulates a recycled pid after the real holder crashed: the
+    // pid-liveness check alone would wrongly block, but the command-identity check
+    // recognizes it as stale and lets us take over.
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid, startedAt: Date.now() }));
+
+    const { lock } = acquireSingleInstanceLock(lockPath, ['collector-daemon-never-matches-vitest']);
+    expect(lock).not.toBeNull();
+    expect(JSON.parse(fs.readFileSync(lockPath, 'utf-8')).pid).toBe(process.pid);
+  });
+
+  it('with patterns, still refuses when the live pid runs a matching command', () => {
+    const selfCmd = readProcessCommand(process.pid);
+    // Guard: if the host `ps`/CIM lookup yields nothing we fail conservative
+    // (treated as held) which this positive case cannot distinguish; skip then.
+    if (!selfCmd) return;
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid, startedAt: Date.now() }));
+
+    // The whole real command string is a trivially-matching substring pattern.
+    const { lock, holderPid } = acquireSingleInstanceLock(lockPath, [selfCmd]);
+    expect(lock).toBeNull();
+    expect(holderPid).toBe(process.pid);
+  });
+
+  it('release is idempotent and deletes our own lockfile', () => {
+    const { lock } = acquireSingleInstanceLock(lockPath);
+    lock!.release();
+    expect(fs.existsSync(lockPath)).toBe(false);
+    expect(() => lock!.release()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

On Windows machines with WDAC/Device Guard, PowerShell is forced system-wide into **Constrained Language Mode (CLM)** — and `-ExecutionPolicy Bypass` does **not** escape it (execution policy ≠ language mode). Our installer, service script, and hook wrappers all relied on .NET static calls that CLM forbids (`[Console]::OpenStandardInput`, `MemoryStream`, `ProcessStartInfo`, `GetEncoding(936)`, `UTF8Encoding`, `[Console]::Out.WriteLine`, `[Environment]::*`, …), so on locked-down machines install failed, the service crashed, and every hook threw — silently dropping all telemetry.

This PR makes all PowerShell components CLM-safe, and folds in two related reliability fixes.

## Changes

### 1. Installer & service script CLM-safe (`8ea350db`)
- `deploy/installer-opensource.ps1`: replace CLM-forbidden .NET calls with cmdlets; rename the service-management script so a bare command isn't shadowed by the `.cmd` shim under a Restricted policy; broadcast the PATH change (best-effort) and hint a new terminal; remove the per-user scheduled task by suffix on uninstall.
- `scripts/loongsuite-pilot.ps1`: same CLM-forbidden calls removed; clean up orphaned collector processes (pairs with the single-instance lock below).

### 2. Hook wrappers CLM-safe + `winShell` selection (`3ae3a8bc`)
- All `*-loongsuite-pilot-hook.ps1` + `shared/common.ps1`: drop .NET calls, switch to a native `& node` passthrough (node inherits fd0 and reads stdin itself) — PowerShell never touches raw bytes in any language mode.
- Move the GBK double-encoding fixup entirely into node: new `shared/decode-payload.mjs`, with the four stdin readers (`stdin-reader`, `hook-processor-base`, `cursor`, `codex`) routed through `decodePayload`.
- New `winShell` hook-config field to pick the Windows wrapper interpreter (e.g. `powershell`); defaults to git bash when unset. Emitted only for the nested format on win32; never sent to codex (`deny_unknown_fields`). The qoder-family configs set `winShell: powershell`.

### 3. Collector cross-process single-instance lock (`4720b2e6`)
- pid-based lock acquired on startup that detects a live prior instance, eliminating duplicate output/metrics collection.

## Testing
- `vitest` unit tests for the hook strategy and single-instance lock: 51 passed.
- CLM end-to-end (forced `LanguageMode='ConstrainedLanguage'`): qoder (discard) + cursor (fail-open `{}`) wrappers run with no THROW, node executes, events land, Chinese decodes correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)