### PR TITLE
fix(cursor): support skill paths outside cursor directory

### DIFF
--- a/assets/hooks/cursor-hook-processor.mjs
+++ b/assets/hooks/cursor-hook-processor.mjs
@@ -181,6 +181,7 @@ function injectSkillRecords(records, skills, runtimeConfig = {}) {
       'gen_ai.tool.call.id': toolCallId,
       'gen_ai.tool.call.arguments': { path: skill.skillPath },
       'gen_ai.skill.name': skill.skillName,
+      'gen_ai.skill.id': skill.skillId || skill.skillName,
       'agent.cursor.skill_detection_source':
         skill.detectionSource || 'transcript_post_assembly',
     }, runtimeConfig));
@@ -195,6 +196,7 @@ function injectSkillRecords(records, skills, runtimeConfig = {}) {
       'gen_ai.tool.name': 'Read',
       'gen_ai.tool.call.id': toolCallId,
       'gen_ai.skill.name': skill.skillName,
+      'gen_ai.skill.id': skill.skillId || skill.skillName,
       'agent.cursor.skill_detection_source':
         skill.detectionSource || 'transcript_post_assembly',
     }, runtimeConfig));
@@ -207,16 +209,19 @@ function injectSkillRecords(records, skills, runtimeConfig = {}) {
 function filterSkillsForReadInjection(skills, assembledFromTranscript) {
   return skills.filter(skill => {
     const sources = skill.detectionSources || [];
+    const hasExplicitUsageSignal = sources.includes('manual_attachment') ||
+      sources.includes('agent_skill');
 
     if (!assembledFromTranscript) {
-      return sources.includes('manual_attachment') ||
+      return hasExplicitUsageSignal ||
         sources.includes('transcript_read');
     }
 
     // The transcript assembler already materializes real Read tool_use entries.
-    // Only synthesize a Read when manual attachment is the sole evidence. A skill
-    // with both sources already has its real transcript Read in the assembled step.
-    return sources.includes('manual_attachment') &&
+    // Only synthesize a Read when an explicit user-row signal has no matching
+    // transcript Read. A skill with both sources already has its real Read in the
+    // assembled step.
+    return hasExplicitUsageSignal &&
       !sources.includes('transcript_read');
   });
 }

--- a/assets/hooks/cursor/skill-detector.mjs
+++ b/assets/hooks/cursor/skill-detector.mjs
@@ -20,6 +20,12 @@ const MANUALLY_ATTACHED_SKILLS_RE =
 const ATTACHED_SKILL_HEADER_RE =
   /(?:^|\r?\n)Skill Name:\s*([^\r\n]+)\r?\nPath:\s*([^\r\n]+)\r?\nSKILL\.md content:\s*(?:\r?\n|$)/g;
 const USER_QUERY_RE = /<user_query>\s*([\s\S]*?)\s*<\/user_query>/i;
+const USER_QUERY_CONTAINER_RE =
+  /<user_query\b[^>]*>[\s\S]*?<\/user_query>/gi;
+const MANUALLY_ATTACHED_SKILLS_CONTAINER_RE =
+  /<manually_attached_skills\b[^>]*>[\s\S]*?<\/manually_attached_skills>/gi;
+const AGENT_SKILLS_CONTAINER_RE =
+  /<agent_skills\b[^>]*>([\s\S]*?)<\/agent_skills>/gi;
 const AVAILABLE_SKILLS_RE =
   /<available_skills\b[^>]*>([\s\S]*?)<\/available_skills>/gi;
 const AGENT_SKILL_RE =
@@ -88,7 +94,7 @@ export function detectSkillFromTranscript(transcriptPath, userPrompt) {
     addDetectedSkill(detected, skill, 'manual_attachment');
   }
 
-  // Cursor also emits an <agent_skills><available_skills> catalog. Parse it for
+  // Step 3: Cursor emits an <agent_skills><available_skills> catalog. Parse it for
   // compatibility, but only standalone <agent_skill> elements outside that
   // catalog are per-turn usage evidence.
   const agentSkills = extractAgentSkillsMetadata(matchedUserText);
@@ -170,18 +176,35 @@ export function extractAgentSkillsMetadata(userText) {
   if (!userText) return { availableSkills: [], usedSkills: [] };
 
   const availableSkills = [];
-  AVAILABLE_SKILLS_RE.lastIndex = 0;
-  const textWithoutCatalogs = userText.replace(
-    AVAILABLE_SKILLS_RE,
-    (_container, catalogBody) => {
-      availableSkills.push(...extractAgentSkillElements(catalogBody));
-      return '';
-    },
-  );
+  const usedSkills = [];
+
+  // Both containers below contain user-controlled text, including the full
+  // inlined SKILL.md body. Remove them before looking for Cursor metadata so an
+  // XML example cannot become a synthetic skill usage signal.
+  MANUALLY_ATTACHED_SKILLS_CONTAINER_RE.lastIndex = 0;
+  USER_QUERY_CONTAINER_RE.lastIndex = 0;
+  const metadataText = userText
+    .replace(MANUALLY_ATTACHED_SKILLS_CONTAINER_RE, '')
+    .replace(USER_QUERY_CONTAINER_RE, '');
+
+  // Only <agent_skill> elements inside Cursor's <agent_skills> metadata
+  // container are eligible. Catalog entries remain available-only metadata.
+  AGENT_SKILLS_CONTAINER_RE.lastIndex = 0;
+  for (const containerMatch of metadataText.matchAll(AGENT_SKILLS_CONTAINER_RE)) {
+    AVAILABLE_SKILLS_RE.lastIndex = 0;
+    const usageBody = containerMatch[1].replace(
+      AVAILABLE_SKILLS_RE,
+      (_container, catalogBody) => {
+        availableSkills.push(...extractAgentSkillElements(catalogBody));
+        return '';
+      },
+    );
+    usedSkills.push(...extractAgentSkillElements(usageBody));
+  }
 
   return {
     availableSkills,
-    usedSkills: extractAgentSkillElements(textWithoutCatalogs),
+    usedSkills,
   };
 }
 

--- a/assets/hooks/cursor/skill-detector.mjs
+++ b/assets/hooks/cursor/skill-detector.mjs
@@ -4,18 +4,28 @@
  * Strategy: After assembly completes, match the transcript user row for the
  * current turn, then collect skills from either:
  * - Cursor's <manually_attached_skills> metadata on that user row; or
- * - Read tool_use entries targeting ~/.cursor/skills/<name>/SKILL.md.
+ * - A standalone <agent_skill fullPath="..."> usage signal; or
+ * - Read tool_use entries targeting a recognized skills[-suffix] path.
  */
 
 import fs from 'node:fs';
 
-// Path pattern: /.cursor/skills/<skill-name>/SKILL.md (case-insensitive)
-const SKILL_PATH_RE = /[/\\]\.cursor[/\\]skills[/\\]([\w-]+)[/\\]SKILL\.md/i;
+// Keep path semantics aligned with @loongsuite/otel-util-genai while requiring
+// the path to end at the skill definition document. The stricter suffix avoids
+// treating arbitrary files below an ordinary "skills" directory as usage.
+const SKILL_DOCUMENT_PATH_RE =
+  /(?:^|[/\\])skills(?:-[A-Za-z0-9][A-Za-z0-9_-]*)?[/\\](?:\.system[/\\])?([^/\\"'\s]+)[/\\]SKILL\.md$/i;
 const MANUALLY_ATTACHED_SKILLS_RE =
   /<manually_attached_skills>([\s\S]*?)<\/manually_attached_skills>/i;
 const ATTACHED_SKILL_HEADER_RE =
   /(?:^|\r?\n)Skill Name:\s*([^\r\n]+)\r?\nPath:\s*([^\r\n]+)\r?\nSKILL\.md content:\s*(?:\r?\n|$)/g;
 const USER_QUERY_RE = /<user_query>\s*([\s\S]*?)\s*<\/user_query>/i;
+const AVAILABLE_SKILLS_RE =
+  /<available_skills\b[^>]*>([\s\S]*?)<\/available_skills>/gi;
+const AGENT_SKILL_RE =
+  /<agent_skill\b([^>]*)>[\s\S]*?<\/agent_skill>/gi;
+const AGENT_SKILL_FULL_PATH_RE =
+  /\bfullPath\s*=\s*(?:"([^"]+)"|'([^']+)')/i;
 
 /**
  * Detect skill usage from transcript for a specific turn.
@@ -25,8 +35,8 @@ const USER_QUERY_RE = /<user_query>\s*([\s\S]*?)\s*<\/user_query>/i;
  * @returns {{
  *   skillName: string,
  *   skillPath: string,
- *   detectionSource: 'manual_attachment' | 'transcript_read',
- *   detectionSources: ('manual_attachment' | 'transcript_read')[]
+ *   detectionSource: 'manual_attachment' | 'agent_skill' | 'transcript_read',
+ *   detectionSources: ('manual_attachment' | 'agent_skill' | 'transcript_read')[]
  * }[] | null}
  */
 export function detectSkillFromTranscript(transcriptPath, userPrompt) {
@@ -78,7 +88,15 @@ export function detectSkillFromTranscript(transcriptPath, userPrompt) {
     addDetectedSkill(detected, skill, 'manual_attachment');
   }
 
-  // Step 3: Scan assistant messages after the matched user message until the
+  // Cursor also emits an <agent_skills><available_skills> catalog. Parse it for
+  // compatibility, but only standalone <agent_skill> elements outside that
+  // catalog are per-turn usage evidence.
+  const agentSkills = extractAgentSkillsMetadata(matchedUserText);
+  for (const skill of agentSkills.usedSkills) {
+    addDetectedSkill(detected, skill, 'agent_skill');
+  }
+
+  // Step 4: Scan assistant messages after the matched user message until the
   // turn boundary for actual Read SKILL.md tool calls.
   for (let i = matchedTurnStart + 1; i < entries.length; i++) {
     const e = entries[i];
@@ -88,12 +106,9 @@ export function detectSkillFromTranscript(transcriptPath, userPrompt) {
       for (const block of e.message.content) {
         if (block.type === 'tool_use' && (block.name === 'Read' || block.name === 'ReadFile')) {
           const filePath = block.input?.path || block.input?.file_path || '';
-          const match = filePath.match(SKILL_PATH_RE);
-          if (match) {
-            addDetectedSkill(detected, {
-              skillName: match[1],
-              skillPath: filePath,
-            }, 'transcript_read');
+          const skill = parseSkillDocumentPath(filePath);
+          if (skill) {
+            addDetectedSkill(detected, skill, 'transcript_read');
           }
         }
       }
@@ -132,14 +147,66 @@ export function extractManuallyAttachedSkills(userText) {
   for (const match of container.matchAll(ATTACHED_SKILL_HEADER_RE)) {
     const declaredName = match[1].trim();
     const skillPath = match[2].trim();
-    const pathMatch = skillPath.match(SKILL_PATH_RE);
-    if (!declaredName || !pathMatch) continue;
+    const parsedPath = parseSkillDocumentPath(skillPath);
+    if (!declaredName || !parsedPath) continue;
     skills.push({
       skillName: declaredName,
       skillPath,
     });
   }
   return skills;
+}
+
+/**
+ * Parse Cursor's agent skill metadata without treating the available-skills
+ * catalog as actual usage.
+ *
+ * @returns {{
+ *   availableSkills: { skillName: string, skillPath: string }[],
+ *   usedSkills: { skillName: string, skillPath: string }[]
+ * }}
+ */
+export function extractAgentSkillsMetadata(userText) {
+  if (!userText) return { availableSkills: [], usedSkills: [] };
+
+  const availableSkills = [];
+  AVAILABLE_SKILLS_RE.lastIndex = 0;
+  const textWithoutCatalogs = userText.replace(
+    AVAILABLE_SKILLS_RE,
+    (_container, catalogBody) => {
+      availableSkills.push(...extractAgentSkillElements(catalogBody));
+      return '';
+    },
+  );
+
+  return {
+    availableSkills,
+    usedSkills: extractAgentSkillElements(textWithoutCatalogs),
+  };
+}
+
+function extractAgentSkillElements(text) {
+  const skills = [];
+  AGENT_SKILL_RE.lastIndex = 0;
+  for (const match of text.matchAll(AGENT_SKILL_RE)) {
+    const attributes = match[1] || '';
+    const fullPathMatch = attributes.match(AGENT_SKILL_FULL_PATH_RE);
+    const skillPath = (fullPathMatch?.[1] || fullPathMatch?.[2] || '').trim();
+    const skill = parseSkillDocumentPath(skillPath);
+    if (skill) skills.push(skill);
+  }
+  return skills;
+}
+
+export function parseSkillDocumentPath(filePath) {
+  if (typeof filePath !== 'string') return null;
+  const skillPath = filePath.trim();
+  const match = skillPath.match(SKILL_DOCUMENT_PATH_RE);
+  if (!match) return null;
+  return {
+    skillName: match[1],
+    skillPath,
+  };
 }
 
 function addDetectedSkill(detected, skill, source) {

--- a/tests/unit/hooks/cursor/inject-skill-records.test.mjs
+++ b/tests/unit/hooks/cursor/inject-skill-records.test.mjs
@@ -59,6 +59,12 @@ describe('filterSkillsForReadInjection', () => {
     expect(filterSkillsForReadInjection(skills, true)).toEqual(skills);
   });
 
+  it('should synthesize standalone agent_skill usage after transcript assembly', () => {
+    const skills = [skillWithSources('agent_skill')];
+
+    expect(filterSkillsForReadInjection(skills, true)).toEqual(skills);
+  });
+
   it('should not synthesize transcript reads after transcript assembly', () => {
     const transcriptOnly = skillWithSources('transcript_read');
     const dualSource = skillWithSources('manual_attachment', 'transcript_read');
@@ -109,11 +115,13 @@ describe('injectSkillRecords', () => {
     expect(toolCall['gen_ai.tool.name']).toBe('Read');
     expect(toolCall['gen_ai.tool.call.arguments']).toEqual({ path: '/Users/test/.cursor/skills/my-skill/SKILL.md' });
     expect(toolCall['gen_ai.skill.name']).toBe('my-skill');
+    expect(toolCall['gen_ai.skill.id']).toBe('my-skill');
     expect(toolCall['agent.cursor.skill_detection_source']).toBe('transcript_post_assembly');
 
     expect(toolResult['event.name']).toBe('tool.result');
     expect(toolResult['gen_ai.tool.name']).toBe('Read');
     expect(toolResult['gen_ai.skill.name']).toBe('my-skill');
+    expect(toolResult['gen_ai.skill.id']).toBe('my-skill');
     expect(toolResult['agent.cursor.skill_detection_source']).toBe('transcript_post_assembly');
   });
 
@@ -296,12 +304,14 @@ describe('injectSkillRecords', () => {
         path: '/Users/test/.cursor/skills/count-if-statements/SKILL.md',
       },
       'gen_ai.skill.name': 'count-if-statements',
+      'gen_ai.skill.id': 'count-if-statements',
       'agent.cursor.skill_detection_source': 'manual_attachment',
     });
     expect(records[2]).toMatchObject({
       'event.name': 'tool.result',
       'gen_ai.tool.name': 'Read',
       'gen_ai.skill.name': 'count-if-statements',
+      'gen_ai.skill.id': 'count-if-statements',
       'agent.cursor.skill_detection_source': 'manual_attachment',
     });
   });

--- a/tests/unit/hooks/cursor/skill-detector.test.mjs
+++ b/tests/unit/hooks/cursor/skill-detector.test.mjs
@@ -1,8 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { detectSkillFromTranscript } from '../../../../assets/hooks/cursor/skill-detector.mjs';
+import {
+  detectSkillFromTranscript,
+  extractAgentSkillsMetadata,
+  parseSkillDocumentPath,
+} from '../../../../assets/hooks/cursor/skill-detector.mjs';
 
 function createTempTranscript(lines) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-detector-test-'));
@@ -15,6 +19,73 @@ function createTempTranscript(lines) {
 function cleanup(dir) {
   fs.rmSync(dir, { recursive: true, force: true });
 }
+
+describe('parseSkillDocumentPath', () => {
+  it.each([
+    ['/Users/utkvrjan/.agents/skills/ai-rag2/SKILL.md', 'ai-rag2'],
+    [
+      '/Users/utkvrjan/.claude/plugins/cache/context-hub/utilities/431adcc76243/skills/ai-rag2/SKILL.md',
+      'ai-rag2',
+    ],
+    ['/Users/test/.cursor/skills/code-review/SKILL.md', 'code-review'],
+    ['/Users/test/.cursor/skills-cursor/create-rule/SKILL.md', 'create-rule'],
+    ['/Users/test/.codex/skills/.system/imagegen/SKILL.md', 'imagegen'],
+    ['/workspace/project/skills/deploy-helper/SKILL.md', 'deploy-helper'],
+    ['C:\\Users\\test\\.agents\\skills\\ai-rag2\\SKILL.md', 'ai-rag2'],
+  ])('should recognize supported skill document path %s', (skillPath, skillName) => {
+    expect(parseSkillDocumentPath(skillPath)).toEqual({ skillName, skillPath });
+  });
+
+  it.each([
+    '/Users/test/.cursor/commands/ai-rag2.md',
+    '/Users/test/.agents/skills/ai-rag2/README.md',
+    '/Users/test/.agents/skills/ai-rag2/scripts/run.js',
+  ])('should reject non-SKILL.md path %s', skillPath => {
+    expect(parseSkillDocumentPath(skillPath)).toBeNull();
+  });
+});
+
+describe('extractAgentSkillsMetadata', () => {
+  it('should parse available skills as catalog entries without usage', () => {
+    const userText = [
+      '<agent_skills>',
+      '<available_skills>',
+      '<agent_skill fullPath="/Users/test/.cursor/skills-cursor/create-rule/SKILL.md">create</agent_skill>',
+      '<agent_skill fullPath="/Users/test/.agents/skills/ai-rag2/SKILL.md">rag</agent_skill>',
+      '</available_skills>',
+      '</agent_skills>',
+    ].join('\n');
+
+    expect(extractAgentSkillsMetadata(userText)).toEqual({
+      availableSkills: [
+        {
+          skillName: 'create-rule',
+          skillPath: '/Users/test/.cursor/skills-cursor/create-rule/SKILL.md',
+        },
+        {
+          skillName: 'ai-rag2',
+          skillPath: '/Users/test/.agents/skills/ai-rag2/SKILL.md',
+        },
+      ],
+      usedSkills: [],
+    });
+  });
+
+  it('should treat only standalone agent_skill elements as usage', () => {
+    const pluginSkillPath =
+      '/Users/test/.claude/plugins/cache/context-hub/utilities/431adcc76243/skills/ai-rag2/SKILL.md';
+    const userText = [
+      '<agent_skills>',
+      `<agent_skill fullPath='${pluginSkillPath}'>rag</agent_skill>`,
+      '</agent_skills>',
+    ].join('\n');
+
+    expect(extractAgentSkillsMetadata(userText)).toEqual({
+      availableSkills: [],
+      usedSkills: [{ skillName: 'ai-rag2', skillPath: pluginSkillPath }],
+    });
+  });
+});
 
 describe('detectSkillFromTranscript', () => {
   let tempDir;
@@ -85,6 +156,78 @@ describe('detectSkillFromTranscript', () => {
       skillPath: '/Users/test/.cursor/skills/count-if-statements/SKILL.md',
       detectionSource: 'manual_attachment',
       detectionSources: ['manual_attachment'],
+    }]);
+  });
+
+  it('should detect manually attached skills outside .cursor/skills', () => {
+    const pluginSkillPath =
+      '/Users/utkvrjan/.claude/plugins/cache/context-hub/utilities/431adcc76243/skills/ai-rag2/SKILL.md';
+    const lines = [
+      { role: 'user', message: { content: [{ type: 'text', text: [
+        '<manually_attached_skills>',
+        'Skill Name: ai-rag2',
+        `Path: ${pluginSkillPath}`,
+        'SKILL.md content:',
+        '# AI RAG',
+        '</manually_attached_skills>',
+        '<user_query>',
+        'use ai-rag2',
+        '</user_query>',
+      ].join('\n') }] } },
+      { type: 'turn_ended' },
+    ];
+
+    ({ dir: tempDir, filePath: transcriptPath } = createTempTranscript(lines));
+
+    expect(detectSkillFromTranscript(transcriptPath, 'use ai-rag2')).toEqual([{
+      skillName: 'ai-rag2',
+      skillPath: pluginSkillPath,
+      detectionSource: 'manual_attachment',
+      detectionSources: ['manual_attachment'],
+    }]);
+  });
+
+  it('should not treat available agent skills catalog as usage', () => {
+    const lines = [
+      { role: 'user', message: { content: [{ type: 'text', text: [
+        '<agent_skills>',
+        '<available_skills>',
+        '<agent_skill fullPath="/Users/test/.agents/skills/ai-rag2/SKILL.md">rag</agent_skill>',
+        '</available_skills>',
+        '</agent_skills>',
+        '<user_query>',
+        'answer without a skill',
+        '</user_query>',
+      ].join('\n') }] } },
+      { type: 'turn_ended' },
+    ];
+
+    ({ dir: tempDir, filePath: transcriptPath } = createTempTranscript(lines));
+
+    expect(detectSkillFromTranscript(transcriptPath, 'answer without a skill')).toBeNull();
+  });
+
+  it('should detect a standalone agent_skill usage signal', () => {
+    const skillPath = '/Users/test/.agents/skills/ai-rag2/SKILL.md';
+    const lines = [
+      { role: 'user', message: { content: [{ type: 'text', text: [
+        '<agent_skills>',
+        `<agent_skill fullPath="${skillPath}">rag</agent_skill>`,
+        '</agent_skills>',
+        '<user_query>',
+        'use ai-rag2',
+        '</user_query>',
+      ].join('\n') }] } },
+      { type: 'turn_ended' },
+    ];
+
+    ({ dir: tempDir, filePath: transcriptPath } = createTempTranscript(lines));
+
+    expect(detectSkillFromTranscript(transcriptPath, 'use ai-rag2')).toEqual([{
+      skillName: 'ai-rag2',
+      skillPath,
+      detectionSource: 'agent_skill',
+      detectionSources: ['agent_skill'],
     }]);
   });
 
@@ -254,7 +397,7 @@ describe('detectSkillFromTranscript', () => {
     expect(result[0].skillPath).toBe('C:\\Users\\test\\.cursor\\skills\\code-review\\SKILL.md');
   });
 
-  it('should return null when path is not under .cursor/skills/', () => {
+  it('should detect a skill under a generic skills directory', () => {
     const lines = [
       { role: 'user', message: { content: [{ type: 'text', text: '<user_query>\nread some file\n</user_query>' }] } },
       { role: 'assistant', message: { content: [
@@ -266,7 +409,12 @@ describe('detectSkillFromTranscript', () => {
     ({ dir: tempDir, filePath: transcriptPath } = createTempTranscript(lines));
 
     const result = detectSkillFromTranscript(transcriptPath, 'read some file');
-    expect(result).toBeNull();
+    expect(result).toEqual([{
+      skillName: 'my-skill',
+      skillPath: '/Users/test/projects/skills/my-skill/SKILL.md',
+      detectionSource: 'transcript_read',
+      detectionSources: ['transcript_read'],
+    }]);
   });
 
   it('should return null when transcriptPath is empty or null', () => {

--- a/tests/unit/hooks/cursor/skill-detector.test.mjs
+++ b/tests/unit/hooks/cursor/skill-detector.test.mjs
@@ -71,7 +71,7 @@ describe('extractAgentSkillsMetadata', () => {
     });
   });
 
-  it('should treat only standalone agent_skill elements as usage', () => {
+  it('should treat standalone agent_skill elements inside agent_skills as usage', () => {
     const pluginSkillPath =
       '/Users/test/.claude/plugins/cache/context-hub/utilities/431adcc76243/skills/ai-rag2/SKILL.md';
     const userText = [
@@ -83,6 +83,16 @@ describe('extractAgentSkillsMetadata', () => {
     expect(extractAgentSkillsMetadata(userText)).toEqual({
       availableSkills: [],
       usedSkills: [{ skillName: 'ai-rag2', skillPath: pluginSkillPath }],
+    });
+  });
+
+  it('should ignore agent_skill elements outside the agent_skills container', () => {
+    const userText =
+      '<agent_skill fullPath="/Users/test/.agents/skills/demo/SKILL.md">example</agent_skill>';
+
+    expect(extractAgentSkillsMetadata(userText)).toEqual({
+      availableSkills: [],
+      usedSkills: [],
     });
   });
 });
@@ -228,6 +238,57 @@ describe('detectSkillFromTranscript', () => {
       skillPath,
       detectionSource: 'agent_skill',
       detectionSources: ['agent_skill'],
+    }]);
+  });
+
+  it('should ignore an agent_skill example inside user_query', () => {
+    const lines = [
+      { role: 'user', message: { content: [{ type: 'text', text: [
+        '<user_query>',
+        'explain this example:',
+        '<agent_skills>',
+        '<agent_skill fullPath="/Users/test/.agents/skills/demo/SKILL.md">example</agent_skill>',
+        '</agent_skills>',
+        '</user_query>',
+      ].join('\n') }] } },
+      { type: 'turn_ended' },
+    ];
+
+    ({ dir: tempDir, filePath: transcriptPath } = createTempTranscript(lines));
+
+    expect(detectSkillFromTranscript(
+      transcriptPath,
+      'explain this example: example',
+    )).toBeNull();
+  });
+
+  it('should ignore an agent_skill example inside attached SKILL.md content', () => {
+    const attachedSkillPath = '/Users/test/.agents/skills/attached/SKILL.md';
+    const lines = [
+      { role: 'user', message: { content: [{ type: 'text', text: [
+        '<manually_attached_skills>',
+        'Skill Name: attached',
+        `Path: ${attachedSkillPath}`,
+        'SKILL.md content:',
+        '# Attached Skill',
+        '<agent_skills>',
+        '<agent_skill fullPath="/Users/test/.agents/skills/demo/SKILL.md">example</agent_skill>',
+        '</agent_skills>',
+        '</manually_attached_skills>',
+        '<user_query>',
+        'use attached',
+        '</user_query>',
+      ].join('\n') }] } },
+      { type: 'turn_ended' },
+    ];
+
+    ({ dir: tempDir, filePath: transcriptPath } = createTempTranscript(lines));
+
+    expect(detectSkillFromTranscript(transcriptPath, 'use attached')).toEqual([{
+      skillName: 'attached',
+      skillPath: attachedSkillPath,
+      detectionSource: 'manual_attachment',
+      detectionSources: ['manual_attachment'],
     }]);
   });
 


### PR DESCRIPTION
## Summary

- align Cursor skill path recognition with genai util for skills and skills-* directories, while requiring the path to end in SKILL.md
- support manually attached, Read/ReadFile, and standalone agent_skill usage signals without treating the available_skills catalog as actual usage
- restrict agent_skill parsing to Cursor-generated agent_skills metadata after excluding user_query and inlined attached skill content
- add gen_ai.skill.name and gen_ai.skill.id to synthesized skill Read records
- keep Cursor commands excluded from skill detection

## Supported examples

- /Users/utkvrjan/.agents/skills/ai-rag2/SKILL.md
- /Users/utkvrjan/.claude/plugins/cache/context-hub/utilities/431adcc76243/skills/ai-rag2/SKILL.md
- /Users/test/.cursor/skills-cursor/create-rule/SKILL.md
- /Users/test/.codex/skills/.system/imagegen/SKILL.md

## Testing

- npm run typecheck
- npm test: 207 files passed, 2433 tests passed, 3 files and 11 tests skipped