### PR TITLE
fix(daemon): 修复退出竞态孤儿进程 + Windows pid 文件由 node 写入

### DIFF
--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -600,7 +600,11 @@ function Cmd-Run {
         exit 1
     }
 
-    Set-Content -Path $PID_FILE -Value $PID
+    # Windows has no exec(2): node runs as our child, so it publishes its own pid file
+    # (see src/index.ts) instead of us recording the wrapper pid here. Export the data
+    # dir so node's env-first resolution writes $DATA_DIR\loongsuite-pilot.pid — the exact
+    # path stop/status read.
+    $env:LOONGSUITE_PILOT_DATA_DIR = $DATA_DIR
     $env:AGENT_DATA_COLLECTION_CONFIG = $CONFIG_FILE
     & $nodeBin $entry
 }
@@ -621,7 +625,9 @@ function Cmd-RunUpdater {
         exit 1
     }
 
-    Set-Content -Path $UPDATER_PID_FILE -Value $PID
+    # See Cmd-Run: node publishes its own pid file on Windows. Export the data dir so
+    # node writes $DATA_DIR\loongsuite-pilot-updater.pid where stop/status read it.
+    $env:LOONGSUITE_PILOT_DATA_DIR = $DATA_DIR
     $env:AGENT_DATA_COLLECTION_CONFIG = $CONFIG_FILE
     & $nodeBin $entry
 }
@@ -820,12 +826,13 @@ function Cmd-RestartCollector {
                     exit 1
                 }
                 $errLog = Join-Path $LOG_DIR "loongsuite-pilot-service-err.log"
-                $proc = Start-Process -FilePath "powershell.exe" `
-                    -ArgumentList "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$entry' >> '$LOG_FILE' 2>> '$errLog'`"" `
+                # node publishes its own pid file on Windows (see src/index.ts); export the
+                # data dir so it lands at $DATA_DIR\loongsuite-pilot.pid. No Set-Content here —
+                # $proc.Id would be the wrapper pid, not node's.
+                Start-Process -FilePath "powershell.exe" `
+                    -ArgumentList "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:LOONGSUITE_PILOT_DATA_DIR='$DATA_DIR'; `$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$entry' >> '$LOG_FILE' 2>> '$errLog'`"" `
                     -WorkingDirectory $CACHE_DIR `
-                    -WindowStyle Hidden `
-                    -PassThru
-                Set-Content -Path $PID_FILE -Value $proc.Id
+                    -WindowStyle Hidden
                 Write-Host "collector restarted (background fallback, self-heal failed)" -ForegroundColor Yellow
             } else {
                 Write-Error "Service manager failed to restart collector (init_type=$initType)"
@@ -917,12 +924,13 @@ function Cmd-RestartUpdater {
                     return
                 }
                 $updaterErrLog = Join-Path $LOG_DIR "loongsuite-pilot-updater-err.log"
-                $proc = Start-Process -FilePath "powershell.exe" `
-                    -ArgumentList "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$entry' >> '$UPDATER_LOG_FILE' 2>> '$updaterErrLog'`"" `
+                # node publishes its own pid file on Windows (see src/updater/index.ts); export
+                # the data dir so it lands at $DATA_DIR\loongsuite-pilot-updater.pid. No
+                # Set-Content — $proc.Id would be the wrapper pid, not node's.
+                Start-Process -FilePath "powershell.exe" `
+                    -ArgumentList "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:LOONGSUITE_PILOT_DATA_DIR='$DATA_DIR'; `$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$entry' >> '$UPDATER_LOG_FILE' 2>> '$updaterErrLog'`"" `
                     -WorkingDirectory $CACHE_DIR `
-                    -WindowStyle Hidden `
-                    -PassThru
-                Set-Content -Path $UPDATER_PID_FILE -Value $proc.Id
+                    -WindowStyle Hidden
                 Write-Host "updater restarted (background fallback, self-heal failed)" -ForegroundColor Yellow
             } else {
                 Write-Error "Service manager failed to restart updater (init_type=$initType)"

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,12 @@ async function main(): Promise<void> {
 
   // Fires for normal completion, signal-driven shutdown (via process.exit below),
   // and the fatal-error path in main().catch — covering every exit route.
+  // flushLogsSync() goes first and is the single guaranteed flush: the pino-roll
+  // SonicBoom has no on-exit flush of its own, and this handler is the one path that
+  // always runs — even if shutdown()'s own flush is skipped because orchestrator.stop()
+  // rejected. Sync + idempotent + already try/catch, so it is zero-risk here.
   process.on('exit', () => {
+    flushLogsSync();
     lock.release();
     if (pidFile) removeOwnPidFileSync(pidFile);
   });
@@ -87,10 +92,18 @@ async function main(): Promise<void> {
 
   const shutdown = async () => {
     logger.info('shutdown signal received');
-    await orchestrator.stop();
-    lock.release();
-    flushLogsSync();
-    process.exit(0);
+    try {
+      await orchestrator.stop();
+    } catch (err) {
+      // A rejected stop() (e.g. flusher.shutdown()/stateStore.save() throwing) must not
+      // skip the flush+exit below and silently fall through to the process.on('exit')
+      // fallback with stop() half-done and this shutdown log lost.
+      logger.error('error during orchestrator shutdown', { error: String(err) });
+    } finally {
+      lock.release();
+      flushLogsSync();
+      process.exit(0);
+    }
   };
   process.on('SIGINT', () => void shutdown());
   process.on('SIGTERM', () => void shutdown());

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,9 @@ async function main(): Promise<void> {
   // `MultipleInstances=IgnoreNew` policy is bypassed whenever the task is
   // re-registered while an instance is still running, so this pid lock — acquired
   // before any pipeline is wired up — is the daemon's own last line of defense.
-  const lockPath = path.join(logDir, 'collector.lock');
+  // Lock file is runtime state, not a log — keep it in the dataDir root alongside
+  // the pid file, not under logs/.
+  const lockPath = path.join(dataDir, 'collector.lock');
   const { lock, holderPid } = acquireSingleInstanceLock(lockPath, COLLECTOR_PROCESS_PATTERNS);
   if (!lock) {
     logger.warn('another collector instance already holds the lock; exiting', {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,12 @@
 import * as path from 'path';
 import { Orchestrator } from './core/orchestrator.js';
 import { loadConfig } from './core/config-loader.js';
-import { createLogger, initFileLogging } from './utils/logger.js';
+import { createLogger, initFileLogging, flushLogsSync } from './utils/logger.js';
 import { resolveHome, readInstalledVersion } from './utils/fs-utils.js';
 import { writeStartupCrash, clearStartupCrash, resolveBreadcrumbDataDir } from './utils/crash-breadcrumb.js';
 import { handleWorkerCli } from './local-workers/worker-cli.js';
 import { acquireSingleInstanceLock } from './utils/single-instance-lock.js';
-import { COLLECTOR_PROCESS_PATTERNS } from './utils/pid-utils.js';
+import { COLLECTOR_PROCESS_PATTERNS, writePidFileSync, removeOwnPidFileSync } from './utils/pid-utils.js';
 
 const logger = createLogger('Main');
 
@@ -35,7 +35,10 @@ async function main(): Promise<void> {
     // misread as this run's failure cause.
     clearStartupCrash(resolveBreadcrumbDataDir());
     logger.info('analytics disabled via config or LOONGSUITE_PILOT_ENABLED=false');
-    return;
+    // initFileLogging arms a non-unref'd pino-roll rotation timer that keeps the
+    // event loop alive, so a bare `return` would linger as an orphan — exit explicitly.
+    flushLogsSync();
+    process.exit(0);
   }
 
   // Cross-process single-instance guard. Multiple collector daemons on one machine
@@ -52,12 +55,31 @@ async function main(): Promise<void> {
       holderPid,
       lockPath,
     });
-    return;
+    // See the disabled-config branch above: the pino-roll rotation timer keeps the
+    // event loop alive, so a bare `return` here leaves an orphan under the race where
+    // a peer already holds the lock. Exit explicitly.
+    flushLogsSync();
+    process.exit(0);
   }
   logger.info('single-instance lock acquired', { pid: process.pid, lockPath });
+
+  // On Windows the launcher cannot record the daemon's real pid: there is no exec(2),
+  // so wscript/PowerShell run node as a *child* and would only ever capture the wrapper
+  // pid (or, on the Task Scheduler path, nothing at all). Unix keeps writing the pid file
+  // from the script via `echo $$ + exec`, so this is win32-only. dataDir is env-first here
+  // and the Windows launchers inject LOONGSUITE_PILOT_DATA_DIR, so this path matches the
+  // `$DATA_DIR\loongsuite-pilot.pid` the .ps1 reads for stop/status.
+  const pidFile = process.platform === 'win32'
+    ? path.join(dataDir, 'loongsuite-pilot.pid')
+    : null;
+  if (pidFile) writePidFileSync(pidFile);
+
   // Fires for normal completion, signal-driven shutdown (via process.exit below),
   // and the fatal-error path in main().catch — covering every exit route.
-  process.on('exit', () => lock.release());
+  process.on('exit', () => {
+    lock.release();
+    if (pidFile) removeOwnPidFileSync(pidFile);
+  });
 
   const orchestrator = new Orchestrator(config);
 
@@ -65,6 +87,7 @@ async function main(): Promise<void> {
     logger.info('shutdown signal received');
     await orchestrator.stop();
     lock.release();
+    flushLogsSync();
     process.exit(0);
   };
   process.on('SIGINT', () => void shutdown());
@@ -94,6 +117,7 @@ main().catch((err) => {
     version: readInstalledVersion(breadcrumbDir),
     error: err,
   });
+  flushLogsSync();
   process.exit(1);
 });
 

--- a/src/updater/index.ts
+++ b/src/updater/index.ts
@@ -36,7 +36,9 @@ async function main(): Promise<void> {
   // Same single-instance guard as the collector: a re-registered scheduled task
   // can leave a previous updater daemon orphaned, and duplicate updaters race on
   // version pointers and rollout state. Acquire before starting any work.
-  const lockPath = path.join(dataDir, 'logs', 'updater.lock');
+  // Lock file is runtime state, not a log — keep it in the dataDir root alongside
+  // the pid file, not under logs/.
+  const lockPath = path.join(dataDir, 'updater.lock');
   const { lock, holderPid } = acquireSingleInstanceLock(lockPath, UPDATER_PROCESS_PATTERNS);
   if (!lock) {
     logger.warn('another updater instance already holds the lock; exiting', {

--- a/src/updater/index.ts
+++ b/src/updater/index.ts
@@ -60,7 +60,10 @@ async function main(): Promise<void> {
     : null;
   if (pidFile) writePidFileSync(pidFile);
 
+  // flushLogsSync() first: same rationale as the collector — this is the one exit path
+  // guaranteed to run, so it is the single reliable place to flush the pino-roll stream.
   process.on('exit', () => {
+    flushLogsSync();
     lock.release();
     if (pidFile) removeOwnPidFileSync(pidFile);
   });

--- a/src/updater/index.ts
+++ b/src/updater/index.ts
@@ -3,10 +3,10 @@ import * as os from 'os';
 import { Updater } from './updater.js';
 import { UpdaterMetrics } from './updater-metrics.js';
 import { buildAutoUpdateConfig, type ConfigFile } from '../core/config-loader.js';
-import { createLogger, initFileLogging } from '../utils/logger.js';
+import { createLogger, initFileLogging, flushLogsSync } from '../utils/logger.js';
 import { readJsonFile, resolveHome, readInstalledVersion } from '../utils/fs-utils.js';
 import { acquireSingleInstanceLock } from '../utils/single-instance-lock.js';
-import { UPDATER_PROCESS_PATTERNS } from '../utils/pid-utils.js';
+import { UPDATER_PROCESS_PATTERNS, writePidFileSync, removeOwnPidFileSync } from '../utils/pid-utils.js';
 
 const logger = createLogger('UpdaterMain');
 
@@ -29,6 +29,7 @@ async function main(): Promise<void> {
 
   if (!config.enabled) {
     logger.info('auto-update disabled via config, exiting');
+    flushLogsSync();
     process.exit(0);
   }
 
@@ -43,10 +44,24 @@ async function main(): Promise<void> {
       holderPid,
       lockPath,
     });
+    flushLogsSync();
     process.exit(0);
   }
   logger.info('single-instance lock acquired', { pid: process.pid, lockPath });
-  process.on('exit', () => lock.release());
+
+  // Win32-only pid file: see the collector's index.ts for the rationale — Windows has no
+  // exec(2), so the launcher can't record the daemon's real pid and the daemon publishes
+  // its own. Unix keeps writing it from the script. dataDir is env-first and matches the
+  // `$DATA_DIR\loongsuite-pilot-updater.pid` the .ps1 reads.
+  const pidFile = process.platform === 'win32'
+    ? path.join(dataDir, 'loongsuite-pilot-updater.pid')
+    : null;
+  if (pidFile) writePidFileSync(pidFile);
+
+  process.on('exit', () => {
+    lock.release();
+    if (pidFile) removeOwnPidFileSync(pidFile);
+  });
 
   const userId = process.env.LOONGSUITE_PILOT_USER_ID
     ?? file?.userId ?? file?.['user.id'] ?? os.hostname();
@@ -66,11 +81,17 @@ async function main(): Promise<void> {
   const shutdown = () => {
     logger.info('received shutdown signal');
     updater.stop();
-    const exitTimeout = setTimeout(() => process.exit(1), 10_000);
+    const exitTimeout = setTimeout(() => {
+      flushLogsSync();
+      process.exit(1);
+    }, 10_000);
     exitTimeout.unref();
     metrics.stop()
       .catch(err => logger.warn('metrics stop failed', { error: String(err) }))
-      .finally(() => process.exit(0));
+      .finally(() => {
+        flushLogsSync();
+        process.exit(0);
+      });
   };
 
   process.on('SIGTERM', shutdown);
@@ -86,5 +107,6 @@ async function main(): Promise<void> {
 
 main().catch((err) => {
   logger.error('updater fatal error', { error: String(err) });
+  flushLogsSync();
   process.exit(1);
 });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -16,6 +16,12 @@ const pinoOpts: pino.LoggerOptions = {
 
 let rootLogger: pino.Logger = pino(pinoOpts);
 
+// The pino-roll file stream, kept so callers can flush it synchronously before a
+// hard process.exit(). pino-roll builds its SonicBoom directly (not via pino's
+// buildSafeSonicBoom), so it gets no on-exit flush handler and buffered writes are
+// lost on exit unless flushed explicitly.
+let fileStreamRef: { flushSync?: () => void } | null = null;
+
 let fileLoggingInitialized = false;
 let loggerVersion = 0;
 const childCache = new Map<string, { version: number; child: pino.Logger }>();
@@ -45,6 +51,7 @@ export async function initFileLogging(logFilePath: string): Promise<void> {
     dateFormat: 'yyyy-MM-dd',
     limit: { count: 10, removeOtherLogFiles: true },
   });
+  fileStreamRef = fileStream as unknown as { flushSync?: () => void };
 
   const useStdout = process.stdout.isTTY || process.env.LOONGSUITE_PILOT_STDOUT === '1';
   const streams: pino.StreamEntry[] = [{ stream: fileStream, level: LOG_LEVEL }];
@@ -61,6 +68,19 @@ export async function initFileLogging(logFilePath: string): Promise<void> {
 
   loggerVersion++;
   childCache.clear();
+}
+
+/**
+ * Synchronously flush buffered file-log writes. Call before a hard process.exit()
+ * so the last log lines survive — the pino-roll SonicBoom stream is async and has
+ * no on-exit flush of its own. No-op when file logging was never initialized.
+ */
+export function flushLogsSync(): void {
+  try {
+    fileStreamRef?.flushSync?.();
+  } catch {
+    // Best-effort: never let a flush failure block exit.
+  }
 }
 
 export type BoundLogger = {

--- a/src/utils/pid-utils.ts
+++ b/src/utils/pid-utils.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { execFileSync } from 'node:child_process';
 
 export type ProcessLivenessSource = 'pid-file' | 'process-scan' | 'none';
@@ -43,6 +44,39 @@ export function readPidFile(pidFile: string): number | null {
     return Number.isInteger(pid) && pid > 0 ? pid : null;
   } catch {
     return null;
+  }
+}
+
+/**
+ * Write this process's pid to `pidFile` as a bare integer + newline — the exact
+ * format the launcher scripts read (`Get-Content .Trim()` / `cat`). Used on Windows,
+ * where there is no exec(2) to let the wrapper record the daemon's real pid, so the
+ * daemon publishes its own. Best-effort: a write failure must not block startup.
+ */
+export function writePidFileSync(pidFile: string): void {
+  try {
+    fs.mkdirSync(path.dirname(pidFile), { recursive: true });
+  } catch {
+    // Dir may already exist; the write below surfaces any real failure.
+  }
+  try {
+    fs.writeFileSync(pidFile, `${process.pid}\n`);
+  } catch {
+    // Best-effort: never let pid-file publishing crash the daemon.
+  }
+}
+
+/**
+ * Remove `pidFile`, but only when it still records this process — so a crash-recovery
+ * peer that already took over is never clobbered. Idempotent and best-effort.
+ */
+export function removeOwnPidFileSync(pidFile: string): void {
+  try {
+    if (readPidFile(pidFile) === process.pid) {
+      fs.unlinkSync(pidFile);
+    }
+  } catch {
+    // Best-effort: never let pid-file cleanup crash shutdown.
   }
 }
 

--- a/src/utils/single-instance-lock.ts
+++ b/src/utils/single-instance-lock.ts
@@ -17,7 +17,7 @@ import {
 // own last line of defense: it must be acquired before the daemon wires up any
 // input/output pipeline.
 //
-// The lockfile lives at a caller-chosen path (e.g. <dataDir>/logs/collector.lock)
+// The lockfile lives at a caller-chosen path (e.g. <dataDir>/collector.lock)
 // and holds JSON `{ pid, startedAt }`. It is published atomically (temp file + hardlink)
 // so a peer never observes a created-but-empty lockfile — see `writeOwnLock`.
 

--- a/tests/unit/utils/logger-flush.test.ts
+++ b/tests/unit/utils/logger-flush.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { flushLogsSync } from '../../../src/utils/logger.js';
+
+describe('logger flushLogsSync', () => {
+  it('is a safe no-op before file logging is initialized', () => {
+    // fileStreamRef is null until initFileLogging runs; the guarded optional-call must
+    // not throw. This is the state every early exit path (analytics disabled, lock not
+    // acquired, pre-init fatal) relies on when it calls flushLogsSync() before exit.
+    expect(() => flushLogsSync()).not.toThrow();
+  });
+});

--- a/tests/unit/utils/pid-utils.write.test.ts
+++ b/tests/unit/utils/pid-utils.write.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  writePidFileSync,
+  removeOwnPidFileSync,
+  readPidFile,
+} from '../../../src/utils/pid-utils.js';
+
+// Real-filesystem tests (temp dir) rather than fs mocks: these functions are all about
+// exact on-disk behavior — bare-int format, recursive mkdir, and the peer-preservation
+// branch in removeOwnPidFileSync — which a mock would only re-assert, not verify.
+describe('pid-utils write/remove', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pilot-pid-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes the current pid as a bare integer + trailing newline', () => {
+    const pidFile = path.join(dir, 'loongsuite-pilot.pid');
+    writePidFileSync(pidFile);
+
+    // Exact format the launcher scripts read via Get-Content .Trim() / cat.
+    expect(fs.readFileSync(pidFile, 'utf-8')).toBe(`${process.pid}\n`);
+    expect(readPidFile(pidFile)).toBe(process.pid);
+  });
+
+  it('creates missing parent directories (recursive mkdir)', () => {
+    const pidFile = path.join(dir, 'nested', 'deep', 'loongsuite-pilot.pid');
+    writePidFileSync(pidFile);
+
+    expect(fs.existsSync(pidFile)).toBe(true);
+    expect(readPidFile(pidFile)).toBe(process.pid);
+  });
+
+  it('removeOwnPidFileSync removes the file when it still records this process', () => {
+    const pidFile = path.join(dir, 'own.pid');
+    writePidFileSync(pidFile);
+
+    removeOwnPidFileSync(pidFile);
+
+    expect(fs.existsSync(pidFile)).toBe(false);
+  });
+
+  it('removeOwnPidFileSync preserves a file owned by a peer (different pid)', () => {
+    // Simulates a crash-recovery peer that already took over the pid file: our cleanup
+    // must NOT clobber it. Regressing this to an unconditional unlink would break here.
+    const pidFile = path.join(dir, 'peer.pid');
+    const foreignPid = process.pid + 1;
+    fs.writeFileSync(pidFile, `${foreignPid}\n`);
+
+    removeOwnPidFileSync(pidFile);
+
+    expect(fs.existsSync(pidFile)).toBe(true);
+    expect(readPidFile(pidFile)).toBe(foreignPid);
+  });
+
+  it('removeOwnPidFileSync is a no-op when the file is missing', () => {
+    expect(() => removeOwnPidFileSync(path.join(dir, 'ghost.pid'))).not.toThrow();
+  });
+
+  it('write and remove are best-effort: an unwritable path never throws', () => {
+    // Parent is a regular file, so both mkdir and write/unlink fail internally.
+    const asFile = path.join(dir, 'a-file');
+    fs.writeFileSync(asFile, 'x');
+    const bad = path.join(asFile, 'nope.pid');
+
+    expect(() => writePidFileSync(bad)).not.toThrow();
+    expect(() => removeOwnPidFileSync(bad)).not.toThrow();
+    expect(fs.existsSync(bad)).toBe(false);
+  });
+});


### PR DESCRIPTION
## 背景

线上遇到竞态场景:collector 未抢到单实例锁时走 `return` 退出,但残留了孤儿进程。

根因:`initFileLogging` 里 pino-roll 的每日轮转 `setTimeout` 未 `unref()`,常驻 event loop,`return` 无法让进程自然退出。

## 改动

**1. 退出路径改为显式 exit(覆盖 collector 与 updater)**
- analytics disabled、未抢到锁两条 `return` → `flushLogsSync(); process.exit(0)`
- shutdown / 致命错误路径补上 `flushLogsSync()`

**2. 新增 `logger.flushLogsSync()`**
- pino-roll 直接构建 SonicBoom(绕过 pino 的 `buildSafeSonicBoom`),没有 on-exit flush,硬退出会丢失缓冲日志。显式同步刷盘保证最后几行日志落盘。

**3. 补齐 Windows pid 文件缺口(仅 win32)**
- Windows 无 `exec(2)`,launcher 只能以子进程方式拉起 node,拿不到守护进程真实 pid(Task Scheduler 路径甚至完全不写)。
- 改为仅在 win32 下由 node 自身发布 pid:`writePidFileSync` 写 bare int + newline(与脚本 `Get-Content .Trim()` 读取格式一致);`removeOwnPidFileSync` 退出时仅在 pid 仍属本进程时清理,避免误删崩溃恢复后接管的对等进程。
- Unix 保持脚本 `echo $$ + exec` 写入,行为不变。
- `loongsuite-pilot.ps1` 各 node 启动路径统一注入 `LOONGSUITE_PILOT_DATA_DIR`,对齐 node 与脚本的 dataDir 解析。

## 影响面
- Unix 行为完全不变(pid 仍由脚本写)。
- Windows 获得唯一可靠的 pid 写入者。
- 修复孤儿进程 + 硬退出丢日志两个问题。

## 变更文件
- `src/index.ts`
- `src/updater/index.ts`
- `src/utils/logger.ts`
- `src/utils/pid-utils.ts`
- `scripts/loongsuite-pilot.ps1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)