### PR TITLE
feat: support custom agent name and instance id across agents

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -107,7 +107,7 @@ loongsuite-pilot info
 | 任务 | 文档 |
 |------|------|
 | 选择采集哪些 Agent，控制内容采集策略 | [Agent 配置](docs/zh-CN/agents.md) |
-| 为 AgentTeams Worker 标记 Agent 名称和实例 | [AgentTeams Worker 上下文](docs/zh-CN/agentteams-worker-context.md) |
+| 自定义 Agent 名称和实例 | [自定义 `gen_ai.agent.name` 和 `agentteams.instance.id`](docs/zh-CN/custom-agent-identity.md) |
 | 写入本地 JSONL 日志 | [本地 JSONL 输出](docs/zh-CN/local-jsonl-output.md) |
 | 上报日志到 SLS | [SLS 输出](docs/zh-CN/sls-output.md) |
 | 上报 OTLP Trace | [Trace 输出](docs/zh-CN/trace-output.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -107,6 +107,7 @@ loongsuite-pilot info
 | 任务 | 文档 |
 |------|------|
 | 选择采集哪些 Agent，控制内容采集策略 | [Agent 配置](docs/zh-CN/agents.md) |
+| 为 AgentTeams Worker 标记 Agent 名称和实例 | [AgentTeams Worker 上下文](docs/zh-CN/agentteams-worker-context.md) |
 | 写入本地 JSONL 日志 | [本地 JSONL 输出](docs/zh-CN/local-jsonl-output.md) |
 | 上报日志到 SLS | [SLS 输出](docs/zh-CN/sls-output.md) |
 | 上报 OTLP Trace | [Trace 输出](docs/zh-CN/trace-output.md) |

--- a/assets/hooks/cursor-hook-processor.mjs
+++ b/assets/hooks/cursor-hook-processor.mjs
@@ -26,6 +26,10 @@ import { toInternalEvent } from './cursor/source-event.mjs';
 import { appendEvent, readAllEvents, rewriteJournal } from './cursor/event-journal.mjs';
 import { assembleTurn } from './cursor/react-assembler.mjs';
 import { buildCursorRecordsFromTranscript } from './cursor/transcript-assembler.mjs';
+import {
+  agentBaseFieldPatch,
+  collectResourceAttributesFromEnv,
+} from './shared/resource-context.mjs';
 
 function resolveDataDir() {
   const configured = process.env.LOONGSUITE_PILOT_DATA_DIR;
@@ -93,6 +97,37 @@ function inferVariant(events) {
     if (ev.cursor_version && CLI_VERSION_PATTERN.test(ev.cursor_version)) return 'cursor-cli';
   }
   return 'cursor';
+}
+
+function findConversationResourceAttributes(events, conversationId) {
+  const scopedEvents = events.filter(event => event.conversation_id === conversationId);
+  const promptContext = scopedEvents.find(event =>
+    event.hook_event === 'beforeSubmitPrompt' &&
+    event.resource_attributes &&
+    Object.keys(event.resource_attributes).length > 0
+  );
+  const contextEvent = promptContext || scopedEvents.find(event =>
+    event.resource_attributes && Object.keys(event.resource_attributes).length > 0
+  );
+  return contextEvent?.resource_attributes || {};
+}
+
+function applyCursorCliResourceContext(records, events, conversationId, variant) {
+  if (variant !== 'cursor-cli' || records.length === 0) return;
+  // The journal is shared by Cursor Desktop and Cursor CLI. Re-check only the
+  // current conversation so a pending CLI event cannot activate this feature
+  // for an unrelated Desktop turn.
+  const conversationVariant = inferVariant(
+    events.filter(event => event.conversation_id === conversationId),
+  );
+  if (conversationVariant !== 'cursor-cli') return;
+  const resourceAttributes = findConversationResourceAttributes(events, conversationId);
+  if (Object.keys(resourceAttributes).length === 0) return;
+
+  const baseFieldPatch = agentBaseFieldPatch(resourceAttributes);
+  for (const record of records) {
+    Object.assign(record, baseFieldPatch, { resourceAttributes });
+  }
 }
 
 function compactJournal(allEvents, consumedConversationIds) {
@@ -284,6 +319,12 @@ async function main() {
 
   // Convert to internal event and append to journal
   const internalEvent = toInternalEvent(payload);
+  const invocationResourceAttributes = collectResourceAttributesFromEnv(process.env, {
+    agentId: 'cursor-cli',
+  });
+  if (Object.keys(invocationResourceAttributes).length > 0) {
+    internalEvent.resource_attributes = invocationResourceAttributes;
+  }
   try {
     appendEvent(internalEvent);
   } catch (err) {
@@ -403,6 +444,8 @@ async function main() {
         }
       } catch { /* best-effort skill detection — never block output */ }
 
+      applyCursorCliResourceContext(records, allEvents, convId, variant);
+
       if (records.length > 0) {
         const day = localDateString(now);
         const historyFile = path.join(dataDir, 'logs', 'cursor', 'history', `cursor-${day}.jsonl`);
@@ -440,6 +483,8 @@ async function main() {
           stopConversationId: convId,
         });
 
+        applyCursorCliResourceContext(result.records, allEvents, convId, variant);
+
         if (result.records.length > 0) {
           const day = localDateString(now);
           const historyFile = path.join(dataDir, 'logs', 'cursor', 'history', `cursor-${day}.jsonl`);
@@ -474,4 +519,9 @@ if (
   });
 }
 
-export { filterSkillsForReadInjection, injectSkillRecords };
+export {
+  applyCursorCliResourceContext,
+  filterSkillsForReadInjection,
+  findConversationResourceAttributes,
+  injectSkillRecords,
+};

--- a/assets/hooks/qwen-code-cli-hook-processor.mjs
+++ b/assets/hooks/qwen-code-cli-hook-processor.mjs
@@ -38,6 +38,10 @@ import {
 import { logHookError } from './shared/error-logger.mjs';
 import { recordUpstreamContextOnce } from './shared/upstream-context.mjs';
 import {
+  agentBaseFieldPatch,
+  collectResourceAttributesFromEnv,
+} from './shared/resource-context.mjs';
+import {
   sanitizeObject,
   loadHookRuntimeConfig,
   resolveUserId,
@@ -58,6 +62,19 @@ import {
 import { inferProvider } from './qwen-code-cli/provider-inferrer.mjs';
 
 const AGENT_ID = 'qwen-code-cli';
+const INVOCATION_RESOURCE_ATTRIBUTES = collectResourceAttributesFromEnv(process.env, {
+  agentId: AGENT_ID,
+});
+
+function bindInvocationResourceContext(state) {
+  if (Object.keys(INVOCATION_RESOURCE_ATTRIBUTES).length > 0) {
+    state.resource_attributes = INVOCATION_RESOURCE_ATTRIBUTES;
+  } else {
+    // A session can be resumed outside AgentTeams. Do not retain a stale
+    // worker identity from an earlier invocation.
+    delete state.resource_attributes;
+  }
+}
 
 // ─── utilities ───
 
@@ -172,6 +189,7 @@ async function cmdStop() {
   recordUpstreamContextOnce({ agentId: AGENT_ID, sessionId, dataDir: pilotDataDir() });
 
   const state = loadState(sessionId);
+  bindInvocationResourceContext(state);
   if (!state.transcript_path && event.transcript_path) {
     state.transcript_path = event.transcript_path;
   }
@@ -302,6 +320,7 @@ async function exportSession(state, stopReason) {
     const turnStopReason = isLast ? stopReason : 'end_turn';
     const { records, hash } = buildTurnRecords(
       turn, baseTurnCount + i, sessionId, logHash, userId, turnStopReason, cwd,
+      state.resource_attributes,
     );
     allRecords.push(...records);
     logHash = hash;
@@ -345,10 +364,25 @@ async function exportSession(state, stopReason) {
  * @param userId    Resolved user.id
  * @param turnStopReason Stop reason for the last LLM call in this turn
  * @param cwd       Optional working dir for agent.qwen-code-cli.cwd
+ * @param resourceAttributes  Invocation-scoped resource attributes captured by the Stop hook
  * @returns {{records: object[], hash: string}}
  */
-export function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStopReason, cwd) {
+export function buildTurnRecords(
+  turn,
+  turnIndex,
+  sessionId,
+  prevHash,
+  userId,
+  turnStopReason,
+  cwd,
+  resourceAttributes = {},
+) {
   const records = [];
+  const safeResourceAttributes = resourceAttributes &&
+    typeof resourceAttributes === 'object' &&
+    !Array.isArray(resourceAttributes)
+    ? resourceAttributes
+    : {};
   // [C2] turn.id = <sessionId>:t<N>
   const turnId = `${sessionId}:t${turnIndex + 1}`;
   let runningHash = prevHash;
@@ -364,6 +398,10 @@ export function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, t
     'user.id': userId,
     ...(cwd ? { 'agent.qwen-code-cli.cwd': cwd } : {}),
     ...(turn.gitBranch ? { 'git.branch': turn.gitBranch } : {}),
+    ...agentBaseFieldPatch(safeResourceAttributes),
+    ...(Object.keys(safeResourceAttributes).length > 0
+      ? { resourceAttributes: safeResourceAttributes }
+      : {}),
   };
 
   // [C7] User input → event.name=other + messages_delta (做法 A).

--- a/assets/hooks/qwen-code-cli-hook-processor.mjs
+++ b/assets/hooks/qwen-code-cli-hook-processor.mjs
@@ -70,8 +70,8 @@ function bindInvocationResourceContext(state) {
   if (Object.keys(INVOCATION_RESOURCE_ATTRIBUTES).length > 0) {
     state.resource_attributes = INVOCATION_RESOURCE_ATTRIBUTES;
   } else {
-    // A session can be resumed outside AgentTeams. Do not retain a stale
-    // worker identity from an earlier invocation.
+    // A session can be resumed without custom identity variables. Do not
+    // retain a stale worker identity from an earlier invocation.
     delete state.resource_attributes;
   }
 }

--- a/assets/hooks/qwen-code-cli/state.mjs
+++ b/assets/hooks/qwen-code-cli/state.mjs
@@ -13,6 +13,7 @@
  *     session_id, start_time, cwd,
  *     transcript_path, transcript_offset?,
  *     turn_count,                  // turns already exported (incl. skipped historic)
+ *     resource_attributes?,         // invocation context captured by the latest Stop hook
  *     stop_time?,
  *     events: []                   // v2 subagent_start/stop accumulator (unused in v1)
  *   }

--- a/assets/plugins/mimo-code/plugin.mjs
+++ b/assets/plugins/mimo-code/plugin.mjs
@@ -37,10 +37,20 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import crypto from "node:crypto";
+import {
+  agentBaseFieldPatch,
+  collectResourceAttributesFromEnv,
+} from "../shared/resource-context.mjs";
 
 const AGENT_TYPE = "mimo-code";
 const MAX_SESSIONS = 100;
 const MAX_CONTENT_SIZE = 64 * 1024;
+
+const RESOURCE_ATTRIBUTES = collectResourceAttributesFromEnv(process.env, { agentId: AGENT_TYPE });
+const RESOURCE_BASE_FIELD_PATCH = agentBaseFieldPatch(RESOURCE_ATTRIBUTES);
+const RESOURCE_ATTRIBUTE_FIELDS = Object.keys(RESOURCE_ATTRIBUTES).length > 0
+  ? { resourceAttributes: RESOURCE_ATTRIBUTES }
+  : {};
 
 // ---------------------------------------------------------------------------
 // Path helpers
@@ -261,6 +271,8 @@ function buildCommonFields(sessionID, session, userId) {
     // it as a resource attribute, but mirroring it here on every record keeps
     // the event log self-describing for downstream tooling.
     "gen_ai.framework": AGENT_TYPE,
+    ...RESOURCE_BASE_FIELD_PATCH,
+    ...RESOURCE_ATTRIBUTE_FIELDS,
   };
 }
 

--- a/assets/plugins/opencode/plugin.mjs
+++ b/assets/plugins/opencode/plugin.mjs
@@ -22,10 +22,20 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import crypto from "node:crypto";
+import {
+  agentBaseFieldPatch,
+  collectResourceAttributesFromEnv,
+} from "../shared/resource-context.mjs";
 
 const AGENT_TYPE = "opencode";
 const MAX_SESSIONS = 100;
 const MAX_CONTENT_SIZE = 64 * 1024;
+
+const RESOURCE_ATTRIBUTES = collectResourceAttributesFromEnv(process.env, { agentId: AGENT_TYPE });
+const RESOURCE_BASE_FIELD_PATCH = agentBaseFieldPatch(RESOURCE_ATTRIBUTES);
+const RESOURCE_ATTRIBUTE_FIELDS = Object.keys(RESOURCE_ATTRIBUTES).length > 0
+  ? { resourceAttributes: RESOURCE_ATTRIBUTES }
+  : {};
 
 // ---------------------------------------------------------------------------
 // Caller-supplied span attributes
@@ -292,6 +302,8 @@ function buildCommonFields(sessionID, session, userId) {
     "gen_ai.agent.id": session.agentMeta?.name || undefined,
     ...(agentCwd ? { [`agent.${AGENT_TYPE}.cwd`]: agentCwd } : {}),
     ...SPAN_ATTRIBUTES,
+    ...RESOURCE_BASE_FIELD_PATCH,
+    ...RESOURCE_ATTRIBUTE_FIELDS,
   };
 }
 

--- a/assets/plugins/pi-coding-agent/index.mjs
+++ b/assets/plugins/pi-coding-agent/index.mjs
@@ -13,6 +13,10 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  agentBaseFieldPatch,
+  collectResourceAttributesFromEnv,
+} from '../shared/resource-context.mjs';
 
 const AGENT_TYPE = 'pi-coding-agent';
 const MAX_STRING_LENGTH = 64 * 1024;
@@ -20,6 +24,12 @@ const MAX_MESSAGES = 40;
 const MAX_ARRAY_ITEMS = 100;
 const MAX_OBJECT_KEYS = 100;
 const MAX_DEPTH = 8;
+
+const RESOURCE_ATTRIBUTES = collectResourceAttributesFromEnv(process.env, { agentId: AGENT_TYPE });
+const RESOURCE_BASE_FIELD_PATCH = agentBaseFieldPatch(RESOURCE_ATTRIBUTES);
+const RESOURCE_ATTRIBUTE_FIELDS = Object.keys(RESOURCE_ATTRIBUTES).length > 0
+  ? { resourceAttributes: RESOURCE_ATTRIBUTES }
+  : {};
 
 const pluginDir = path.dirname(fileURLToPath(import.meta.url));
 // Installed layout: $PILOT_DATA/plugins/pi-coding-agent/index.mjs.
@@ -339,6 +349,8 @@ function turnFields(ctx, state, timestamp = Date.now()) {
     'gen_ai.agent.type': AGENT_TYPE,
     'gen_ai.agent.name': 'Pi Coding Agent',
     [`agent.${AGENT_TYPE}.cwd`]: ctx.cwd,
+    ...RESOURCE_BASE_FIELD_PATCH,
+    ...RESOURCE_ATTRIBUTE_FIELDS,
   };
 }
 

--- a/assets/plugins/shared/resource-context.mjs
+++ b/assets/plugins/shared/resource-context.mjs
@@ -1,0 +1,62 @@
+// Copyright 2026 Alibaba Group Holding Limited
+// SPDX-License-Identifier: Apache-2.0
+
+// Plugins are installed as a self-contained tree under $PILOT_DATA/plugins,
+// so they keep a plugin-local copy of the resource-context helper used by
+// hook processors. Keep its fixed mapping and validation rules aligned with
+// assets/hooks/shared/resource-context.mjs.
+
+const MAX_RESOURCE_FIELD_VALUE_LENGTH = 512;
+const SENSITIVE_FIELD_NAME_RE = /(^|[_.-])(TOKEN|SECRET|PASSWORD|CREDENTIAL|COOKIE)([_.-]|$)|^(API_KEY|API_HEADER)$/i;
+
+export const DEFAULT_RESOURCE_ENV_FIELD_MAP = {
+  AGENTTEAMS_WORKER_NAME: 'agentteams.worker.name',
+  AGENTTEAMS_INSTANCE_ID: 'agentteams.instance.id',
+};
+
+function shouldSkipFieldName(name) {
+  return SENSITIVE_FIELD_NAME_RE.test(String(name || ''));
+}
+
+function warnSkip(agentId, envName, reason) {
+  try {
+    process.stderr.write(`[${agentId || 'plugin'}] skip resource marker ${envName}: ${reason}\n`);
+  } catch {
+    // fail-open: resource marker collection must never block the host agent
+  }
+}
+
+export function collectResourceAttributesFromEnv(env = process.env, opts = {}) {
+  const agentId = opts.agentId || 'plugin';
+  const fieldMap = opts.fieldMap || DEFAULT_RESOURCE_ENV_FIELD_MAP;
+  const fields = {};
+
+  for (const [envName, fieldName] of Object.entries(fieldMap)) {
+    if (shouldSkipFieldName(envName) || shouldSkipFieldName(fieldName)) {
+      warnSkip(agentId, envName, 'sensitive field name');
+      continue;
+    }
+
+    const raw = env[envName];
+    if (typeof raw !== 'string') continue;
+
+    const value = raw.trim();
+    if (!value) continue;
+    if (value.length > MAX_RESOURCE_FIELD_VALUE_LENGTH) {
+      warnSkip(agentId, envName, 'value too long');
+      continue;
+    }
+
+    fields[fieldName] = value;
+  }
+
+  return fields;
+}
+
+export function agentBaseFieldPatch(resourceAttributes = {}, opts = {}) {
+  const nameField = opts.nameField || 'agentteams.worker.name';
+  const agentName = resourceAttributes[nameField];
+  return typeof agentName === 'string' && agentName.trim()
+    ? { 'gen_ai.agent.name': agentName.trim() }
+    : {};
+}

--- a/docs/output-event-schema.md
+++ b/docs/output-event-schema.md
@@ -97,7 +97,7 @@ Required levels follow OpenTelemetry wording:
 | `workspace.path` | string | Recommended | Absolute working directory the agent ran in (process cwd), independent of git. Present even when the directory is not a git repository. |
 | `agent.*` | json | Opt-In | Agent-specific extension attributes. Stable high-query dimensions should become structured fields over time. |
 
-## AgentTeams Invocation Context
+## Custom Agent Identity
 
 When a supported agent process starts with the following environment variables, Pilot writes the worker context to the current turn:
 

--- a/docs/output-event-schema.md
+++ b/docs/output-event-schema.md
@@ -97,6 +97,17 @@ Required levels follow OpenTelemetry wording:
 | `workspace.path` | string | Recommended | Absolute working directory the agent ran in (process cwd), independent of git. Present even when the directory is not a git repository. |
 | `agent.*` | json | Opt-In | Agent-specific extension attributes. Stable high-query dimensions should become structured fields over time. |
 
+## AgentTeams Invocation Context
+
+When a supported agent process starts with the following environment variables, Pilot captures the invocation context inside the agent Hook or Plugin and binds it to the current turn:
+
+| Environment variable | Event field | Description |
+|----------------------|-------------|-------------|
+| `AGENTTEAMS_WORKER_NAME` | `gen_ai.agent.name`, `resourceAttributes["agentteams.worker.name"]` | Logical worker name; takes precedence over the native name for a main agent. |
+| `AGENTTEAMS_INSTANCE_ID` | `resourceAttributes["agentteams.instance.id"]` | Concrete worker instance; never overwrites `gen_ai.agent.id`. |
+
+This is currently supported for Claude Code, Qoder, Codex, OpenCode, Pi Coding Agent, MiMo Code, Qwen Code CLI, and Cursor CLI. Cursor Desktop does not consume these variables. Existing event fields and name fallbacks remain unchanged when the variables are absent. Pilot collects only the two fixed allowlisted variables above; other `AGENTTEAMS_*` variables are never written to events or OTLP resources.
+
 ## Provider Names
 
 | Value | Description |

--- a/docs/output-event-schema.md
+++ b/docs/output-event-schema.md
@@ -99,7 +99,7 @@ Required levels follow OpenTelemetry wording:
 
 ## AgentTeams Invocation Context
 
-When a supported agent process starts with the following environment variables, Pilot captures the invocation context inside the agent Hook or Plugin and binds it to the current turn:
+When a supported agent process starts with the following environment variables, Pilot writes the worker context to the current turn:
 
 | Environment variable | Event field | Description |
 |----------------------|-------------|-------------|

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -27,7 +27,7 @@
 | 文档 | 用途 |
 |------|------|
 | [Agent 配置](agents.md) | 选择采集哪些 Agent，并控制消息内容采集。 |
-| [AgentTeams Worker 上下文](agentteams-worker-context.md) | 为不同逻辑 Worker 设置 `gen_ai.agent.name` 和 OTLP Resource 属性。 |
+| [自定义 Agent 名称和实例](custom-agent-identity.md) | 设置 `gen_ai.agent.name` 和 `agentteams.instance.id`。 |
 | [数据脱敏](masking.md) | 输出前脱敏密钥和个人敏感信息。 |
 | [输出事件 Schema](output-event-schema.md) | 查看规范化事件名称、字段、Provider 和结束原因。 |
 

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -27,6 +27,7 @@
 | 文档 | 用途 |
 |------|------|
 | [Agent 配置](agents.md) | 选择采集哪些 Agent，并控制消息内容采集。 |
+| [AgentTeams Worker 上下文](agentteams-worker-context.md) | 为不同逻辑 Worker 设置 `gen_ai.agent.name` 和 OTLP Resource 属性。 |
 | [数据脱敏](masking.md) | 输出前脱敏密钥和个人敏感信息。 |
 | [输出事件 Schema](output-event-schema.md) | 查看规范化事件名称、字段、Provider 和结束原因。 |
 

--- a/docs/zh-CN/agentteams-worker-context.md
+++ b/docs/zh-CN/agentteams-worker-context.md
@@ -1,27 +1,59 @@
-# 为 AgentTeams Worker 标记 GenAI 可观测数据
+# AgentTeams Worker 上下文使用指南
 
-当同一种 AI Coding Agent 被 AgentTeams 以不同角色或 Worker 启动时，可以通过两个进程环境变量，把逻辑 Worker 身份写入 Pilot 采集的事件和 OTLP Trace。这样可以按 `planner`、`reviewer`、`coder` 等角色筛选调用链，而不需要改变 Agent 产品类型。
+启动 AI Coding Agent 时设置 AgentTeams Worker 环境变量，Pilot 会使用逻辑 Worker 名称标记 GenAI 事件和 Trace。这样可以在同一种 Agent 下区分 `planner`、`reviewer`、`coder` 等不同角色。
 
 ## 支持范围
 
-| Agent | 启动命令 | 上下文采集时机 |
-|-------|----------|----------------|
-| OpenCode | `opencode` | Plugin 初始化时读取；修改变量后需要重启 Agent。 |
-| Pi Coding Agent | `pi` | Extension 初始化时读取；修改变量后需要重启 Agent。 |
-| MiMo Code | `mimo` | Plugin 初始化时读取；修改变量后需要重启 Agent。 |
-| Qwen Code CLI | `qwen` | Stop Hook 执行时读取，并绑定到本次 Turn。 |
-| Cursor CLI | `cursor-agent` | 每个 Hook 执行时读取，并通过事件 journal 绑定到本次 Turn。 |
+| Agent | `gen_ai.agent.type` | 启动命令 |
+|-------|---------------------|----------|
+| Claude Code | `claude-code` | `claude` |
+| Qoder | `qoder` | `qoder` |
+| Codex | `codex` | `codex` |
+| OpenCode | `opencode` | `opencode` |
+| Pi Coding Agent | `pi-coding-agent` | `pi` |
+| MiMo Code | `mimo-code` | `mimo` |
+| Qwen Code CLI | `qwen-code-cli` | `qwen` |
+| Cursor CLI | `cursor-cli` | `cursor-agent` |
 
-Claude Code、Qoder 和 Codex 也支持相同协议。Cursor Desktop 不读取这组变量，避免 CLI 和桌面端共用 Hook journal 时互相影响。
+Cursor Desktop 不支持这组变量。
 
-## 字段映射
+## 设置环境变量
 
-| 环境变量 | 可观测字段 | 说明 |
-|----------|------------|------|
-| `AGENTTEAMS_WORKER_NAME` | `gen_ai.agent.name`、`resourceAttributes["agentteams.worker.name"]` | 逻辑 Worker 名称，例如 `planner`。主 Agent 上优先于 Agent 原生名称。 |
-| `AGENTTEAMS_INSTANCE_ID` | `resourceAttributes["agentteams.instance.id"]` | 本次 Worker 运行实例，例如任务或容器实例 ID。不会覆盖 `gen_ai.agent.id`。 |
+| 环境变量 | 作用 |
+|----------|------|
+| `AGENTTEAMS_WORKER_NAME` | 设置 `gen_ai.agent.name`，并写入 Resource 属性 `agentteams.worker.name`。 |
+| `AGENTTEAMS_INSTANCE_ID` | 写入 Resource 属性 `agentteams.instance.id`，用于区分同一 Worker 的不同运行实例。 |
 
-`gen_ai.agent.type` 始终表示 Agent 产品，例如 `opencode` 或 `qwen-code-cli`。`gen_ai.agent.name` 表示 AgentTeams 中的逻辑角色。二者应配合使用：
+建议两个变量一起设置：
+
+```bash
+export AGENTTEAMS_WORKER_NAME=planner
+export AGENTTEAMS_INSTANCE_ID=task-42-worker-1
+```
+
+如果由 AgentTeams 或其他编排系统启动 Agent，请把两个变量分别传入每个 Agent 进程的环境。
+
+## 启动 Agent
+
+设置变量后，正常启动对应 Agent。例如：
+
+```bash
+opencode
+```
+
+也可以只对一次启动生效：
+
+```bash
+AGENTTEAMS_WORKER_NAME=planner \
+AGENTTEAMS_INSTANCE_ID=task-42-worker-1 \
+opencode
+```
+
+其他 Agent 只需将最后一行替换为支持范围表格中的启动命令。
+
+## 输出字段
+
+设置变量后，Pilot 采集的记录包含：
 
 ```json
 {
@@ -34,56 +66,13 @@ Claude Code、Qoder 和 Codex 也支持相同协议。Cursor Desktop 不读取�
 }
 ```
 
-## 启动 Agent
+- `gen_ai.agent.type` 表示 Agent 产品类型。
+- `gen_ai.agent.name` 表示 AgentTeams 中的逻辑 Worker 名称。
+- `AGENTTEAMS_INSTANCE_ID` 不会覆盖 Agent 原有的 `gen_ai.agent.id`。
 
-在启动 Agent 的进程上设置变量。不要只把变量设置到 Pilot daemon；daemon 可能同时接收多个 Worker 的数据，无法替 Agent 判断当前调用身份。
+## 验证
 
-### 单次启动
-
-```bash
-AGENTTEAMS_WORKER_NAME=planner \
-AGENTTEAMS_INSTANCE_ID=task-42-worker-1 \
-opencode
-```
-
-将最后一行替换为对应命令即可：
-
-```bash
-AGENTTEAMS_WORKER_NAME=reviewer AGENTTEAMS_INSTANCE_ID=task-42-worker-2 pi
-AGENTTEAMS_WORKER_NAME=coder AGENTTEAMS_INSTANCE_ID=task-42-worker-3 mimo
-AGENTTEAMS_WORKER_NAME=tester AGENTTEAMS_INSTANCE_ID=task-42-worker-4 qwen
-AGENTTEAMS_WORKER_NAME=reviewer AGENTTEAMS_INSTANCE_ID=task-42-worker-5 cursor-agent
-```
-
-### 当前终端持续生效
-
-```bash
-export AGENTTEAMS_WORKER_NAME=planner
-export AGENTTEAMS_INSTANCE_ID=task-42-worker-1
-opencode
-```
-
-OpenCode、Pi Coding Agent 和 MiMo Code 会在 Plugin/Extension 初始化时固定当前上下文。更新 `export` 后，必须退出并重新启动 Agent，不能复用已经运行的进程。
-
-### 编排系统传入
-
-AgentTeams 或其他编排器应为每个 Agent 子进程分别构造环境变量。例如伪代码：
-
-```js
-spawn('qwen', [], {
-  env: {
-    ...process.env,
-    AGENTTEAMS_WORKER_NAME: worker.name,
-    AGENTTEAMS_INSTANCE_ID: worker.instanceId,
-  },
-});
-```
-
-不要在多个并发 Worker 之间修改同一个长驻 Agent 进程的环境。环境变量是进程级上下文，一个 Agent 进程应只对应一个 Worker。
-
-## 验证采集结果
-
-完成至少一个 Agent Turn 后，可以在 Pilot 数据目录中检索字段：
+完成一个 Agent Turn 后，可以在 Pilot 数据目录中检索相关字段：
 
 ```bash
 rg 'gen_ai.agent.name|agentteams.worker.name|agentteams.instance.id' \
@@ -92,29 +81,14 @@ rg 'gen_ai.agent.name|agentteams.worker.name|agentteams.instance.id' \
 
 预期结果：
 
-- 每条属于该 Turn 的 GenAI Record 都带有正确的 `gen_ai.agent.name`。
-- `resourceAttributes` 中包含 Worker 名称和 Instance ID。
-- OTLP Trace 的 Span 上包含 `gen_ai.agent.name`，Resource 上包含两个 `agentteams.*` 属性。
-- `gen_ai.agent.id` 仍然是 Agent 自己提供的 ID。
+- Turn 内的 GenAI 记录具有正确的 `gen_ai.agent.name`。
+- `resourceAttributes` 包含 Worker 名称和 Instance ID。
+- OTLP Trace 的 Span 包含 `gen_ai.agent.name`，Resource 包含两个 `agentteams.*` 属性。
 
-## 兼容性与安全
+## 注意事项
 
-- 未设置两个变量时，Pilot 保持 Agent 原有名称和字段回退行为。
-- 空字符串和超过 512 字符的值会被忽略。
-- Pilot 只允许采集这两个固定变量。`AGENTTEAMS_TOKEN`、`AGENTTEAMS_SECRET` 等其他变量不会进入事件、日志或 OTLP Resource。
-- Qwen Code CLI 同一 session 被不同 Worker 恢复时，以当前 Stop Hook 的环境为准，不会沿用上一次 Worker。
-- Cursor CLI 会把上下文保存在当前 conversation 的事件 journal 中，支持 Stop 早于 `afterAgentResponse` 的延迟组装流程。
-
-## 常见问题
-
-### 设置变量后仍然显示 Agent 默认名称
-
-确认变量设置在 Agent 启动命令所在的进程环境中，并重启 OpenCode、Pi Coding Agent 或 MiMo Code。已经运行的 Plugin/Extension 不会重新读取父进程环境。
-
-### Cursor CLI 没有产生完整 Turn
-
-部分 Cursor CLI headless 版本不会触发完整的 Cursor Hook 事件。Worker 上下文只能附加到实际完成组装的 Turn，不能补齐 Agent 本身没有触发的 Hook。
-
-### 是否可以通过 `LOONGSUITE_PILOT_SPAN_ATTRIBUTES` 设置 `gen_ai.agent.name`
-
-不可以。`gen_ai.*` 是 Pilot 管理的保留字段，会从通用 Span Attribute 输入中移除。应使用 `AGENTTEAMS_WORKER_NAME`。
+- 环境变量必须设置在 Agent 进程中；修改变量后，请重启已经运行的 Agent。
+- 未设置变量时，Pilot 保持 Agent 原有名称和字段行为。
+- 空值和超过 512 个字符的值会被忽略。
+- Pilot 只采集上述两个变量，其他 `AGENTTEAMS_*` 变量不会写入事件或 Trace。
+- `LOONGSUITE_PILOT_SPAN_ATTRIBUTES` 不能用于设置 `gen_ai.agent.name`，请使用 `AGENTTEAMS_WORKER_NAME`。

--- a/docs/zh-CN/agentteams-worker-context.md
+++ b/docs/zh-CN/agentteams-worker-context.md
@@ -1,0 +1,120 @@
+# 为 AgentTeams Worker 标记 GenAI 可观测数据
+
+当同一种 AI Coding Agent 被 AgentTeams 以不同角色或 Worker 启动时，可以通过两个进程环境变量，把逻辑 Worker 身份写入 Pilot 采集的事件和 OTLP Trace。这样可以按 `planner`、`reviewer`、`coder` 等角色筛选调用链，而不需要改变 Agent 产品类型。
+
+## 支持范围
+
+| Agent | 启动命令 | 上下文采集时机 |
+|-------|----------|----------------|
+| OpenCode | `opencode` | Plugin 初始化时读取；修改变量后需要重启 Agent。 |
+| Pi Coding Agent | `pi` | Extension 初始化时读取；修改变量后需要重启 Agent。 |
+| MiMo Code | `mimo` | Plugin 初始化时读取；修改变量后需要重启 Agent。 |
+| Qwen Code CLI | `qwen` | Stop Hook 执行时读取，并绑定到本次 Turn。 |
+| Cursor CLI | `cursor-agent` | 每个 Hook 执行时读取，并通过事件 journal 绑定到本次 Turn。 |
+
+Claude Code、Qoder 和 Codex 也支持相同协议。Cursor Desktop 不读取这组变量，避免 CLI 和桌面端共用 Hook journal 时互相影响。
+
+## 字段映射
+
+| 环境变量 | 可观测字段 | 说明 |
+|----------|------------|------|
+| `AGENTTEAMS_WORKER_NAME` | `gen_ai.agent.name`、`resourceAttributes["agentteams.worker.name"]` | 逻辑 Worker 名称，例如 `planner`。主 Agent 上优先于 Agent 原生名称。 |
+| `AGENTTEAMS_INSTANCE_ID` | `resourceAttributes["agentteams.instance.id"]` | 本次 Worker 运行实例，例如任务或容器实例 ID。不会覆盖 `gen_ai.agent.id`。 |
+
+`gen_ai.agent.type` 始终表示 Agent 产品，例如 `opencode` 或 `qwen-code-cli`。`gen_ai.agent.name` 表示 AgentTeams 中的逻辑角色。二者应配合使用：
+
+```json
+{
+  "gen_ai.agent.type": "opencode",
+  "gen_ai.agent.name": "planner",
+  "resourceAttributes": {
+    "agentteams.worker.name": "planner",
+    "agentteams.instance.id": "task-42-worker-1"
+  }
+}
+```
+
+## 启动 Agent
+
+在启动 Agent 的进程上设置变量。不要只把变量设置到 Pilot daemon；daemon 可能同时接收多个 Worker 的数据，无法替 Agent 判断当前调用身份。
+
+### 单次启动
+
+```bash
+AGENTTEAMS_WORKER_NAME=planner \
+AGENTTEAMS_INSTANCE_ID=task-42-worker-1 \
+opencode
+```
+
+将最后一行替换为对应命令即可：
+
+```bash
+AGENTTEAMS_WORKER_NAME=reviewer AGENTTEAMS_INSTANCE_ID=task-42-worker-2 pi
+AGENTTEAMS_WORKER_NAME=coder AGENTTEAMS_INSTANCE_ID=task-42-worker-3 mimo
+AGENTTEAMS_WORKER_NAME=tester AGENTTEAMS_INSTANCE_ID=task-42-worker-4 qwen
+AGENTTEAMS_WORKER_NAME=reviewer AGENTTEAMS_INSTANCE_ID=task-42-worker-5 cursor-agent
+```
+
+### 当前终端持续生效
+
+```bash
+export AGENTTEAMS_WORKER_NAME=planner
+export AGENTTEAMS_INSTANCE_ID=task-42-worker-1
+opencode
+```
+
+OpenCode、Pi Coding Agent 和 MiMo Code 会在 Plugin/Extension 初始化时固定当前上下文。更新 `export` 后，必须退出并重新启动 Agent，不能复用已经运行的进程。
+
+### 编排系统传入
+
+AgentTeams 或其他编排器应为每个 Agent 子进程分别构造环境变量。例如伪代码：
+
+```js
+spawn('qwen', [], {
+  env: {
+    ...process.env,
+    AGENTTEAMS_WORKER_NAME: worker.name,
+    AGENTTEAMS_INSTANCE_ID: worker.instanceId,
+  },
+});
+```
+
+不要在多个并发 Worker 之间修改同一个长驻 Agent 进程的环境。环境变量是进程级上下文，一个 Agent 进程应只对应一个 Worker。
+
+## 验证采集结果
+
+完成至少一个 Agent Turn 后，可以在 Pilot 数据目录中检索字段：
+
+```bash
+rg 'gen_ai.agent.name|agentteams.worker.name|agentteams.instance.id' \
+  ~/.loongsuite-pilot/logs
+```
+
+预期结果：
+
+- 每条属于该 Turn 的 GenAI Record 都带有正确的 `gen_ai.agent.name`。
+- `resourceAttributes` 中包含 Worker 名称和 Instance ID。
+- OTLP Trace 的 Span 上包含 `gen_ai.agent.name`，Resource 上包含两个 `agentteams.*` 属性。
+- `gen_ai.agent.id` 仍然是 Agent 自己提供的 ID。
+
+## 兼容性与安全
+
+- 未设置两个变量时，Pilot 保持 Agent 原有名称和字段回退行为。
+- 空字符串和超过 512 字符的值会被忽略。
+- Pilot 只允许采集这两个固定变量。`AGENTTEAMS_TOKEN`、`AGENTTEAMS_SECRET` 等其他变量不会进入事件、日志或 OTLP Resource。
+- Qwen Code CLI 同一 session 被不同 Worker 恢复时，以当前 Stop Hook 的环境为准，不会沿用上一次 Worker。
+- Cursor CLI 会把上下文保存在当前 conversation 的事件 journal 中，支持 Stop 早于 `afterAgentResponse` 的延迟组装流程。
+
+## 常见问题
+
+### 设置变量后仍然显示 Agent 默认名称
+
+确认变量设置在 Agent 启动命令所在的进程环境中，并重启 OpenCode、Pi Coding Agent 或 MiMo Code。已经运行的 Plugin/Extension 不会重新读取父进程环境。
+
+### Cursor CLI 没有产生完整 Turn
+
+部分 Cursor CLI headless 版本不会触发完整的 Cursor Hook 事件。Worker 上下文只能附加到实际完成组装的 Turn，不能补齐 Agent 本身没有触发的 Hook。
+
+### 是否可以通过 `LOONGSUITE_PILOT_SPAN_ATTRIBUTES` 设置 `gen_ai.agent.name`
+
+不可以。`gen_ai.*` 是 Pilot 管理的保留字段，会从通用 Span Attribute 输入中移除。应使用 `AGENTTEAMS_WORKER_NAME`。

--- a/docs/zh-CN/custom-agent-identity.md
+++ b/docs/zh-CN/custom-agent-identity.md
@@ -1,6 +1,6 @@
-# AgentTeams Worker 上下文使用指南
+# 自定义 `gen_ai.agent.name` 和 `agentteams.instance.id`
 
-启动 AI Coding Agent 时设置 AgentTeams Worker 环境变量，Pilot 会使用逻辑 Worker 名称标记 GenAI 事件和 Trace。这样可以在同一种 Agent 下区分 `planner`、`reviewer`、`coder` 等不同角色。
+启动 AI Coding Agent 时设置环境变量，可以自定义 Pilot 采集数据中的 Agent 名称和运行实例。例如，在同一种 Agent 下区分 `planner`、`reviewer`、`coder` 等不同角色。
 
 ## 支持范围
 
@@ -31,7 +31,7 @@ export AGENTTEAMS_WORKER_NAME=planner
 export AGENTTEAMS_INSTANCE_ID=task-42-worker-1
 ```
 
-如果由 AgentTeams 或其他编排系统启动 Agent，请把两个变量分别传入每个 Agent 进程的环境。
+如果由编排系统启动 Agent，请把两个变量分别传入每个 Agent 进程的环境。
 
 ## 启动 Agent
 
@@ -67,7 +67,7 @@ opencode
 ```
 
 - `gen_ai.agent.type` 表示 Agent 产品类型。
-- `gen_ai.agent.name` 表示 AgentTeams 中的逻辑 Worker 名称。
+- `gen_ai.agent.name` 表示自定义的逻辑 Agent 名称。
 - `AGENTTEAMS_INSTANCE_ID` 不会覆盖 Agent 原有的 `gen_ai.agent.id`。
 
 ## 验证

--- a/docs/zh-CN/output-event-schema.md
+++ b/docs/zh-CN/output-event-schema.md
@@ -95,6 +95,17 @@ LoongSuite Pilot 会将采集到的活动归一化为 GenAI 遥测事件。Pilot
 | `workspace.path` | string | Recommended | agent 进程实际运行的工作目录（cwd），与 git 无关。即使目录不是 git 仓库也会带上。 |
 | `agent.*` | json | Opt-In | Agent-specific 扩展属性。稳定且高频查询的维度应逐步沉淀为结构化字段。 |
 
+## AgentTeams 调用上下文
+
+当支持的 Agent 进程携带以下环境变量启动时，Pilot 会在 Agent 的 Hook 或 Plugin 内捕获调用上下文，并将其绑定到当前 Turn：
+
+| 环境变量 | Event 字段 | 说明 |
+|----------|------------|------|
+| `AGENTTEAMS_WORKER_NAME` | `gen_ai.agent.name`、`resourceAttributes["agentteams.worker.name"]` | 逻辑 Worker 名称；主 Agent 上优先于 Agent 原生名称。 |
+| `AGENTTEAMS_INSTANCE_ID` | `resourceAttributes["agentteams.instance.id"]` | 当前 Worker 运行实例；不会覆盖 `gen_ai.agent.id`。 |
+
+当前支持 Claude Code、Qoder、Codex、OpenCode、Pi Coding Agent、MiMo Code、Qwen Code CLI 和 Cursor CLI。Cursor Desktop 不读取这组变量。未设置变量时，现有事件字段和名称回退行为不变。Pilot 只采集上述固定白名单字段；其他 `AGENTTEAMS_*` 变量不会进入事件或 OTLP Resource。
+
 ## Provider Names
 
 | 值 | 说明 |

--- a/docs/zh-CN/output-event-schema.md
+++ b/docs/zh-CN/output-event-schema.md
@@ -95,7 +95,7 @@ LoongSuite Pilot 会将采集到的活动归一化为 GenAI 遥测事件。Pilot
 | `workspace.path` | string | Recommended | agent 进程实际运行的工作目录（cwd），与 git 无关。即使目录不是 git 仓库也会带上。 |
 | `agent.*` | json | Opt-In | Agent-specific 扩展属性。稳定且高频查询的维度应逐步沉淀为结构化字段。 |
 
-## AgentTeams 调用上下文
+## 自定义 Agent 标识
 
 当支持的 Agent 进程携带以下环境变量启动时，Pilot 会将 Worker 上下文写入当前 Turn：
 

--- a/docs/zh-CN/output-event-schema.md
+++ b/docs/zh-CN/output-event-schema.md
@@ -97,7 +97,7 @@ LoongSuite Pilot 会将采集到的活动归一化为 GenAI 遥测事件。Pilot
 
 ## AgentTeams 调用上下文
 
-当支持的 Agent 进程携带以下环境变量启动时，Pilot 会在 Agent 的 Hook 或 Plugin 内捕获调用上下文，并将其绑定到当前 Turn：
+当支持的 Agent 进程携带以下环境变量启动时，Pilot 会将 Worker 上下文写入当前 Turn：
 
 | 环境变量 | Event 字段 | 说明 |
 |----------|------------|------|

--- a/tests/unit/hooks/cursor/resource-context.test.mjs
+++ b/tests/unit/hooks/cursor/resource-context.test.mjs
@@ -57,7 +57,7 @@ function readHistoryRecords() {
     .map((line) => JSON.parse(line));
 }
 
-describe('Cursor CLI AgentTeams resource context', () => {
+describe('Cursor CLI custom resource context', () => {
   it('does not let another CLI conversation activate context for Desktop', () => {
     const records = [{ 'gen_ai.agent.type': 'cursor' }];
     const events = [

--- a/tests/unit/hooks/cursor/resource-context.test.mjs
+++ b/tests/unit/hooks/cursor/resource-context.test.mjs
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { applyCursorCliResourceContext } from '../../../../assets/hooks/cursor-hook-processor.mjs';
+
+const PROCESSOR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../../assets/hooks/cursor-hook-processor.mjs',
+);
+
+let dataDir;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-resource-context-'));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+function runHook(payload, extraEnv = {}) {
+  const env = { ...process.env, LOONGSUITE_PILOT_DATA_DIR: dataDir };
+  delete env.AGENTTEAMS_WORKER_NAME;
+  delete env.AGENTTEAMS_INSTANCE_ID;
+  delete env.AGENTTEAMS_TOKEN;
+  Object.assign(env, extraEnv);
+  return spawnSync('node', [PROCESSOR], {
+    input: JSON.stringify(payload),
+    env,
+    encoding: 'utf8',
+    timeout: 10_000,
+  });
+}
+
+function event(hookEvent, version, overrides = {}) {
+  return {
+    hook_event_name: hookEvent,
+    conversation_id: overrides.conversation_id || 'cursor-conversation-1',
+    session_id: overrides.session_id || 'cursor-conversation-1',
+    generation_id: overrides.generation_id || 'cursor-generation-1',
+    cursor_version: version,
+    model: 'gpt-5',
+    ...overrides,
+  };
+}
+
+function readHistoryRecords() {
+  const historyDir = path.join(dataDir, 'logs', 'cursor', 'history');
+  if (!fs.existsSync(historyDir)) return [];
+  return fs.readdirSync(historyDir)
+    .filter((name) => name.endsWith('.jsonl'))
+    .flatMap((name) => fs.readFileSync(path.join(historyDir, name), 'utf8').trim().split('\n'))
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+describe('Cursor CLI AgentTeams resource context', () => {
+  it('does not let another CLI conversation activate context for Desktop', () => {
+    const records = [{ 'gen_ai.agent.type': 'cursor' }];
+    const events = [
+      {
+        hook_event: 'beforeSubmitPrompt',
+        conversation_id: 'cli-conversation',
+        cursor_version: '2026.07.31',
+      },
+      {
+        hook_event: 'beforeSubmitPrompt',
+        conversation_id: 'desktop-conversation',
+        cursor_version: '1.7.0',
+        resource_attributes: { 'agentteams.worker.name': 'desktop-worker' },
+      },
+    ];
+
+    applyCursorCliResourceContext(records, events, 'desktop-conversation', 'cursor-cli');
+
+    expect(records).toEqual([{ 'gen_ai.agent.type': 'cursor' }]);
+  });
+
+  it('persists prompt context across the CLI deferred-stop path', () => {
+    const cliVersion = '2026.07.31';
+    const prompt = runHook(event('beforeSubmitPrompt', cliVersion, { prompt: 'Inspect the repository' }), {
+      AGENTTEAMS_WORKER_NAME: 'planner',
+      AGENTTEAMS_INSTANCE_ID: 'cursor-instance-01',
+      AGENTTEAMS_TOKEN: 'must-not-leak',
+    });
+    const stop = runHook(event('stop', cliVersion, { status: 'completed' }));
+
+    expect(prompt.status).toBe(0);
+    expect(stop.status).toBe(0);
+    expect(readHistoryRecords()).toEqual([]);
+
+    const response = runHook(event('afterAgentResponse', cliVersion, { text: 'Done.' }));
+    expect(response.status).toBe(0);
+
+    const records = readHistoryRecords();
+    expect(records.length).toBeGreaterThan(0);
+    for (const record of records) {
+      expect(record['gen_ai.agent.type']).toBe('cursor-cli');
+      expect(record['gen_ai.agent.name']).toBe('planner');
+      expect(record.resourceAttributes).toEqual({
+        'agentteams.worker.name': 'planner',
+        'agentteams.instance.id': 'cursor-instance-01',
+      });
+      expect(JSON.stringify(record)).not.toContain('must-not-leak');
+    }
+  });
+
+  it('does not change Cursor Desktop records even when the variables exist', () => {
+    const desktopVersion = '1.7.0';
+    const resourceEnv = {
+      AGENTTEAMS_WORKER_NAME: 'desktop-worker',
+      AGENTTEAMS_INSTANCE_ID: 'desktop-instance-01',
+    };
+    runHook(event('beforeSubmitPrompt', desktopVersion, { prompt: 'Inspect the repository' }), resourceEnv);
+    runHook(event('afterAgentResponse', desktopVersion, { text: 'Done.' }), resourceEnv);
+    const stop = runHook(event('stop', desktopVersion, { status: 'completed' }), resourceEnv);
+
+    expect(stop.status).toBe(0);
+    const records = readHistoryRecords();
+    expect(records.length).toBeGreaterThan(0);
+    expect(records.every((record) => record['gen_ai.agent.type'] === 'cursor')).toBe(true);
+    expect(records.every((record) => record['gen_ai.agent.name'] === undefined)).toBe(true);
+    expect(records.every((record) => record.resourceAttributes === undefined)).toBe(true);
+  });
+});

--- a/tests/unit/hooks/mimo-code/resource-context.test.mjs
+++ b/tests/unit/hooks/mimo-code/resource-context.test.mjs
@@ -58,7 +58,7 @@ async function emitUserRecord() {
     .map((line) => JSON.parse(line));
 }
 
-describe('MiMo Code AgentTeams resource context', () => {
+describe('MiMo Code custom resource context', () => {
   it('keeps the native agent name and raw shape when context is absent', async () => {
     const records = await emitUserRecord();
 

--- a/tests/unit/hooks/mimo-code/resource-context.test.mjs
+++ b/tests/unit/hooks/mimo-code/resource-context.test.mjs
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const PLUGIN_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../../assets/plugins/mimo-code/plugin.mjs',
+);
+
+let tmpDir;
+let previousEnv;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mimo-resource-context-'));
+  previousEnv = {
+    LOONGSUITE_PILOT_DATA_DIR: process.env.LOONGSUITE_PILOT_DATA_DIR,
+    AGENTTEAMS_WORKER_NAME: process.env.AGENTTEAMS_WORKER_NAME,
+    AGENTTEAMS_INSTANCE_ID: process.env.AGENTTEAMS_INSTANCE_ID,
+    AGENTTEAMS_TOKEN: process.env.AGENTTEAMS_TOKEN,
+  };
+  process.env.LOONGSUITE_PILOT_DATA_DIR = tmpDir;
+  delete process.env.AGENTTEAMS_WORKER_NAME;
+  delete process.env.AGENTTEAMS_INSTANCE_ID;
+  delete process.env.AGENTTEAMS_TOKEN;
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(previousEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function emitUserRecord() {
+  const mod = await import(`${pathToFileURL(PLUGIN_PATH).href}?t=${Date.now()}_${Math.random()}`);
+  const hooks = await mod.default.server({ cwd: '/workspace/example' }, {});
+  await hooks['chat.message'](
+    { sessionID: 'mimo-session-1' },
+    {
+      message: {
+        id: 'message-1',
+        agent: 'build',
+        agentID: 'main',
+        model: { providerID: 'mimo', modelID: 'mimo-v2.5' },
+      },
+      parts: [{ type: 'text', text: 'Inspect the repository' }],
+    },
+  );
+
+  const logDir = path.join(tmpDir, 'logs', 'mimo-code');
+  return fs.readdirSync(logDir)
+    .filter((name) => name.endsWith('.jsonl'))
+    .flatMap((name) => fs.readFileSync(path.join(logDir, name), 'utf8').trim().split('\n'))
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+describe('MiMo Code AgentTeams resource context', () => {
+  it('keeps the native agent name and raw shape when context is absent', async () => {
+    const records = await emitUserRecord();
+
+    expect(records.length).toBeGreaterThan(0);
+    expect(records.every((record) => record['gen_ai.agent.name'] === 'build')).toBe(true);
+    expect(records.every((record) => record.resourceAttributes === undefined)).toBe(true);
+  });
+
+  it('lets the worker name override the native name while preserving agent.id', async () => {
+    process.env.AGENTTEAMS_WORKER_NAME = 'reviewer';
+    process.env.AGENTTEAMS_INSTANCE_ID = 'mimo-instance-01';
+    process.env.AGENTTEAMS_TOKEN = 'must-not-leak';
+
+    const records = await emitUserRecord();
+
+    expect(records.length).toBeGreaterThan(0);
+    for (const record of records) {
+      expect(record['gen_ai.agent.name']).toBe('reviewer');
+      expect(record['gen_ai.agent.id']).toBe('main');
+      expect(record.resourceAttributes).toEqual({
+        'agentteams.worker.name': 'reviewer',
+        'agentteams.instance.id': 'mimo-instance-01',
+      });
+      expect(JSON.stringify(record)).not.toContain('must-not-leak');
+    }
+  });
+});

--- a/tests/unit/hooks/opencode-plugin-tokens.test.mjs
+++ b/tests/unit/hooks/opencode-plugin-tokens.test.mjs
@@ -117,7 +117,7 @@ describe('opencode plugin token mapping', () => {
     expect(rec.resourceAttributes).toBeUndefined();
   });
 
-  it('uses AgentTeams worker context without exposing non-allowlisted values', async () => {
+  it('uses custom worker context without exposing non-allowlisted values', async () => {
     process.env.AGENTTEAMS_WORKER_NAME = ' planner ';
     process.env.AGENTTEAMS_INSTANCE_ID = ' instance-01 ';
     process.env.AGENTTEAMS_TOKEN = 'must-not-leak';

--- a/tests/unit/hooks/opencode-plugin-tokens.test.mjs
+++ b/tests/unit/hooks/opencode-plugin-tokens.test.mjs
@@ -16,16 +16,29 @@ const PLUGIN_PATH = path.resolve(
  */
 let tmpDir;
 let prevDataDir;
+let previousResourceEnv;
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-tokens-'));
   prevDataDir = process.env.LOONGSUITE_PILOT_DATA_DIR;
   process.env.LOONGSUITE_PILOT_DATA_DIR = tmpDir;
+  previousResourceEnv = {
+    AGENTTEAMS_WORKER_NAME: process.env.AGENTTEAMS_WORKER_NAME,
+    AGENTTEAMS_INSTANCE_ID: process.env.AGENTTEAMS_INSTANCE_ID,
+    AGENTTEAMS_TOKEN: process.env.AGENTTEAMS_TOKEN,
+  };
+  delete process.env.AGENTTEAMS_WORKER_NAME;
+  delete process.env.AGENTTEAMS_INSTANCE_ID;
+  delete process.env.AGENTTEAMS_TOKEN;
 });
 
 afterEach(() => {
   if (prevDataDir === undefined) delete process.env.LOONGSUITE_PILOT_DATA_DIR;
   else process.env.LOONGSUITE_PILOT_DATA_DIR = prevDataDir;
+  for (const [key, value] of Object.entries(previousResourceEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
@@ -100,5 +113,22 @@ describe('opencode plugin token mapping', () => {
     expect(rec['gen_ai.usage.input_tokens']).toBe(300);
     expect(rec['gen_ai.usage.cache_read.input_tokens']).toBe(0);
     expect(rec['gen_ai.usage.total_tokens']).toBe(340);
+    expect(rec['gen_ai.agent.name']).toBe('opencode');
+    expect(rec.resourceAttributes).toBeUndefined();
+  });
+
+  it('uses AgentTeams worker context without exposing non-allowlisted values', async () => {
+    process.env.AGENTTEAMS_WORKER_NAME = ' planner ';
+    process.env.AGENTTEAMS_INSTANCE_ID = ' instance-01 ';
+    process.env.AGENTTEAMS_TOKEN = 'must-not-leak';
+
+    const [rec] = await emitLlmResponse({ input: 1, output: 1, cacheRead: 0, cacheWrite: 0 });
+
+    expect(rec['gen_ai.agent.name']).toBe('planner');
+    expect(rec.resourceAttributes).toEqual({
+      'agentteams.worker.name': 'planner',
+      'agentteams.instance.id': 'instance-01',
+    });
+    expect(JSON.stringify(rec)).not.toContain('must-not-leak');
   });
 });

--- a/tests/unit/hooks/pi-coding-agent-extension.test.mjs
+++ b/tests/unit/hooks/pi-coding-agent-extension.test.mjs
@@ -212,7 +212,7 @@ describe('Pi Coding Agent extension', () => {
     }
   });
 
-  it('stamps AgentTeams worker context on every record in the turn', async () => {
+  it('stamps custom worker context on every record in the turn', async () => {
     process.env.AGENTTEAMS_WORKER_NAME = 'reviewer';
     process.env.AGENTTEAMS_INSTANCE_ID = 'pi-instance-01';
     process.env.AGENTTEAMS_TOKEN = 'must-not-leak';

--- a/tests/unit/hooks/pi-coding-agent-extension.test.mjs
+++ b/tests/unit/hooks/pi-coding-agent-extension.test.mjs
@@ -12,11 +12,20 @@ const EXTENSION_PATH = path.resolve(
 
 let tmpDir;
 let previousDataDir;
+let previousResourceEnv;
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-coding-agent-extension-'));
   previousDataDir = process.env.LOONGSUITE_PILOT_DATA_DIR;
   process.env.LOONGSUITE_PILOT_DATA_DIR = tmpDir;
+  previousResourceEnv = {
+    AGENTTEAMS_WORKER_NAME: process.env.AGENTTEAMS_WORKER_NAME,
+    AGENTTEAMS_INSTANCE_ID: process.env.AGENTTEAMS_INSTANCE_ID,
+    AGENTTEAMS_TOKEN: process.env.AGENTTEAMS_TOKEN,
+  };
+  delete process.env.AGENTTEAMS_WORKER_NAME;
+  delete process.env.AGENTTEAMS_INSTANCE_ID;
+  delete process.env.AGENTTEAMS_TOKEN;
   vi.useFakeTimers();
   vi.setSystemTime(new Date('2026-07-16T08:00:00.000Z'));
 });
@@ -26,6 +35,10 @@ afterEach(() => {
   vi.useRealTimers();
   if (previousDataDir === undefined) delete process.env.LOONGSUITE_PILOT_DATA_DIR;
   else process.env.LOONGSUITE_PILOT_DATA_DIR = previousDataDir;
+  for (const [key, value] of Object.entries(previousResourceEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
@@ -161,6 +174,8 @@ describe('Pi Coding Agent extension', () => {
     const request = records.find(record => record['event.name'] === 'llm.request');
     expect(request['gen_ai.session.id']).toBe('pi-session-1');
     expect(request['gen_ai.agent.type']).toBe('pi-coding-agent');
+    expect(request['gen_ai.agent.name']).toBe('Pi Coding Agent');
+    expect(request.resourceAttributes).toBeUndefined();
     expect(request['agent.pi-coding-agent.cwd']).toBe('/workspace/example');
     expect(request['gen_ai.input.messages'][0].parts[0].content).toBe('Inspect the repository');
     expect(request['gen_ai.tool.definitions'].map(tool => tool.name)).toEqual(['read', 'bash']);
@@ -194,6 +209,29 @@ describe('Pi Coding Agent extension', () => {
       const logFile = path.join(logDir, 'pi-coding-agent-2026-07-16.jsonl');
       expect(fs.statSync(logDir).mode & 0o777).toBe(0o700);
       expect(fs.statSync(logFile).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it('stamps AgentTeams worker context on every record in the turn', async () => {
+    process.env.AGENTTEAMS_WORKER_NAME = 'reviewer';
+    process.env.AGENTTEAMS_INSTANCE_ID = 'pi-instance-01';
+    process.env.AGENTTEAMS_TOKEN = 'must-not-leak';
+
+    const runtime = await createRuntime();
+    await startTurn(runtime);
+    await runtime.emit('context', {
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'Inspect the repository' }] }],
+    });
+
+    const records = readRecords();
+    expect(records.length).toBeGreaterThan(0);
+    for (const record of records) {
+      expect(record['gen_ai.agent.name']).toBe('reviewer');
+      expect(record.resourceAttributes).toEqual({
+        'agentteams.worker.name': 'reviewer',
+        'agentteams.instance.id': 'pi-instance-01',
+      });
+      expect(JSON.stringify(record)).not.toContain('must-not-leak');
     }
   });
 

--- a/tests/unit/hooks/qwen-code-cli/build-turn-records.test.mjs
+++ b/tests/unit/hooks/qwen-code-cli/build-turn-records.test.mjs
@@ -70,6 +70,38 @@ describe('buildTurnRecords — basic shape', () => {
     expect([...traceIds][0]).toMatch(/^[0-9a-f]{32}$/);
   });
 
+  test('keeps the existing raw shape when invocation resource context is absent', () => {
+    const turn = makeTurn({ llmCalls: [makeLlmCall()] });
+    const { records } = buildTurnRecords(turn, 0, 'sess-1', INITIAL_HASH, 'u-1', 'end_turn');
+    for (const record of records) {
+      expect(record['gen_ai.agent.name']).toBeUndefined();
+      expect(record.resourceAttributes).toBeUndefined();
+    }
+  });
+
+  test('stamps invocation resource context on every record', () => {
+    const turn = makeTurn({ llmCalls: [makeLlmCall()] });
+    const resourceAttributes = {
+      'agentteams.worker.name': 'planner',
+      'agentteams.instance.id': 'qwen-instance-01',
+    };
+    const { records } = buildTurnRecords(
+      turn,
+      0,
+      'sess-1',
+      INITIAL_HASH,
+      'u-1',
+      'end_turn',
+      '/work',
+      resourceAttributes,
+    );
+    for (const record of records) {
+      expect(record['gen_ai.agent.name']).toBe('planner');
+      expect(record.resourceAttributes).toEqual(resourceAttributes);
+      expect(record['gen_ai.agent.id']).toBe('sess-1');
+    }
+  });
+
   test('turn.id format = <sessionId>:t<N> (C2)', () => {
     const turn = makeTurn({ llmCalls: [makeLlmCall()] });
     const { records } = buildTurnRecords(turn, 2, 'sess-1', INITIAL_HASH, 'u-1', 'end_turn');

--- a/tests/unit/hooks/qwen-code-cli/hook-processor.test.mjs
+++ b/tests/unit/hooks/qwen-code-cli/hook-processor.test.mjs
@@ -195,7 +195,7 @@ describe('hook-processor: cmdStop end-to-end', () => {
     expect(turn2EventNames).toContain('llm.response');
   });
 
-  test('binds each resumed turn to the current AgentTeams worker without stale context', () => {
+  test('binds each resumed turn to the current worker without stale context', () => {
     const sid = 'sess-worker-resume-1';
     const transcriptPath = writeTranscript(sid, [
       userRec('u1', 'q1', '2026-06-17T08:00:00.000Z', sid),

--- a/tests/unit/hooks/qwen-code-cli/hook-processor.test.mjs
+++ b/tests/unit/hooks/qwen-code-cli/hook-processor.test.mjs
@@ -28,10 +28,15 @@ function writeTranscript(sessionId, records) {
   return file;
 }
 
-function runHook(subcommand, payload) {
+function runHook(subcommand, payload, extraEnv = {}) {
+  const env = { ...process.env, LOONGSUITE_PILOT_DATA_DIR: DATA_DIR };
+  delete env.AGENTTEAMS_WORKER_NAME;
+  delete env.AGENTTEAMS_INSTANCE_ID;
+  delete env.AGENTTEAMS_TOKEN;
+  Object.assign(env, extraEnv);
   const r = spawnSync('node', [PROCESSOR, subcommand], {
     input: JSON.stringify(payload),
-    env: { ...process.env, LOONGSUITE_PILOT_DATA_DIR: DATA_DIR },
+    env,
     encoding: 'utf-8',
     timeout: 10_000,
   });
@@ -188,6 +193,47 @@ describe('hook-processor: cmdStop end-to-end', () => {
       .filter((r) => r['gen_ai.turn.id'] === `${sid}:t2`)
       .map((r) => r['event.name']);
     expect(turn2EventNames).toContain('llm.response');
+  });
+
+  test('binds each resumed turn to the current AgentTeams worker without stale context', () => {
+    const sid = 'sess-worker-resume-1';
+    const transcriptPath = writeTranscript(sid, [
+      userRec('u1', 'q1', '2026-06-17T08:00:00.000Z', sid),
+      assistantRec('a1', [{ text: 'a1' }], '2026-06-17T08:00:10.000Z', {}, sid),
+    ]);
+    const payload = {
+      session_id: sid,
+      transcript_path: transcriptPath,
+      cwd: '/work',
+      stop_reason: 'end_turn',
+    };
+
+    runHook('stop', payload, {
+      AGENTTEAMS_WORKER_NAME: 'planner',
+      AGENTTEAMS_INSTANCE_ID: 'qwen-instance-01',
+      AGENTTEAMS_TOKEN: 'must-not-leak',
+    });
+
+    fs.appendFileSync(transcriptPath, [
+      userRec('u2', 'q2', '2026-06-17T08:01:00.000Z', sid),
+      assistantRec('a2', [{ text: 'a2' }], '2026-06-17T08:01:10.000Z', {}, sid),
+    ].map((record) => JSON.stringify(record)).join('\n') + '\n');
+
+    runHook('stop', payload, {
+      AGENTTEAMS_WORKER_NAME: 'reviewer',
+      AGENTTEAMS_INSTANCE_ID: 'qwen-instance-02',
+    });
+
+    const records = readEmittedRecords();
+    const turn1 = records.filter((record) => record['gen_ai.turn.id'] === `${sid}:t1`);
+    const turn2 = records.filter((record) => record['gen_ai.turn.id'] === `${sid}:t2`);
+    expect(turn1.length).toBeGreaterThan(0);
+    expect(turn2.length).toBeGreaterThan(0);
+    expect(turn1.every((record) => record['gen_ai.agent.name'] === 'planner')).toBe(true);
+    expect(turn2.every((record) => record['gen_ai.agent.name'] === 'reviewer')).toBe(true);
+    expect(turn1[0].resourceAttributes['agentteams.instance.id']).toBe('qwen-instance-01');
+    expect(turn2[0].resourceAttributes['agentteams.instance.id']).toBe('qwen-instance-02');
+    expect(JSON.stringify(records)).not.toContain('must-not-leak');
   });
 
   test('first-run guard: long transcript with many turns only emits last turn', () => {

--- a/tests/unit/hooks/shared/resource-context.test.mjs
+++ b/tests/unit/hooks/shared/resource-context.test.mjs
@@ -4,10 +4,16 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
+  DEFAULT_RESOURCE_ENV_FIELD_MAP,
   agentBaseFieldPatch,
   collectResourceAttributesFromEnv,
   parseSpanAttributesFromEnv,
 } from '../../../../assets/hooks/shared/resource-context.mjs';
+import {
+  DEFAULT_RESOURCE_ENV_FIELD_MAP as PLUGIN_RESOURCE_ENV_FIELD_MAP,
+  agentBaseFieldPatch as pluginAgentBaseFieldPatch,
+  collectResourceAttributesFromEnv as collectPluginResourceAttributesFromEnv,
+} from '../../../../assets/plugins/shared/resource-context.mjs';
 
 const ROOT = path.resolve(fileURLToPath(import.meta.url), '../../../../..');
 
@@ -49,6 +55,39 @@ describe('hook resource context helper', () => {
     })).toEqual({
       'gen_ai.agent.name': 'worker-01',
     });
+  });
+
+  test('hook and plugin helpers keep the same AgentTeams contract', () => {
+    expect(PLUGIN_RESOURCE_ENV_FIELD_MAP).toEqual(DEFAULT_RESOURCE_ENV_FIELD_MAP);
+
+    const env = {
+      AGENTTEAMS_WORKER_NAME: ' planner ',
+      AGENTTEAMS_INSTANCE_ID: ' instance-01 ',
+      AGENTTEAMS_TOKEN: 'must-not-leak',
+      AGENTTEAMS_TEAM_NAME: 'not-allowlisted',
+    };
+    const hookAttributes = collectResourceAttributesFromEnv(env);
+    const pluginAttributes = collectPluginResourceAttributesFromEnv(env);
+
+    expect(pluginAttributes).toEqual(hookAttributes);
+    expect(pluginAgentBaseFieldPatch(pluginAttributes)).toEqual(
+      agentBaseFieldPatch(hookAttributes),
+    );
+    expect(JSON.stringify(pluginAttributes)).not.toContain('must-not-leak');
+  });
+
+  test('hook and plugin helpers both reject empty and over-long values', () => {
+    const warn = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const env = {
+        AGENTTEAMS_WORKER_NAME: ' ',
+        AGENTTEAMS_INSTANCE_ID: 'x'.repeat(513),
+      };
+      expect(collectResourceAttributesFromEnv(env)).toEqual({});
+      expect(collectPluginResourceAttributesFromEnv(env)).toEqual({});
+    } finally {
+      warn.mockRestore();
+    }
   });
 });
 

--- a/tests/unit/hooks/shared/resource-context.test.mjs
+++ b/tests/unit/hooks/shared/resource-context.test.mjs
@@ -57,7 +57,7 @@ describe('hook resource context helper', () => {
     });
   });
 
-  test('hook and plugin helpers keep the same AgentTeams contract', () => {
+  test('hook and plugin helpers keep the same resource context contract', () => {
     expect(PLUGIN_RESOURCE_ENV_FIELD_MAP).toEqual(DEFAULT_RESOURCE_ENV_FIELD_MAP);
 
     const env = {


### PR DESCRIPTION
## Summary

- allow users to customize gen_ai.agent.name and attach agentteams.worker.name and agentteams.instance.id through process environment variables
- extend the capability to OpenCode, Pi Coding Agent, MiMo Code, Qwen Code CLI, and Cursor CLI; Claude Code, Qoder, and Codex remain supported
- preserve existing agent IDs and default naming behavior when custom values are absent
- add a concise usage guide for all supported agents

## Compatibility

- AGENTTEAMS_INSTANCE_ID never overwrites gen_ai.agent.id
- non-allowlisted AGENTTEAMS_* variables are ignored
- Cursor Desktop remains unchanged

## Tests

- npm run typecheck
- npm test -- --silent: 2478 passed, 11 skipped
- targeted custom identity tests: 51 passed