### PR TITLE
fix(windows): sync updater bin path to loongsuite-pilot-service.ps1

### DIFF
--- a/src/core/updater-watchdog.ts
+++ b/src/core/updater-watchdog.ts
@@ -24,8 +24,14 @@ function homeDir(): string {
 }
 
 function defaultPilotBinPath(): string {
-  const ext = process.platform === 'win32' ? '.ps1' : '';
-  return path.join(homeDir(), '.local', 'bin', `loongsuite-pilot${ext}`);
+  // Keep in lockstep with installer-opensource.ps1 / updater.ts pilotBinPath():
+  // Windows installs the management script as loongsuite-pilot-service.ps1 so the
+  // bare `loongsuite-pilot` command resolves the .cmd shim, not a Restricted-
+  // ExecutionPolicy ExternalScript of the same name.
+  if (process.platform === 'win32') {
+    return path.join(homeDir(), '.local', 'bin', 'loongsuite-pilot-service.ps1');
+  }
+  return path.join(homeDir(), '.local', 'bin', 'loongsuite-pilot');
 }
 
 export type UpdaterWatchdogStatus =

--- a/src/updater/updater.ts
+++ b/src/updater/updater.ts
@@ -76,8 +76,16 @@ function homeDir(): string {
 
 function pilotBinPath(): string {
   const home = homeDir();
-  const ext = process.platform === 'win32' ? '.ps1' : '';
-  return path.join(home, '.local', 'bin', `loongsuite-pilot${ext}`);
+  // On Windows deploy as loongsuite-pilot-service.ps1 (not loongsuite-pilot.ps1):
+  // a bare `loongsuite-pilot` resolves an on-PATH .ps1 (ExternalScript) BEFORE the
+  // .cmd shim, and a directly-run .ps1 obeys the session ExecutionPolicy (often
+  // Restricted) instead of the shim's -ExecutionPolicy Bypass. A non-colliding
+  // name keeps the .cmd the only match for the bare command name. Source in the
+  // package remains scripts/loongsuite-pilot.ps1; only the installed basename changes.
+  if (process.platform === 'win32') {
+    return path.join(home, '.local', 'bin', 'loongsuite-pilot-service.ps1');
+  }
+  return path.join(home, '.local', 'bin', 'loongsuite-pilot');
 }
 
 function defaultPaths(): UpdaterPaths {
@@ -637,6 +645,15 @@ export class Updater {
     const cliScript = path.join(srcDir, `loongsuite-pilot${cliExt}`);
     await fs.mkdir(path.dirname(loongsuitePilotBin), { recursive: true });
     await this.copyFileAtomic(cliScript, loongsuitePilotBin, 0o755);
+
+    // Remove any stale same-name script from older installs that would shadow the
+    // .cmd shim. Destination is already -service.ps1 on win32 (see pilotBinPath);
+    // without this cleanup the first post-upgrade sync would leave the legacy
+    // loongsuite-pilot.ps1 in place and re-break bare-command resolution.
+    if (process.platform === 'win32') {
+      const legacyPs1 = path.join(path.dirname(loongsuitePilotBin), 'loongsuite-pilot.ps1');
+      await fs.rm(legacyPs1, { force: true }).catch(() => undefined);
+    }
 
     logger.info('installed scripts synced');
   }

--- a/tests/unit/core/updater-watchdog.test.ts
+++ b/tests/unit/core/updater-watchdog.test.ts
@@ -308,6 +308,30 @@ describe('UpdaterWatchdog', () => {
     ]));
   });
 
+  it('defaults Windows pilot bin to loongsuite-pilot-service.ps1', async () => {
+    mockPlatform('win32');
+    const home = process.env.USERPROFILE ?? process.env.HOME ?? '';
+    mockExecFileAsync.mockResolvedValue({ stdout: '', stderr: '' });
+
+    const wd = new UpdaterWatchdog({
+      enabled: true,
+      dataDir: tmpDir,
+      startupGraceMs: 0,
+    });
+
+    await wd.runCheck();
+
+    expect(mockExecFileAsync).toHaveBeenCalledWith(
+      'powershell.exe',
+      expect.arrayContaining([
+        '-File',
+        path.join(home, '.local', 'bin', 'loongsuite-pilot-service.ps1'),
+        'restart-updater',
+      ]),
+      expect.objectContaining({ windowsHide: true }),
+    );
+  });
+
   it('restarts through PowerShell on Windows', async () => {
     mockPlatform('win32');
     mockExecFileAsync.mockImplementation((cmd: string, args: string[]) => {
@@ -320,7 +344,7 @@ describe('UpdaterWatchdog', () => {
     const wd = new UpdaterWatchdog({
       enabled: true,
       dataDir: tmpDir,
-      loongsuitePilotBin: 'C:\\Users\\test\\.local\\bin\\loongsuite-pilot.ps1',
+      loongsuitePilotBin: 'C:\\Users\\test\\.local\\bin\\loongsuite-pilot-service.ps1',
       startupGraceMs: 0,
     });
 
@@ -331,7 +355,7 @@ describe('UpdaterWatchdog', () => {
       'powershell.exe',
       expect.arrayContaining([
         '-File',
-        'C:\\Users\\test\\.local\\bin\\loongsuite-pilot.ps1',
+        'C:\\Users\\test\\.local\\bin\\loongsuite-pilot-service.ps1',
         'restart-updater',
       ]),
       expect.objectContaining({ windowsHide: true }),
@@ -346,7 +370,7 @@ describe('UpdaterWatchdog', () => {
     const wd = new UpdaterWatchdog({
       enabled: true,
       dataDir: tmpDir,
-      loongsuitePilotBin: 'C:\\Users\\test\\.local\\bin\\loongsuite-pilot.ps1',
+      loongsuitePilotBin: 'C:\\Users\\test\\.local\\bin\\loongsuite-pilot-service.ps1',
       startupGraceMs: 0,
     });
 
@@ -355,7 +379,7 @@ describe('UpdaterWatchdog', () => {
     expect(result.status).toBe('healthy');
     expect(mockExecFileAsync).not.toHaveBeenCalledWith(
       'powershell.exe',
-      expect.arrayContaining(['-File', 'C:\\Users\\test\\.local\\bin\\loongsuite-pilot.ps1', 'restart-updater']),
+      expect.arrayContaining(['-File', 'C:\\Users\\test\\.local\\bin\\loongsuite-pilot-service.ps1', 'restart-updater']),
       expect.anything(),
     );
   });

--- a/tests/unit/updater/updater.test.ts
+++ b/tests/unit/updater/updater.test.ts
@@ -82,7 +82,7 @@ vi.mock('../../../src/utils/fs-utils.js', async (importOriginal) => {
 // --- Mock global fetch ---
 const mockFetch = vi.fn<[string, any?], Promise<Response>>();
 
-import { Updater } from '../../../src/updater/updater.js';
+import { Updater, buildPaths } from '../../../src/updater/updater.js';
 import type { VersionManifest, LocalVersion } from '../../../src/updater/updater.js';
 
 function makeConfig(overrides: Partial<AutoUpdateConfig> = {}): AutoUpdateConfig {
@@ -405,6 +405,40 @@ describe('Updater', () => {
         expect.stringContaining('/versions/1.0.1_aaa/scripts/loongsuite-pilot.sh'),
         expect.stringMatching(/\.local\/bin\/loongsuite-pilot\.tmp$/),
       );
+    });
+
+    it('syncs Windows CLI as -service.ps1 and removes legacy loongsuite-pilot.ps1', async () => {
+      const realPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' });
+      try {
+        expect(buildPaths(tmpDir).loongsuitePilotBin).toMatch(/loongsuite-pilot-service\.ps1$/);
+
+        setupForDownload();
+        mockFsAccess.mockImplementation((p: string) => {
+          if (p.includes('package.json')) return Promise.resolve();
+          if (p.includes('dist/index.js')) return Promise.resolve();
+          if (p.includes('dist/updater/index.js')) return Promise.resolve();
+          if (p.includes('postinstall.js')) return Promise.reject(new Error('ENOENT'));
+          if (p.includes('collector-daemon.js')) return Promise.resolve();
+          if (p.includes('updater-daemon.js')) return Promise.resolve();
+          if (p.includes('loongsuite-pilot.ps1')) return Promise.resolve();
+          return Promise.reject(new Error('ENOENT'));
+        });
+
+        const updater = new Updater(makeConfig(), tmpDir);
+        await updater.check();
+
+        expect(mockFsCopyFile).toHaveBeenCalledWith(
+          expect.stringContaining('/scripts/loongsuite-pilot.ps1'),
+          expect.stringMatching(/loongsuite-pilot-service\.ps1\.tmp$/),
+        );
+        expect(mockFsRm).toHaveBeenCalledWith(
+          expect.stringMatching(/[/\\]loongsuite-pilot\.ps1$/),
+          expect.objectContaining({ force: true }),
+        );
+      } finally {
+        Object.defineProperty(process, 'platform', { configurable: true, value: realPlatform });
+      }
     });
 
     it('updates previous pointer when upgrading', async () => {


### PR DESCRIPTION
## Summary
- Point Windows `updater.ts` / `updater-watchdog.ts` bin path at `loongsuite-pilot-service.ps1`, matching the install layout from #214
- On sync, remove any leftover legacy `loongsuite-pilot.ps1` so auto-update cannot re-shadow the `.cmd` shim
- Cover the win32 destination + legacy cleanup in unit tests

## Why
#214 renamed the installed management script so a bare `loongsuite-pilot` resolves the `.cmd` shim (with `-ExecutionPolicy Bypass`) instead of a same-named Restricted-policy `.ps1`. The shared updater still wrote the old basename on every upgrade, undoing that fix after the first auto-update — including on internal installs that already use `-service.ps1`.

## Test plan
- [x] `npx vitest run tests/unit/core/updater-watchdog.test.ts tests/unit/updater/updater.test.ts` (54 passed)
- [ ] CI green
- [ ] After merge: internal CR https://code.alibaba-inc.com/sls/loongsuite-pilot/codereview/29008518 H2 discussion can close (installer + runtime contract aligned)


Made with [Cursor](https://cursor.com)