### PR TITLE
fix(hook): write back winShell to already-installed hook config on upgrade

### DIFF
--- a/src/hooks/hook-manager.ts
+++ b/src/hooks/hook-manager.ts
@@ -118,7 +118,11 @@ export class HookManager {
       const updatedArr = target[lastKey] as any[];
 
       if (this.isCommandPresent(updatedArr, def.hookCommand)) {
-        if (updatedArr !== arr) {
+        // Entry already present. It may predate a newly-added `shell` field
+        // (e.g. Qoder gained winShell after the hook was first installed) —
+        // repair the stale entry in place instead of leaving it untouched.
+        const shellRepaired = this.applyShellToEntries(updatedArr, def.hookCommand, def.shell);
+        if (updatedArr !== arr || shellRepaired) {
           await writeJsonFile(def.settingsPath, settings);
         }
         logger.debug('hook already installed', { agentId: def.agentId });
@@ -227,7 +231,12 @@ export class HookManager {
         return false;
       }
 
-      return this.isCommandPresent(hooks, def.hookCommand);
+      if (!this.isCommandPresent(hooks, def.hookCommand)) return false;
+
+      // A matching command whose nested entry lacks the required `shell` counts
+      // as not fully installed, so an upgrade that adds winShell (Qoder family
+      // on Windows) redeploys and repairs the entry rather than skipping it.
+      return this.hasRequiredShell(hooks, def.hookCommand, def.shell);
     } catch {
       return false;
     }
@@ -555,6 +564,41 @@ export class HookManager {
 
   private isCommandPresent(arr: any[], command: string): boolean {
     return arr.some((entry: any) => this.entryMatchesCommand(entry, command));
+  }
+
+  /**
+   * Whether the nested inner hook matching `command` declares the required
+   * `shell`. `shell` lives only on nested inner entries (`{ command, type,
+   * shell }`), so this only inspects those. Returns true when `shell` is unset
+   * (non-Windows, or agents that don't declare winShell) — the shell dimension
+   * is simply ignored there.
+   */
+  private hasRequiredShell(arr: any[], command: string, shell?: string): boolean {
+    if (!shell) return true;
+    return arr.some((entry: any) =>
+      Array.isArray(entry.hooks) &&
+      entry.hooks.some((h: any) => h.command === command && h.shell === shell),
+    );
+  }
+
+  /**
+   * Set `shell` on every nested inner hook matching `command` when it is
+   * missing or stale. Returns true if any entry was mutated. No-op when `shell`
+   * is unset. Used to repair entries installed before winShell was introduced.
+   */
+  private applyShellToEntries(arr: any[], command: string, shell?: string): boolean {
+    if (!shell) return false;
+    let changed = false;
+    for (const entry of arr) {
+      if (!Array.isArray(entry.hooks)) continue;
+      for (const h of entry.hooks) {
+        if (h.command === command && h.shell !== shell) {
+          h.shell = shell;
+          changed = true;
+        }
+      }
+    }
+    return changed;
   }
 
   private removeCommands(arr: any[], commands: string[]): any[] {

--- a/tests/unit/hooks/hook-manager.test.ts
+++ b/tests/unit/hooks/hook-manager.test.ts
@@ -393,4 +393,89 @@ describe('HookManager', () => {
     expect(ok).toBe(false);
     await expect(fs.readFile(settingsPath, 'utf-8')).resolves.toBe(invalid);
   });
+
+  describe('winShell upgrade (nested `shell` field)', () => {
+    const HOOK_CMD = 'powershell -NoProfile -ExecutionPolicy Bypass -File "C:\\qoder-loongsuite-pilot-hook.ps1" qoder';
+
+    async function writeStaleEntry(settingsPath: string): Promise<void> {
+      // An entry as written by an older pilot that predates winShell: no `shell`.
+      await fs.mkdir(path.dirname(settingsPath), { recursive: true });
+      await fs.writeFile(settingsPath, JSON.stringify({
+        hooks: {
+          Stop: [
+            {
+              matcher: '*',
+              hooks: [{ command: HOOK_CMD, type: 'command' }],
+            },
+          ],
+        },
+      }, null, 2));
+    }
+
+    it('treats a shell-less entry as not installed when winShell is required', async () => {
+      const settingsPath = path.join(tmpDir, '.qoder', 'settings.json');
+      await writeStaleEntry(settingsPath);
+
+      const manager = new HookManager(path.join(tmpDir, 'hooks'), path.join(tmpDir, 'logs'));
+      await expect(manager.isHookInstalled({
+        agentId: 'qoder',
+        settingsPath,
+        hookJsonPath: ['hooks', 'Stop'],
+        hookCommand: HOOK_CMD,
+        matcher: '*',
+        useNestedFormat: true,
+        shell: 'powershell',
+      })).resolves.toBe(false);
+    });
+
+    it('repairs a shell-less entry on (re)install without duplicating it', async () => {
+      const settingsPath = path.join(tmpDir, '.qoder', 'settings.json');
+      await writeStaleEntry(settingsPath);
+
+      const manager = new HookManager(path.join(tmpDir, 'hooks'), path.join(tmpDir, 'logs'));
+      const ok = await manager.installHook({
+        agentId: 'qoder',
+        settingsPath,
+        hookJsonPath: ['hooks', 'Stop'],
+        hookCommand: HOOK_CMD,
+        matcher: '*',
+        useNestedFormat: true,
+        shell: 'powershell',
+      });
+
+      expect(ok).toBe(true);
+      const settings = JSON.parse(await fs.readFile(settingsPath, 'utf-8'));
+      expect(settings.hooks.Stop).toEqual([
+        {
+          matcher: '*',
+          hooks: [{ command: HOOK_CMD, type: 'command', shell: 'powershell' }],
+        },
+      ]);
+      // Once repaired, it reads back as fully installed.
+      await expect(manager.isHookInstalled({
+        agentId: 'qoder',
+        settingsPath,
+        hookJsonPath: ['hooks', 'Stop'],
+        hookCommand: HOOK_CMD,
+        matcher: '*',
+        useNestedFormat: true,
+        shell: 'powershell',
+      })).resolves.toBe(true);
+    });
+
+    it('ignores the shell dimension when winShell is not declared', async () => {
+      const settingsPath = path.join(tmpDir, '.qoder', 'settings.json');
+      await writeStaleEntry(settingsPath);
+
+      const manager = new HookManager(path.join(tmpDir, 'hooks'), path.join(tmpDir, 'logs'));
+      await expect(manager.isHookInstalled({
+        agentId: 'qoder',
+        settingsPath,
+        hookJsonPath: ['hooks', 'Stop'],
+        hookCommand: HOOK_CMD,
+        matcher: '*',
+        useNestedFormat: true,
+      })).resolves.toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Background

`agents.d/qoder*.json` declares `"winShell": "powershell"` (the nested inner hook's `shell` field) so that `.ps1` hooks run through PowerShell on Windows. The strategy layer (`hook-strategy.ts`) already passes it through as `def.shell`, but `HookManager` ignored it on the **upgrade path**, so users who installed the hook with an older pilot never got their config updated.

## Root cause

- `isHookInstalled` only compared the `command` string, not `shell`. An entry written by an older version (no `shell`) was still treated as installed → `needsDeploy` returned `false` → no redeploy.
- Even on redeploy, `installHook` returned early once `isCommandPresent` matched, so it never wrote back the new `shell` field.

Net effect: `"shell": "powershell"` was only written on a fresh install; upgrades never took effect, so `.ps1` hooks were not executed via PowerShell on Windows.

## Fix (`src/hooks/hook-manager.ts`)

- `isHookInstalled`: after the `command` matches, additionally require the matching nested inner entry to declare the required `shell` (only when `def.shell` is set). A stale entry without `shell` is treated as "not fully installed" → triggers redeploy.
- `installHook`: when an existing entry is matched, repair (write back) the `shell` field in place — idempotent, no duplicate entries.
- New helpers `hasRequiredShell` / `applyShellToEntries` are both no-ops when `shell` is unset, so non-Windows and agents that don't declare `winShell` (codex / cursor / kiro) are unaffected.

## Note

The jsonc install path (`installJsoncHook`) does not do shell repair: no jsonc agent currently declares `winShell`, so `hasRequiredShell` returns `true` for them and no redeploy loop occurs. If a jsonc agent gains `winShell` in the future, that path needs the same fix.

## Tests

- 3 new unit tests covering the upgrade scenarios (stale entry treated as not-installed / in-place repair without duplication / shell dimension ignored when winShell is not declared).
- `hook-manager` + `hook-strategy`: 58 passing; full `tests/unit/deployment`: 205 passing; `tsc --noEmit` passes.
