### PR TITLE
fix: skip updater watchdog for AgentShell builds

### DIFF
--- a/src/core/updater-watchdog.ts
+++ b/src/core/updater-watchdog.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { promisify } from 'node:util';
@@ -32,6 +33,15 @@ function defaultPilotBinPath(): string {
     return path.join(homeDir(), '.local', 'bin', 'loongsuite-pilot-service.ps1');
   }
   return path.join(homeDir(), '.local', 'bin', 'loongsuite-pilot');
+}
+
+function isAgentShellCurrentVersion(dataDir: string): boolean {
+  try {
+    const current = fs.readFileSync(path.join(dataDir, 'current'), 'utf-8').trim();
+    return current.toLowerCase().includes('-agentshell');
+  } catch {
+    return false;
+  }
 }
 
 export type UpdaterWatchdogStatus =
@@ -109,6 +119,10 @@ export class UpdaterWatchdog {
       logger.info('updater-watchdog disabled');
       return;
     }
+    if (isAgentShellCurrentVersion(this.dataDir)) {
+      logger.info('updater-watchdog disabled for agentshell version');
+      return;
+    }
     this.startedAt = Date.now();
     this.lastTickAt = 0;
     logger.info('updater-watchdog started', {
@@ -129,6 +143,7 @@ export class UpdaterWatchdog {
 
   async runCheck(): Promise<UpdaterWatchdogResult> {
     if (!this.enabled) return { status: 'disabled' };
+    if (isAgentShellCurrentVersion(this.dataDir)) return { status: 'disabled' };
 
     const now = Date.now();
     if (this.lastTickAt > 0 && now - this.lastTickAt > this.intervalMs + this.sleepWakeGraceMs) {

--- a/tests/unit/core/updater-watchdog.test.ts
+++ b/tests/unit/core/updater-watchdog.test.ts
@@ -394,4 +394,27 @@ describe('UpdaterWatchdog', () => {
     expect(await wd.runCheck()).toEqual({ status: 'disabled' });
     expect(mockExecFileAsync).not.toHaveBeenCalled();
   });
+
+  it('does not check or restart updater for an agentshell current version', async () => {
+    await fs.writeFile(path.join(tmpDir, 'current'), '1.1.20-agentshell_abcdef0\n', 'utf-8');
+    const alarms = makeAlarmManager();
+    const updaterLiveness = vi.fn(() => ({
+      running: false,
+      source: 'none' as const,
+      reason: 'pid file is missing; no matching process found',
+    }));
+    const wd = new UpdaterWatchdog({
+      enabled: true,
+      dataDir: tmpDir,
+      loongsuitePilotBin: '/bin/loongsuite-pilot',
+      startupGraceMs: 0,
+      alarmManager: alarms,
+      updaterLiveness,
+    });
+
+    expect(await wd.runCheck()).toEqual({ status: 'disabled' });
+    expect(updaterLiveness).not.toHaveBeenCalled();
+    expect(mockExecFileAsync).not.toHaveBeenCalled();
+    expect(alarms.serialize()).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

- read the installed `current` version pointer before starting or running the updater watchdog
- disable updater liveness checks when the current version contains the `-agentshell` suffix
- add coverage proving AgentShell builds do not scan for, restart, or alarm on a missing updater

## Root cause

AgentShell builds intentionally do not run an updater process, but the collector-side updater watchdog could still be enabled by the resolved auto-update configuration. The watchdog then treated the expected missing updater PID/process as a service failure and emitted `SERVICE_NOT_RUNNING_ALARM` with `input_name=updater`.

## Impact

AgentShell installations no longer emit false missing-updater alarms or attempt updater restarts. Other distributions retain the existing watchdog behavior. If the `current` pointer is missing or unreadable, the watchdog continues using the existing behavior.

## Validation

- `npm test -- tests/unit/core/updater-watchdog.test.ts` (14/14)
- `npm run typecheck`
- `git diff --check`
