### PR TITLE
fix(qoder): collect IDE turns ending at Stop EOF

### DIFF
--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -225,9 +225,17 @@ async function main() {
       let range = null;
       if (Number.isFinite(triggerEndLine)) {
         // Stop may be appended only after the hook process receives its
-        // payload. Poll briefly for that Stop's SessionEnd, without ever
-        // falling through into a queued next prompt.
+        // payload. Poll briefly for that Stop and a stable right boundary,
+        // without ever falling through into a queued next prompt.
         const maxBoundaryPolls = 3;
+        const configuredPollInterval = Number.parseInt(
+          process.env.HOOK_RETRY_BOUNDARY_POLL_INTERVAL_MS || '1000',
+          10,
+        );
+        const boundaryPollIntervalMs = Number.isFinite(configuredPollInterval)
+          ? Math.max(0, configuredPollInterval)
+          : 1000;
+        let previousEofCandidateKey = null;
         for (let poll = 0; poll < maxBoundaryPolls; poll++) {
           // One immutable snapshot per poll supplies both EOF/cursor validation
           // and turn-boundary discovery. The successful snapshot is passed
@@ -242,8 +250,27 @@ async function main() {
           if (!range) return;
           targetWindow = findTriggeredTurnWindow(retrySnapshot, triggerEndLine);
           if (targetWindow.status === 'complete') break;
+          if (targetWindow.reason === 'stop-at-eof') {
+            const candidateKey = [
+              targetWindow.startLine,
+              targetWindow.stopLine,
+              targetWindow.endLine,
+              retrySnapshot.contentHash,
+            ].join(':');
+            if (candidateKey === previousEofCandidateKey) {
+              targetWindow = {
+                ...targetWindow,
+                status: 'complete',
+                reason: 'stable-stop-eof',
+              };
+              break;
+            }
+            previousEofCandidateKey = candidateKey;
+          } else {
+            previousEofCandidateKey = null;
+          }
           if (poll + 1 < maxBoundaryPolls) {
-            await new Promise(r => setTimeout(r, 1000));
+            await new Promise(r => setTimeout(r, boundaryPollIntervalMs));
           }
         }
 
@@ -411,9 +438,10 @@ async function processTranscript(agentId, logPrefix, transcriptPath, sessionId, 
 
   const snapshot = opts?.snapshot || readTranscriptSnapshot(transcriptPath);
 
-  // A Stop-anchored retry receives an exact UserPromptSubmit -> SessionEnd
-  // window. Do not expand that range to the current EOF: it may already contain
-  // the next queued prompt.
+  // A Stop-anchored retry receives an exact Turn window ending at an explicit
+  // terminal marker, the next prompt boundary, or a stable EOF after Stop. Do
+  // not expand that range to the current EOF: it may already contain a queued
+  // next prompt.
   let endLine = initialEndLine;
   if (!opts?.fixedTurnWindow) {
     const currentCount = snapshot.lineCount;
@@ -574,7 +602,7 @@ export function selectTurnSegmentsForCollection(turnSegments, rangeReason, agent
 export function readTranscriptSnapshot(transcriptPath) {
   try {
     if (!fs.existsSync(transcriptPath)) {
-      return { lineCount: 0, rows: [], reason: 'transcript-missing' };
+      return { lineCount: 0, rows: [], contentHash: '', reason: 'transcript-missing' };
     }
     const content = fs.readFileSync(transcriptPath, 'utf-8');
     const lines = content.split('\n');
@@ -587,9 +615,10 @@ export function readTranscriptSnapshot(transcriptPath) {
       if (!text) continue;
       try { rows[i] = JSON.parse(text); } catch { /* skip malformed line */ }
     }
-    return { lineCount, rows, reason: 'ok' };
+    const contentHash = crypto.createHash('sha1').update(content).digest('hex');
+    return { lineCount, rows, contentHash, reason: 'ok' };
   } catch {
-    return { lineCount: 0, rows: [], reason: 'read-failed' };
+    return { lineCount: 0, rows: [], contentHash: '', reason: 'read-failed' };
   }
 }
 
@@ -617,12 +646,13 @@ export function findIncrementalTurnEndLine(snapshot, startLine, scanEndLine) {
 }
 
 export function findTriggeredTurnWindow(snapshot, triggerEndLine) {
-  const waiting = reason => ({
+  const waiting = (reason, details = {}) => ({
     status: 'waiting',
     reason,
     startLine: null,
     stopLine: null,
     endLine: null,
+    ...details,
   });
 
   try {
@@ -710,10 +740,27 @@ export function findTriggeredTurnWindow(snapshot, triggerEndLine) {
         hookEvent === 'UserPromptSubmit' ||
         (rows[i]?.type === 'user' && !isToolResult(rows[i]))
       ) {
-        return waiting('next-prompt-before-session-end');
+        // The next real prompt is itself an unambiguous right boundary for the
+        // completed Stop turn. Exclude it from this fixed window so its own Stop
+        // callback can consume it later.
+        return {
+          status: 'complete',
+          reason: 'next-prompt',
+          startLine,
+          stopLine,
+          endLine: i,
+        };
       }
     }
-    return waiting('session-end-not-found');
+    // Desktop/JetBrains sessions may remain open after every Stop and therefore
+    // emit neither SessionEnd nor qodercli's last-prompt marker. The retry caller
+    // promotes this candidate only after two byte-identical snapshots, proving
+    // the transcript has stopped growing before the fixed EOF window is used.
+    return waiting('stop-at-eof', {
+      startLine,
+      stopLine,
+      endLine: limit,
+    });
   } catch {
     return waiting('read-failed');
   }

--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -45,17 +45,20 @@ const RESOURCE_ATTRIBUTE_FIELDS = Object.keys(RESOURCE_ATTRIBUTES).length > 0
 // fields so the trace flusher can pass matching keys through to span attributes.
 const SPAN_ATTRIBUTES = parseSpanAttributesFromEnv(process.env, { agentId: 'qoder' });
 
-// --- Retry lockfile (qoder-cn only) -----------------------------------------
-// QoderCN fires Stop hook multiple times per turn AND incomplete transcript
-// causes background retries — without coordination these can stack up and
-// produce duplicate records. We guard at two points:
-//   1. parent process: skip spawn if a live lock exists
-//   2. retry subprocess: refuse to enter processTranscript if a peer holds it
-// The lock file lives at <HOOKS_DIR>/.retry-locks/<sha1>.lock and contains
-// JSON `{ pid, sessionId, startedAt }`.
+// --- Per-transcript processing lock -----------------------------------------
+// Every Stop can create a detached retry. Serialize the complete read -> append
+// -> cursor-advance transaction for one transcript so duplicate or adjacent
+// retries cannot commit from the same stale cursor. Contenders wait and re-read
+// state after acquiring the lock; they never treat lock contention as a reason
+// to discard a distinct Turn.
+//
+// The lock file lives at <HOOKS_DIR>/.retry-locks/<sha1>.lock and contains JSON
+// `{ pid, sessionId, startedAt }`.
 
 export const RETRY_LOCK_DIR = path.join(HOOKS_DIR, '.retry-locks');
 export const RETRY_LOCK_MAX_AGE_MS = 60_000;
+export const RETRY_LOCK_WAIT_TIMEOUT_MS = 15_000;
+export const RETRY_LOCK_POLL_INTERVAL_MS = 25;
 
 export function retryLockPath(transcriptPath, dir = RETRY_LOCK_DIR) {
   const hash = crypto.createHash('sha1').update(transcriptPath).digest('hex');
@@ -128,6 +131,33 @@ export function releaseRetryLock(transcriptPath, dir = RETRY_LOCK_DIR) {
       fs.unlinkSync(lockPath);
     }
   } catch { /* best-effort */ }
+}
+
+export async function acquireRetryLock(
+  transcriptPath,
+  sessionId,
+  {
+    dir = RETRY_LOCK_DIR,
+    waitMs = RETRY_LOCK_WAIT_TIMEOUT_MS,
+    pollMs = RETRY_LOCK_POLL_INTERVAL_MS,
+  } = {},
+) {
+  const boundedWaitMs = clampInteger(waitMs, RETRY_LOCK_WAIT_TIMEOUT_MS, 0, 60_000);
+  const boundedPollMs = clampInteger(pollMs, RETRY_LOCK_POLL_INTERVAL_MS, 5, 1_000);
+  const deadline = Date.now() + boundedWaitMs;
+
+  while (true) {
+    if (tryAcquireRetryLock(transcriptPath, sessionId, dir)) return true;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return false;
+    await new Promise(resolve => setTimeout(resolve, Math.min(boundedPollMs, remaining)));
+  }
+}
+
+function clampInteger(value, fallback, min, max) {
+  const parsed = typeof value === 'number' ? value : Number.parseInt(String(value), 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(max, Math.max(min, Math.trunc(parsed)));
 }
 
 // --- Timestamp helpers -------------------------------------------------------
@@ -204,22 +234,27 @@ async function main() {
     logDebug(agentId, `Retry: processing ${transcriptPath} for session ${sessionId}`);
     const runtimeConfig = loadHookRuntimeConfig(path.join(HOOKS_DIR, '..'));
 
-    // qoder-cn only: serialize concurrent retries on the same transcript.
-    // We wait the HOOK_RETRY_DELAY first (so all queued Stop hooks have
-    // already advanced the offset via updateLineRecord), then acquire the
-    // lock. The losers see currentCount==lastCount in getLineRangeInfo and exit.
+    // Reserve the transcript before applying the flush delay. Earlier Stop
+    // retries therefore retain commit order while later retries wait. The wait
+    // time counts toward HOOK_RETRY_DELAY, so a contender does not sleep for an
+    // extra five seconds after its predecessor finishes.
     const retryDelay = parseInt(process.env.HOOK_RETRY_DELAY || '0', 10);
-    if (retryDelay > 0) {
-      await new Promise(r => setTimeout(r, retryDelay));
-    }
-
-    if (agentId === 'qoder-cn') {
-      if (!tryAcquireRetryLock(transcriptPath, sessionId)) {
-        logDebug(agentId, `Retry skipped: lock held by peer for ${transcriptPath}`);
-        return;
-      }
+    const lockWaitStartedAt = Date.now();
+    const lockAcquired = await acquireRetryLock(transcriptPath, sessionId, {
+      waitMs: process.env.HOOK_RETRY_LOCK_WAIT_MS,
+      pollMs: process.env.HOOK_RETRY_LOCK_POLL_MS,
+    });
+    if (!lockAcquired) {
+      logDebug(agentId, `Retry lock wait timed out; rescheduling ${transcriptPath}`);
+      spawnDelayedRetry(agentId, transcriptPath, sessionId, logPrefix, cwd, triggerEndLine);
+      return;
     }
     try {
+      const remainingDelay = retryDelay - (Date.now() - lockWaitStartedAt);
+      if (remainingDelay > 0) {
+        await new Promise(r => setTimeout(r, remainingDelay));
+      }
+
       let targetWindow = null;
       let retrySnapshot = null;
       let range = null;
@@ -228,19 +263,18 @@ async function main() {
         // payload. Poll briefly for that Stop and a stable right boundary,
         // without ever falling through into a queued next prompt.
         const maxBoundaryPolls = 3;
-        const configuredPollInterval = Number.parseInt(
-          process.env.HOOK_RETRY_BOUNDARY_POLL_INTERVAL_MS || '1000',
+        const boundaryPollIntervalMs = clampInteger(
+          process.env.HOOK_RETRY_BOUNDARY_POLL_INTERVAL_MS,
+          1000,
           10,
+          5000,
         );
-        const boundaryPollIntervalMs = Number.isFinite(configuredPollInterval)
-          ? Math.max(0, configuredPollInterval)
-          : 1000;
         let previousEofCandidateKey = null;
         for (let poll = 0; poll < maxBoundaryPolls; poll++) {
           // One immutable snapshot per poll supplies both EOF/cursor validation
           // and turn-boundary discovery. The successful snapshot is passed
           // directly to processTranscript, so it is never read again.
-          retrySnapshot = readTranscriptSnapshot(transcriptPath);
+          retrySnapshot = readTranscriptSnapshot(transcriptPath, { includeContentHash: true });
           range = getLineRangeInfo(
             agentId,
             transcriptPath,
@@ -250,25 +284,14 @@ async function main() {
           if (!range) return;
           targetWindow = findTriggeredTurnWindow(retrySnapshot, triggerEndLine);
           if (targetWindow.status === 'complete') break;
-          if (targetWindow.reason === 'stop-at-eof') {
-            const candidateKey = [
-              targetWindow.startLine,
-              targetWindow.stopLine,
-              targetWindow.endLine,
-              retrySnapshot.contentHash,
-            ].join(':');
-            if (candidateKey === previousEofCandidateKey) {
-              targetWindow = {
-                ...targetWindow,
-                status: 'complete',
-                reason: 'stable-stop-eof',
-              };
-              break;
-            }
-            previousEofCandidateKey = candidateKey;
-          } else {
-            previousEofCandidateKey = null;
-          }
+          const stability = assessStableEofCandidate(
+            previousEofCandidateKey,
+            targetWindow,
+            retrySnapshot,
+          );
+          previousEofCandidateKey = stability.candidateKey;
+          targetWindow = stability.targetWindow;
+          if (targetWindow.status === 'complete') break;
           if (poll + 1 < maxBoundaryPolls) {
             await new Promise(r => setTimeout(r, boundaryPollIntervalMs));
           }
@@ -306,7 +329,7 @@ async function main() {
         if (!range) return;
       }
 
-      await processTranscript(
+      const committed = await processTranscript(
         agentId, logPrefix, transcriptPath, sessionId,
         targetWindow?.startLine ?? range.startLine,
         targetWindow?.endLine ?? range.endLine,
@@ -318,8 +341,12 @@ async function main() {
           snapshot: retrySnapshot,
         },
       );
+      if (committed === false) {
+        logDebug(agentId, `Retry commit failed; rescheduling ${transcriptPath}`);
+        spawnDelayedRetry(agentId, transcriptPath, sessionId, logPrefix, cwd, triggerEndLine);
+      }
     } finally {
-      if (agentId === 'qoder-cn') releaseRetryLock(transcriptPath);
+      releaseRetryLock(transcriptPath);
     }
     return;
   }
@@ -349,7 +376,38 @@ async function main() {
   const parsed = snapshot.rows.slice(startLine, endLine).filter(Boolean);
   logDebug(agentId, `Read ${parsed.length} lines (range: ${startLine}-${endLine})`);
   if (!parsed.length) {
-    updateLineRecord(agentId, transcriptPath, sessionId, endLine);
+    if (!tryAcquireRetryLock(transcriptPath, sessionId)) {
+      logDebug(agentId, `Empty range deferred: transcript lock held for ${transcriptPath}`);
+      return;
+    }
+    try {
+      const lockedSnapshot = readTranscriptSnapshot(transcriptPath);
+      const lockedRange = getLineRangeInfo(
+        agentId,
+        transcriptPath,
+        sessionId,
+        lockedSnapshot.lineCount,
+      );
+      if (lockedRange) {
+        const lockedRows = lockedSnapshot.rows
+          .slice(lockedRange.startLine, lockedRange.endLine)
+          .filter(Boolean);
+        if (lockedRows.length === 0) {
+          updateLineRecord(agentId, transcriptPath, sessionId, lockedRange.endLine);
+        } else {
+          spawnDelayedRetry(
+            agentId,
+            transcriptPath,
+            sessionId,
+            logPrefix,
+            cwd,
+            lockedRange.endLine,
+          );
+        }
+      }
+    } finally {
+      releaseRetryLock(transcriptPath);
+    }
     return;
   }
 
@@ -361,49 +419,47 @@ async function main() {
   const hasLastPrompt = parsed.some(p => p.type === 'last-prompt');
   if (parsed.length > 0 && !hasLastPrompt) {
     logDebug(agentId, `Transcript incomplete (${parsed.length} lines, no last-prompt marker). Spawning background retry in 5s.`);
-    if (agentId === 'qoder-cn') {
-      // qoder-cn: QoderCN fires Stop multiple times per turn. The retry's
-      // child-side lock serializes actual processing, but skipping needless
-      // spawn calls here keeps process churn down.
-      const lockPath = retryLockPath(transcriptPath);
-      const existing = readRetryLock(lockPath);
-      if (existing && !isRetryLockStale(existing)) {
-        logDebug(agentId, `Skip spawn: live retry lock held by pid ${existing.pid}`);
-      } else {
-        if (existing) { try { fs.unlinkSync(lockPath); } catch { /* ignore */ } }
-        spawnDelayedRetry(agentId, transcriptPath, sessionId, logPrefix, cwd, endLine);
-      }
-    } else {
+    // Do not suppress a spawn just because a retry currently owns the lock:
+    // the new Stop may belong to a distinct queued Turn. The child waits, then
+    // re-reads the cursor and either commits that Turn or proves it is a duplicate.
+    spawnDelayedRetry(agentId, transcriptPath, sessionId, logPrefix, cwd, endLine);
+    return;
+  }
+
+  // A complete normal-mode snapshot writes the same history/cursor state as a
+  // retry. If a retry is already committing, enqueue this exact Stop instead of
+  // blocking the foreground hook or dropping it.
+  if (!tryAcquireRetryLock(transcriptPath, sessionId)) {
+    logDebug(agentId, `Stop deferred: transcript lock held for ${transcriptPath}`);
+    spawnDelayedRetry(agentId, transcriptPath, sessionId, logPrefix, cwd, endLine);
+    return;
+  }
+  try {
+    // Re-read both snapshot and cursor under the lock; the values inspected
+    // above are only a fast-path completion check and may already be stale.
+    const lockedSnapshot = readTranscriptSnapshot(transcriptPath);
+    const lockedRange = getLineRangeInfo(
+      agentId,
+      transcriptPath,
+      sessionId,
+      lockedSnapshot.lineCount,
+    );
+    if (!lockedRange) return;
+    const committed = await processTranscript(
+      agentId, logPrefix, transcriptPath, sessionId,
+      lockedRange.startLine, lockedRange.endLine,
+      runtimeConfig, cwd,
+      { rangeReason: lockedRange.reason, snapshot: lockedSnapshot },
+    );
+    if (committed === false) {
+      logDebug(agentId, `Stop commit failed; rescheduling ${transcriptPath}`);
       spawnDelayedRetry(agentId, transcriptPath, sessionId, logPrefix, cwd, endLine);
     }
-    return;
+  } finally {
+    releaseRetryLock(transcriptPath);
   }
-
-  if (agentId === 'qoder-cn') {
-    if (!tryAcquireRetryLock(transcriptPath, sessionId)) {
-      logDebug(agentId, `Stop skipped: peer retry/handler holds lock for ${transcriptPath}`);
-      return;
-    }
-    try {
-      await processTranscript(
-        agentId, logPrefix, transcriptPath, sessionId, startLine, endLine,
-        runtimeConfig, cwd, { rangeReason: range.reason, snapshot },
-      );
-    } finally {
-      releaseRetryLock(transcriptPath);
-    }
-    return;
-  }
-
-  await processTranscript(
-    agentId, logPrefix, transcriptPath, sessionId, startLine, endLine,
-    runtimeConfig, cwd, { rangeReason: range.reason, snapshot },
-  );
 }
 
-// NOTE: Retry subprocess won't race with normal hook because non-interactive mode (--print)
-// only fires Stop once per session (process exits after hook returns). The offset check in
-// getLineRangeInfo prevents double-processing if another hook invocation somehow occurs.
 function spawnDelayedRetry(agentId, transcriptPath, sessionId, logPrefix, cwd, triggerEndLine) {
   const nodebin = process.argv[0];
   const script = fileURLToPath(import.meta.url);
@@ -588,6 +644,7 @@ async function processTranscript(agentId, logPrefix, transcriptPath, sessionId, 
     logDebug(agentId, `Appended ${rowsToAppend.length} rows`);
     updateLineRecord(agentId, transcriptPath, sessionId, endLine);
   }
+  return success;
 }
 
 export function selectTurnSegmentsForCollection(turnSegments, rangeReason, agentId) {
@@ -599,7 +656,7 @@ export function selectTurnSegmentsForCollection(turnSegments, rangeReason, agent
   return turnSegments;
 }
 
-export function readTranscriptSnapshot(transcriptPath) {
+export function readTranscriptSnapshot(transcriptPath, { includeContentHash = false } = {}) {
   try {
     if (!fs.existsSync(transcriptPath)) {
       return { lineCount: 0, rows: [], contentHash: '', reason: 'transcript-missing' };
@@ -615,11 +672,38 @@ export function readTranscriptSnapshot(transcriptPath) {
       if (!text) continue;
       try { rows[i] = JSON.parse(text); } catch { /* skip malformed line */ }
     }
-    const contentHash = crypto.createHash('sha1').update(content).digest('hex');
+    const contentHash = includeContentHash
+      ? crypto.createHash('sha1').update(content).digest('hex')
+      : '';
     return { lineCount, rows, contentHash, reason: 'ok' };
   } catch {
     return { lineCount: 0, rows: [], contentHash: '', reason: 'read-failed' };
   }
+}
+
+export function assessStableEofCandidate(previousKey, targetWindow, snapshot) {
+  if (targetWindow?.reason !== 'stop-at-eof' || !snapshot?.contentHash) {
+    return { candidateKey: null, targetWindow };
+  }
+
+  const candidateKey = [
+    targetWindow.startLine,
+    targetWindow.stopLine,
+    targetWindow.endLine,
+    snapshot.contentHash,
+  ].join(':');
+  if (candidateKey !== previousKey) {
+    return { candidateKey, targetWindow };
+  }
+
+  return {
+    candidateKey,
+    targetWindow: {
+      ...targetWindow,
+      status: 'complete',
+      reason: 'stable-stop-eof',
+    },
+  };
 }
 
 export function findIncrementalTurnEndLine(snapshot, startLine, scanEndLine) {

--- a/assets/hooks/shared/hook-processor-base.mjs
+++ b/assets/hooks/shared/hook-processor-base.mjs
@@ -165,31 +165,40 @@ function isLineRecordNewer(candidate, existing) {
 
 const LOCK_WAIT_ARRAY = new Int32Array(new SharedArrayBuffer(4));
 
-function updateAggregateShadow(file, transcriptPath, record) {
-  const lockFile = `${file}.lock`;
-  const deadline = Date.now() + 1_000;
+function withSyncFileLock(lockFile, waitMs, staleMs, action) {
+  const deadline = Date.now() + waitMs;
   let acquired = false;
   try {
-    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.mkdirSync(path.dirname(lockFile), { recursive: true });
     while (!acquired) {
       try {
         const fd = fs.openSync(lockFile, 'wx');
         fs.closeSync(fd);
         acquired = true;
       } catch (err) {
-        if (err?.code !== 'EEXIST') return false;
+        if (err?.code !== 'EEXIST') return { acquired: false };
         try {
           const stat = fs.statSync(lockFile);
-          if (Date.now() - stat.mtimeMs > 30_000) {
+          if (Date.now() - stat.mtimeMs > staleMs) {
             fs.unlinkSync(lockFile);
             continue;
           }
         } catch { /* retry acquisition */ }
-        if (Date.now() >= deadline) return false;
+        if (Date.now() >= deadline) return { acquired: false };
         Atomics.wait(LOCK_WAIT_ARRAY, 0, 0, 10);
       }
     }
 
+    return { acquired: true, value: action() };
+  } finally {
+    if (acquired) {
+      try { fs.unlinkSync(lockFile); } catch { /* best-effort lock cleanup */ }
+    }
+  }
+}
+
+function updateAggregateShadow(file, transcriptPath, record) {
+  const result = withSyncFileLock(`${file}.lock`, 1_000, 30_000, () => {
     const records = readJsonObject(file) || {};
     const existing = records[transcriptPath];
     if (existing?.session_id === record.session_id
@@ -202,11 +211,9 @@ function updateAggregateShadow(file, transcriptPath, record) {
       updated_at: record.updated_at,
     };
     return saveJsonObject(file, records);
-  } finally {
-    if (acquired) {
-      try { fs.unlinkSync(lockFile); } catch { /* best-effort lock cleanup */ }
-    }
-  }
+  });
+
+  return result.acquired ? result.value : false;
 }
 
 function rollbackShadowFiles(agentId) {
@@ -367,7 +374,14 @@ export function appendRowsToHistory(agentId, logPrefix, rows) {
   const logFile = getHistoryLogFile(agentId, logPrefix);
   try {
     fs.mkdirSync(path.dirname(logFile), { recursive: true });
-    fs.appendFileSync(logFile, rows.join('\n') + '\n', 'utf-8');
+    const result = withSyncFileLock(`${logFile}.lock`, 15_000, 10_000, () => {
+      fs.appendFileSync(logFile, rows.join('\n') + '\n', 'utf-8');
+      return true;
+    });
+    if (!result.acquired) {
+      logDebug(agentId, `ERROR appending rows to history: timed out waiting for ${logFile}.lock`);
+      return false;
+    }
     logDebug(agentId, `Appended ${rows.length} rows to ${logFile}`);
     return true;
   } catch (e) {

--- a/tests/unit/hooks/qoder-hook-processor-cold-start.test.mjs
+++ b/tests/unit/hooks/qoder-hook-processor-cold-start.test.mjs
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -78,10 +78,43 @@ function runRetry(triggerEndLine, sessionId = 'session-old') {
       ...process.env,
       LOONGSUITE_PILOT_DATA_DIR: dataDir,
       HOOK_RETRY_DELAY: '0',
-      HOOK_RETRY_BOUNDARY_POLL_INTERVAL_MS: '0',
+      HOOK_RETRY_BOUNDARY_POLL_INTERVAL_MS: '10',
     },
     encoding: 'utf-8',
     timeout: 30_000,
+  });
+}
+
+function runRetryAsync(triggerEndLine, sessionId = 'session-old', { retryDelay = '0' } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [
+      PROCESSOR,
+      '--agent-id', 'qoder',
+      '--log-prefix', 'qoder',
+      '--retry',
+      '--transcript', transcriptPath,
+      '--session', sessionId,
+      '--trigger-end-line', String(triggerEndLine),
+      '--cwd', '/tmp/qoder-project',
+    ], {
+      env: {
+        ...process.env,
+        LOONGSUITE_PILOT_DATA_DIR: dataDir,
+        HOOK_RETRY_DELAY: retryDelay,
+        HOOK_RETRY_BOUNDARY_POLL_INTERVAL_MS: '10',
+        HOOK_RETRY_LOCK_WAIT_MS: '2000',
+        HOOK_RETRY_LOCK_POLL_MS: '5',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf-8');
+    child.stderr.setEncoding('utf-8');
+    child.stdout.on('data', chunk => { stdout += chunk; });
+    child.stderr.on('data', chunk => { stderr += chunk; });
+    child.once('error', reject);
+    child.once('close', (status, signal) => resolve({ status, signal, stdout, stderr }));
   });
 }
 
@@ -277,6 +310,97 @@ describe('qoder-hook-processor cold-start recovery', () => {
     expect(result.status).toBe(0);
     expect(userBoundaryPrompts(readHistory())).toEqual(['IDE prompt']);
     expect(readHistory().some(record => record['event.name'] === 'llm.response')).toBe(true);
+  });
+
+  it('commits one copy when duplicate retries race on the same Stop window', async () => {
+    const progress = hookEvent => ({
+      type: 'progress',
+      timestamp: '2026-08-05T04:00:20.000Z',
+      data: { hookEvent, hookName: hookEvent },
+    });
+    const rows = [
+      { type: 'session_meta', sessionId: 'ide-session' },
+      progress('SessionStart'),
+      {
+        type: 'user',
+        timestamp: '2026-08-05T04:00:16.000Z',
+        sessionId: 'ide-session',
+        message: { role: 'user', content: 'one prompt' },
+      },
+      {
+        type: 'assistant',
+        timestamp: '2026-08-05T04:00:19.000Z',
+        sessionId: 'ide-session',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'one answer' }] },
+      },
+      progress('Stop'),
+    ];
+    fs.writeFileSync(transcriptPath, `${rows.map(row => JSON.stringify(row)).join('\n')}\n`);
+
+    const results = await Promise.all([
+      runRetryAsync(rows.length - 1, 'ide-session'),
+      runRetryAsync(rows.length - 1, 'ide-session'),
+    ]);
+
+    expect(results.map(result => result.status)).toEqual([0, 0]);
+    expect(userBoundaryPrompts(readHistory())).toEqual(['one prompt']);
+    expect(readHistory().filter(record => record['event.name'] === 'llm.response')).toHaveLength(1);
+  });
+
+  it('serializes adjacent Stop retries and commits both Turns once', async () => {
+    const progress = hookEvent => ({
+      type: 'progress',
+      timestamp: '2026-08-05T04:00:20.000Z',
+      data: { hookEvent, hookName: hookEvent },
+    });
+    const rows = [
+      { type: 'session_meta', sessionId: 'ide-session' },
+      progress('UserPromptSubmit'),
+      {
+        type: 'user',
+        timestamp: '2026-08-05T04:00:16.000Z',
+        sessionId: 'ide-session',
+        message: { role: 'user', content: 'first prompt' },
+      },
+      {
+        type: 'assistant',
+        timestamp: '2026-08-05T04:00:19.000Z',
+        sessionId: 'ide-session',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'first answer' }] },
+      },
+      progress('Stop'),
+      progress('UserPromptSubmit'),
+      {
+        type: 'user',
+        timestamp: '2026-08-05T04:00:21.000Z',
+        sessionId: 'ide-session',
+        message: { role: 'user', content: 'second prompt' },
+      },
+      {
+        type: 'assistant',
+        timestamp: '2026-08-05T04:00:24.000Z',
+        sessionId: 'ide-session',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'second answer' }] },
+      },
+      progress('Stop'),
+    ];
+    fs.writeFileSync(transcriptPath, `${rows.map(row => JSON.stringify(row)).join('\n')}\n`);
+
+    const first = runRetryAsync(4, 'ide-session', { retryDelay: '50' });
+    await new Promise(resolve => setTimeout(resolve, 10));
+    const second = runRetryAsync(8, 'ide-session', { retryDelay: '50' });
+    const results = await Promise.all([first, second]);
+
+    expect(results.map(result => result.status)).toEqual([0, 0]);
+    expect(userBoundaryPrompts(readHistory())).toEqual(['first prompt', 'second prompt']);
+    expect(readHistory().filter(record => record['event.name'] === 'llm.response')).toHaveLength(2);
+
+    const cursorDir = path.join(dataDir, 'state', 'hooks', 'qoder-line-records');
+    const cursor = JSON.parse(fs.readFileSync(
+      path.join(cursorDir, fs.readdirSync(cursorDir)[0]),
+      'utf-8',
+    ));
+    expect(cursor.last_line_count).toBe(rows.length);
   });
 
   it('keeps equal PostToolUse events from separate tool cycles', () => {

--- a/tests/unit/hooks/qoder-hook-processor-cold-start.test.mjs
+++ b/tests/unit/hooks/qoder-hook-processor-cold-start.test.mjs
@@ -78,6 +78,7 @@ function runRetry(triggerEndLine, sessionId = 'session-old') {
       ...process.env,
       LOONGSUITE_PILOT_DATA_DIR: dataDir,
       HOOK_RETRY_DELAY: '0',
+      HOOK_RETRY_BOUNDARY_POLL_INTERVAL_MS: '0',
     },
     encoding: 'utf-8',
     timeout: 30_000,
@@ -189,7 +190,6 @@ describe('qoder-hook-processor cold-start recovery', () => {
       ...targetTurn,
       progress('Stop'),
       progress('Stop'),
-      progress('SessionEnd'),
       { type: 'session_meta', sessionId: 'session-old' },
       progress('UserPromptSubmit'),
       queuedPrompt,
@@ -222,12 +222,61 @@ describe('qoder-hook-processor cold-start recovery', () => {
         },
       },
       progress('Stop'),
-      progress('SessionEnd'),
     ].map(row => JSON.stringify(row)).join('\n') + '\n');
 
     const second = runRetry(secondTriggerEndLine);
     expect(second.status).toBe(0);
     expect(userBoundaryPrompts(readHistory())).toEqual(['target prompt', 'queued prompt']);
+  });
+
+  it('collects a real IDE-shaped Turn that ends with Stop at stable EOF', () => {
+    const progress = hookEvent => ({
+      type: 'progress',
+      timestamp: '2026-08-05T04:00:20.496534Z',
+      data: { hookEvent, hookName: hookEvent },
+    });
+    const rows = [
+      {
+        type: 'session_meta',
+        sessionId: 'ide-session',
+        data: { meta_type: 'session_info', content: { mode: 'agent', session_type: 'assistant' } },
+      },
+      progress('SessionStart'),
+      {
+        type: 'user',
+        uuid: 'ide-user',
+        timestamp: '2026-08-05T04:00:16.005147Z',
+        sessionId: 'ide-session',
+        message: { role: 'user', content: 'IDE prompt' },
+      },
+      {
+        type: 'assistant',
+        uuid: 'ide-thinking',
+        timestamp: '2026-08-05T04:00:19.821317Z',
+        sessionId: 'ide-session',
+        message: { role: 'assistant', content: [{ type: 'thinking', thinking: 'reasoning' }] },
+      },
+      {
+        type: 'assistant',
+        uuid: 'ide-text',
+        timestamp: '2026-08-05T04:00:19.821627Z',
+        sessionId: 'ide-session',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'IDE answer' }] },
+      },
+      progress('Stop'),
+    ];
+    fs.writeFileSync(
+      transcriptPath,
+      `${rows.map(row => JSON.stringify(row)).join('\n')}\n`,
+    );
+
+    // The Stop hook snapshot ended immediately before Qoder appended its Stop
+    // progress row, matching the production race from the attached user log.
+    const result = runRetry(rows.length - 1, 'ide-session');
+
+    expect(result.status).toBe(0);
+    expect(userBoundaryPrompts(readHistory())).toEqual(['IDE prompt']);
+    expect(readHistory().some(record => record['event.name'] === 'llm.response')).toBe(true);
   });
 
   it('keeps equal PostToolUse events from separate tool cycles', () => {

--- a/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
+++ b/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
@@ -460,7 +460,7 @@ describe('findTriggeredTurnWindow', () => {
     });
   });
 
-  it('waits instead of consuming the next prompt when SessionEnd is missing', () => {
+  it('uses the next prompt as a boundary when SessionEnd is missing', () => {
     const rows = [
       progress('UserPromptSubmit'),
       user('target prompt'),
@@ -471,9 +471,29 @@ describe('findTriggeredTurnWindow', () => {
     ];
     const transcript = writeTranscript('missing-session-end.jsonl', rows);
 
-    expect(findTriggeredTurnWindow(readTranscriptSnapshot(transcript), 3)).toMatchObject({
+    expect(findTriggeredTurnWindow(readTranscriptSnapshot(transcript), 3)).toEqual({
+      status: 'complete',
+      reason: 'next-prompt',
+      startLine: 0,
+      stopLine: 3,
+      endLine: 4,
+    });
+  });
+
+  it('returns a stable-EOF candidate when Stop is the final row', () => {
+    const rows = [
+      user('target prompt'),
+      assistant('target answer'),
+      progress('Stop'),
+    ];
+    const transcript = writeTranscript('stop-at-eof.jsonl', rows);
+
+    expect(findTriggeredTurnWindow(readTranscriptSnapshot(transcript), 2)).toEqual({
       status: 'waiting',
-      reason: 'next-prompt-before-session-end',
+      reason: 'stop-at-eof',
+      startLine: 0,
+      stopLine: 2,
+      endLine: 3,
     });
   });
 

--- a/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
+++ b/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
@@ -3,6 +3,8 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
+  acquireRetryLock,
+  assessStableEofCandidate,
   buildLlmBoundaries,
   buildEventsFromBoundaries,
   findIncrementalTurnEndLine,
@@ -73,6 +75,32 @@ describe('tryAcquireRetryLock', () => {
     fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid, sessionId: 'old', startedAt: 1 }));
     expect(tryAcquireRetryLock('/tmp/t.jsonl', 'sess-2', lockDir)).toBe(true);
     expect(readRetryLock(lockPath).sessionId).toBe('sess-2');
+  });
+});
+
+describe('acquireRetryLock', () => {
+  it('waits for a peer lock and acquires it after release', async () => {
+    expect(tryAcquireRetryLock('/tmp/t.jsonl', 'peer', lockDir)).toBe(true);
+    const waiting = acquireRetryLock('/tmp/t.jsonl', 'sess-2', {
+      dir: lockDir,
+      waitMs: 500,
+      pollMs: 5,
+    });
+    setTimeout(() => releaseRetryLock('/tmp/t.jsonl', lockDir), 20);
+
+    await expect(waiting).resolves.toBe(true);
+    expect(readRetryLock(retryLockPath('/tmp/t.jsonl', lockDir)).sessionId).toBe('sess-2');
+  });
+
+  it('times out without deleting a live peer lock', async () => {
+    expect(tryAcquireRetryLock('/tmp/t.jsonl', 'peer', lockDir)).toBe(true);
+
+    await expect(acquireRetryLock('/tmp/t.jsonl', 'sess-2', {
+      dir: lockDir,
+      waitMs: 20,
+      pollMs: 5,
+    })).resolves.toBe(false);
+    expect(readRetryLock(retryLockPath('/tmp/t.jsonl', lockDir)).sessionId).toBe('peer');
   });
 });
 
@@ -494,6 +522,35 @@ describe('findTriggeredTurnWindow', () => {
       startLine: 0,
       stopLine: 2,
       endLine: 3,
+    });
+  });
+
+  it('requires two identical hashed snapshots before accepting Stop at EOF', () => {
+    const waitingWindow = {
+      status: 'waiting',
+      reason: 'stop-at-eof',
+      startLine: 0,
+      stopLine: 2,
+      endLine: 3,
+    };
+    const first = assessStableEofCandidate(null, waitingWindow, { contentHash: 'hash-a' });
+    expect(first.targetWindow.status).toBe('waiting');
+
+    const changed = assessStableEofCandidate(
+      first.candidateKey,
+      waitingWindow,
+      { contentHash: 'hash-b' },
+    );
+    expect(changed.targetWindow.status).toBe('waiting');
+
+    const stable = assessStableEofCandidate(
+      changed.candidateKey,
+      waitingWindow,
+      { contentHash: 'hash-b' },
+    );
+    expect(stable.targetWindow).toMatchObject({
+      status: 'complete',
+      reason: 'stable-stop-eof',
     });
   });
 


### PR DESCRIPTION
## 问题

PR #212 将 retry 改为 Stop 锚定的固定窗口，避免延迟读取 EOF 时把排队的下一轮 prompt 吞进上一轮。但 Qoder Desktop / JetBrains transcript 在正常一轮结束后可能只写入 `Stop` 并停在 EOF，不会写 `SessionEnd` 或 qodercli 的 `last-prompt`。现有 retry 因此持续返回 `session-end-not-found`，整轮 trace/token 都不会产出。

## 修复

- 保留 #212 的 Stop 锚定和固定窗口设计。
- `Stop` 后出现下一轮真实 prompt 时，将该 prompt 作为右边界并排除在当前轮之外。
- `Stop` 位于 EOF 时，只有连续两次 transcript 快照完全一致才接受该 EOF，避免读取仍在增长的文件。
- 保持 `SessionEnd` / `last-prompt` 的显式终止标记优先。
- 增加贴近 Qoder JetBrains 实际 transcript 结构的回归测试，并覆盖无 `SessionEnd` 的连续两轮场景。

## 验证

- `npm run typecheck`
- 针对性测试：6 个文件、82 个用例通过
- 全量测试：207 个文件、2416 个用例通过（11 个仓库既有 skipped）