### PR TITLE
fix: remove installed hook and stop re-injecting it when an agent is disabled

### DIFF
--- a/assets/skills/loongsuite-pilot-ops/references/watchdog-diagnostics.md
+++ b/assets/skills/loongsuite-pilot-ops/references/watchdog-diagnostics.md
@@ -12,9 +12,9 @@ HookWatchdog 是 pilot daemon 内置的巡检器，每 5 分钟（`intervalMs`�
 
 检测 agent settings.json 文件中 `hooks.<event>` 数组是否包含 pilot 的 hook 命令条目。
 
-targets 来源有两种：
-- `HookWatchdog.defaultTargets()`：硬编码的 otel plugin 类（claude-code / codex），用外部安装命令修复
-- `orchestrator.buildHookWatchdogTargets()`：从 `agents.d/*.json` 中 `deployMode: "hook"` 的定义动态构建，用 `DeploymentManager.deploySingle()` 修复
+targets 来源：
+- `orchestrator.buildHookWatchdogTargets()`：从 `agents.d/*.json` 中 `deployMode: "hook"` 的定义动态构建，用 `DeploymentManager.deploySingle()` 修复。每个 target 带 `enabled()` 门禁（`config.agents[id].enabled !== false`），被禁用的 agent 运行期跳过，不再重注入。
+- （已移除）早期的 `HookWatchdog.defaultTargets()` 硬编码 otel plugin 目标已删除：claude-code / codex 已是 hook 模式并由上面的动态构建覆盖，旧 otel 缓存目录也由 plugin-migration 主动清理。
 
 修复方式二选一：
 - **repairFn**（优先）：调用 `DeploymentManager.deploySingle(def)` 重新执行 `HookStrategy.deploy()`，重写 settings.json hook 条目

--- a/src/cli-probe.ts
+++ b/src/cli-probe.ts
@@ -40,6 +40,14 @@ async function main(): Promise<void> {
     dataDir,
   });
 
+  // --list: enumerate the same set of agents as a normal probe, but skip the
+  // on-disk machine detection. Used by the installer when the user explicitly
+  // picks agents (--agents), where the detection result is irrelevant — we only
+  // need each id to write the enable/disable gate. Agents with no detection
+  // rules (e.g. internal *-local-runtime runtimes) stay excluded here, exactly
+  // as a normal probe excludes them — they are not user-selectable.
+  const listOnly = process.argv.includes('--list');
+
   const defs = await loader.load();
   const results: ProbeResult[] = [];
 
@@ -47,7 +55,7 @@ async function main(): Promise<void> {
     if (def.detection.paths.length === 0 && def.detection.commands.length === 0) {
       continue;
     }
-    const detected = await detectAgent(def.detection);
+    const detected = listOnly ? false : await detectAgent(def.detection);
     const reason = detected ? await findDetectionReason(def.detection) : '';
     results.push({
       id: def.id,

--- a/src/core/hook-watchdog.ts
+++ b/src/core/hook-watchdog.ts
@@ -4,7 +4,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import type { HookWatchdogConfig } from '../types/index.js';
-import { directoryExists, fileExists, resolveHome } from '../utils/fs-utils.js';
+import { directoryExists, fileExists } from '../utils/fs-utils.js';
 import { readJsonDocument, type JsonSyntax } from '../utils/json-document.js';
 import { createLogger } from '../utils/logger.js';
 
@@ -30,6 +30,14 @@ export interface PluginCheckTarget {
   installArgs?: string[];
   /** Direct repair function (for hook-type repair via HookManager). Takes precedence over binPath. */
   repairFn?: () => Promise<boolean>;
+
+  /**
+   * Whether the owning agent is enabled by the user's selection
+   * (config.agents[<id>].enabled). When this returns false the target is
+   * neither checked nor repaired — a disabled agent must never have its hook
+   * (re)injected. Omitted → treated as enabled (backward compatible).
+   */
+  enabled?: () => boolean | Promise<boolean>;
 }
 
 export interface InterceptCheckTarget {
@@ -79,7 +87,7 @@ export interface CheckResult {
 
 export interface TargetResult {
   agentId: string;
-  status: 'healthy' | 'repaired' | 'cooldown' | 'unavailable' | 'invalid-config' | 'repair-failed';
+  status: 'healthy' | 'repaired' | 'cooldown' | 'unavailable' | 'invalid-config' | 'repair-failed' | 'disabled';
   expected?: number;
   found?: number;
   missing?: string[];
@@ -112,7 +120,7 @@ export class HookWatchdog {
     interceptTargets?: InterceptCheckTarget[],
   ) {
     this.config = config;
-    this.targets = targets ?? HookWatchdog.defaultTargets();
+    this.targets = targets ?? [];
     this.interceptTargets = interceptTargets ?? [];
   }
 
@@ -151,7 +159,7 @@ export class HookWatchdog {
     for (const target of this.targets) {
       try {
         const result = await this.checkTarget(target);
-        if (result.status === 'unavailable' || result.status === 'invalid-config') {
+        if (result.status === 'unavailable' || result.status === 'invalid-config' || result.status === 'disabled') {
           summary.skipped++;
         } else if (result.status === 'repaired') {
           summary.repaired++;
@@ -172,6 +180,14 @@ export class HookWatchdog {
   }
 
   private async checkTarget(target: PluginCheckTarget): Promise<TargetResult> {
+    if (target.enabled && !(await target.enabled())) {
+      logger.debug('hook-watchdog.skipped', {
+        agent: target.agentId,
+        reason: 'disabled',
+      });
+      return { agentId: target.agentId, status: 'disabled' };
+    }
+
     const settingsDirOk = await directoryExists(path.dirname(target.settingsPath));
     if (!settingsDirOk) {
       logger.debug('hook-watchdog.skipped', {
@@ -460,42 +476,6 @@ export class HookWatchdog {
     }
   }
 
-  // ─── Default targets (hardcoded, matching existing style) ───────────────
-
-  static defaultTargets(): PluginCheckTarget[] {
-    return [
-      {
-        agentId: 'claude-code',
-        settingsPath: resolveHome('~/.claude/settings.json'),
-        expectedHooks: [
-          'Stop',
-          'SubagentStart',
-          'SubagentStop',
-        ],
-        binPath: resolveHome(
-          '~/.cache/opentelemetry.instrumentation.claude/package/bin/otel-claude-hook',
-        ),
-        installArgs: ['install', '--user', '--no-alias', '--quiet'],
-        markers: ['otel-claude-hook', 'opentelemetry.instrumentation.claude'],
-      },
-      {
-        agentId: 'codex',
-        settingsPath: resolveHome('~/.codex/hooks.json'),
-        expectedHooks: [
-          'SessionStart',
-          'UserPromptSubmit',
-          'PreToolUse',
-          'PostToolUse',
-          'Stop',
-        ],
-        binPath: resolveHome(
-          '~/.cache/opentelemetry.instrumentation.codex/package/bin/otel-codex-hook',
-        ),
-        installArgs: ['install'],
-        markers: ['otel-codex-hook', 'opentelemetry.instrumentation.codex'],
-      },
-    ];
-  }
 
   /**
    * Shell-rc intercept block definitions (qodercli + claude-code).

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -243,10 +243,7 @@ export class Orchestrator extends EventEmitter {
     this.logRetentionService.start();
 
     // 10. Start hook watchdog (periodically restores hooks overwritten by other tools)
-    const hookWatchdogTargets = [
-      ...HookWatchdog.defaultTargets(),
-      ...this.buildHookWatchdogTargets(),
-    ];
+    const hookWatchdogTargets = this.buildHookWatchdogTargets();
     const interceptTargets = [
       ...HookWatchdog.defaultInterceptTargets(this.dataDir, (id) => this.isAgentGatedEnabled(id)),
       ...this.buildPluginInjectInterceptTargets(),
@@ -415,7 +412,6 @@ export class Orchestrator extends EventEmitter {
 
     for (const def of defs) {
       if (def.deployMode !== 'hook' || !def.hook) continue;
-      if (!this.isAgentGatedEnabled(def.id)) continue;
 
       const scriptName = path.basename(def.hook.hookCommand.split(' ')[0]);
       targets.push({
@@ -424,6 +420,10 @@ export class Orchestrator extends EventEmitter {
         settingsSyntax: def.hook.settingsSyntax,
         expectedHooks: def.hook.events,
         markers: [scriptName],
+        // Runtime gate: a user who has turned this agent off (config.agents[id]
+        // .enabled === false) must never have its hook re-injected. Evaluated on
+        // each check so a config change takes effect without rebuilding targets.
+        enabled: () => this.isAgentGatedEnabled(def.id),
         repairFn: () => this.deploymentManager.deploySingle(def).then(r => r.success),
       });
     }

--- a/src/deployment/deployment-manager.ts
+++ b/src/deployment/deployment-manager.ts
@@ -83,13 +83,7 @@ export class DeploymentManager {
 
     for (const def of this.definitions) {
       if (enabled && !enabled(def)) {
-        logger.debug('agent excluded from deployment', { agentId: def.id });
-        results.push({
-          success: true,
-          agentId: def.id,
-          deployMode: def.deployMode,
-          skipped: true,
-        });
+        results.push(await this.undeployDisabledAgent(def));
         continue;
       }
       try {
@@ -108,6 +102,52 @@ export class DeploymentManager {
     logger.info('deployAll complete', { total: results.length, deployed, skipped, failed });
 
     return results;
+  }
+
+  /**
+   * Handle a hook agent the user has turned off (config.agents[<id>].enabled ===
+   * false). Skipping (re)deployment alone is not enough: a hook installed on a
+   * prior run — while the agent was still enabled — stays in the tool's
+   * settings file and keeps firing. So when a deployed-agents record exists we
+   * actively undeploy it (mirroring the intercept watchdog's disabled-cleanup),
+   * then drop the record so this runs at most once per disable.
+   *
+   * Gated on an existing state record: an agent the user has never enabled has
+   * no record, so we never touch its settings file (matching the "does not
+   * detect or deploy disabled agents" contract).
+   *
+   * Scope is limited to hook agents — plugin-probe / plugin-inject /
+   * directory-plugin integrations self-heal through their own enabled-gated
+   * watchdog targets and carry heavier undeploy semantics (uninstall scripts,
+   * JSONC rewrites), so their disable path is intentionally left unchanged.
+   *
+   * Best-effort: undeploy failure is logged but the record is still cleared to
+   * avoid re-running the (partial) cleanup on every startup.
+   */
+  private async undeployDisabledAgent(def: AgentDefinition): Promise<DeployResult> {
+    const result: DeployResult = {
+      success: true,
+      agentId: def.id,
+      deployMode: def.deployMode,
+      skipped: true,
+    };
+
+    if (def.deployMode !== 'hook' || !this.state[def.id]) {
+      logger.debug('agent excluded from deployment', { agentId: def.id });
+      return result;
+    }
+
+    logger.info('agent disabled — removing previously deployed hook', { agentId: def.id });
+    try {
+      const ok = await this.hookStrategy.undeploy(def);
+      if (!ok) {
+        logger.warn('agent disable undeploy incomplete', { agentId: def.id });
+      }
+    } catch (err) {
+      logger.error('agent disable undeploy failed', { agentId: def.id, error: String(err) });
+    }
+    delete this.state[def.id];
+    return result;
   }
 
   deploySingle(def: AgentDefinition): Promise<DeployResult> {

--- a/src/deployment/deployment-manager.ts
+++ b/src/deployment/deployment-manager.ts
@@ -121,8 +121,11 @@ export class DeploymentManager {
    * watchdog targets and carry heavier undeploy semantics (uninstall scripts,
    * JSONC rewrites), so their disable path is intentionally left unchanged.
    *
-   * Best-effort: undeploy failure is logged but the record is still cleared to
-   * avoid re-running the (partial) cleanup on every startup.
+   * The record is dropped only once cleanup succeeds. Hook uninstall is
+   * idempotent (a no-op when nothing matches — hook-manager.ts), so a failure
+   * means the hook is still in the settings file; we keep the record so the
+   * next startup retries rather than early-returning (:135) and leaking a
+   * firing hook forever (the watchdog also skips it via enabled()===false).
    */
   private async undeployDisabledAgent(def: AgentDefinition): Promise<DeployResult> {
     const result: DeployResult = {
@@ -138,14 +141,19 @@ export class DeploymentManager {
     }
 
     logger.info('agent disabled — removing previously deployed hook', { agentId: def.id });
+    let ok = false;
     try {
-      const ok = await this.hookStrategy.undeploy(def);
-      if (!ok) {
-        logger.warn('agent disable undeploy incomplete', { agentId: def.id });
-      }
+      ok = await this.hookStrategy.undeploy(def);
     } catch (err) {
       logger.error('agent disable undeploy failed', { agentId: def.id, error: String(err) });
     }
+
+    if (!ok) {
+      // Keep the record so the idempotent cleanup is retried next start.
+      logger.warn('agent disable undeploy incomplete — keeping record to retry', { agentId: def.id });
+      return { ...result, success: false, skipped: false, error: 'hook undeploy incomplete' };
+    }
+
     delete this.state[def.id];
     return result;
   }

--- a/src/deployment/hook-strategy.ts
+++ b/src/deployment/hook-strategy.ts
@@ -334,7 +334,12 @@ export class HookStrategy implements DeployStrategy {
   }
 
   async undeploy(def: AgentDefinition): Promise<boolean> {
-    const hookDefs = this.buildHookDefinitions(def);
+    // Mirror deploy(): also remove retiredEvents (e.g. codex's PreToolUse/
+    // PostToolUse from an older version). Otherwise disabling a codex agent
+    // that was first deployed by an old build leaves those retired hooks
+    // firing, since current events don't cover them.
+    const retiredHookDefs = this.buildRetiredHookDefinitions(def);
+    const hookDefs = [...this.buildHookDefinitions(def), ...retiredHookDefs];
     let allOk = true;
     for (const hookDef of hookDefs) {
       const ok = await this.hookManager.uninstallHook(hookDef);
@@ -346,7 +351,11 @@ export class HookStrategy implements DeployStrategy {
         const cfg = def.hook.trustToml;
         const configPath = resolveHome(cfg.configPath);
         const hooksJsonAbsPath = path.resolve(resolveHome(def.hook.settingsPath));
-        removeTrustBlock(configPath, cfg.marker, hooksJsonAbsPath, def.hook.events);
+        const retiredEvents = retiredHookDefs.map(d => d.hookJsonPath.at(-1) as string);
+        removeTrustBlock(configPath, cfg.marker, hooksJsonAbsPath, [
+          ...def.hook.events,
+          ...retiredEvents,
+        ]);
       } catch (err) {
         logger.warn('codex trust cleanup failed (non-blocking)', { error: String(err) });
       }

--- a/tests/unit/core/hook-watchdog.test.ts
+++ b/tests/unit/core/hook-watchdog.test.ts
@@ -286,6 +286,58 @@ describe('HookWatchdog', () => {
     });
   });
 
+  describe('disabled', () => {
+    it('does not repair a plugin target whose agent is disabled, even with hooks missing', async () => {
+      const target = makeClaudeTarget(tmpDir, { enabled: () => false });
+      await makeBin(target.binPath);
+
+      // Hooks are missing — a repair would fire if the target were enabled.
+      const settings = buildHealthySettings(target);
+      delete (settings.hooks as Record<string, unknown>).Stop;
+      await writeSettings(target.settingsPath, settings);
+
+      const wd = new HookWatchdog(makeConfig(), [target]);
+      const summary = await wd.runCheck();
+
+      expect(summary).toEqual({ checked: 0, repaired: 0, skipped: 1 });
+      expect(spawnCalls).toHaveLength(0);
+    });
+
+    it('does not invoke repairFn for a disabled hook target', async () => {
+      const repairFn = vi.fn(async () => true);
+      const target: PluginCheckTarget = {
+        agentId: 'claude-code',
+        settingsPath: path.join(tmpDir, '.claude', 'settings.json'),
+        expectedHooks: ['Stop'],
+        markers: ['claude-code-loongsuite-pilot-hook.sh'],
+        repairFn,
+        enabled: () => false,
+      };
+      await fs.mkdir(path.dirname(target.settingsPath), { recursive: true });
+      // No settings.json → all hooks missing → repair would fire if enabled.
+
+      const wd = new HookWatchdog(makeConfig(), [target]);
+      const summary = await wd.runCheck();
+
+      expect(summary).toEqual({ checked: 0, repaired: 0, skipped: 1 });
+      expect(repairFn).not.toHaveBeenCalled();
+    });
+
+    it('still repairs when enabled() returns true', async () => {
+      const target = makeClaudeTarget(tmpDir, { enabled: () => true });
+      await makeBin(target.binPath);
+      const settings = buildHealthySettings(target);
+      delete (settings.hooks as Record<string, unknown>).Stop;
+      await writeSettings(target.settingsPath, settings);
+
+      const wd = new HookWatchdog(makeConfig(), [target]);
+      const summary = await wd.runCheck();
+
+      expect(summary.repaired).toBe(1);
+      expect(spawnCalls).toHaveLength(1);
+    });
+  });
+
   describe('repair failure', () => {
     it('does not throw when spawn exits non-zero', async () => {
       const target = makeClaudeTarget(tmpDir);

--- a/tests/unit/deployment/deployment-manager.test.ts
+++ b/tests/unit/deployment/deployment-manager.test.ts
@@ -147,6 +147,62 @@ describe('DeploymentManager', () => {
       });
     });
 
+    it('undeploys a hook agent that was deployed then disabled', async () => {
+      const settingsPath = path.join(tmpDir, 'toggle-hooks.json');
+      const def: AgentDefinition = {
+        id: 'toggle-agent',
+        displayName: 'Toggle',
+        deployMode: 'hook',
+        detection: { paths: [], commands: [] },
+        hook: {
+          settingsPath,
+          events: ['Stop'],
+          hookCommand: '/opt/toggle.sh',
+          format: 'flat',
+        },
+      };
+      await writeAgentDef(def);
+      vi.mocked(detectAgent).mockResolvedValue(true);
+
+      const mgr = makeManager();
+
+      // 1) enabled → hook is installed into the settings file
+      await mgr.deployAll(() => true);
+      const afterDeploy = await fs.readFile(settingsPath, 'utf-8');
+      expect(afterDeploy).toContain('/opt/toggle.sh');
+
+      // 2) disabled → the previously installed hook is removed, not merely skipped
+      const results = await mgr.deployAll(() => false);
+      expect(results.find(result => result.agentId === def.id)?.skipped).toBe(true);
+      const afterDisable = await fs.readFile(settingsPath, 'utf-8');
+      expect(afterDisable).not.toContain('/opt/toggle.sh');
+    });
+
+    it('does not touch settings for an agent disabled without a prior deployment', async () => {
+      const settingsPath = path.join(tmpDir, 'never-deployed-hooks.json');
+      const def: AgentDefinition = {
+        id: 'never-deployed-agent',
+        displayName: 'Never Deployed',
+        deployMode: 'hook',
+        detection: { paths: [], commands: [] },
+        hook: {
+          settingsPath,
+          events: ['Stop'],
+          hookCommand: '/opt/never.sh',
+          format: 'flat',
+        },
+      };
+      await writeAgentDef(def);
+      vi.mocked(detectAgent).mockResolvedValue(true);
+
+      const mgr = makeManager();
+      const results = await mgr.deployAll(() => false);
+
+      expect(results.find(result => result.agentId === def.id)?.skipped).toBe(true);
+      // No state record → cleanup must not create/rewrite the settings file.
+      await expect(fs.stat(settingsPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+
     it('continues when one agent fails', async () => {
       const def1: AgentDefinition = {
         id: 'agent-ok',

--- a/tests/unit/deployment/deployment-manager.test.ts
+++ b/tests/unit/deployment/deployment-manager.test.ts
@@ -203,6 +203,87 @@ describe('DeploymentManager', () => {
       await expect(fs.stat(settingsPath)).rejects.toMatchObject({ code: 'ENOENT' });
     });
 
+    it('keeps the deploy record when undeploy fails so cleanup is retried', async () => {
+      const def: AgentDefinition = {
+        id: 'retry-agent',
+        displayName: 'Retry',
+        deployMode: 'hook',
+        detection: { paths: [], commands: [] },
+        hook: {
+          settingsPath: path.join(tmpDir, 'retry-hooks.json'),
+          events: ['Stop'],
+          hookCommand: '/opt/retry.sh',
+          format: 'flat',
+        },
+      };
+      await writeAgentDef(def);
+      vi.mocked(detectAgent).mockResolvedValue(true);
+
+      const mgr = makeManager();
+      await mgr.deployAll(() => true); // record created
+
+      const undeploySpy = vi
+        .spyOn((mgr as unknown as { hookStrategy: { undeploy: (d: AgentDefinition) => Promise<boolean> } }).hookStrategy, 'undeploy')
+        .mockResolvedValue(false);
+
+      // 1st disable: undeploy fails → record kept, result surfaced as failed.
+      const first = await mgr.deployAll(() => false);
+      expect(first.find(result => result.agentId === def.id)?.success).toBe(false);
+      expect(undeploySpy).toHaveBeenCalledTimes(1);
+
+      // 2nd disable: record still present → cleanup retried (not early-returned).
+      await mgr.deployAll(() => false);
+      expect(undeploySpy).toHaveBeenCalledTimes(2);
+
+      // Once cleanup finally succeeds the record is dropped and retries stop.
+      undeploySpy.mockResolvedValue(true);
+      await mgr.deployAll(() => false);
+      expect(undeploySpy).toHaveBeenCalledTimes(3);
+      await mgr.deployAll(() => false);
+      expect(undeploySpy).toHaveBeenCalledTimes(3);
+    });
+
+    it('removes retired hook events on disable, not just current events', async () => {
+      const settingsPath = path.join(tmpDir, 'retired-hooks.json');
+      const withBoth: AgentDefinition = {
+        id: 'retired-agent',
+        displayName: 'Retired',
+        deployMode: 'hook',
+        detection: { paths: [], commands: [] },
+        hook: {
+          settingsPath,
+          events: ['Stop', 'PreToolUse'],
+          hookCommand: '/opt/retired.sh',
+          format: 'flat',
+        },
+      };
+      await writeAgentDef(withBoth);
+      vi.mocked(detectAgent).mockResolvedValue(true);
+
+      const mgr = makeManager();
+      await mgr.deployAll(() => true); // installs Stop + PreToolUse
+      const afterDeploy = JSON.parse(await fs.readFile(settingsPath, 'utf-8'));
+      expect(afterDeploy.hooks.Stop).toBeDefined();
+      expect(afterDeploy.hooks.PreToolUse).toBeDefined();
+
+      // New version retires PreToolUse (current events drop it).
+      await writeAgentDef({
+        ...withBoth,
+        hook: {
+          settingsPath,
+          events: ['Stop'],
+          retiredEvents: ['PreToolUse'],
+          hookCommand: '/opt/retired.sh',
+          format: 'flat',
+        },
+      });
+
+      // Disable → must remove BOTH the current Stop hook and the retired one.
+      await mgr.deployAll(() => false);
+      const afterDisable = await fs.readFile(settingsPath, 'utf-8');
+      expect(afterDisable).not.toContain('/opt/retired.sh');
+    });
+
     it('continues when one agent fails', async () => {
       const def1: AgentDefinition = {
         id: 'agent-ok',


### PR DESCRIPTION
## What & why

Fixes the "hook still fires after the agent is disabled" / "claude hook injected even though only qoder was selected" class of problems.

## Changes

- **deployment**: when `config.agents.<id>.enabled` is set to `false`, `deployAll` now calls `undeploy` on disabled hook-mode agents that have a deploy record, so the hook previously written into the tool's settings file is actively removed and the deploy record cleared. Gated on the deploy record, so an agent that was never enabled is never touched. hook mode only; `plugin-probe` / `plugin-inject` / `directory-plugin` keep their existing gated watchdog behaviour.
- **watchdog**: add an `enabled()` gate to `PluginCheckTarget` (matching `InterceptCheckTarget`), intercepted at the top of `checkTarget` with a new `'disabled'` status counted as skipped, so a stale otel bin can no longer cause a disabled agent's hook to be re-injected.
- **watchdog**: remove the redundant `HookWatchdog.defaultTargets()` (the legacy claude-code/codex otel plugin targets) — that path is already covered by `buildHookWatchdogTargets` and contradicts `plugin-migration`, which purges those otel cache dirs. The default target list is now empty and the per-agent gate is evaluated at runtime via `enabled()` rather than skipped at construction, so a config change takes effect without rebuilding targets.
- **cli-probe**: add a `--list` mode that enumerates agent definitions without running on-disk detection (`detected` always `false`); the enumerated set matches a normal probe (empty-detection internal runtimes stay excluded).

## Tests

- `tests/unit/deployment/deployment-manager.test.ts`: undeploy-on-disable behaviour.
- `tests/unit/core/hook-watchdog.test.ts`: `disabled` status / `enabled()` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
