### PR TITLE
fix(codex): preserve subagent rollout identity

### DIFF
--- a/docs/codex-subagent-fusion.md
+++ b/docs/codex-subagent-fusion.md
@@ -1,0 +1,95 @@
+# Codex subagent trace fusion
+
+Codex depth-one subagent rollouts are formally fused into the parent trace.
+The linker still exposes lower-confidence matches for diagnostics, but those
+matches do not all have authority to change trace ownership.
+
+## Reliable identity and confidence
+
+Each `spawn_agent` lifecycle is uniquely identified by the parent
+`parentToolCallId`. An `agent_path` is descriptive metadata and may be reused
+by multiple spawn calls, so it is never used as a deduplication key.
+
+Only these confidence levels can execute fusion:
+
+- `explicit_id`: the child thread id occurs on exactly one parent spawn.
+- `agent_path`: the child path matches exactly one still-available parent
+  spawn. Repeated matching paths are ambiguous and cannot execute fusion.
+
+`time_order` is diagnostic-only. It can explain a likely relationship in the
+link snapshot and logs, but it cannot create a fusion candidate, capture a
+child terminal, or delay a parent terminal. `orphan` is also never fused.
+
+## Fusion state machine
+
+1. `activeTurn`: incremental parent and child records continue to emit
+   normally. A parent turn also retains observed `spawn_agent` descriptors,
+   keyed by `parentToolCallId`.
+2. `pendingSubagent`: when a child terminal has a reliable candidate, its scan
+   offset advances past the terminal. The completed active-turn snapshot and
+   exact parent spawn identity are persisted here. This means the terminal is
+   consumed but has not been emitted as an independent trace. Later turns in
+   the same child rollout can continue to be scanned.
+3. `pendingFusion`: the parent `task_complete` is the direct-child lifecycle
+   barrier. Its terminal range and reliable candidates are persisted as a
+   crash-safe staging state while the current collection cycle finishes
+   processing child files.
+4. `ready/finalize`: a captured child is rebuilt from `pendingSubagent`. A
+   reliably linked child that has an un-emitted `activeTurn` but no terminal is
+   force-closed at its consumed file offset and marked interrupted. Missing or
+   unsafe-to-rebuild children are degraded instead of delaying the parent.
+   Rebuilt children are rewritten with parent trace attributes and emitted
+   before the parent terminal; the parent is always released in that finalize
+   pass.
+
+There is no wall-clock fusion timeout because `pendingFusion` is not a
+long-running wait state. Parent `task_complete` causes same-cycle finalize or
+independent degradation.
+
+## Independent-trace degradation
+
+Fusion is deliberately conservative:
+
+- A child terminal without a reliable candidate is emitted immediately as an
+  independent trace.
+- If a captured `agent_path` candidate later becomes ambiguous or its exact
+  spawn identity no longer matches, the saved child snapshot is rebuilt and
+  emitted once as an independent trace.
+- If a pending parent loses all reliable candidates, its terminal is rebuilt
+  and emitted independently and its offset advances.
+- If a reliable child has no terminal when the parent completes, its complete
+  un-emitted active turn is rebuilt as interrupted. If that is not possible,
+  the parent still completes and the child is left to the independent path.
+- `followup_task` does not create a new child lifecycle.
+- Aborted child turns use their terminal marker and follow the same ownership
+  and degradation rules.
+
+## Checkpoint fields and compatibility
+
+`CodexTranscriptCheckpoint` persists:
+
+- `scanOffset`: the next unread rollout byte. It advances past a captured child
+  terminal even while that terminal is awaiting fusion.
+- `activeTurn`: the currently streaming turn and its incremental emission
+  state. Parent turns also retain spawn descriptors keyed by
+  `parentToolCallId`.
+- `pendingSubagent`: a consumed, not-independently-emitted child terminal. It
+  stores `turnId`, `parentThreadId`, `parentTurnId`, `parentTraceId`,
+  `parentToolCallId`, reliable `confidence`, `terminalEndOffset`, and the full
+  active-turn snapshot needed for restart recovery.
+- `pendingFusion`: a held parent terminal containing its parent identity,
+  terminal range, and reliable child candidates.
+- `pendingTerminal`: a terminal range that was persisted but could not yet be
+  parsed; it is retried before later transcript data.
+- `emittedTerminalTurnIds`: bounded per-rollout protection against duplicate
+  terminal emission. A bounded global registry provides cross-rollout
+  protection.
+- `ownerSessionMetaOffset`: identifies the rollout's own `session_meta` rather
+  than copied parent history.
+
+Legacy `pendingSubagent` checkpoints kept the active child turn at the top
+level and did not store a reliable spawn identity. They cannot be safely
+fused, so checkpoint loading migrates them into the normal independent
+`pendingTerminal` recovery path. Legacy metadata checkpoints without
+`ownerSessionMetaOffset` use a bounded header scan to recover the owning
+session metadata.

--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -388,10 +388,16 @@ export class OtlpTraceFlusher extends BaseFlusher {
   private isTerminalEvent(entry: AgentActivityEntry): boolean {
     // A fused child shares the parent's turn buffer. Its stop closes only the
     // child lifecycle; the delayed root response remains the turn boundary.
-    if (
-      normalizeAgentType(String(entry['gen_ai.agent.type'] ?? '')) === 'codex'
-      && entry['gen_ai.agent.scope'] === 'subagent'
-    ) return false;
+    if (normalizeAgentType(String(entry['gen_ai.agent.type'] ?? '')) === 'codex') {
+      if (entry['gen_ai.agent.scope'] === 'subagent') return false;
+      // A `stop` closes one Codex model wave, not necessarily the surrounding
+      // transcript turn. The transcript input stamps this status only when it
+      // has observed task_complete / turn_aborted, which is the lifecycle
+      // boundary that is safe to flush.
+      const turnStatus = entry['agent.codex.turn_status'];
+      if (turnStatus !== 'completed' && turnStatus !== 'interrupted') return false;
+      return entry['gen_ai.turn.end'] === true;
+    }
     // OpenClaw emits one finish reason per ReAct model call. Those values close
     // individual LLM spans, not the whole agent turn. Its llm_output hook is the
     // stable end-of-run boundary in every supported version (>=2026.5.12).

--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -386,6 +386,12 @@ export class OtlpTraceFlusher extends BaseFlusher {
   // --- Internal ---
 
   private isTerminalEvent(entry: AgentActivityEntry): boolean {
+    // A fused child shares the parent's turn buffer. Its stop closes only the
+    // child lifecycle; the delayed root response remains the turn boundary.
+    if (
+      normalizeAgentType(String(entry['gen_ai.agent.type'] ?? '')) === 'codex'
+      && entry['gen_ai.agent.scope'] === 'subagent'
+    ) return false;
     // OpenClaw emits one finish reason per ReAct model call. Those values close
     // individual LLM spans, not the whole agent turn. Its llm_output hook is the
     // stable end-of-run boundary in every supported version (>=2026.5.12).

--- a/src/inputs/codex-aborted-turn/codex-aborted-turn-builder.ts
+++ b/src/inputs/codex-aborted-turn/codex-aborted-turn-builder.ts
@@ -290,6 +290,7 @@ function buildCancelledResponse(
     'gen_ai.request.model': model,
     'gen_ai.response.model': model,
     'gen_ai.response.finish_reasons': ['cancelled'],
+    'gen_ai.turn.end': true,
     ...(messages.length > 0 ? { 'gen_ai.output.messages': agentResponseMessages(messages) } : {}),
     ...usageFields(usage),
     ...sharedLlmFields(turn),

--- a/src/inputs/codex-transcript/codex-subagent-linker.ts
+++ b/src/inputs/codex-transcript/codex-subagent-linker.ts
@@ -1,0 +1,311 @@
+import type {
+  CodexExtractedTranscriptTurn,
+  CodexTranscriptMeta,
+  CodexTranscriptSourceRecord,
+  CodexTranscriptTool,
+} from './codex-transcript-types.js';
+import { stringValue } from './codex-transcript-utils.js';
+
+export type CodexSubagentLinkConfidence =
+  | 'explicit_id'
+  | 'agent_path'
+  | 'time_order'
+  | 'orphan';
+
+export interface CodexSpawnDescriptor {
+  parentThreadId: string;
+  parentTurnId: string;
+  parentTraceId: string;
+  parentToolCallId: string;
+  spawnedAtMs: number;
+  taskName?: string;
+  agentPath?: string;
+  childThreadId?: string;
+}
+
+export interface CodexChildThreadDescriptor {
+  childThreadId: string;
+  parentThreadId: string;
+  rootSessionId: string;
+  depth: number;
+  createdAtMs: number;
+  agentPath?: string;
+  agentNickname?: string;
+}
+
+export interface CodexSubagentLink {
+  parentThreadId: string;
+  parentTurnId?: string;
+  parentTraceId?: string;
+  parentToolCallId?: string;
+  childThreadId: string;
+  agentPath?: string;
+  confidence: CodexSubagentLinkConfidence;
+  orphanReason?: 'parent_not_found' | 'ambiguous_explicit_id' | 'ambiguous_agent_path' | 'no_candidate';
+}
+
+export interface CodexSubagentLinkSnapshot {
+  detectedChildren: number;
+  detectedSpawns: number;
+  linkedChildren: number;
+  orphanChildren: number;
+  links: CodexSubagentLink[];
+}
+
+interface CandidateSelection {
+  spawn?: CodexSpawnDescriptor;
+  confidence?: Exclude<CodexSubagentLinkConfidence, 'orphan'>;
+  orphanReason?: CodexSubagentLink['orphanReason'];
+}
+
+const MAX_SHADOW_DESCRIPTORS = 10_000;
+
+/**
+ * In-memory, depth-one linker used by the phase-2 shadow path.
+ *
+ * The linker recalculates assignments from its descriptor registry instead of
+ * locking the first match. This lets a child observed before its parent move
+ * from orphan/time-order to an exact match when later parent facts arrive.
+ */
+export class CodexSubagentLinker {
+  private readonly spawns = new Map<string, CodexSpawnDescriptor>();
+  private readonly children = new Map<string, CodexChildThreadDescriptor>();
+
+  registerSpawns(descriptors: CodexSpawnDescriptor[]): void {
+    for (const descriptor of descriptors) {
+      const key = spawnKey(descriptor);
+      const previous = this.spawns.get(key);
+      this.spawns.set(key, previous ? mergeSpawn(previous, descriptor) : descriptor);
+      trimOldest(this.spawns, MAX_SHADOW_DESCRIPTORS);
+    }
+  }
+
+  registerChild(meta: CodexTranscriptMeta): void {
+    if (meta.threadSource !== 'subagent' || meta.depth !== 1 || !meta.parentThreadId) return;
+    this.children.set(meta.threadId, {
+      childThreadId: meta.threadId,
+      parentThreadId: meta.parentThreadId,
+      rootSessionId: meta.rootSessionId,
+      depth: meta.depth,
+      createdAtMs: meta.createdAtMs ?? 0,
+      ...(meta.agentPath ? { agentPath: meta.agentPath } : {}),
+      ...(meta.agentNickname ? { agentNickname: meta.agentNickname } : {}),
+    });
+    trimOldest(this.children, MAX_SHADOW_DESCRIPTORS);
+  }
+
+  hasThread(threadId: string): boolean {
+    return this.children.has(threadId);
+  }
+
+  snapshot(): CodexSubagentLinkSnapshot {
+    const spawns = [...this.spawns.values()];
+    const children = [...this.children.values()]
+      .sort((left, right) => left.createdAtMs - right.createdAtMs || left.childThreadId.localeCompare(right.childThreadId));
+    const usedSpawnKeys = new Set<string>();
+    const linksByChild = new Map<string, CodexSubagentLink>();
+
+    // Apply priorities globally. Otherwise an earlier child that only has a
+    // time-order fallback could consume the exact spawn of a later child.
+    assignLinks(children, spawns, usedSpawnKeys, linksByChild, 'explicit_id');
+    assignLinks(children, spawns, usedSpawnKeys, linksByChild, 'agent_path');
+    assignLinks(children, spawns, usedSpawnKeys, linksByChild, 'time_order');
+
+    for (const child of children) {
+      if (linksByChild.has(child.childThreadId)) continue;
+      const hasParentSpawn = spawns.some(spawn => spawn.parentThreadId === child.parentThreadId);
+      linksByChild.set(child.childThreadId, orphanLink(
+        child,
+        hasParentSpawn ? 'no_candidate' : 'parent_not_found',
+      ));
+    }
+
+    const links = children.map(child => linksByChild.get(child.childThreadId)!);
+
+    const linkedChildren = links.filter(link => link.confidence !== 'orphan').length;
+    return {
+      detectedChildren: children.length,
+      detectedSpawns: spawns.length,
+      linkedChildren,
+      orphanChildren: links.length - linkedChildren,
+      links,
+    };
+  }
+}
+
+function assignLinks(
+  children: CodexChildThreadDescriptor[],
+  spawns: CodexSpawnDescriptor[],
+  usedSpawnKeys: Set<string>,
+  linksByChild: Map<string, CodexSubagentLink>,
+  phase: Exclude<CodexSubagentLinkConfidence, 'orphan'>,
+): void {
+  for (const child of children) {
+    if (linksByChild.has(child.childThreadId)) continue;
+    const candidates = spawns.filter(spawn =>
+      spawn.parentThreadId === child.parentThreadId && !usedSpawnKeys.has(spawnKey(spawn)));
+    const selection = selectCandidateForPhase(child, candidates, phase);
+    if (selection.orphanReason) {
+      linksByChild.set(child.childThreadId, orphanLink(child, selection.orphanReason));
+      continue;
+    }
+    if (!selection.spawn || !selection.confidence) continue;
+    usedSpawnKeys.add(spawnKey(selection.spawn));
+    linksByChild.set(child.childThreadId, linkedChild(child, selection.spawn, selection.confidence));
+  }
+}
+
+export function extractCodexSpawnDescriptors(
+  turn: CodexExtractedTranscriptTurn,
+  sourceRecords: CodexTranscriptSourceRecord[],
+  parentTraceId: string,
+): CodexSpawnDescriptor[] {
+  const activities = new Map<string, {
+    childThreadId?: string;
+    agentPath?: string;
+    occurredAtMs?: number;
+  }>();
+
+  for (const source of sourceRecords) {
+    if (source.record.type !== 'event_msg') continue;
+    const payload = asRecord(source.record.payload);
+    if (!payload || payload.type !== 'sub_agent_activity' || payload.kind !== 'started') continue;
+    const callId = stringValue(payload.event_id);
+    if (!callId) continue;
+    const occurredAtMs = finiteNumber(payload.occurred_at_ms);
+    activities.set(callId, {
+      ...(stringValue(payload.agent_thread_id) ? { childThreadId: stringValue(payload.agent_thread_id)! } : {}),
+      ...(stringValue(payload.agent_path) ? { agentPath: stringValue(payload.agent_path)! } : {}),
+      ...(occurredAtMs !== undefined ? { occurredAtMs } : {}),
+    });
+  }
+
+  const descriptors: CodexSpawnDescriptor[] = [];
+  for (const step of turn.steps) {
+    for (const tool of step.tools) {
+      if (tool.name !== 'spawn_agent') continue;
+      const activity = activities.get(tool.callId);
+      const taskName = spawnTaskName(tool);
+      descriptors.push({
+        parentThreadId: turn.sessionId,
+        parentTurnId: turn.transcriptTurnId,
+        parentTraceId,
+        parentToolCallId: tool.callId,
+        spawnedAtMs: activity?.occurredAtMs ?? tool.startedAtMs,
+        ...(taskName ? { taskName } : {}),
+        ...(activity?.agentPath ? { agentPath: activity.agentPath } : {}),
+        ...(activity?.childThreadId ? { childThreadId: activity.childThreadId } : {}),
+      });
+    }
+  }
+  return descriptors;
+}
+
+function selectCandidateForPhase(
+  child: CodexChildThreadDescriptor,
+  candidates: CodexSpawnDescriptor[],
+  phase: Exclude<CodexSubagentLinkConfidence, 'orphan'>,
+): CandidateSelection {
+  if (phase === 'explicit_id') {
+    const explicit = candidates.filter(spawn => spawn.childThreadId === child.childThreadId);
+    if (explicit.length === 1) return { spawn: explicit[0], confidence: 'explicit_id' };
+    if (explicit.length > 1) return { orphanReason: 'ambiguous_explicit_id' };
+    return {};
+  }
+
+  if (phase === 'agent_path') {
+    if (!child.agentPath) return {};
+    const exactPath = candidates.filter(spawn => {
+      const candidatePath = spawn.agentPath ?? spawn.taskName;
+      return candidatePath !== undefined && normalizeAgentPath(candidatePath) === normalizeAgentPath(child.agentPath!);
+    });
+    if (exactPath.length === 1) return { spawn: exactPath[0], confidence: 'agent_path' };
+    if (exactPath.length > 1) return { orphanReason: 'ambiguous_agent_path' };
+    return {};
+  }
+
+  const preceding = candidates
+    .filter(spawn => child.createdAtMs <= 0 || spawn.spawnedAtMs <= child.createdAtMs)
+    .sort((left, right) => right.spawnedAtMs - left.spawnedAtMs || spawnKey(left).localeCompare(spawnKey(right)));
+  if (preceding.length === 0) return candidates.length === 0 ? {} : { orphanReason: 'no_candidate' };
+  if (preceding.length > 1 && preceding[0].spawnedAtMs === preceding[1].spawnedAtMs) {
+    return { orphanReason: 'no_candidate' };
+  }
+  return { spawn: preceding[0], confidence: 'time_order' };
+}
+
+function linkedChild(
+  child: CodexChildThreadDescriptor,
+  spawn: CodexSpawnDescriptor,
+  confidence: Exclude<CodexSubagentLinkConfidence, 'orphan'>,
+): CodexSubagentLink {
+  return {
+    parentThreadId: child.parentThreadId,
+    parentTurnId: spawn.parentTurnId,
+    parentTraceId: spawn.parentTraceId,
+    parentToolCallId: spawn.parentToolCallId,
+    childThreadId: child.childThreadId,
+    ...(child.agentPath ? { agentPath: child.agentPath } : {}),
+    confidence,
+  };
+}
+
+function orphanLink(
+  child: CodexChildThreadDescriptor,
+  orphanReason: NonNullable<CodexSubagentLink['orphanReason']>,
+): CodexSubagentLink {
+  return {
+    parentThreadId: child.parentThreadId,
+    childThreadId: child.childThreadId,
+    ...(child.agentPath ? { agentPath: child.agentPath } : {}),
+    confidence: 'orphan',
+    orphanReason,
+  };
+}
+
+function spawnTaskName(tool: CodexTranscriptTool): string | undefined {
+  const output = asRecord(tool.output);
+  const input = asRecord(tool.input);
+  return stringValue(output?.task_name)
+    ?? stringValue(output?.agent_path)
+    ?? stringValue(input?.task_name)
+    ?? stringValue(input?.agent_path);
+}
+
+function mergeSpawn(previous: CodexSpawnDescriptor, next: CodexSpawnDescriptor): CodexSpawnDescriptor {
+  return {
+    ...previous,
+    ...next,
+    taskName: next.taskName ?? previous.taskName,
+    agentPath: next.agentPath ?? previous.agentPath,
+    childThreadId: next.childThreadId ?? previous.childThreadId,
+  };
+}
+
+function spawnKey(spawn: CodexSpawnDescriptor): string {
+  return `${spawn.parentThreadId}:${spawn.parentToolCallId}`;
+}
+
+function normalizeAgentPath(value: string): string {
+  const trimmed = value.trim().replace(/\/+$/, '');
+  if (!trimmed) return trimmed;
+  return trimmed.startsWith('/') ? trimmed : `/root/${trimmed.replace(/^root\//, '')}`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function trimOldest<T>(values: Map<string, T>, maxSize: number): void {
+  while (values.size > maxSize) {
+    const oldest = values.keys().next().value as string | undefined;
+    if (oldest === undefined) return;
+    values.delete(oldest);
+  }
+}

--- a/src/inputs/codex-transcript/codex-subagent-linker.ts
+++ b/src/inputs/codex-transcript/codex-subagent-linker.ts
@@ -185,6 +185,12 @@ export function extractCodexSpawnDescriptors(
     for (const tool of step.tools) {
       if (tool.name !== 'spawn_agent') continue;
       const activity = activities.get(tool.callId);
+      const output = asRecord(tool.output);
+      // A rejected spawn still has a function_call and an input task_name, but
+      // it creates no child lifecycle. Only a started activity or a structured
+      // successful result is eligible for linking/fusion.
+      const resultAgentPath = stringValue(output?.agent_path) ?? stringValue(output?.task_name);
+      if (!activity && !resultAgentPath) continue;
       const taskName = spawnTaskName(tool);
       descriptors.push({
         parentThreadId: turn.sessionId,

--- a/src/inputs/codex-transcript/codex-subagent-linker.ts
+++ b/src/inputs/codex-transcript/codex-subagent-linker.ts
@@ -58,14 +58,16 @@ interface CandidateSelection {
   orphanReason?: CodexSubagentLink['orphanReason'];
 }
 
-const MAX_SHADOW_DESCRIPTORS = 10_000;
+export const MAX_LINK_DESCRIPTORS = 10_000;
 
 /**
- * In-memory, depth-one linker used by the phase-2 shadow path.
+ * In-memory linker for depth-one Codex subagents.
  *
- * The linker recalculates assignments from its descriptor registry instead of
- * locking the first match. This lets a child observed before its parent move
- * from orphan/time-order to an exact match when later parent facts arrive.
+ * The linker recalculates assignments as parent and child facts arrive. Only
+ * explicit child ids and unambiguous agent paths are eligible for trace
+ * fusion; time-order links remain available for diagnostics only. Spawn
+ * identity is keyed by parentToolCallId, so repeated agent paths remain
+ * distinct child lifecycles.
  */
 export class CodexSubagentLinker {
   private readonly spawns = new Map<string, CodexSpawnDescriptor>();
@@ -76,7 +78,7 @@ export class CodexSubagentLinker {
       const key = spawnKey(descriptor);
       const previous = this.spawns.get(key);
       this.spawns.set(key, previous ? mergeSpawn(previous, descriptor) : descriptor);
-      trimOldest(this.spawns, MAX_SHADOW_DESCRIPTORS);
+      trimOldest(this.spawns, MAX_LINK_DESCRIPTORS);
     }
   }
 
@@ -91,7 +93,7 @@ export class CodexSubagentLinker {
       ...(meta.agentPath ? { agentPath: meta.agentPath } : {}),
       ...(meta.agentNickname ? { agentNickname: meta.agentNickname } : {}),
     });
-    trimOldest(this.children, MAX_SHADOW_DESCRIPTORS);
+    trimOldest(this.children, MAX_LINK_DESCRIPTORS);
   }
 
   hasThread(threadId: string): boolean {

--- a/src/inputs/codex-transcript/codex-transcript-builder.ts
+++ b/src/inputs/codex-transcript/codex-transcript-builder.ts
@@ -248,7 +248,7 @@ function buildToolEntries(
   stepId: string,
   stepSpanId: string,
 ): AgentActivityEntry[] {
-  const spanId = hashId([turn.sessionId, turn.transcriptTurnId, 'tool', tool.callId], 16);
+  const spanId = codexToolSpanId(turn.sessionId, turn.transcriptTurnId, tool.callId);
   const records = [buildEntry({
     ...base,
     timestamp: tool.startedAtMs,
@@ -328,6 +328,10 @@ function buildEntry(fields: Record<string, JsonValue>): AgentActivityEntry {
 
 function hashId(parts: string[], length: number): string {
   return crypto.createHash('sha256').update(parts.join('\0')).digest('hex').slice(0, length);
+}
+
+export function codexToolSpanId(sessionId: string, turnId: string, toolCallId: string): string {
+  return hashId([sessionId, turnId, 'tool', toolCallId], 16);
 }
 
 function hashInputMessages(previousHash: string, messages: JsonValue[]): string {

--- a/src/inputs/codex-transcript/codex-transcript-extractor.ts
+++ b/src/inputs/codex-transcript/codex-transcript-extractor.ts
@@ -36,6 +36,7 @@ export function extractCodexTranscriptMeta(record: Record<string, unknown>): Cod
   const depth = rawDepth !== undefined && rawDepth >= 0
     ? Math.trunc(rawDepth)
     : threadSource === 'subagent' ? 1 : 0;
+  const createdAtMs = timestampMs(payload, timestampMs(record, Number.NaN));
   const baseInstructions = readInstructionText(payload.base_instructions);
   const toolDefinitions = Array.isArray(payload.dynamic_tools)
     ? toJsonValue(payload.dynamic_tools)
@@ -46,6 +47,7 @@ export function extractCodexTranscriptMeta(record: Record<string, unknown>): Cod
     threadSource,
     ...(parentThreadId ? { parentThreadId } : {}),
     depth,
+    ...(Number.isFinite(createdAtMs) ? { createdAtMs } : {}),
     ...(agentPath ? { agentPath } : {}),
     ...(agentNickname ? { agentNickname } : {}),
     ...(agentRole ? { agentRole } : {}),

--- a/src/inputs/codex-transcript/codex-transcript-extractor.ts
+++ b/src/inputs/codex-transcript/codex-transcript-extractor.ts
@@ -324,6 +324,28 @@ function extractCodexTurn(
 
     if (record.type !== 'response_item') continue;
     const itemType = stringValue(payload.type);
+    if (itemType === 'agent_message' && meta?.threadSource === 'subagent') {
+      const recipient = stringValue(payload.recipient);
+      const communicationMeta = asRecord(payload.internal_chat_message_metadata_passthrough);
+      const messageTurnId = stringValue(communicationMeta?.turn_id);
+      // Codex represents the initial parent → child delegation as an internal
+      // agent_message rather than a user_message. Treat it as the child turn's
+      // input only when it targets this child and belongs to this turn; child →
+      // parent completion messages in root rollouts must not become prompts.
+      if (
+        (!meta.agentPath || !recipient || recipient === meta.agentPath)
+        && (!messageTurnId || messageTurnId === expectedTurnId)
+      ) {
+        const message = transcriptInputMessage('user', payload.content);
+        if (message) {
+          inputMessages.push(message);
+          appendPrompt(message.parts[0]?.content);
+          sawSubmittedUserMessage = true;
+          markActivity(timestamp);
+        }
+      }
+      continue;
+    }
     if (itemType === 'message') {
       const role = stringValue(payload.role);
       if (role === 'assistant') {

--- a/src/inputs/codex-transcript/codex-transcript-extractor.ts
+++ b/src/inputs/codex-transcript/codex-transcript-extractor.ts
@@ -18,12 +18,37 @@ export function extractCodexTranscriptMeta(record: Record<string, unknown>): Cod
   const payload = asRecord(record.payload);
   if (!payload) return null;
 
+  const threadId = stringValue(payload.id) ?? '';
+  const source = asRecord(payload.source);
+  const subagent = asRecord(source?.subagent);
+  const threadSpawn = asRecord(subagent?.thread_spawn);
+  const parentThreadId = stringValue(threadSpawn?.parent_thread_id);
+  const agentPath = stringValue(threadSpawn?.agent_path);
+  const agentNickname = stringValue(threadSpawn?.agent_nickname);
+  const agentRole = stringValue(threadSpawn?.agent_role);
+  const rawThreadSource = stringValue(payload.thread_source);
+  const threadSource: CodexTranscriptMeta['threadSource'] = rawThreadSource === 'subagent' || parentThreadId
+    ? 'subagent'
+    : rawThreadSource === 'user'
+      ? 'user'
+      : 'unknown';
+  const rawDepth = numberValue(threadSpawn?.depth);
+  const depth = rawDepth !== undefined && rawDepth >= 0
+    ? Math.trunc(rawDepth)
+    : threadSource === 'subagent' ? 1 : 0;
   const baseInstructions = readInstructionText(payload.base_instructions);
   const toolDefinitions = Array.isArray(payload.dynamic_tools)
     ? toJsonValue(payload.dynamic_tools)
     : undefined;
   return {
-    sessionId: stringValue(payload.id) ?? '',
+    threadId,
+    rootSessionId: stringValue(payload.session_id) ?? threadId,
+    threadSource,
+    ...(parentThreadId ? { parentThreadId } : {}),
+    depth,
+    ...(agentPath ? { agentPath } : {}),
+    ...(agentNickname ? { agentNickname } : {}),
+    ...(agentRole ? { agentRole } : {}),
     provider: stringValue(payload.model_provider) ?? 'openai',
     ...(baseInstructions ? { baseInstructions } : {}),
     ...(toolDefinitions !== undefined ? { toolDefinitions } : {}),
@@ -419,7 +444,7 @@ function extractCodexTurn(
     && (sawSubmittedUserMessage || steps.length > 0 || sawTerminal),
   );
   const turn: CodexExtractedTranscriptTurn = {
-    sessionId: meta?.sessionId || fallbackSessionId,
+    sessionId: meta?.threadId || fallbackSessionId,
     transcriptTurnId: expectedTurnId,
     provider: meta?.provider ?? 'openai',
     model,

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -10,6 +10,7 @@ import { directoryExists, resolveHome } from '../../utils/fs-utils.js';
 import { BaseInput, type InputOptions } from '../base/base-input.js';
 import {
   buildCodexTranscriptSegment,
+  codexToolSpanId,
   nextInputMessagesForStep,
 } from './codex-transcript-builder.js';
 import {
@@ -27,6 +28,9 @@ import {
   MAX_EMITTED_TERMINAL_TURNS,
   MAX_GLOBAL_EMITTED_TERMINAL_TURNS,
   type CodexActiveTranscriptTurn,
+  type CodexPendingFusionChild,
+  type CodexPendingFusionTurn,
+  type CodexPendingSubagentTurn,
   type CodexPendingTerminalTurn,
   type CodexTranscriptInputContext,
   type CodexTranscriptCheckpoint,
@@ -139,6 +143,8 @@ export class CodexTranscriptInput extends BaseInput {
   private lastSubagentShadowSummary = '';
   private lastWakeupMarkerCleanupAtMs = 0;
   private lastSpanContextCleanupAtMs = 0;
+  private readonly transcriptMetaByPath = new Map<string, ReturnType<typeof extractCodexTranscriptMeta>>();
+  private readonly transcriptPathByThreadId = new Map<string, string>();
 
   constructor(opts: CodexTranscriptInputOptions) {
     super({ stateStore: opts.stateStore, pollIntervalMs: opts.pollIntervalMs ?? 30_000 });
@@ -157,9 +163,17 @@ export class CodexTranscriptInput extends BaseInput {
 
   protected override async onStart(): Promise<void> {
     this.loadGlobalProcessedTerminalTurnIds();
-    for (const { filePath, baselineOnStart } of await this.discoverSessionFiles()) {
+    const discovered = await this.discoverSessionFiles();
+    await this.indexDiscoveredTranscriptOwners(discovered);
+    for (const { filePath, baselineOnStart } of discovered) {
       const key = this.stateKey(filePath);
-      if (baselineOnStart && !this.readCheckpoint(key)) await this.baselineFile(filePath, key);
+      const meta = this.transcriptMetaByPath.get(filePath);
+      const neededByPendingFusion = meta?.depth === 1
+        && meta.parentThreadId !== undefined
+        && this.hasPendingFusionForParent(meta.parentThreadId);
+      if (baselineOnStart && !neededByPendingFusion && !this.readCheckpoint(key)) {
+        await this.baselineFile(filePath, key);
+      }
     }
     this.saveGlobalProcessedTerminalTurnIds();
     await Promise.all([
@@ -189,9 +203,17 @@ export class CodexTranscriptInput extends BaseInput {
   protected override async collect(): Promise<AgentActivityEntry[]> {
     await this.cleanupExpiredSpanContexts(Date.now());
     let emittedCount = 0;
-    for (const { filePath } of await this.discoverSessionFiles()) {
+    const discovered = await this.discoverSessionFiles();
+    await this.indexDiscoveredTranscriptOwners(discovered);
+    discovered.sort((left, right) => {
+      const leftDepth = this.transcriptMetaByPath.get(left.filePath)?.depth ?? 0;
+      const rightDepth = this.transcriptMetaByPath.get(right.filePath)?.depth ?? 0;
+      return leftDepth - rightDepth || left.filePath.localeCompare(right.filePath);
+    });
+    for (const { filePath } of discovered) {
       emittedCount += await this.processFile(filePath);
     }
+    emittedCount += await this.finalizeReadySubagentFusions();
     this.reportSubagentShadowLinks();
     if (emittedCount > 0) {
       this.logger.debug('cycle produced entries', { count: emittedCount });
@@ -248,6 +270,8 @@ export class CodexTranscriptInput extends BaseInput {
         scanOffset: 0,
         activeTurn: null,
         pendingTerminal: null,
+        pendingFusion: null,
+        pendingSubagent: null,
         ownerSessionMetaOffset: null,
         emittedTerminalTurnIds: [],
       };
@@ -263,6 +287,15 @@ export class CodexTranscriptInput extends BaseInput {
       checkpointChanged = true;
     }
     await this.registerSubagentOwnerMeta(filePath, checkpoint.ownerSessionMetaOffset);
+
+    const ownerMeta = this.transcriptMetaByPath.get(filePath) ?? null;
+    const isDirectSubagent = ownerMeta?.threadSource === 'subagent' && ownerMeta.depth === 1;
+    if (ownerMeta?.depth === 0) this.registerPersistedSubagentSpawns(checkpoint, ownerMeta.threadId);
+
+    if (checkpoint.pendingFusion || checkpoint.pendingSubagent) {
+      if (checkpointChanged) this.saveCheckpoint(key, checkpoint);
+      return 0;
+    }
 
     let emittedCount = 0;
     let processedTerminalCount = 0;
@@ -346,15 +379,72 @@ export class CodexTranscriptInput extends BaseInput {
           checkpoint.pendingTerminal = null;
           processedTerminalCount++;
         } else {
+          if (
+            isDirectSubagent
+            && terminalTurnId
+            && ownerMeta?.createdAtMs !== undefined
+            && checkpoint.activeTurn.startedAtMs < ownerMeta.createdAtMs
+          ) {
+            // Forked child rollouts contain copied parent history after their
+            // owning session_meta. It must not become the child's pending turn.
+            checkpoint.activeTurn = null;
+            processedTerminalCount++;
+            checkpoint.scanOffset = nextScanOffset;
+            continue;
+          }
+
+          if (isDirectSubagent) {
+            if (terminalTurnId) {
+              checkpoint.pendingSubagent = {
+                turnId: terminalTurnId,
+                terminalEndOffset: nextScanOffset,
+              };
+              blocked = true;
+            }
+            checkpoint.scanOffset = nextScanOffset;
+            break;
+          }
+
+          const activeBeforeRecovery = terminalTurnId
+            ? cloneActiveTurn(checkpoint.activeTurn)
+            : null;
           const recovered = await this.recoverTurnSegment(
             filePath,
             checkpoint,
             nextScanOffset,
             terminalTurnId !== null,
           );
-          emittedCount += this.emitEntryBatches(recovered.entries);
+          const fusionChildren = terminalTurnId
+            ? checkpoint.activeTurn?.subagentSpawns ?? []
+            : [];
+          if (
+            terminalTurnId
+            && recovered.kind !== 'unparseable'
+            && fusionChildren.length > 0
+            && activeBeforeRecovery
+            // A root rollout can contain many completed historical turns. Only
+            // the terminal at the current file tail may still be waiting for
+            // its children. Gating an earlier terminal lets later children be
+            // consumed by that stale turn's time-order fallback.
+            && nextScanOffset >= stat.size
+          ) {
+            activeBeforeRecovery.subagentSpawns = fusionChildren;
+            checkpoint.activeTurn = activeBeforeRecovery;
+            checkpoint.pendingFusion = {
+              turnId: terminalTurnId,
+              parentThreadId: ownerMeta?.threadId ?? sessionIdFromTranscriptPath(filePath),
+              parentTraceId: parentTraceIdForChildren(fusionChildren),
+              terminalEndOffset: nextScanOffset,
+              children: fusionChildren,
+              createdAtMs: Date.now(),
+            };
+            blocked = true;
+          } else {
+            emittedCount += this.emitEntryBatches(recovered.entries);
+          }
           if (
             recovered.kind !== 'unparseable'
+            && !checkpoint.pendingFusion
             && recovered.consumedEndOffset > checkpoint.activeTurn.startOffset
           ) {
             checkpoint.activeTurn.startOffset = recovered.consumedEndOffset;
@@ -375,7 +465,7 @@ export class CodexTranscriptInput extends BaseInput {
                 sourceRecordCount: recovered.diagnostics.sourceRecordCount,
               });
               blocked = true;
-            } else {
+            } else if (!checkpoint.pendingFusion) {
               this.rememberProcessedTerminalTurnId(checkpoint, terminalTurnId);
               this.rememberGlobalProcessedTerminalTurnId(terminalTurnId);
               checkpoint.activeTurn = null;
@@ -508,8 +598,18 @@ export class CodexTranscriptInput extends BaseInput {
     if (meta?.depth === 0) {
       const parentTraceId = stringValue(built.entries[0]?.trace_id);
       if (parentTraceId) {
-        this.subagentLinker.registerSpawns(
-          extractCodexSpawnDescriptors(turn, records.items, parentTraceId),
+        const spawns = extractCodexSpawnDescriptors(turn, records.items, parentTraceId);
+        this.subagentLinker.registerSpawns(spawns);
+        activeTurn.subagentSpawns = mergePendingFusionChildren(
+          activeTurn.subagentSpawns ?? [],
+          spawns.map(spawn => ({
+            parentToolCallId: spawn.parentToolCallId,
+            parentTraceId: spawn.parentTraceId,
+            spawnedAtMs: spawn.spawnedAtMs,
+            ...(spawn.taskName ? { taskName: spawn.taskName } : {}),
+            ...(spawn.agentPath ? { agentPath: spawn.agentPath } : {}),
+            ...(spawn.childThreadId ? { childThreadId: spawn.childThreadId } : {}),
+          })),
         );
       }
     }
@@ -624,7 +724,154 @@ export class CodexTranscriptInput extends BaseInput {
     if (this.subagentLinker.hasThread(threadId)) return;
     const record = await readJsonLineAt(filePath, ownerSessionMetaOffset);
     const meta = record ? extractCodexTranscriptMeta(record) : null;
-    if (meta) this.subagentLinker.registerChild(meta);
+    if (meta) {
+      this.transcriptMetaByPath.set(filePath, meta);
+      this.transcriptPathByThreadId.set(meta.threadId, filePath);
+      this.subagentLinker.registerChild(meta);
+    }
+  }
+
+  private async indexDiscoveredTranscriptOwners(files: DiscoveredSessionFile[]): Promise<void> {
+    this.transcriptMetaByPath.clear();
+    this.transcriptPathByThreadId.clear();
+    for (const { filePath } of files) {
+      let stat;
+      try {
+        stat = await fs.stat(filePath);
+      } catch {
+        continue;
+      }
+      const checkpoint = this.readCheckpoint(this.stateKey(filePath));
+      const ownerOffset = checkpoint?.ownerSessionMetaOffset
+        ?? await findOwnerSessionMetaOffset(filePath, stat.size);
+      if (ownerOffset === null) continue;
+      const record = await readJsonLineAt(filePath, ownerOffset);
+      const meta = record ? extractCodexTranscriptMeta(record) : null;
+      if (!meta) continue;
+      this.transcriptMetaByPath.set(filePath, meta);
+      this.transcriptPathByThreadId.set(meta.threadId, filePath);
+      this.subagentLinker.registerChild(meta);
+    }
+  }
+
+  private registerPersistedSubagentSpawns(
+    checkpoint: CodexTranscriptCheckpoint,
+    parentThreadId: string,
+  ): void {
+    const active = checkpoint.activeTurn;
+    if (!active?.subagentSpawns?.length) return;
+    this.subagentLinker.registerSpawns(active.subagentSpawns.map(spawn => ({
+      parentThreadId,
+      parentTurnId: active.turnId,
+      parentTraceId: spawn.parentTraceId,
+      parentToolCallId: spawn.parentToolCallId,
+      spawnedAtMs: spawn.spawnedAtMs,
+      ...(spawn.taskName ? { taskName: spawn.taskName } : {}),
+      ...(spawn.agentPath ? { agentPath: spawn.agentPath } : {}),
+      ...(spawn.childThreadId ? { childThreadId: spawn.childThreadId } : {}),
+    })));
+  }
+
+  private hasPendingFusionForParent(parentThreadId: string): boolean {
+    for (const key of this.stateStore.keys()) {
+      if (!key.startsWith(`${this.id}:`)) continue;
+      const checkpoint = this.readCheckpoint(key);
+      if (checkpoint?.pendingFusion?.parentThreadId === parentThreadId) return true;
+    }
+    return false;
+  }
+
+  private async finalizeReadySubagentFusions(): Promise<number> {
+    let emittedCount = 0;
+    const links = this.subagentLinker.snapshot().links;
+    for (const [parentPath, meta] of this.transcriptMetaByPath) {
+      if (!meta || meta.depth !== 0) continue;
+      const parentKey = this.stateKey(parentPath);
+      const parentCheckpoint = this.readCheckpoint(parentKey);
+      const pending = parentCheckpoint?.pendingFusion;
+      if (!parentCheckpoint || !pending || !parentCheckpoint.activeTurn) continue;
+
+      const resolved = pending.children.map(child => {
+        const linked = links.find(link => (
+          link.parentThreadId === pending.parentThreadId
+          && link.parentTurnId === pending.turnId
+          && link.parentToolCallId === child.parentToolCallId
+          && (!child.childThreadId || link.childThreadId === child.childThreadId)
+        ));
+        const childThreadId = child.childThreadId ?? linked?.childThreadId;
+        const childPath = childThreadId ? this.transcriptPathByThreadId.get(childThreadId) : undefined;
+        const childCheckpoint = childPath ? this.readCheckpoint(this.stateKey(childPath)) : null;
+        return { child, linked, childThreadId, childPath, childCheckpoint };
+      });
+      if (resolved.some(item => (
+        !item.childThreadId
+        || !item.childPath
+        || !item.childCheckpoint?.pendingSubagent
+        || !item.childCheckpoint.activeTurn
+      ))) continue;
+
+      const childOutputs: Array<{
+        entries: AgentActivityEntry[];
+        path: string;
+        checkpoint: CodexTranscriptCheckpoint;
+      }> = [];
+      let ready = true;
+      for (const item of resolved) {
+        const childCheckpoint = item.childCheckpoint!;
+        const childPending = childCheckpoint.pendingSubagent!;
+        const recovered = await this.recoverTurnSegment(
+          item.childPath!,
+          childCheckpoint,
+          childPending.terminalEndOffset,
+          true,
+        );
+        if (recovered.kind === 'unparseable') {
+          ready = false;
+          break;
+        }
+        childOutputs.push({
+          entries: rewriteSubagentEntries(recovered.entries, {
+            parentThreadId: pending.parentThreadId,
+            parentTurnId: pending.turnId,
+            parentTraceId: pending.parentTraceId,
+            parentToolCallId: item.child.parentToolCallId,
+            childThreadId: item.childThreadId!,
+            agentName: this.transcriptMetaByPath.get(item.childPath!)?.agentNickname
+              ?? item.child.agentPath
+              ?? item.child.taskName,
+          }),
+          path: item.childPath!,
+          checkpoint: childCheckpoint,
+        });
+      }
+      if (!ready) continue;
+
+      const parentRecovered = await this.recoverTurnSegment(
+        parentPath,
+        parentCheckpoint,
+        pending.terminalEndOffset,
+        true,
+      );
+      if (parentRecovered.kind === 'unparseable') continue;
+
+      for (const output of childOutputs) {
+        emittedCount += this.emitEntryBatches(output.entries);
+        const turnId = output.checkpoint.pendingSubagent!.turnId;
+        this.rememberProcessedTerminalTurnId(output.checkpoint, turnId);
+        this.rememberGlobalProcessedTerminalTurnId(turnId);
+        output.checkpoint.activeTurn = null;
+        output.checkpoint.pendingSubagent = null;
+        this.saveCheckpoint(this.stateKey(output.path), output.checkpoint);
+      }
+      emittedCount += this.emitEntryBatches(parentRecovered.entries);
+      this.rememberProcessedTerminalTurnId(parentCheckpoint, pending.turnId);
+      this.rememberGlobalProcessedTerminalTurnId(pending.turnId);
+      parentCheckpoint.activeTurn = null;
+      parentCheckpoint.pendingFusion = null;
+      this.saveCheckpoint(parentKey, parentCheckpoint);
+    }
+    this.saveGlobalProcessedTerminalTurnIds();
+    return emittedCount;
   }
 
   private reportSubagentShadowLinks(): void {
@@ -875,6 +1122,8 @@ export class CodexTranscriptInput extends BaseInput {
       scanOffset: nextOffset,
       activeTurn,
       pendingTerminal: null,
+      pendingFusion: null,
+      pendingSubagent: null,
       ownerSessionMetaOffset,
       emittedTerminalTurnIds: [],
     });
@@ -1089,6 +1338,7 @@ export class CodexTranscriptInput extends BaseInput {
           emittedToolCallIds: stringArray(active.emittedToolCallIds),
           emittedToolResultIds: stringArray(active.emittedToolResultIds),
           inputContext: parseInputContext(active.inputContext),
+          subagentSpawns: parsePendingFusionChildren(active.subagentSpawns),
         }
       : null;
     const pending = asRecord(value.pendingTerminal);
@@ -1104,11 +1354,37 @@ export class CodexTranscriptInput extends BaseInput {
           ...(typeof pending.sourceRecordCount === 'number' ? { sourceRecordCount: pending.sourceRecordCount } : {}),
         }
       : null;
+    const fusion = asRecord(value.pendingFusion);
+    const fusionChildren = parsePendingFusionChildren(fusion?.children);
+    const pendingFusion: CodexPendingFusionTurn | null = fusion
+      && typeof fusion.turnId === 'string'
+      && typeof fusion.parentThreadId === 'string'
+      && typeof fusion.parentTraceId === 'string'
+      && typeof fusion.terminalEndOffset === 'number'
+      && typeof fusion.createdAtMs === 'number'
+      && fusionChildren.length > 0
+      ? {
+          turnId: fusion.turnId,
+          parentThreadId: fusion.parentThreadId,
+          parentTraceId: fusion.parentTraceId,
+          terminalEndOffset: fusion.terminalEndOffset,
+          children: fusionChildren,
+          createdAtMs: fusion.createdAtMs,
+        }
+      : null;
+    const subagent = asRecord(value.pendingSubagent);
+    const pendingSubagent: CodexPendingSubagentTurn | null = subagent
+      && typeof subagent.turnId === 'string'
+      && typeof subagent.terminalEndOffset === 'number'
+      ? { turnId: subagent.turnId, terminalEndOffset: subagent.terminalEndOffset }
+      : null;
     return {
       inode: value.inode,
       scanOffset: value.scanOffset,
       activeTurn,
       pendingTerminal,
+      pendingFusion,
+      pendingSubagent,
       // Do not migrate legacy latestSessionMetaOffset. In forked rollouts that
       // value commonly points at copied parent metadata, so processFile will
       // perform one bounded header scan to recover the owning meta safely.
@@ -1492,6 +1768,80 @@ function stringArray(value: unknown): string[] {
   return Array.isArray(value)
     ? value.filter((item): item is string => typeof item === 'string')
     : [];
+}
+
+function parsePendingFusionChildren(value: unknown): CodexPendingFusionChild[] {
+  if (!Array.isArray(value)) return [];
+  const children: CodexPendingFusionChild[] = [];
+  for (const item of value) {
+    const child = asRecord(item);
+    if (
+      !child
+      || typeof child.parentToolCallId !== 'string'
+      || typeof child.parentTraceId !== 'string'
+      || typeof child.spawnedAtMs !== 'number'
+    ) continue;
+    children.push({
+      parentToolCallId: child.parentToolCallId,
+      parentTraceId: child.parentTraceId,
+      spawnedAtMs: child.spawnedAtMs,
+      ...(typeof child.taskName === 'string' ? { taskName: child.taskName } : {}),
+      ...(typeof child.agentPath === 'string' ? { agentPath: child.agentPath } : {}),
+      ...(typeof child.childThreadId === 'string' ? { childThreadId: child.childThreadId } : {}),
+    });
+  }
+  return children;
+}
+
+function mergePendingFusionChildren(
+  current: CodexPendingFusionChild[],
+  incoming: CodexPendingFusionChild[],
+): CodexPendingFusionChild[] {
+  const merged = new Map(current.map(child => [child.parentToolCallId, child]));
+  for (const child of incoming) {
+    merged.set(child.parentToolCallId, { ...merged.get(child.parentToolCallId), ...child });
+  }
+  return [...merged.values()];
+}
+
+function cloneActiveTurn(activeTurn: CodexActiveTranscriptTurn): CodexActiveTranscriptTurn {
+  return structuredClone(activeTurn);
+}
+
+function parentTraceIdForChildren(children: CodexPendingFusionChild[]): string {
+  return children[0]?.parentTraceId ?? '';
+}
+
+function rewriteSubagentEntries(
+  entries: AgentActivityEntry[],
+  context: {
+    parentThreadId: string;
+    parentTurnId: string;
+    parentTraceId: string;
+    parentToolCallId: string;
+    childThreadId: string;
+    agentName?: string;
+  },
+): AgentActivityEntry[] {
+  const parentTurnId = `${context.parentThreadId}:${context.parentTurnId}`;
+  const parentToolSpanId = codexToolSpanId(
+    context.parentThreadId,
+    context.parentTurnId,
+    context.parentToolCallId,
+  );
+  return entries.map(entry => ({
+    ...entry,
+    trace_id: context.parentTraceId,
+    'gen_ai.session.id': context.parentThreadId,
+    'gen_ai.turn.id': parentTurnId,
+    'gen_ai.agent.scope': 'subagent',
+    'gen_ai.agent.depth': 1,
+    'gen_ai.agent.id': context.childThreadId,
+    ...(context.agentName ? { 'gen_ai.agent.name': context.agentName } : {}),
+    'gen_ai.agent.parent.id': context.parentThreadId,
+    'gen_ai.subagent.parent_tool_call.id': context.parentToolCallId,
+    ...(entry['event.name'] === 'other' ? { parent_span_id: parentToolSpanId } : {}),
+  }));
 }
 
 function serializedEntryBytes(entry: AgentActivityEntry): number {

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -290,8 +290,30 @@ export class CodexTranscriptInput extends BaseInput {
 
     const ownerMeta = this.transcriptMetaByPath.get(filePath) ?? null;
     const isDirectSubagent = ownerMeta?.threadSource === 'subagent' && ownerMeta.depth === 1;
+    if (
+      isDirectSubagent
+      && checkpoint.pendingSubagent
+      && checkpoint.activeTurn
+      && ownerMeta?.createdAtMs !== undefined
+      && isCopiedParentTurn(
+        checkpoint.pendingSubagent.turnId,
+        checkpoint.activeTurn.startedAtMs,
+        ownerMeta.createdAtMs,
+      )
+    ) {
+      checkpoint.pendingSubagent = null;
+      checkpoint.activeTurn = null;
+      checkpointChanged = true;
+    }
+    if (checkpoint.pendingFusion) {
+      const pruned = pruneSupersededFusionChildren(checkpoint.pendingFusion.children);
+      if (pruned.length !== checkpoint.pendingFusion.children.length) {
+        checkpoint.pendingFusion.children = pruned;
+        if (checkpoint.activeTurn) checkpoint.activeTurn.subagentSpawns = pruned;
+        checkpointChanged = true;
+      }
+    }
     if (ownerMeta?.depth === 0) this.registerPersistedSubagentSpawns(checkpoint, ownerMeta.threadId);
-
     if (checkpoint.pendingFusion || checkpoint.pendingSubagent) {
       if (checkpointChanged) this.saveCheckpoint(key, checkpoint);
       return 0;
@@ -383,7 +405,11 @@ export class CodexTranscriptInput extends BaseInput {
             isDirectSubagent
             && terminalTurnId
             && ownerMeta?.createdAtMs !== undefined
-            && checkpoint.activeTurn.startedAtMs < ownerMeta.createdAtMs
+            && isCopiedParentTurn(
+              terminalTurnId,
+              checkpoint.activeTurn.startedAtMs,
+              ownerMeta.createdAtMs,
+            )
           ) {
             // Forked child rollouts contain copied parent history after their
             // owning session_meta. It must not become the child's pending turn.
@@ -600,16 +626,17 @@ export class CodexTranscriptInput extends BaseInput {
       if (parentTraceId) {
         const spawns = extractCodexSpawnDescriptors(turn, records.items, parentTraceId);
         this.subagentLinker.registerSpawns(spawns);
+        const fusionChildren = spawns.map(spawn => ({
+          parentToolCallId: spawn.parentToolCallId,
+          parentTraceId: spawn.parentTraceId,
+          spawnedAtMs: spawn.spawnedAtMs,
+          ...(spawn.taskName ? { taskName: spawn.taskName } : {}),
+          ...(spawn.agentPath ? { agentPath: spawn.agentPath } : {}),
+          ...(spawn.childThreadId ? { childThreadId: spawn.childThreadId } : {}),
+        }));
         activeTurn.subagentSpawns = mergePendingFusionChildren(
           activeTurn.subagentSpawns ?? [],
-          spawns.map(spawn => ({
-            parentToolCallId: spawn.parentToolCallId,
-            parentTraceId: spawn.parentTraceId,
-            spawnedAtMs: spawn.spawnedAtMs,
-            ...(spawn.taskName ? { taskName: spawn.taskName } : {}),
-            ...(spawn.agentPath ? { agentPath: spawn.agentPath } : {}),
-            ...(spawn.childThreadId ? { childThreadId: spawn.childThreadId } : {}),
-          })),
+          fusionChildren,
         );
       }
     }
@@ -1802,6 +1829,43 @@ function mergePendingFusionChildren(
     merged.set(child.parentToolCallId, { ...merged.get(child.parentToolCallId), ...child });
   }
   return [...merged.values()];
+}
+
+function pruneSupersededFusionChildren(
+  children: CodexPendingFusionChild[],
+): CodexPendingFusionChild[] {
+  const successfulPaths = new Set(children
+    .filter(child => child.childThreadId)
+    .map(child => normalizeFusionAgentPath(child.agentPath ?? child.taskName))
+    .filter((value): value is string => value !== undefined));
+  return children.filter(child => (
+    child.childThreadId
+    || !successfulPaths.has(normalizeFusionAgentPath(child.agentPath ?? child.taskName) ?? '')
+  ));
+}
+
+function normalizeFusionAgentPath(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim().replace(/\/+$/, '');
+  if (!trimmed) return undefined;
+  return trimmed.startsWith('/') ? trimmed : `/root/${trimmed.replace(/^root\//, '')}`;
+}
+
+function isCopiedParentTurn(
+  turnId: string,
+  observedStartedAtMs: number,
+  ownerCreatedAtMs: number,
+): boolean {
+  const uuidTimestamp = uuidV7TimestampMs(turnId);
+  return (uuidTimestamp ?? observedStartedAtMs) < ownerCreatedAtMs;
+}
+
+function uuidV7TimestampMs(value: string): number | undefined {
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)) {
+    return undefined;
+  }
+  const timestamp = Number.parseInt(value.replace(/-/g, '').slice(0, 12), 16);
+  return Number.isSafeInteger(timestamp) ? timestamp : undefined;
 }
 
 function cloneActiveTurn(activeTurn: CodexActiveTranscriptTurn): CodexActiveTranscriptTurn {

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -10,7 +10,6 @@ import { directoryExists, resolveHome } from '../../utils/fs-utils.js';
 import { BaseInput, type InputOptions } from '../base/base-input.js';
 import {
   buildCodexTranscriptSegment,
-  codexToolSpanId,
   nextInputMessagesForStep,
 } from './codex-transcript-builder.js';
 import {
@@ -1899,12 +1898,11 @@ function rewriteSubagentEntries(
   },
 ): AgentActivityEntry[] {
   const parentTurnId = `${context.parentThreadId}:${context.parentTurnId}`;
-  const parentToolSpanId = codexToolSpanId(
-    context.parentThreadId,
-    context.parentTurnId,
-    context.parentToolCallId,
-  );
-  return entries.map(entry => ({
+  // The converter consumes every `other` record as a turn-level ENTRY input
+  // before it partitions subagent records. Keep the child prompt on its
+  // llm.request and omit child `other` markers so they cannot pollute or
+  // re-parent the parent ENTRY span.
+  return entries.filter(entry => entry['event.name'] !== 'other').map(entry => ({
     ...entry,
     trace_id: context.parentTraceId,
     'gen_ai.session.id': context.parentThreadId,
@@ -1915,9 +1913,6 @@ function rewriteSubagentEntries(
     ...(context.agentName ? { 'gen_ai.agent.name': context.agentName } : {}),
     'gen_ai.agent.parent.id': context.parentThreadId,
     'gen_ai.subagent.parent_tool_call.id': context.parentToolCallId,
-    ...(entry['event.name'] === 'other' && entry['gen_ai.turn.end'] !== true
-      ? { parent_span_id: parentToolSpanId }
-      : {}),
   }));
 }
 

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -15,6 +15,8 @@ import {
 import {
   CodexSubagentLinker,
   extractCodexSpawnDescriptors,
+  MAX_LINK_DESCRIPTORS,
+  type CodexSubagentLink,
   type CodexSubagentLinkSnapshot,
 } from './codex-subagent-linker.js';
 import {
@@ -34,9 +36,17 @@ import {
   type CodexTranscriptInputContext,
   type CodexTranscriptCheckpoint,
   type CodexTranscriptGlobalState,
+  type CodexTranscriptMeta,
   type CodexTranscriptSourceRange,
 } from './codex-transcript-types.js';
 import { stringValue, timestampMs } from './codex-transcript-utils.js';
+
+type ReliableCodexSubagentLink = CodexSubagentLink & {
+  parentTurnId: string;
+  parentTraceId: string;
+  parentToolCallId: string;
+  confidence: 'explicit_id' | 'agent_path';
+};
 
 const DEFAULT_SESSION_DIR = '~/.codex/sessions';
 const READ_CHUNK_SIZE = 1024 * 1024;
@@ -118,6 +128,14 @@ interface DynamicDirectoryWalkBudget {
   remainingRolloutFiles: number;
 }
 
+interface ParentTurnIndex {
+  filePath: string;
+  inode: number;
+  scanOffset: number;
+  complete: boolean;
+  turnIds: Set<string>;
+}
+
 export interface CodexTranscriptInputOptions extends InputOptions {
   sessionDir?: string;
   wakeupDir?: string;
@@ -139,7 +157,8 @@ export class CodexTranscriptInput extends BaseInput {
   private processedTerminalTurnIdOrder: string[] = [];
   private readonly subagentLinker = new CodexSubagentLinker();
   private readonly reportedSubagentLinks = new Map<string, string>();
-  private lastSubagentShadowSummary = '';
+  private readonly parentTurnIndexes = new Map<string, ParentTurnIndex>();
+  private lastSubagentLinkSummary = '';
   private lastWakeupMarkerCleanupAtMs = 0;
   private lastSpanContextCleanupAtMs = 0;
   private readonly transcriptMetaByPath = new Map<string, ReturnType<typeof extractCodexTranscriptMeta>>();
@@ -213,14 +232,14 @@ export class CodexTranscriptInput extends BaseInput {
       emittedCount += await this.processFile(filePath);
     }
     emittedCount += await this.finalizeReadySubagentFusions();
-    this.reportSubagentShadowLinks();
+    this.reportSubagentLinks();
     if (emittedCount > 0) {
       this.logger.debug('cycle produced entries', { count: emittedCount });
     }
     return [];
   }
 
-  /** Phase-2 diagnostic surface. Shadow linking never mutates emitted records. */
+  /** Current parent/child assignments, including diagnostic-only confidence levels. */
   getSubagentLinkSnapshot(): CodexSubagentLinkSnapshot {
     return this.subagentLinker.snapshot();
   }
@@ -289,37 +308,69 @@ export class CodexTranscriptInput extends BaseInput {
 
     const ownerMeta = this.transcriptMetaByPath.get(filePath) ?? null;
     const isDirectSubagent = ownerMeta?.threadSource === 'subagent' && ownerMeta.depth === 1;
-    if (
-      isDirectSubagent
-      && checkpoint.pendingSubagent
-      && checkpoint.activeTurn
-      && ownerMeta?.createdAtMs !== undefined
-      && isCopiedParentTurn(
-        checkpoint.pendingSubagent.turnId,
-        checkpoint.activeTurn.startedAtMs,
-        ownerMeta.createdAtMs,
-      )
-    ) {
-      checkpoint.pendingSubagent = null;
-      checkpoint.activeTurn = null;
-      checkpointChanged = true;
-    }
-    if (checkpoint.pendingFusion) {
-      const pruned = pruneSupersededFusionChildren(checkpoint.pendingFusion.children);
-      if (pruned.length !== checkpoint.pendingFusion.children.length) {
-        checkpoint.pendingFusion.children = pruned;
-        if (checkpoint.activeTurn) checkpoint.activeTurn.subagentSpawns = pruned;
-        checkpointChanged = true;
-      }
-    }
+    const parentTurnIndex = isDirectSubagent
+      && ownerMeta?.parentThreadId
+      && (checkpoint.scanOffset < stat.size || checkpoint.activeTurn !== null || checkpoint.pendingTerminal !== null)
+      ? await this.refreshParentTurnIndex(ownerMeta.parentThreadId)
+      : undefined;
     if (ownerMeta?.depth === 0) this.registerPersistedSubagentSpawns(checkpoint, ownerMeta.threadId);
-    if (checkpoint.pendingFusion || checkpoint.pendingSubagent) {
-      if (checkpointChanged) this.saveCheckpoint(key, checkpoint);
-      return 0;
-    }
 
     let emittedCount = 0;
     let processedTerminalCount = 0;
+    if (
+      isDirectSubagent
+      && checkpoint.pendingTerminal
+      && checkpoint.activeTurn?.turnId === checkpoint.pendingTerminal.turnId
+      && shouldSkipCopiedParentTurn(
+        checkpoint.pendingTerminal.turnId,
+        checkpoint.activeTurn.startedAtMs,
+        ownerMeta?.createdAtMs,
+        parentTurnIndex,
+      )
+    ) {
+      checkpoint.activeTurn = null;
+      checkpoint.pendingTerminal = null;
+      processedTerminalCount++;
+      checkpointChanged = true;
+    }
+    if (isDirectSubagent && ownerMeta && checkpoint.pendingSubagent) {
+      const candidate = this.reliableCandidateForChild(ownerMeta);
+      if (
+        !candidate
+        || candidate.parentThreadId !== checkpoint.pendingSubagent.parentThreadId
+        || candidate.parentTurnId !== checkpoint.pendingSubagent.parentTurnId
+        || candidate.parentTraceId !== checkpoint.pendingSubagent.parentTraceId
+        || candidate.parentToolCallId !== checkpoint.pendingSubagent.parentToolCallId
+      ) {
+        const released = await this.releaseCapturedSubagentIndependently(filePath, checkpoint);
+        emittedCount += released.emittedCount;
+        processedTerminalCount += released.processedTerminalCount;
+        checkpointChanged = true;
+      }
+    }
+    if (checkpoint.pendingFusion) {
+      const reliableChildren = this.reliableFusionChildren(
+        checkpoint.pendingFusion.parentThreadId,
+        checkpoint.pendingFusion.turnId,
+        checkpoint.pendingFusion.children,
+      );
+      if (reliableChildren.length !== checkpoint.pendingFusion.children.length) {
+        checkpoint.pendingFusion.children = reliableChildren;
+        if (checkpoint.activeTurn) checkpoint.activeTurn.subagentSpawns = reliableChildren;
+        checkpointChanged = true;
+      }
+    }
+    if (checkpoint.pendingFusion?.children.length === 0) {
+      const released = await this.releaseParentFusionIndependently(filePath, checkpoint);
+      emittedCount += released.emittedCount;
+      processedTerminalCount += released.processedTerminalCount;
+      checkpointChanged = true;
+    }
+    if (checkpoint.pendingFusion) {
+      if (checkpointChanged) this.saveCheckpoint(key, checkpoint);
+      return emittedCount;
+    }
+
     let scannedBytes = 0;
 
     const hadPendingTerminal = checkpoint.pendingTerminal !== null;
@@ -403,11 +454,11 @@ export class CodexTranscriptInput extends BaseInput {
           if (
             isDirectSubagent
             && terminalTurnId
-            && ownerMeta?.createdAtMs !== undefined
-            && isCopiedParentTurn(
+            && shouldSkipCopiedParentTurn(
               terminalTurnId,
               checkpoint.activeTurn.startedAtMs,
-              ownerMeta.createdAtMs,
+              ownerMeta?.createdAtMs,
+              parentTurnIndex,
             )
           ) {
             // Forked child rollouts contain copied parent history after their
@@ -418,29 +469,60 @@ export class CodexTranscriptInput extends BaseInput {
             continue;
           }
 
-          if (isDirectSubagent) {
-            if (terminalTurnId) {
-              checkpoint.pendingSubagent = {
-                turnId: terminalTurnId,
-                terminalEndOffset: nextScanOffset,
-              };
-              blocked = true;
-            }
-            checkpoint.scanOffset = nextScanOffset;
-            break;
-          }
-
           const activeBeforeRecovery = terminalTurnId
             ? cloneActiveTurn(checkpoint.activeTurn)
             : null;
+          const reliableCandidate = isDirectSubagent
+            && ownerMeta
+            && !checkpoint.pendingSubagent
+            ? this.reliableCandidateForChild(ownerMeta)
+            : undefined;
+          // A reliably linked child must not emit an independent partial trace
+          // before the parent reaches task_complete. Recover on a clone so the
+          // persisted child snapshot keeps the complete turn range and empty
+          // emission registry for terminal capture or forced finalization.
+          const recoveryCheckpoint = reliableCandidate
+            ? {
+                ...checkpoint,
+                activeTurn: cloneActiveTurn(checkpoint.activeTurn),
+              }
+            : checkpoint;
           const recovered = await this.recoverTurnSegment(
             filePath,
-            checkpoint,
+            recoveryCheckpoint,
             nextScanOffset,
             terminalTurnId !== null,
           );
+          if (
+            terminalTurnId
+            && activeBeforeRecovery
+            && recovered.kind !== 'unparseable'
+            && reliableCandidate
+          ) {
+            checkpoint.pendingSubagent = {
+              turnId: terminalTurnId,
+              parentThreadId: reliableCandidate.parentThreadId,
+              parentTurnId: reliableCandidate.parentTurnId,
+              parentTraceId: reliableCandidate.parentTraceId,
+              parentToolCallId: reliableCandidate.parentToolCallId,
+              confidence: reliableCandidate.confidence,
+              terminalEndOffset: nextScanOffset,
+              activeTurn: activeBeforeRecovery,
+            };
+            // The terminal range is consumed but deliberately not marked as
+            // emitted. The persisted snapshot is the sole owner until fusion.
+            checkpoint.activeTurn = null;
+            checkpoint.scanOffset = nextScanOffset;
+            processedTerminalCount++;
+            continue;
+          }
+          const fusionParentThreadId = ownerMeta?.threadId ?? sessionIdFromTranscriptPath(filePath);
           const fusionChildren = terminalTurnId
-            ? checkpoint.activeTurn?.subagentSpawns ?? []
+            ? this.reliableFusionChildren(
+                fusionParentThreadId,
+                terminalTurnId,
+                checkpoint.activeTurn?.subagentSpawns ?? [],
+              )
             : [];
           if (
             terminalTurnId
@@ -457,19 +539,19 @@ export class CodexTranscriptInput extends BaseInput {
             checkpoint.activeTurn = activeBeforeRecovery;
             checkpoint.pendingFusion = {
               turnId: terminalTurnId,
-              parentThreadId: ownerMeta?.threadId ?? sessionIdFromTranscriptPath(filePath),
+              parentThreadId: fusionParentThreadId,
               parentTraceId: parentTraceIdForChildren(fusionChildren),
               terminalEndOffset: nextScanOffset,
               children: fusionChildren,
-              createdAtMs: Date.now(),
             };
             blocked = true;
-          } else {
+          } else if (!reliableCandidate) {
             emittedCount += this.emitEntryBatches(recovered.entries);
           }
           if (
             recovered.kind !== 'unparseable'
             && !checkpoint.pendingFusion
+            && !reliableCandidate
             && recovered.consumedEndOffset > checkpoint.activeTurn.startOffset
           ) {
             checkpoint.activeTurn.startOffset = recovered.consumedEndOffset;
@@ -564,6 +646,7 @@ export class CodexTranscriptInput extends BaseInput {
     checkpoint: CodexTranscriptCheckpoint,
     endOffset: number,
     terminal: boolean,
+    inferredTerminalStatus?: 'interrupted',
   ): Promise<SegmentRecoveryResult> {
     const activeTurn = checkpoint.activeTurn;
     if (!activeTurn) {
@@ -596,6 +679,7 @@ export class CodexTranscriptInput extends BaseInput {
       };
     }
     const turn = extraction.turn;
+    if (inferredTerminalStatus) turn.status = inferredTerminalStatus;
     updateActiveTurnFromExtractedTurn(activeTurn, turn);
     if (turn.unmatchedTokenUsages.length > 0) {
       this.logger.warn('Codex transcript token samples could not be assigned to a response wave', {
@@ -787,6 +871,67 @@ export class CodexTranscriptInput extends BaseInput {
     }
   }
 
+  /**
+   * Build an incremental ownership index for the exact parent rollout named by
+   * a depth-one child's session_meta. An exact turn-id hit is positive evidence
+   * of copied parent history; a miss is authoritative only after this snapshot
+   * has been scanned to a stable EOF.
+   */
+  private async refreshParentTurnIndex(parentThreadId: string): Promise<ParentTurnIndex | undefined> {
+    const filePath = this.transcriptPathByThreadId.get(parentThreadId);
+    if (!filePath) return undefined;
+    const meta = this.transcriptMetaByPath.get(filePath);
+    if (!meta || meta.threadId !== parentThreadId || meta.depth !== 0) return undefined;
+
+    let stat;
+    try {
+      stat = await fs.stat(filePath);
+    } catch {
+      return undefined;
+    }
+
+    let index = this.parentTurnIndexes.get(parentThreadId);
+    if (
+      !index
+      || index.filePath !== filePath
+      || index.inode !== stat.ino
+      || index.scanOffset > stat.size
+    ) {
+      index = {
+        filePath,
+        inode: stat.ino,
+        scanOffset: 0,
+        complete: false,
+        turnIds: new Set<string>(),
+      };
+      this.parentTurnIndexes.set(parentThreadId, index);
+    }
+
+    if (index.scanOffset < stat.size) {
+      const scan = await scanJsonLines(filePath, index.scanOffset, stat.size, line => {
+        const payload = asRecord(line.record.payload);
+        if (!payload) return;
+        const turnId = turnIdForStart(line.record, payload)
+          ?? terminalTurnIdFor(line.record, payload);
+        if (turnId) index!.turnIds.add(turnId);
+      });
+      index.scanOffset = scan.nextOffset;
+    }
+
+    // Re-stat after scanning so a concurrent parent append cannot turn a stale
+    // EOF snapshot into an authoritative negative ownership decision.
+    try {
+      const current = await fs.stat(filePath);
+      index.complete = current.ino === index.inode && index.scanOffset >= current.size;
+    } catch {
+      index.complete = false;
+    }
+    this.parentTurnIndexes.delete(parentThreadId);
+    this.parentTurnIndexes.set(parentThreadId, index);
+    trimOldestMap(this.parentTurnIndexes, MAX_LINK_DESCRIPTORS);
+    return index;
+  }
+
   private registerPersistedSubagentSpawns(
     checkpoint: CodexTranscriptCheckpoint,
     parentThreadId: string,
@@ -814,9 +959,151 @@ export class CodexTranscriptInput extends BaseInput {
     return false;
   }
 
+  private reliableCandidateForChild(
+    meta: CodexTranscriptMeta,
+  ): ReliableCodexSubagentLink | undefined {
+    if (!meta.parentThreadId) return undefined;
+    const link = this.subagentLinker.snapshot().links.find(candidate => (
+      candidate.childThreadId === meta.threadId
+      && candidate.parentThreadId === meta.parentThreadId
+      && candidate.parentTurnId !== undefined
+      && candidate.parentTraceId !== undefined
+      && candidate.parentToolCallId !== undefined
+      && isReliableFusionConfidence(candidate.confidence)
+    ));
+    if (
+      !link
+      || !link.parentTurnId
+      || !link.parentTraceId
+      || !link.parentToolCallId
+      || !isReliableFusionConfidence(link.confidence)
+    ) return undefined;
+    for (const [filePath, parentMeta] of this.transcriptMetaByPath) {
+      if (parentMeta?.threadId !== link.parentThreadId || parentMeta.depth !== 0) continue;
+      const checkpoint = this.readCheckpoint(this.stateKey(filePath));
+      const parentTurnId = checkpoint?.pendingFusion?.turnId ?? checkpoint?.activeTurn?.turnId;
+      const spawns = checkpoint?.pendingFusion?.children ?? checkpoint?.activeTurn?.subagentSpawns ?? [];
+      if (
+        parentTurnId === link.parentTurnId
+        && spawns.some(spawn => spawn.parentToolCallId === link.parentToolCallId)
+      ) {
+        return {
+          ...link,
+          parentTurnId: link.parentTurnId,
+          parentTraceId: link.parentTraceId,
+          parentToolCallId: link.parentToolCallId,
+          confidence: link.confidence,
+        };
+      }
+    }
+    return undefined;
+  }
+
+  private reliableFusionChildren(
+    parentThreadId: string,
+    parentTurnId: string,
+    children: CodexPendingFusionChild[],
+  ): CodexPendingFusionChild[] {
+    const links = this.subagentLinker.snapshot().links;
+    const reliable: CodexPendingFusionChild[] = [];
+    for (const child of children) {
+      const matches = links.filter(link => (
+        link.parentThreadId === parentThreadId
+        && link.parentTurnId === parentTurnId
+        && link.parentToolCallId === child.parentToolCallId
+        && isReliableFusionConfidence(link.confidence)
+      ));
+      if (matches.length !== 1) continue;
+      const link = matches[0]!;
+      const childPath = this.transcriptPathByThreadId.get(link.childThreadId);
+      const checkpoint = childPath ? this.readCheckpoint(this.stateKey(childPath)) : null;
+      const captured = checkpoint?.pendingSubagent;
+      if (captured && captured.parentToolCallId !== child.parentToolCallId) continue;
+      if (
+        checkpoint
+        && !captured
+        && checkpoint.activeTurn === null
+        && checkpoint.emittedTerminalTurnIds.length > 0
+      ) continue;
+      reliable.push({ ...child, childThreadId: link.childThreadId });
+    }
+    return reliable;
+  }
+
+  private async releaseParentFusionIndependently(
+    filePath: string,
+    checkpoint: CodexTranscriptCheckpoint,
+  ): Promise<{ emittedCount: number; processedTerminalCount: number }> {
+    const pending = checkpoint.pendingFusion;
+    if (!pending) return { emittedCount: 0, processedTerminalCount: 0 };
+
+    checkpoint.scanOffset = Math.max(checkpoint.scanOffset, pending.terminalEndOffset);
+    checkpoint.pendingFusion = null;
+    this.logger.warn('Codex parent fusion has no reliable child candidates; emitting independently', {
+      transcriptPath: filePath,
+      turnId: pending.turnId,
+    });
+
+    if (!checkpoint.activeTurn) {
+      return { emittedCount: 0, processedTerminalCount: 0 };
+    }
+    const recovered = await this.recoverTurnSegment(
+      filePath,
+      checkpoint,
+      pending.terminalEndOffset,
+      true,
+    );
+    if (recovered.kind === 'unparseable') {
+      checkpoint.pendingTerminal = newPendingTerminal(
+        pending.turnId,
+        pending.terminalEndOffset,
+        recovered.diagnostics.sourceRecordCount,
+      );
+      return { emittedCount: 0, processedTerminalCount: 0 };
+    }
+
+    const emittedCount = this.emitEntryBatches(recovered.entries);
+    this.rememberProcessedTerminalTurnId(checkpoint, pending.turnId);
+    this.rememberGlobalProcessedTerminalTurnId(pending.turnId);
+    checkpoint.activeTurn = null;
+    checkpoint.pendingTerminal = null;
+    return { emittedCount, processedTerminalCount: 1 };
+  }
+
+  private async releaseCapturedSubagentIndependently(
+    filePath: string,
+    checkpoint: CodexTranscriptCheckpoint,
+  ): Promise<{ emittedCount: number; processedTerminalCount: number }> {
+    const captured = checkpoint.pendingSubagent;
+    if (!captured) return { emittedCount: 0, processedTerminalCount: 0 };
+    const recoveryCheckpoint: CodexTranscriptCheckpoint = {
+      ...checkpoint,
+      activeTurn: cloneActiveTurn(captured.activeTurn),
+      pendingSubagent: null,
+    };
+    const recovered = await this.recoverTurnSegment(
+      filePath,
+      recoveryCheckpoint,
+      captured.terminalEndOffset,
+      true,
+    );
+    if (recovered.kind === 'unparseable') {
+      this.logger.warn('captured Codex child could not be rebuilt for independent fallback', {
+        transcriptPath: filePath,
+        turnId: captured.turnId,
+        parentToolCallId: captured.parentToolCallId,
+      });
+      return { emittedCount: 0, processedTerminalCount: 0 };
+    }
+    const emittedCount = this.emitEntryBatches(recovered.entries);
+    this.rememberProcessedTerminalTurnId(checkpoint, captured.turnId);
+    this.rememberGlobalProcessedTerminalTurnId(captured.turnId);
+    checkpoint.pendingSubagent = null;
+    return { emittedCount, processedTerminalCount: 1 };
+  }
+
   private async finalizeReadySubagentFusions(): Promise<number> {
     let emittedCount = 0;
-    const links = this.subagentLinker.snapshot().links;
     for (const [parentPath, meta] of this.transcriptMetaByPath) {
       if (!meta || meta.depth !== 0) continue;
       const parentKey = this.stateKey(parentPath);
@@ -825,42 +1112,66 @@ export class CodexTranscriptInput extends BaseInput {
       if (!parentCheckpoint || !pending || !parentCheckpoint.activeTurn) continue;
 
       const resolved = pending.children.map(child => {
-        const linked = links.find(link => (
-          link.parentThreadId === pending.parentThreadId
-          && link.parentTurnId === pending.turnId
-          && link.parentToolCallId === child.parentToolCallId
-          && (!child.childThreadId || link.childThreadId === child.childThreadId)
-        ));
-        const childThreadId = child.childThreadId ?? linked?.childThreadId;
+        const childThreadId = child.childThreadId;
         const childPath = childThreadId ? this.transcriptPathByThreadId.get(childThreadId) : undefined;
         const childCheckpoint = childPath ? this.readCheckpoint(this.stateKey(childPath)) : null;
-        return { child, linked, childThreadId, childPath, childCheckpoint };
+        const captured = childCheckpoint?.pendingSubagent;
+        return { child, childThreadId, childPath, childCheckpoint, captured };
       });
-      if (resolved.some(item => (
-        !item.childThreadId
-        || !item.childPath
-        || !item.childCheckpoint?.pendingSubagent
-        || !item.childCheckpoint.activeTurn
-      ))) continue;
 
       const childOutputs: Array<{
         entries: AgentActivityEntry[];
         path: string;
         checkpoint: CodexTranscriptCheckpoint;
+        turnId: string;
+        parentToolCallId: string;
+        source: 'captured-terminal' | 'forced-parent-terminal';
       }> = [];
-      let ready = true;
+      const degradedToolCallIds: string[] = [];
       for (const item of resolved) {
-        const childCheckpoint = item.childCheckpoint!;
-        const childPending = childCheckpoint.pendingSubagent!;
+        const childCheckpoint = item.childCheckpoint;
+        const childPath = item.childPath;
+        const childThreadId = item.childThreadId;
+        if (!childCheckpoint || !childPath || !childThreadId) {
+          degradedToolCallIds.push(item.child.parentToolCallId);
+          continue;
+        }
+        const captured = item.captured;
+        const capturedMatches = captured
+          && captured.parentThreadId === pending.parentThreadId
+          && captured.parentTurnId === pending.turnId
+          && captured.parentTraceId === pending.parentTraceId
+          && captured.parentToolCallId === item.child.parentToolCallId;
+        const canForceActive = !captured
+          && childCheckpoint.activeTurn !== null
+          && !hasEmittedActiveTurnState(childCheckpoint.activeTurn)
+          && childCheckpoint.scanOffset > childCheckpoint.activeTurn.startOffset;
+        if (!capturedMatches && !canForceActive) {
+          degradedToolCallIds.push(item.child.parentToolCallId);
+          continue;
+        }
+
+        const activeSnapshot = capturedMatches
+          ? captured.activeTurn
+          : childCheckpoint.activeTurn!;
+        const terminalEndOffset = capturedMatches
+          ? captured.terminalEndOffset
+          : childCheckpoint.scanOffset;
+        const recoveryCheckpoint: CodexTranscriptCheckpoint = {
+          ...childCheckpoint,
+          activeTurn: cloneActiveTurn(activeSnapshot),
+          pendingSubagent: null,
+        };
         const recovered = await this.recoverTurnSegment(
-          item.childPath!,
-          childCheckpoint,
-          childPending.terminalEndOffset,
+          childPath,
+          recoveryCheckpoint,
+          terminalEndOffset,
           true,
+          capturedMatches ? undefined : 'interrupted',
         );
         if (recovered.kind === 'unparseable') {
-          ready = false;
-          break;
+          degradedToolCallIds.push(item.child.parentToolCallId);
+          continue;
         }
         childOutputs.push({
           entries: rewriteSubagentEntries(recovered.entries, {
@@ -868,16 +1179,18 @@ export class CodexTranscriptInput extends BaseInput {
             parentTurnId: pending.turnId,
             parentTraceId: pending.parentTraceId,
             parentToolCallId: item.child.parentToolCallId,
-            childThreadId: item.childThreadId!,
-            agentName: this.transcriptMetaByPath.get(item.childPath!)?.agentNickname
+            childThreadId,
+            agentName: this.transcriptMetaByPath.get(childPath)?.agentNickname
               ?? item.child.agentPath
               ?? item.child.taskName,
           }),
-          path: item.childPath!,
+          path: childPath,
           checkpoint: childCheckpoint,
+          turnId: activeSnapshot.turnId,
+          parentToolCallId: item.child.parentToolCallId,
+          source: capturedMatches ? 'captured-terminal' : 'forced-parent-terminal',
         });
       }
-      if (!ready) continue;
 
       const parentRecovered = await this.recoverTurnSegment(
         parentPath,
@@ -887,13 +1200,30 @@ export class CodexTranscriptInput extends BaseInput {
       );
       if (parentRecovered.kind === 'unparseable') continue;
 
+      if (degradedToolCallIds.length > 0) {
+        this.logger.warn('Codex parent reached task_complete before every child could be rebuilt; degrading missing children', {
+          transcriptPath: parentPath,
+          turnId: pending.turnId,
+          parentToolCallIds: degradedToolCallIds,
+        });
+      }
+
       for (const output of childOutputs) {
         emittedCount += this.emitEntryBatches(output.entries);
-        const turnId = output.checkpoint.pendingSubagent!.turnId;
-        this.rememberProcessedTerminalTurnId(output.checkpoint, turnId);
-        this.rememberGlobalProcessedTerminalTurnId(turnId);
-        output.checkpoint.activeTurn = null;
-        output.checkpoint.pendingSubagent = null;
+        this.rememberProcessedTerminalTurnId(output.checkpoint, output.turnId);
+        this.rememberGlobalProcessedTerminalTurnId(output.turnId);
+        if (
+          output.source === 'captured-terminal'
+          && output.checkpoint.pendingSubagent?.parentToolCallId === output.parentToolCallId
+        ) {
+          output.checkpoint.pendingSubagent = null;
+        } else if (
+          output.source === 'forced-parent-terminal'
+          && output.checkpoint.activeTurn?.turnId === output.turnId
+        ) {
+          output.checkpoint.activeTurn = null;
+          output.checkpoint.pendingTerminal = null;
+        }
         this.saveCheckpoint(this.stateKey(output.path), output.checkpoint);
       }
       emittedCount += this.emitEntryBatches(parentRecovered.entries);
@@ -907,7 +1237,7 @@ export class CodexTranscriptInput extends BaseInput {
     return emittedCount;
   }
 
-  private reportSubagentShadowLinks(): void {
+  private reportSubagentLinks(): void {
     const snapshot = this.subagentLinker.snapshot();
     if (snapshot.detectedChildren === 0 && snapshot.detectedSpawns === 0) return;
 
@@ -917,9 +1247,9 @@ export class CodexTranscriptInput extends BaseInput {
       snapshot.linkedChildren,
       snapshot.orphanChildren,
     ].join(':');
-    if (summary !== this.lastSubagentShadowSummary) {
-      this.lastSubagentShadowSummary = summary;
-      this.logger.info('Codex subagent linker shadow summary', {
+    if (summary !== this.lastSubagentLinkSummary) {
+      this.lastSubagentLinkSummary = summary;
+      this.logger.info('Codex subagent linker summary', {
         detectedChildren: snapshot.detectedChildren,
         detectedSpawns: snapshot.detectedSpawns,
         linkedChildren: snapshot.linkedChildren,
@@ -934,8 +1264,12 @@ export class CodexTranscriptInput extends BaseInput {
         link.orphanReason ?? '',
       ].join(':');
       if (this.reportedSubagentLinks.get(link.childThreadId) === fingerprint) continue;
+      // Refresh insertion order when a link changes so the bounded map keeps
+      // the most recently reported lifecycle fingerprints.
+      this.reportedSubagentLinks.delete(link.childThreadId);
       this.reportedSubagentLinks.set(link.childThreadId, fingerprint);
-      this.logger.debug('Codex subagent shadow link resolved', {
+      trimOldestMap(this.reportedSubagentLinks, MAX_LINK_DESCRIPTORS);
+      this.logger.debug('Codex subagent link resolved', {
         childThreadId: link.childThreadId,
         parentThreadId: link.parentThreadId,
         parentTurnId: link.parentTurnId,
@@ -1353,33 +1687,9 @@ export class CodexTranscriptInput extends BaseInput {
     const raw = this.stateStore.get(key).extra?.codexTranscript;
     const value = asRecord(raw);
     if (!value || typeof value.inode !== 'number' || typeof value.scanOffset !== 'number') return null;
-    const active = asRecord(value.activeTurn);
-    const model = stringValue(active?.model);
-    const cwd = stringValue(active?.cwd);
-    const developerInstructions = stringValue(active?.developerInstructions);
-    const activeTurn = active
-      && typeof active.turnId === 'string'
-      && typeof active.startOffset === 'number'
-      && typeof active.startedAtMs === 'number'
-      ? {
-          turnId: active.turnId,
-          startOffset: active.startOffset,
-          startedAtMs: active.startedAtMs,
-          ...(model ? { model } : {}),
-          ...(cwd ? { cwd } : {}),
-          ...(developerInstructions ? { developerInstructions } : {}),
-          emittedPrompt: active.emittedPrompt === true,
-          emittedStepCount: typeof active.emittedStepCount === 'number' ? active.emittedStepCount : 0,
-          emittedStepRequestIds: stringArray(active.emittedStepRequestIds),
-          emittedStepResponseIds: stringArray(active.emittedStepResponseIds),
-          emittedToolCallIds: stringArray(active.emittedToolCallIds),
-          emittedToolResultIds: stringArray(active.emittedToolResultIds),
-          inputContext: parseInputContext(active.inputContext),
-          subagentSpawns: parsePendingFusionChildren(active.subagentSpawns),
-        }
-      : null;
+    const activeTurn = parseActiveTranscriptTurn(value.activeTurn);
     const pending = asRecord(value.pendingTerminal);
-    const pendingTerminal = pending
+    let pendingTerminal = pending
       && typeof pending.turnId === 'string'
       && typeof pending.terminalEndOffset === 'number'
       ? {
@@ -1398,7 +1708,6 @@ export class CodexTranscriptInput extends BaseInput {
       && typeof fusion.parentThreadId === 'string'
       && typeof fusion.parentTraceId === 'string'
       && typeof fusion.terminalEndOffset === 'number'
-      && typeof fusion.createdAtMs === 'number'
       && fusionChildren.length > 0
       ? {
           turnId: fusion.turnId,
@@ -1406,15 +1715,44 @@ export class CodexTranscriptInput extends BaseInput {
           parentTraceId: fusion.parentTraceId,
           terminalEndOffset: fusion.terminalEndOffset,
           children: fusionChildren,
-          createdAtMs: fusion.createdAtMs,
         }
       : null;
     const subagent = asRecord(value.pendingSubagent);
+    const capturedActiveTurn = parseActiveTranscriptTurn(subagent?.activeTurn);
+    const confidence = subagent?.confidence;
     const pendingSubagent: CodexPendingSubagentTurn | null = subagent
       && typeof subagent.turnId === 'string'
+      && typeof subagent.parentThreadId === 'string'
+      && typeof subagent.parentTurnId === 'string'
+      && typeof subagent.parentTraceId === 'string'
+      && typeof subagent.parentToolCallId === 'string'
+      && (confidence === 'explicit_id' || confidence === 'agent_path')
       && typeof subagent.terminalEndOffset === 'number'
-      ? { turnId: subagent.turnId, terminalEndOffset: subagent.terminalEndOffset }
+      && capturedActiveTurn
+      ? {
+          turnId: subagent.turnId,
+          parentThreadId: subagent.parentThreadId,
+          parentTurnId: subagent.parentTurnId,
+          parentTraceId: subagent.parentTraceId,
+          parentToolCallId: subagent.parentToolCallId,
+          confidence,
+          terminalEndOffset: subagent.terminalEndOffset,
+          activeTurn: capturedActiveTurn,
+        }
       : null;
+    if (
+      subagent
+      && !pendingSubagent
+      && activeTurn
+      && typeof subagent.turnId === 'string'
+      && typeof subagent.terminalEndOffset === 'number'
+      && activeTurn.turnId === subagent.turnId
+    ) {
+      // Older pendingSubagent checkpoints blocked the child file and retained
+      // the active turn at the top level. They have no reliable spawn identity,
+      // so recover them through the normal independent terminal path.
+      pendingTerminal ??= newPendingTerminal(subagent.turnId, subagent.terminalEndOffset, 0);
+    }
     return {
       inode: value.inode,
       scanOffset: value.scanOffset,
@@ -1807,6 +2145,41 @@ function stringArray(value: unknown): string[] {
     : [];
 }
 
+function parseActiveTranscriptTurn(value: unknown): CodexActiveTranscriptTurn | null {
+  const active = asRecord(value);
+  if (
+    !active
+    || typeof active.turnId !== 'string'
+    || typeof active.startOffset !== 'number'
+    || typeof active.startedAtMs !== 'number'
+  ) return null;
+  const model = stringValue(active.model);
+  const cwd = stringValue(active.cwd);
+  const developerInstructions = stringValue(active.developerInstructions);
+  return {
+    turnId: active.turnId,
+    startOffset: active.startOffset,
+    startedAtMs: active.startedAtMs,
+    ...(model ? { model } : {}),
+    ...(cwd ? { cwd } : {}),
+    ...(developerInstructions ? { developerInstructions } : {}),
+    emittedPrompt: active.emittedPrompt === true,
+    emittedStepCount: typeof active.emittedStepCount === 'number' ? active.emittedStepCount : 0,
+    emittedStepRequestIds: stringArray(active.emittedStepRequestIds),
+    emittedStepResponseIds: stringArray(active.emittedStepResponseIds),
+    emittedToolCallIds: stringArray(active.emittedToolCallIds),
+    emittedToolResultIds: stringArray(active.emittedToolResultIds),
+    inputContext: parseInputContext(active.inputContext),
+    subagentSpawns: parsePendingFusionChildren(active.subagentSpawns),
+  };
+}
+
+function isReliableFusionConfidence(
+  confidence: CodexSubagentLink['confidence'],
+): confidence is 'explicit_id' | 'agent_path' {
+  return confidence === 'explicit_id' || confidence === 'agent_path';
+}
+
 function parsePendingFusionChildren(value: unknown): CodexPendingFusionChild[] {
   if (!Array.isArray(value)) return [];
   const children: CodexPendingFusionChild[] = [];
@@ -1841,33 +2214,42 @@ function mergePendingFusionChildren(
   return [...merged.values()];
 }
 
-function pruneSupersededFusionChildren(
-  children: CodexPendingFusionChild[],
-): CodexPendingFusionChild[] {
-  const successfulPaths = new Set(children
-    .filter(child => child.childThreadId)
-    .map(child => normalizeFusionAgentPath(child.agentPath ?? child.taskName))
-    .filter((value): value is string => value !== undefined));
-  return children.filter(child => (
-    child.childThreadId
-    || !successfulPaths.has(normalizeFusionAgentPath(child.agentPath ?? child.taskName) ?? '')
-  ));
+function classifyParentTurnOwnership(
+  turnId: string,
+  index: ParentTurnIndex | undefined,
+): 'copied' | 'child' | 'unknown' {
+  if (!index) return 'unknown';
+  if (index.turnIds.has(turnId)) return 'copied';
+  return index.complete ? 'child' : 'unknown';
 }
 
-function normalizeFusionAgentPath(value: string | undefined): string | undefined {
-  if (!value) return undefined;
-  const trimmed = value.trim().replace(/\/+$/, '');
-  if (!trimmed) return undefined;
-  return trimmed.startsWith('/') ? trimmed : `/root/${trimmed.replace(/^root\//, '')}`;
+function shouldSkipCopiedParentTurn(
+  turnId: string,
+  observedStartedAtMs: number,
+  ownerCreatedAtMs: number | undefined,
+  index: ParentTurnIndex | undefined,
+): boolean {
+  const ownership = classifyParentTurnOwnership(turnId, index);
+  if (ownership === 'copied') return true;
+  if (ownership === 'child' || ownerCreatedAtMs === undefined) return false;
+  return isCopiedParentTurnByTime(turnId, observedStartedAtMs, ownerCreatedAtMs);
 }
 
-function isCopiedParentTurn(
+function isCopiedParentTurnByTime(
   turnId: string,
   observedStartedAtMs: number,
   ownerCreatedAtMs: number,
 ): boolean {
   const uuidTimestamp = uuidV7TimestampMs(turnId);
   return (uuidTimestamp ?? observedStartedAtMs) < ownerCreatedAtMs;
+}
+
+function trimOldestMap<T>(values: Map<string, T>, maxSize: number): void {
+  while (values.size > maxSize) {
+    const oldest = values.keys().next().value as string | undefined;
+    if (oldest === undefined) return;
+    values.delete(oldest);
+  }
 }
 
 function uuidV7TimestampMs(value: string): number | undefined {
@@ -1880,6 +2262,15 @@ function uuidV7TimestampMs(value: string): number | undefined {
 
 function cloneActiveTurn(activeTurn: CodexActiveTranscriptTurn): CodexActiveTranscriptTurn {
   return structuredClone(activeTurn);
+}
+
+function hasEmittedActiveTurnState(activeTurn: CodexActiveTranscriptTurn): boolean {
+  return activeTurn.emittedPrompt === true
+    || (activeTurn.emittedStepCount ?? 0) > 0
+    || (activeTurn.emittedStepRequestIds?.length ?? 0) > 0
+    || (activeTurn.emittedStepResponseIds?.length ?? 0) > 0
+    || (activeTurn.emittedToolCallIds?.length ?? 0) > 0
+    || (activeTurn.emittedToolResultIds?.length ?? 0) > 0;
 }
 
 function parentTraceIdForChildren(children: CodexPendingFusionChild[]): string {

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -13,6 +13,11 @@ import {
   nextInputMessagesForStep,
 } from './codex-transcript-builder.js';
 import {
+  CodexSubagentLinker,
+  extractCodexSpawnDescriptors,
+  type CodexSubagentLinkSnapshot,
+} from './codex-subagent-linker.js';
+import {
   extractCodexPartialTurn,
   extractCodexPartialTurnWithBoundaries,
   extractCodexTranscriptMeta,
@@ -129,6 +134,9 @@ export class CodexTranscriptInput extends BaseInput {
   private processedTerminalTurnIdsDirty = false;
   private processedTerminalTurnIds = new Set<string>();
   private processedTerminalTurnIdOrder: string[] = [];
+  private readonly subagentLinker = new CodexSubagentLinker();
+  private readonly reportedSubagentLinks = new Map<string, string>();
+  private lastSubagentShadowSummary = '';
   private lastWakeupMarkerCleanupAtMs = 0;
   private lastSpanContextCleanupAtMs = 0;
 
@@ -184,10 +192,16 @@ export class CodexTranscriptInput extends BaseInput {
     for (const { filePath } of await this.discoverSessionFiles()) {
       emittedCount += await this.processFile(filePath);
     }
+    this.reportSubagentShadowLinks();
     if (emittedCount > 0) {
       this.logger.debug('cycle produced entries', { count: emittedCount });
     }
     return [];
+  }
+
+  /** Phase-2 diagnostic surface. Shadow linking never mutates emitted records. */
+  getSubagentLinkSnapshot(): CodexSubagentLinkSnapshot {
+    return this.subagentLinker.snapshot();
   }
 
   private emitEntryBatches(entries: AgentActivityEntry[]): number {
@@ -248,6 +262,7 @@ export class CodexTranscriptInput extends BaseInput {
       checkpoint.ownerSessionMetaOffset = await findOwnerSessionMetaOffset(filePath, stat.size);
       checkpointChanged = true;
     }
+    await this.registerSubagentOwnerMeta(filePath, checkpoint.ownerSessionMetaOffset);
 
     let emittedCount = 0;
     let processedTerminalCount = 0;
@@ -490,6 +505,14 @@ export class CodexTranscriptInput extends BaseInput {
       ...(inputContext ? { inputContext } : {}),
       contextStepCount: committedTurn.steps.length,
     });
+    if (meta?.depth === 0) {
+      const parentTraceId = stringValue(built.entries[0]?.trace_id);
+      if (parentTraceId) {
+        this.subagentLinker.registerSpawns(
+          extractCodexSpawnDescriptors(turn, records.items, parentTraceId),
+        );
+      }
+    }
     const readyEntries = built.entries;
     const entries = this.filterNewSegmentEntries(readyEntries, activeTurn);
     const diagnostics: SegmentRecoveryDiagnostics = {
@@ -590,6 +613,58 @@ export class CodexTranscriptInput extends BaseInput {
       return context;
     }
     return { ...context, delta: nextInputMessagesForStep(lastStep) };
+  }
+
+  private async registerSubagentOwnerMeta(
+    filePath: string,
+    ownerSessionMetaOffset: number | null,
+  ): Promise<void> {
+    if (ownerSessionMetaOffset === null) return;
+    const threadId = sessionIdFromTranscriptPath(filePath);
+    if (this.subagentLinker.hasThread(threadId)) return;
+    const record = await readJsonLineAt(filePath, ownerSessionMetaOffset);
+    const meta = record ? extractCodexTranscriptMeta(record) : null;
+    if (meta) this.subagentLinker.registerChild(meta);
+  }
+
+  private reportSubagentShadowLinks(): void {
+    const snapshot = this.subagentLinker.snapshot();
+    if (snapshot.detectedChildren === 0 && snapshot.detectedSpawns === 0) return;
+
+    const summary = [
+      snapshot.detectedChildren,
+      snapshot.detectedSpawns,
+      snapshot.linkedChildren,
+      snapshot.orphanChildren,
+    ].join(':');
+    if (summary !== this.lastSubagentShadowSummary) {
+      this.lastSubagentShadowSummary = summary;
+      this.logger.info('Codex subagent linker shadow summary', {
+        detectedChildren: snapshot.detectedChildren,
+        detectedSpawns: snapshot.detectedSpawns,
+        linkedChildren: snapshot.linkedChildren,
+        orphanChildren: snapshot.orphanChildren,
+      });
+    }
+
+    for (const link of snapshot.links) {
+      const fingerprint = [
+        link.confidence,
+        link.parentToolCallId ?? '',
+        link.orphanReason ?? '',
+      ].join(':');
+      if (this.reportedSubagentLinks.get(link.childThreadId) === fingerprint) continue;
+      this.reportedSubagentLinks.set(link.childThreadId, fingerprint);
+      this.logger.debug('Codex subagent shadow link resolved', {
+        childThreadId: link.childThreadId,
+        parentThreadId: link.parentThreadId,
+        parentTurnId: link.parentTurnId,
+        parentToolCallId: link.parentToolCallId,
+        agentPath: link.agentPath,
+        confidence: link.confidence,
+        orphanReason: link.orphanReason,
+      });
+    }
   }
 
   private filterNewSegmentEntries(

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -234,7 +234,7 @@ export class CodexTranscriptInput extends BaseInput {
         scanOffset: 0,
         activeTurn: null,
         pendingTerminal: null,
-        latestSessionMetaOffset: null,
+        ownerSessionMetaOffset: null,
         emittedTerminalTurnIds: [],
       };
       checkpointChanged = true;
@@ -242,6 +242,11 @@ export class CodexTranscriptInput extends BaseInput {
       await this.baselineFile(filePath, key);
       this.saveGlobalProcessedTerminalTurnIds();
       return 0;
+    }
+
+    if (checkpoint.ownerSessionMetaOffset === null) {
+      checkpoint.ownerSessionMetaOffset = await findOwnerSessionMetaOffset(filePath, stat.size);
+      checkpointChanged = true;
     }
 
     let emittedCount = 0;
@@ -275,7 +280,11 @@ export class CodexTranscriptInput extends BaseInput {
         const payload = asRecord(line.record.payload);
         if (!payload) return;
         if (line.record.type === 'session_meta') {
-          checkpoint.latestSessionMetaOffset = line.startOffset;
+          checkpoint.ownerSessionMetaOffset = selectOwnerSessionMetaOffset(
+            filePath,
+            checkpoint.ownerSessionMetaOffset,
+            line,
+          );
           return;
         }
 
@@ -436,9 +445,9 @@ export class CodexTranscriptInput extends BaseInput {
       };
     }
     const records = await readJsonLines(filePath, activeTurn.startOffset, endOffset);
-    const metaRecord = checkpoint.latestSessionMetaOffset === null
+    const metaRecord = checkpoint.ownerSessionMetaOffset === null
       ? null
-      : await readJsonLineAt(filePath, checkpoint.latestSessionMetaOffset);
+      : await readJsonLineAt(filePath, checkpoint.ownerSessionMetaOffset);
     const meta = metaRecord ? extractCodexTranscriptMeta(metaRecord) : null;
     const extraction = extractCodexPartialTurnWithBoundaries(
       records.items,
@@ -753,14 +762,18 @@ export class CodexTranscriptInput extends BaseInput {
     } catch {
       return;
     }
-    let latestSessionMetaOffset: number | null = null;
+    let ownerSessionMetaOffset: number | null = null;
     let activeTurn: CodexActiveTranscriptTurn | null = null;
     const completedTurnIds: string[] = [];
     const { nextOffset } = await scanJsonLines(filePath, 0, stat.size, line => {
       const payload = asRecord(line.record.payload);
       if (!payload) return;
       if (line.record.type === 'session_meta') {
-        latestSessionMetaOffset = line.startOffset;
+        ownerSessionMetaOffset = selectOwnerSessionMetaOffset(
+          filePath,
+          ownerSessionMetaOffset,
+          line,
+        );
         return;
       }
       const turnId = turnIdForStart(line.record, payload);
@@ -787,7 +800,7 @@ export class CodexTranscriptInput extends BaseInput {
       scanOffset: nextOffset,
       activeTurn,
       pendingTerminal: null,
-      latestSessionMetaOffset,
+      ownerSessionMetaOffset,
       emittedTerminalTurnIds: [],
     });
   }
@@ -1021,8 +1034,11 @@ export class CodexTranscriptInput extends BaseInput {
       scanOffset: value.scanOffset,
       activeTurn,
       pendingTerminal,
-      latestSessionMetaOffset: typeof value.latestSessionMetaOffset === 'number'
-        ? value.latestSessionMetaOffset
+      // Do not migrate legacy latestSessionMetaOffset. In forked rollouts that
+      // value commonly points at copied parent metadata, so processFile will
+      // perform one bounded header scan to recover the owning meta safely.
+      ownerSessionMetaOffset: typeof value.ownerSessionMetaOffset === 'number'
+        ? value.ownerSessionMetaOffset
         : null,
       emittedTerminalTurnIds: Array.isArray(value.emittedTerminalTurnIds)
         ? value.emittedTerminalTurnIds.filter((item): item is string => typeof item === 'string')
@@ -1265,6 +1281,37 @@ async function scanJsonLines(
   } finally {
     await handle.close();
   }
+}
+
+async function findOwnerSessionMetaOffset(
+  filePath: string,
+  endOffset: number,
+): Promise<number | null> {
+  let ownerOffset: number | null = null;
+  let sawSessionMeta = false;
+  await scanJsonLines(filePath, 0, endOffset, line => {
+    if (line.record.type !== 'session_meta') {
+      // Codex writes the owning meta and any copied fork metadata as a header.
+      // Stop before scanning the potentially large inherited conversation.
+      return sawSessionMeta ? false : undefined;
+    }
+    sawSessionMeta = true;
+    ownerOffset = selectOwnerSessionMetaOffset(filePath, ownerOffset, line);
+    return undefined;
+  });
+  return ownerOffset;
+}
+
+function selectOwnerSessionMetaOffset(
+  filePath: string,
+  currentOffset: number | null,
+  line: JsonLine,
+): number | null {
+  const meta = extractCodexTranscriptMeta(line.record);
+  if (!meta) return currentOffset;
+  const rolloutThreadId = sessionIdFromTranscriptPath(filePath);
+  if (meta.threadId === rolloutThreadId) return line.startOffset;
+  return currentOffset ?? line.startOffset;
 }
 
 async function readJsonLineAt(filePath: string, offset: number): Promise<Record<string, unknown> | null> {

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -640,7 +640,14 @@ export class CodexTranscriptInput extends BaseInput {
         );
       }
     }
-    const readyEntries = built.entries;
+    // A Codex model wave may finish with `stop` and then resume in the same
+    // transcript turn (for example after a subagent completion notification or
+    // a failed spawn retry). Emit a distinct lifecycle marker only after the
+    // authoritative task_complete / turn_aborted boundary. This also closes a
+    // turn whose final LLM response was already emitted in an earlier poll.
+    const readyEntries = terminal && built.entries.length > 0
+      ? [...built.entries, codexTurnEndMarker(built.entries, turn.status)]
+      : built.entries;
     const entries = this.filterNewSegmentEntries(readyEntries, activeTurn);
     const diagnostics: SegmentRecoveryDiagnostics = {
       sourceRecordCount: records.items.length,
@@ -959,6 +966,10 @@ export class CodexTranscriptInput extends BaseInput {
     for (const entry of entries) {
       const eventName = entry['event.name'];
       if (eventName === 'other') {
+        if (entry['gen_ai.turn.end'] === true) {
+          out.push(entry);
+          continue;
+        }
         if (activeTurn.emittedPrompt) continue;
         activeTurn.emittedPrompt = true;
         out.push(entry);
@@ -1904,8 +1915,41 @@ function rewriteSubagentEntries(
     ...(context.agentName ? { 'gen_ai.agent.name': context.agentName } : {}),
     'gen_ai.agent.parent.id': context.parentThreadId,
     'gen_ai.subagent.parent_tool_call.id': context.parentToolCallId,
-    ...(entry['event.name'] === 'other' ? { parent_span_id: parentToolSpanId } : {}),
+    ...(entry['event.name'] === 'other' && entry['gen_ai.turn.end'] !== true
+      ? { parent_span_id: parentToolSpanId }
+      : {}),
   }));
+}
+
+function codexTurnEndMarker(
+  entries: AgentActivityEntry[],
+  status: 'completed' | 'interrupted',
+): AgentActivityEntry {
+  const source = [...entries].reverse().find(entry => entry['event.name'] === 'llm.response')
+    ?? entries.at(-1);
+  if (!source) throw new Error('cannot build Codex turn-end marker without a source entry');
+  return {
+    time_unix_nano: source.time_unix_nano,
+    ...(source.observed_time_unix_nano
+      ? { observed_time_unix_nano: source.observed_time_unix_nano }
+      : {}),
+    'event.id': `${source['event.id']}:turn-end`,
+    'event.name': 'other',
+    'user.id': source['user.id'],
+    ...(source.trace_id ? { trace_id: source.trace_id } : {}),
+    parent_span_id: '0000000000000001',
+    'gen_ai.session.id': source['gen_ai.session.id'],
+    ...(source['gen_ai.turn.id'] ? { 'gen_ai.turn.id': source['gen_ai.turn.id'] } : {}),
+    'gen_ai.turn.end': true,
+    'gen_ai.agent.type': source['gen_ai.agent.type'],
+    ...(source['gen_ai.agent.id'] ? { 'gen_ai.agent.id': source['gen_ai.agent.id'] } : {}),
+    ...(source['gen_ai.agent.name'] ? { 'gen_ai.agent.name': source['gen_ai.agent.name'] } : {}),
+    'gen_ai.provider.name': source['gen_ai.provider.name'],
+    ...(source['agent.codex.transcript_turn_id']
+      ? { 'agent.codex.transcript_turn_id': source['agent.codex.transcript_turn_id'] }
+      : {}),
+    'agent.codex.turn_status': status,
+  };
 }
 
 function serializedEntryBytes(entry: AgentActivityEntry): number {

--- a/src/inputs/codex-transcript/codex-transcript-types.ts
+++ b/src/inputs/codex-transcript/codex-transcript-types.ts
@@ -80,6 +80,7 @@ export interface CodexTranscriptMeta {
   threadSource: 'user' | 'subagent' | 'unknown';
   parentThreadId?: string;
   depth: number;
+  createdAtMs?: number;
   agentPath?: string;
   agentNickname?: string;
   agentRole?: string;

--- a/src/inputs/codex-transcript/codex-transcript-types.ts
+++ b/src/inputs/codex-transcript/codex-transcript-types.ts
@@ -47,20 +47,29 @@ export interface CodexPendingFusionChild {
   childThreadId?: string;
 }
 
-/** Parent terminal held until every direct child rollout reaches a terminal. */
+/** Parent task_complete staged until the current cycle rebuilds or degrades its direct children. */
 export interface CodexPendingFusionTurn {
   turnId: string;
   parentThreadId: string;
   parentTraceId: string;
   terminalEndOffset: number;
   children: CodexPendingFusionChild[];
-  createdAtMs: number;
 }
 
-/** Completed child range retained in its rollout until it can be fused. */
+/**
+ * Completed child turn consumed from its rollout but not emitted independently.
+ * The active-turn snapshot lets fusion reconstruct it after the child scan
+ * offset advances or the collector restarts.
+ */
 export interface CodexPendingSubagentTurn {
   turnId: string;
+  parentThreadId: string;
+  parentTurnId: string;
+  parentTraceId: string;
+  parentToolCallId: string;
+  confidence: 'explicit_id' | 'agent_path';
   terminalEndOffset: number;
+  activeTurn: CodexActiveTranscriptTurn;
 }
 
 /**

--- a/src/inputs/codex-transcript/codex-transcript-types.ts
+++ b/src/inputs/codex-transcript/codex-transcript-types.ts
@@ -55,7 +55,14 @@ export interface CodexTranscriptCheckpoint {
   scanOffset: number;
   activeTurn: CodexActiveTranscriptTurn | null;
   pendingTerminal: CodexPendingTerminalTurn | null;
-  latestSessionMetaOffset: number | null;
+  /**
+   * Offset of the session_meta that describes this rollout file itself.
+   *
+   * Forked Codex rollouts can contain multiple session_meta records: the
+   * child's own meta followed by copied parent history. Keeping the latest
+   * meta therefore misattributes child turns to the parent session.
+   */
+  ownerSessionMetaOffset: number | null;
   /** Terminal turns already processed by this transcript, including empty control turns. */
   emittedTerminalTurnIds: string[];
 }
@@ -66,7 +73,16 @@ export interface CodexTranscriptGlobalState {
 }
 
 export interface CodexTranscriptMeta {
-  sessionId: string;
+  /** The Codex thread/rollout described by this session_meta record. */
+  threadId: string;
+  /** Root user session shared by a subagent tree when Codex supplies it. */
+  rootSessionId: string;
+  threadSource: 'user' | 'subagent' | 'unknown';
+  parentThreadId?: string;
+  depth: number;
+  agentPath?: string;
+  agentNickname?: string;
+  agentRole?: string;
   provider: string;
   baseInstructions?: string;
   toolDefinitions?: JsonValue;

--- a/src/inputs/codex-transcript/codex-transcript-types.ts
+++ b/src/inputs/codex-transcript/codex-transcript-types.ts
@@ -34,6 +34,33 @@ export interface CodexActiveTranscriptTurn {
   emittedToolCallIds?: string[];
   emittedToolResultIds?: string[];
   inputContext?: CodexTranscriptInputContext;
+  /** Direct spawn_agent calls already observed while this parent turn streamed. */
+  subagentSpawns?: CodexPendingFusionChild[];
+}
+
+export interface CodexPendingFusionChild {
+  parentToolCallId: string;
+  parentTraceId: string;
+  spawnedAtMs: number;
+  taskName?: string;
+  agentPath?: string;
+  childThreadId?: string;
+}
+
+/** Parent terminal held until every direct child rollout reaches a terminal. */
+export interface CodexPendingFusionTurn {
+  turnId: string;
+  parentThreadId: string;
+  parentTraceId: string;
+  terminalEndOffset: number;
+  children: CodexPendingFusionChild[];
+  createdAtMs: number;
+}
+
+/** Completed child range retained in its rollout until it can be fused. */
+export interface CodexPendingSubagentTurn {
+  turnId: string;
+  terminalEndOffset: number;
 }
 
 /**
@@ -55,6 +82,8 @@ export interface CodexTranscriptCheckpoint {
   scanOffset: number;
   activeTurn: CodexActiveTranscriptTurn | null;
   pendingTerminal: CodexPendingTerminalTurn | null;
+  pendingFusion: CodexPendingFusionTurn | null;
+  pendingSubagent: CodexPendingSubagentTurn | null;
   /**
    * Offset of the session_meta that describes this rollout file itself.
    *

--- a/tests/fixtures/codex-subagent/README.md
+++ b/tests/fixtures/codex-subagent/README.md
@@ -8,3 +8,8 @@ The child rollout intentionally starts with its own `session_meta`, followed by
 the copied parent `session_meta` and parent turn history. This ordering is the
 regression case for selecting the rollout's owning metadata instead of the last
 metadata record in the file.
+
+The parent contains four `spawn_agent` calls whose returned task paths match
+the four child `agent_path` values. Phase-2 shadow-link tests use that mapping
+to prove parallel children are associated one-to-one without changing emitted
+trace records.

--- a/tests/fixtures/codex-subagent/README.md
+++ b/tests/fixtures/codex-subagent/README.md
@@ -10,6 +10,6 @@ regression case for selecting the rollout's owning metadata instead of the last
 metadata record in the file.
 
 The parent contains four `spawn_agent` calls whose returned task paths match
-the four child `agent_path` values. Phase-2 shadow-link tests use that mapping
-to prove parallel children are associated one-to-one without changing emitted
-trace records.
+the four child `agent_path` values. Fusion tests use that mapping to prove
+parallel children are associated one-to-one by `parentToolCallId` and emitted
+under their parent trace.

--- a/tests/fixtures/codex-subagent/README.md
+++ b/tests/fixtures/codex-subagent/README.md
@@ -1,0 +1,10 @@
+# Codex subagent rollout fixtures
+
+These compact JSONL fixtures preserve the structure observed in Codex Desktop
+multi-agent v2 rollouts while replacing prompts, responses, thread IDs, names,
+paths, and tool arguments with synthetic values.
+
+The child rollout intentionally starts with its own `session_meta`, followed by
+the copied parent `session_meta` and parent turn history. This ordering is the
+regression case for selecting the rollout's owning metadata instead of the last
+metadata record in the file.

--- a/tests/fixtures/codex-subagent/rollout-2026-08-07T10-00-00-aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa.jsonl
+++ b/tests/fixtures/codex-subagent/rollout-2026-08-07T10-00-00-aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa.jsonl
@@ -1,0 +1,8 @@
+{"timestamp":"2026-08-07T02:00:00.000Z","type":"session_meta","payload":{"id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","session_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","timestamp":"2026-08-07T02:00:00.000Z","cwd":"/tmp/codex-subagent-fixture","originator":"Codex Desktop","source":"vscode","thread_source":"user","model_provider":"openai"}}
+{"timestamp":"2026-08-07T02:00:01.000Z","type":"turn_context","payload":{"turn_id":"parent-turn-1","model":"gpt-test","cwd":"/tmp/codex-subagent-fixture"}}
+{"timestamp":"2026-08-07T02:00:02.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"parent-turn-1"}}
+{"timestamp":"2026-08-07T02:00:03.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"delegate a synthetic task"}]}}
+{"timestamp":"2026-08-07T02:00:04.000Z","type":"response_item","payload":{"type":"function_call","call_id":"call-subagent-1","name":"spawn_agent","arguments":"{\"task_name\":\"fixture_child\",\"message\":\"redacted\"}"}}
+{"timestamp":"2026-08-07T02:00:05.000Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-subagent-1","output":"{\"task_name\":\"/root/fixture_child\"}"}}
+{"timestamp":"2026-08-07T02:00:06.000Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"output_tokens":10,"cached_input_tokens":0,"total_tokens":110}}}}
+{"timestamp":"2026-08-07T02:00:07.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"parent-turn-1","last_agent_message":"delegated"}}

--- a/tests/fixtures/codex-subagent/rollout-2026-08-07T10-00-00-aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa.jsonl
+++ b/tests/fixtures/codex-subagent/rollout-2026-08-07T10-00-00-aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa.jsonl
@@ -3,6 +3,12 @@
 {"timestamp":"2026-08-07T02:00:02.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"parent-turn-1"}}
 {"timestamp":"2026-08-07T02:00:03.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"delegate a synthetic task"}]}}
 {"timestamp":"2026-08-07T02:00:04.000Z","type":"response_item","payload":{"type":"function_call","call_id":"call-subagent-1","name":"spawn_agent","arguments":"{\"task_name\":\"fixture_child\",\"message\":\"redacted\"}"}}
-{"timestamp":"2026-08-07T02:00:05.000Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-subagent-1","output":"{\"task_name\":\"/root/fixture_child\"}"}}
-{"timestamp":"2026-08-07T02:00:06.000Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"output_tokens":10,"cached_input_tokens":0,"total_tokens":110}}}}
-{"timestamp":"2026-08-07T02:00:07.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"parent-turn-1","last_agent_message":"delegated"}}
+{"timestamp":"2026-08-07T02:00:04.050Z","type":"response_item","payload":{"type":"function_call","call_id":"call-subagent-2","name":"spawn_agent","arguments":"{\"task_name\":\"fixture_child_2\",\"message\":\"redacted\"}"}}
+{"timestamp":"2026-08-07T02:00:04.100Z","type":"response_item","payload":{"type":"function_call","call_id":"call-subagent-3","name":"spawn_agent","arguments":"{\"task_name\":\"fixture_child_3\",\"message\":\"redacted\"}"}}
+{"timestamp":"2026-08-07T02:00:04.150Z","type":"response_item","payload":{"type":"function_call","call_id":"call-subagent-4","name":"spawn_agent","arguments":"{\"task_name\":\"fixture_child_4\",\"message\":\"redacted\"}"}}
+{"timestamp":"2026-08-07T02:00:04.200Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-subagent-1","output":"{\"task_name\":\"/root/fixture_child\"}"}}
+{"timestamp":"2026-08-07T02:00:04.250Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-subagent-2","output":"{\"task_name\":\"/root/fixture_child_2\"}"}}
+{"timestamp":"2026-08-07T02:00:04.300Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-subagent-3","output":"{\"task_name\":\"/root/fixture_child_3\"}"}}
+{"timestamp":"2026-08-07T02:00:04.350Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-subagent-4","output":"{\"task_name\":\"/root/fixture_child_4\"}"}}
+{"timestamp":"2026-08-07T02:00:05.000Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"output_tokens":10,"cached_input_tokens":0,"total_tokens":110}}}}
+{"timestamp":"2026-08-07T02:00:06.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"parent-turn-1","last_agent_message":"delegated"}}

--- a/tests/fixtures/codex-subagent/rollout-2026-08-07T10-00-04-bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb.jsonl
+++ b/tests/fixtures/codex-subagent/rollout-2026-08-07T10-00-04-bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb.jsonl
@@ -1,0 +1,15 @@
+{"timestamp":"2026-08-07T02:00:04.100Z","type":"session_meta","payload":{"id":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb","session_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","timestamp":"2026-08-07T02:00:04.100Z","cwd":"/tmp/codex-subagent-fixture","originator":"Codex Desktop","source":{"subagent":{"thread_spawn":{"parent_thread_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","depth":1,"agent_path":"/root/fixture_child","agent_nickname":"FixtureChild","agent_role":null}}},"thread_source":"subagent","model_provider":"openai","multi_agent_version":"v2"}}
+{"timestamp":"2026-08-07T02:00:00.000Z","type":"session_meta","payload":{"id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","session_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","timestamp":"2026-08-07T02:00:00.000Z","cwd":"/tmp/codex-subagent-fixture","originator":"Codex Desktop","source":"vscode","thread_source":"user","model_provider":"openai"}}
+{"timestamp":"2026-08-07T02:00:01.000Z","type":"turn_context","payload":{"turn_id":"parent-turn-1","model":"gpt-test","cwd":"/tmp/codex-subagent-fixture"}}
+{"timestamp":"2026-08-07T02:00:02.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"parent-turn-1"}}
+{"timestamp":"2026-08-07T02:00:03.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"delegate a synthetic task"}]}}
+{"timestamp":"2026-08-07T02:00:04.000Z","type":"response_item","payload":{"type":"function_call","call_id":"call-subagent-1","name":"spawn_agent","arguments":"{\"task_name\":\"fixture_child\",\"message\":\"redacted\"}"}}
+{"timestamp":"2026-08-07T02:00:05.000Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-subagent-1","output":"{\"task_name\":\"/root/fixture_child\"}"}}
+{"timestamp":"2026-08-07T02:00:06.000Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"output_tokens":10,"cached_input_tokens":0,"total_tokens":110}}}}
+{"timestamp":"2026-08-07T02:00:07.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"parent-turn-1","last_agent_message":"delegated"}}
+{"timestamp":"2026-08-07T02:00:08.000Z","type":"turn_context","payload":{"turn_id":"child-turn-1","model":"gpt-test","cwd":"/tmp/codex-subagent-fixture"}}
+{"timestamp":"2026-08-07T02:00:09.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"child-turn-1"}}
+{"timestamp":"2026-08-07T02:00:10.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"synthetic child task"}]}}
+{"timestamp":"2026-08-07T02:00:11.000Z","type":"event_msg","payload":{"type":"agent_message","message":"synthetic child response","phase":"final"}}
+{"timestamp":"2026-08-07T02:00:11.100Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":80,"output_tokens":8,"cached_input_tokens":0,"total_tokens":88}}}}
+{"timestamp":"2026-08-07T02:00:12.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"child-turn-1","last_agent_message":"synthetic child response"}}

--- a/tests/fixtures/codex-subagent/rollout-2026-08-07T10-00-05-cccccccc-cccc-4ccc-8ccc-cccccccccccc.jsonl
+++ b/tests/fixtures/codex-subagent/rollout-2026-08-07T10-00-05-cccccccc-cccc-4ccc-8ccc-cccccccccccc.jsonl
@@ -1,0 +1,11 @@
+{"timestamp":"2026-08-07T02:00:05.100Z","type":"session_meta","payload":{"id":"cccccccc-cccc-4ccc-8ccc-cccccccccccc","session_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","timestamp":"2026-08-07T02:00:05.100Z","cwd":"/tmp/codex-subagent-fixture","originator":"Codex Desktop","source":{"subagent":{"thread_spawn":{"parent_thread_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","depth":1,"agent_path":"/root/fixture_child_2","agent_nickname":"FixtureChild2","agent_role":null}}},"thread_source":"subagent","model_provider":"openai","multi_agent_version":"v2"}}
+{"timestamp":"2026-08-07T02:00:00.000Z","type":"session_meta","payload":{"id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","session_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","thread_source":"user","model_provider":"openai"}}
+{"timestamp":"2026-08-07T02:00:01.000Z","type":"turn_context","payload":{"turn_id":"parent-turn-1","model":"gpt-test"}}
+{"timestamp":"2026-08-07T02:00:02.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"parent-turn-1"}}
+{"timestamp":"2026-08-07T02:00:07.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"parent-turn-1","last_agent_message":"delegated"}}
+{"timestamp":"2026-08-07T02:00:13.000Z","type":"turn_context","payload":{"turn_id":"child-turn-2","model":"gpt-test"}}
+{"timestamp":"2026-08-07T02:00:14.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"child-turn-2"}}
+{"timestamp":"2026-08-07T02:00:15.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"synthetic child task 2"}]}}
+{"timestamp":"2026-08-07T02:00:16.000Z","type":"event_msg","payload":{"type":"agent_message","message":"synthetic child response 2","phase":"final"}}
+{"timestamp":"2026-08-07T02:00:16.100Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":81,"output_tokens":8,"cached_input_tokens":0,"total_tokens":89}}}}
+{"timestamp":"2026-08-07T02:00:17.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"child-turn-2","last_agent_message":"synthetic child response 2"}}

--- a/tests/fixtures/codex-subagent/rollout-2026-08-07T10-00-06-dddddddd-dddd-4ddd-8ddd-dddddddddddd.jsonl
+++ b/tests/fixtures/codex-subagent/rollout-2026-08-07T10-00-06-dddddddd-dddd-4ddd-8ddd-dddddddddddd.jsonl
@@ -1,0 +1,11 @@
+{"timestamp":"2026-08-07T02:00:06.100Z","type":"session_meta","payload":{"id":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","session_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","timestamp":"2026-08-07T02:00:06.100Z","cwd":"/tmp/codex-subagent-fixture","originator":"Codex Desktop","source":{"subagent":{"thread_spawn":{"parent_thread_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","depth":1,"agent_path":"/root/fixture_child_3","agent_nickname":"FixtureChild3","agent_role":null}}},"thread_source":"subagent","model_provider":"openai","multi_agent_version":"v2"}}
+{"timestamp":"2026-08-07T02:00:00.000Z","type":"session_meta","payload":{"id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","session_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","thread_source":"user","model_provider":"openai"}}
+{"timestamp":"2026-08-07T02:00:01.000Z","type":"turn_context","payload":{"turn_id":"parent-turn-1","model":"gpt-test"}}
+{"timestamp":"2026-08-07T02:00:02.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"parent-turn-1"}}
+{"timestamp":"2026-08-07T02:00:07.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"parent-turn-1","last_agent_message":"delegated"}}
+{"timestamp":"2026-08-07T02:00:18.000Z","type":"turn_context","payload":{"turn_id":"child-turn-3","model":"gpt-test"}}
+{"timestamp":"2026-08-07T02:00:19.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"child-turn-3"}}
+{"timestamp":"2026-08-07T02:00:20.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"synthetic child task 3"}]}}
+{"timestamp":"2026-08-07T02:00:21.000Z","type":"event_msg","payload":{"type":"agent_message","message":"synthetic child response 3","phase":"final"}}
+{"timestamp":"2026-08-07T02:00:21.100Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":82,"output_tokens":8,"cached_input_tokens":0,"total_tokens":90}}}}
+{"timestamp":"2026-08-07T02:00:22.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"child-turn-3","last_agent_message":"synthetic child response 3"}}

--- a/tests/fixtures/codex-subagent/rollout-2026-08-07T10-00-07-eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee.jsonl
+++ b/tests/fixtures/codex-subagent/rollout-2026-08-07T10-00-07-eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee.jsonl
@@ -1,0 +1,11 @@
+{"timestamp":"2026-08-07T02:00:07.100Z","type":"session_meta","payload":{"id":"eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee","session_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","timestamp":"2026-08-07T02:00:07.100Z","cwd":"/tmp/codex-subagent-fixture","originator":"Codex Desktop","source":{"subagent":{"thread_spawn":{"parent_thread_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","depth":1,"agent_path":"/root/fixture_child_4","agent_nickname":"FixtureChild4","agent_role":null}}},"thread_source":"subagent","model_provider":"openai","multi_agent_version":"v2"}}
+{"timestamp":"2026-08-07T02:00:00.000Z","type":"session_meta","payload":{"id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","session_id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","thread_source":"user","model_provider":"openai"}}
+{"timestamp":"2026-08-07T02:00:01.000Z","type":"turn_context","payload":{"turn_id":"parent-turn-1","model":"gpt-test"}}
+{"timestamp":"2026-08-07T02:00:02.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"parent-turn-1"}}
+{"timestamp":"2026-08-07T02:00:07.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"parent-turn-1","last_agent_message":"delegated"}}
+{"timestamp":"2026-08-07T02:00:23.000Z","type":"turn_context","payload":{"turn_id":"child-turn-4","model":"gpt-test"}}
+{"timestamp":"2026-08-07T02:00:24.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"child-turn-4"}}
+{"timestamp":"2026-08-07T02:00:25.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"synthetic child task 4"}]}}
+{"timestamp":"2026-08-07T02:00:26.000Z","type":"event_msg","payload":{"type":"agent_message","message":"synthetic child response 4","phase":"final"}}
+{"timestamp":"2026-08-07T02:00:26.100Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":83,"output_tokens":8,"cached_input_tokens":0,"total_tokens":91}}}}
+{"timestamp":"2026-08-07T02:00:27.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"child-turn-4","last_agent_message":"synthetic child response 4"}}

--- a/tests/integration/codex-subagent-converter.test.ts
+++ b/tests/integration/codex-subagent-converter.test.ts
@@ -74,6 +74,10 @@ describe('Codex subagent converter integration', () => {
           'gen_ai.agent.id': `child-${index}`,
           'gen_ai.agent.parent.id': 'parent-session',
           'gen_ai.subagent.parent_tool_call.id': callId,
+          'gen_ai.input.messages_delta': [{
+            role: 'user',
+            parts: [{ type: 'text', content: `delegated task ${index}` }],
+          }],
         },
         {
           ...base,
@@ -141,6 +145,7 @@ describe('Codex subagent converter integration', () => {
       expect(tool).toBeDefined();
       expect(child).toBeDefined();
       expect(child?.parentSpanId).toBe(tool?.spanContext().spanId);
+      expect(child?.attributes['gen_ai.input.messages']).toContain(`delegated task ${index}`);
     }
   });
 });

--- a/tests/integration/codex-subagent-converter.test.ts
+++ b/tests/integration/codex-subagent-converter.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import {
+  convertEventLogToReadableSpans,
+  type EventLogRecord,
+} from '@loongsuite/otel-util-genai';
+
+function ns(milliseconds: number): string {
+  return `${milliseconds}000000`;
+}
+
+describe('Codex subagent converter integration', () => {
+  it('nests three completed children under their spawn_agent tool spans in one trace', async () => {
+    process.env.OTEL_SEMCONV_STABILITY_OPT_IN ??= 'gen_ai_latest_experimental';
+    process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT ??= 'SPAN_ONLY';
+
+    const base = {
+      trace_id: '1234567890abcdef1234567890abcdef',
+      'gen_ai.session.id': 'parent-session',
+      'gen_ai.turn.id': 'parent-session:turn-1',
+      'gen_ai.agent.type': 'codex',
+      'gen_ai.agent.id': 'parent-session',
+      'gen_ai.provider.name': 'openai',
+      'gen_ai.request.model': 'gpt-5.4',
+    };
+    const records: EventLogRecord[] = [
+      {
+        ...base,
+        'event.name': 'other',
+        time_unix_nano: ns(1_000),
+        parent_span_id: '0000000000000001',
+        'gen_ai.input.messages_delta': [{ role: 'user', parts: [{ type: 'text', content: 'delegate' }] }],
+      },
+      {
+        ...base,
+        'event.name': 'llm.request',
+        time_unix_nano: ns(1_010),
+        'gen_ai.step.id': 'parent-session:turn-1:s1',
+      },
+      {
+        ...base,
+        'event.name': 'llm.response',
+        time_unix_nano: ns(1_020),
+        'gen_ai.step.id': 'parent-session:turn-1:s1',
+        'gen_ai.response.finish_reasons': ['tool_call'],
+      },
+    ];
+
+    for (let index = 1; index <= 3; index += 1) {
+      const callId = `call-child-${index}`;
+      records.push(
+        {
+          ...base,
+          'event.name': 'tool.call',
+          time_unix_nano: ns(1_020 + index),
+          'gen_ai.step.id': 'parent-session:turn-1:s1',
+          'gen_ai.tool.name': 'spawn_agent',
+          'gen_ai.tool.call.id': callId,
+        },
+        {
+          ...base,
+          'event.name': 'tool.result',
+          time_unix_nano: ns(1_030 + index),
+          'gen_ai.step.id': 'parent-session:turn-1:s1',
+          'gen_ai.tool.name': 'spawn_agent',
+          'gen_ai.tool.call.id': callId,
+          'tool.result.status': 'success',
+        },
+        {
+          ...base,
+          'event.name': 'llm.request',
+          time_unix_nano: ns(1_025 + index),
+          'gen_ai.step.id': `child-${index}:turn:s1`,
+          'gen_ai.agent.scope': 'subagent',
+          'gen_ai.agent.id': `child-${index}`,
+          'gen_ai.agent.parent.id': 'parent-session',
+          'gen_ai.subagent.parent_tool_call.id': callId,
+        },
+        {
+          ...base,
+          'event.name': 'llm.response',
+          time_unix_nano: ns(1_040 + index),
+          'gen_ai.step.id': `child-${index}:turn:s1`,
+          'gen_ai.agent.scope': 'subagent',
+          'gen_ai.agent.id': `child-${index}`,
+          'gen_ai.agent.parent.id': 'parent-session',
+          'gen_ai.subagent.parent_tool_call.id': callId,
+          'gen_ai.response.finish_reasons': ['stop'],
+        },
+      );
+    }
+
+    records.push(
+      {
+        ...base,
+        'event.name': 'llm.request',
+        time_unix_nano: ns(1_050),
+        'gen_ai.step.id': 'parent-session:turn-1:s2',
+      },
+      {
+        ...base,
+        'event.name': 'llm.response',
+        time_unix_nano: ns(1_060),
+        'gen_ai.step.id': 'parent-session:turn-1:s2',
+        'gen_ai.response.finish_reasons': ['stop'],
+      },
+      {
+        ...base,
+        'event.name': 'other',
+        time_unix_nano: ns(1_061),
+        parent_span_id: '0000000000000001',
+        'gen_ai.turn.end': true,
+        'agent.codex.turn_status': 'completed',
+      },
+    );
+
+    const result = await convertEventLogToReadableSpans(records, {
+      strict: false,
+      passthroughKeys: [
+        'gen_ai.agent.scope',
+        'gen_ai.agent.id',
+        'gen_ai.agent.parent.id',
+        'gen_ai.subagent.parent_tool_call.id',
+      ],
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(new Set(result.spans.map(span => span.spanContext().traceId))).toEqual(
+      new Set([base.trace_id]),
+    );
+    const agents = result.spans.filter(span => span.attributes['gen_ai.span.kind'] === 'AGENT');
+    const tools = result.spans.filter(span => span.attributes['gen_ai.span.kind'] === 'TOOL');
+    expect(agents).toHaveLength(4);
+    expect(tools).toHaveLength(3);
+
+    for (let index = 1; index <= 3; index += 1) {
+      const callId = `call-child-${index}`;
+      const tool = tools.find(span => span.attributes['gen_ai.tool.call.id'] === callId);
+      const child = agents.find(span => (
+        span.attributes['gen_ai.subagent.parent_tool_call.id'] === callId
+      ));
+      expect(tool).toBeDefined();
+      expect(child).toBeDefined();
+      expect(child?.parentSpanId).toBe(tool?.spanContext().spanId);
+    }
+  });
+});

--- a/tests/unit/flushers/otlp-trace-flusher/conversion.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/conversion.test.ts
@@ -55,10 +55,11 @@ describe('OtlpTraceFlusher - conversion', () => {
 
   it('passes handler from per-agent convert state', async () => {
     const entry = {
-      'event.name': 'llm.response',
+      'event.name': 'other',
       'gen_ai.agent.type': 'codex',
       'gen_ai.turn.id': 't2',
-      'gen_ai.response.finish_reasons': ['stop'],
+      'agent.codex.turn_status': 'completed',
+      'gen_ai.turn.end': true,
     } as unknown as AgentActivityEntry;
 
     await flusher.send(entry);

--- a/tests/unit/flushers/otlp-trace-flusher/turn-boundary.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/turn-boundary.test.ts
@@ -75,6 +75,34 @@ describe('OtlpTraceFlusher - turn boundary detection', () => {
     expect(mockConvert.mock.calls[0][0]).toHaveLength(2);
   });
 
+  it('does not close a fused parent turn on a subagent stop', async () => {
+    const { convertEventLogToTrace } = await import('@loongsuite/otel-util-genai');
+    const mockConvert = vi.mocked(convertEventLogToTrace);
+    mockConvert.mockClear();
+    const turnId = 'parent:turn-1';
+
+    await flusher.send(makeEntry({
+      'gen_ai.turn.id': turnId,
+      'gen_ai.agent.type': 'codex',
+      'event.name': 'llm.request',
+    }));
+    await flusher.send(makeEntry({
+      'gen_ai.turn.id': turnId,
+      'gen_ai.agent.type': 'codex',
+      'gen_ai.agent.scope': 'subagent',
+      'gen_ai.response.finish_reasons': ['stop'],
+    }));
+    expect(mockConvert).not.toHaveBeenCalled();
+
+    await flusher.send(makeEntry({
+      'gen_ai.turn.id': turnId,
+      'gen_ai.agent.type': 'codex',
+      'gen_ai.response.finish_reasons': ['stop'],
+    }));
+    expect(mockConvert).toHaveBeenCalledTimes(1);
+    expect(mockConvert.mock.calls[0][0]).toHaveLength(3);
+  });
+
   it('Signal A: finish_reason=error triggers immediate flush', async () => {
     const { convertEventLogToTrace } = await import('@loongsuite/otel-util-genai');
     const mockConvert = vi.mocked(convertEventLogToTrace);

--- a/tests/unit/flushers/otlp-trace-flusher/turn-boundary.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/turn-boundary.test.ts
@@ -75,7 +75,7 @@ describe('OtlpTraceFlusher - turn boundary detection', () => {
     expect(mockConvert.mock.calls[0][0]).toHaveLength(2);
   });
 
-  it('does not close a fused parent turn on a subagent stop', async () => {
+  it('does not close a Codex turn on intermediate root or subagent stops', async () => {
     const { convertEventLogToTrace } = await import('@loongsuite/otel-util-genai');
     const mockConvert = vi.mocked(convertEventLogToTrace);
     mockConvert.mockClear();
@@ -85,6 +85,11 @@ describe('OtlpTraceFlusher - turn boundary detection', () => {
       'gen_ai.turn.id': turnId,
       'gen_ai.agent.type': 'codex',
       'event.name': 'llm.request',
+    }));
+    await flusher.send(makeEntry({
+      'gen_ai.turn.id': turnId,
+      'gen_ai.agent.type': 'codex',
+      'gen_ai.response.finish_reasons': ['stop'],
     }));
     await flusher.send(makeEntry({
       'gen_ai.turn.id': turnId,
@@ -99,8 +104,16 @@ describe('OtlpTraceFlusher - turn boundary detection', () => {
       'gen_ai.agent.type': 'codex',
       'gen_ai.response.finish_reasons': ['stop'],
     }));
+    expect(mockConvert).not.toHaveBeenCalled();
+    await flusher.send(makeEntry({
+      'gen_ai.turn.id': turnId,
+      'gen_ai.agent.type': 'codex',
+      'event.name': 'other',
+      'agent.codex.turn_status': 'completed',
+      'gen_ai.turn.end': true,
+    }));
     expect(mockConvert).toHaveBeenCalledTimes(1);
-    expect(mockConvert.mock.calls[0][0]).toHaveLength(3);
+    expect(mockConvert.mock.calls[0][0]).toHaveLength(5);
   });
 
   it('Signal A: finish_reason=error triggers immediate flush', async () => {
@@ -272,10 +285,16 @@ describe('OtlpTraceFlusher - turn boundary detection', () => {
           'gen_ai.step.id': `${turnId}:s2`,
           'gen_ai.response.finish_reasons': ['stop'],
         }),
+        makeEntry({
+          ...base,
+          'event.name': 'other',
+          'agent.codex.turn_status': 'completed',
+          'gen_ai.turn.end': true,
+        }),
       ]);
 
       expect(mockConvert).toHaveBeenCalledTimes(1);
-      expect(mockConvert.mock.calls[0][0]).toHaveLength(5);
+      expect(mockConvert.mock.calls[0][0]).toHaveLength(6);
     });
 
     it('Hermes retry batch: error response does not drop the successful retry', async () => {

--- a/tests/unit/inputs/codex-aborted-turn/codex-aborted-turn-input.test.ts
+++ b/tests/unit/inputs/codex-aborted-turn/codex-aborted-turn-input.test.ts
@@ -69,10 +69,16 @@ describe('CodexAbortedTurnInput', () => {
     ));
     await input.stop();
 
-    const response = entries.find(entry => entry['event.name'] === 'llm.response');
+    const response = entries.find(entry => (
+      entry['event.name'] === 'llm.response'
+      && entry['gen_ai.response.finish_reasons']?.includes('cancelled')
+    ));
     expect(response).toMatchObject({
       'gen_ai.response.model': 'gpt-5.4-mini',
       'agent.codex.cwd': '/tmp/project',
+      'agent.codex.turn_status': 'interrupted',
+      'gen_ai.response.finish_reasons': ['cancelled'],
+      'gen_ai.turn.end': true,
     });
   });
 

--- a/tests/unit/inputs/codex-transcript/codex-subagent-linker.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-subagent-linker.test.ts
@@ -171,6 +171,13 @@ describe('CodexSubagentLinker', () => {
       }),
     ]);
   });
+
+  it('does not create a descriptor for a rejected spawn call', () => {
+    const turn = turnWithSpawn();
+    turn.steps[0].tools[0].output = 'collab spawn failed: agent thread limit reached';
+
+    expect(extractCodexSpawnDescriptors(turn, [], 'trace-rejected')).toEqual([]);
+  });
 });
 
 async function readOwnerMeta(fixture: string): Promise<CodexTranscriptMeta> {

--- a/tests/unit/inputs/codex-transcript/codex-subagent-linker.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-subagent-linker.test.ts
@@ -26,6 +26,69 @@ const CHILD_FIXTURES = [
 ] as const;
 
 describe('CodexSubagentLinker', () => {
+  it('extracts the parent delegation agent_message as the child prompt', () => {
+    const turnId = 'child-turn-agent-message';
+    const meta = childMeta({
+      threadId: 'child-agent-message',
+      agentPath: '/root/child_agent_message',
+    });
+    const records = [
+      {
+        timestamp: '2026-08-07T09:20:31.534Z',
+        type: 'turn_context',
+        payload: { turn_id: turnId, model: 'gpt-5.4' },
+      },
+      {
+        timestamp: '2026-08-07T09:20:31.538Z',
+        type: 'response_item',
+        payload: {
+          type: 'agent_message',
+          author: '/root',
+          recipient: '/root/child_agent_message',
+          content: [
+            { type: 'input_text', text: 'inspect the delegated file' },
+            { type: 'encrypted_content', encrypted_content: 'redacted' },
+          ],
+          internal_chat_message_metadata_passthrough: { turn_id: turnId },
+        },
+      },
+      {
+        timestamp: '2026-08-07T09:20:42.113Z',
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          id: 'response-child',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'done' }],
+        },
+      },
+      {
+        timestamp: '2026-08-07T09:20:42.255Z',
+        type: 'event_msg',
+        payload: {
+          type: 'token_count',
+          info: { total_token_usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 } },
+        },
+      },
+      {
+        timestamp: '2026-08-07T09:20:42.270Z',
+        type: 'event_msg',
+        payload: { type: 'task_complete', turn_id: turnId, last_agent_message: 'done' },
+      },
+    ];
+
+    const turn = extractCodexPartialTurn(records, meta, meta.threadId, turnId);
+
+    expect(turn).toMatchObject({
+      prompt: 'inspect the delegated file',
+      promptReady: true,
+      inputMessages: [{
+        role: 'user',
+        parts: [{ type: 'text', content: 'inspect the delegated file' }],
+      }],
+    });
+  });
+
   it('links all four fixture children by agent path even when children arrive first', async () => {
     const linker = new CodexSubagentLinker();
     for (const fixture of CHILD_FIXTURES) {

--- a/tests/unit/inputs/codex-transcript/codex-subagent-linker.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-subagent-linker.test.ts
@@ -1,0 +1,263 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  CodexSubagentLinker,
+  extractCodexSpawnDescriptors,
+  type CodexSpawnDescriptor,
+} from '../../../../src/inputs/codex-transcript/codex-subagent-linker.js';
+import {
+  extractCodexPartialTurn,
+  extractCodexTranscriptMeta,
+} from '../../../../src/inputs/codex-transcript/codex-transcript-extractor.js';
+import type {
+  CodexExtractedTranscriptTurn,
+  CodexTranscriptMeta,
+  CodexTranscriptSourceRecord,
+} from '../../../../src/inputs/codex-transcript/codex-transcript-types.js';
+
+const FIXTURE_DIR = path.resolve(process.cwd(), 'tests/fixtures/codex-subagent');
+const PARENT_FIXTURE = 'rollout-2026-08-07T10-00-00-aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa.jsonl';
+const CHILD_FIXTURES = [
+  'rollout-2026-08-07T10-00-04-bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb.jsonl',
+  'rollout-2026-08-07T10-00-05-cccccccc-cccc-4ccc-8ccc-cccccccccccc.jsonl',
+  'rollout-2026-08-07T10-00-06-dddddddd-dddd-4ddd-8ddd-dddddddddddd.jsonl',
+  'rollout-2026-08-07T10-00-07-eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee.jsonl',
+] as const;
+
+describe('CodexSubagentLinker', () => {
+  it('links all four fixture children by agent path even when children arrive first', async () => {
+    const linker = new CodexSubagentLinker();
+    for (const fixture of CHILD_FIXTURES) {
+      linker.registerChild(await readOwnerMeta(fixture));
+    }
+
+    expect(linker.snapshot()).toMatchObject({
+      detectedChildren: 4,
+      detectedSpawns: 0,
+      linkedChildren: 0,
+      orphanChildren: 4,
+    });
+
+    const { turn, sources } = await readParentTurn();
+    linker.registerSpawns(extractCodexSpawnDescriptors(turn, sources, 'parent-trace-id'));
+
+    const snapshot = linker.snapshot();
+    expect(snapshot).toMatchObject({
+      detectedChildren: 4,
+      detectedSpawns: 4,
+      linkedChildren: 4,
+      orphanChildren: 0,
+    });
+    expect(snapshot.links.map(link => ({
+      childThreadId: link.childThreadId,
+      parentToolCallId: link.parentToolCallId,
+      confidence: link.confidence,
+    }))).toEqual([
+      { childThreadId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', parentToolCallId: 'call-subagent-1', confidence: 'agent_path' },
+      { childThreadId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc', parentToolCallId: 'call-subagent-2', confidence: 'agent_path' },
+      { childThreadId: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd', parentToolCallId: 'call-subagent-3', confidence: 'agent_path' },
+      { childThreadId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee', parentToolCallId: 'call-subagent-4', confidence: 'agent_path' },
+    ]);
+  });
+
+  it('prefers an explicit child thread id over a mismatched path', () => {
+    const linker = new CodexSubagentLinker();
+    linker.registerSpawns([
+      spawn({
+        parentToolCallId: 'call-explicit',
+        taskName: '/root/not-the-child-path',
+        childThreadId: 'child-explicit',
+      }),
+    ]);
+    linker.registerChild(childMeta({
+      threadId: 'child-explicit',
+      agentPath: '/root/actual-child-path',
+    }));
+
+    expect(linker.snapshot().links).toEqual([
+      expect.objectContaining({
+        childThreadId: 'child-explicit',
+        parentToolCallId: 'call-explicit',
+        confidence: 'explicit_id',
+      }),
+    ]);
+  });
+
+  it('pairs unmatched children with the nearest preceding unclaimed spawn', () => {
+    const linker = new CodexSubagentLinker();
+    linker.registerSpawns([
+      spawn({ parentToolCallId: 'call-1', spawnedAtMs: 10 }),
+      spawn({ parentToolCallId: 'call-2', spawnedAtMs: 20 }),
+    ]);
+    linker.registerChild(childMeta({ threadId: 'child-1', createdAtMs: 15, agentPath: undefined }));
+    linker.registerChild(childMeta({ threadId: 'child-2', createdAtMs: 25, agentPath: undefined }));
+
+    expect(linker.snapshot().links.map(link => [link.childThreadId, link.parentToolCallId, link.confidence])).toEqual([
+      ['child-1', 'call-1', 'time_order'],
+      ['child-2', 'call-2', 'time_order'],
+    ]);
+  });
+
+  it('reserves exact path matches before assigning time-order fallbacks', () => {
+    const linker = new CodexSubagentLinker();
+    linker.registerSpawns([
+      spawn({ parentToolCallId: 'call-fallback', spawnedAtMs: 10 }),
+      spawn({ parentToolCallId: 'call-exact', spawnedAtMs: 20, taskName: '/root/exact' }),
+    ]);
+    linker.registerChild(childMeta({ threadId: 'child-without-path', createdAtMs: 25, agentPath: undefined }));
+    linker.registerChild(childMeta({ threadId: 'child-exact', createdAtMs: 30, agentPath: '/root/exact' }));
+
+    expect(linker.snapshot().links.map(link => [link.childThreadId, link.parentToolCallId, link.confidence])).toEqual([
+      ['child-without-path', 'call-fallback', 'time_order'],
+      ['child-exact', 'call-exact', 'agent_path'],
+    ]);
+  });
+
+  it('leaves duplicate exact paths orphaned instead of guessing by time', () => {
+    const linker = new CodexSubagentLinker();
+    linker.registerSpawns([
+      spawn({ parentToolCallId: 'call-1', spawnedAtMs: 10, taskName: '/root/reused' }),
+      spawn({ parentToolCallId: 'call-2', spawnedAtMs: 20, taskName: '/root/reused' }),
+    ]);
+    linker.registerChild(childMeta({
+      threadId: 'child-ambiguous',
+      createdAtMs: 30,
+      agentPath: '/root/reused',
+    }));
+
+    expect(linker.snapshot().links).toEqual([
+      expect.objectContaining({
+        childThreadId: 'child-ambiguous',
+        confidence: 'orphan',
+        orphanReason: 'ambiguous_agent_path',
+      }),
+    ]);
+  });
+
+  it('ignores nested children because phase 2 is depth-one only', () => {
+    const linker = new CodexSubagentLinker();
+    linker.registerChild(childMeta({ threadId: 'nested-child', depth: 2 }));
+    expect(linker.snapshot().detectedChildren).toBe(0);
+  });
+
+  it('extracts explicit child facts from sub_agent_activity records', () => {
+    const turn = turnWithSpawn();
+    const sources: CodexTranscriptSourceRecord[] = [{
+      startOffset: 0,
+      endOffset: 1,
+      record: {
+        type: 'event_msg',
+        payload: {
+          type: 'sub_agent_activity',
+          kind: 'started',
+          event_id: 'call-activity',
+          occurred_at_ms: 1234,
+          agent_thread_id: 'child-from-activity',
+          agent_path: '/root/activity-child',
+        },
+      },
+    }];
+
+    expect(extractCodexSpawnDescriptors(turn, sources, 'trace-activity')).toEqual([
+      expect.objectContaining({
+        parentThreadId: 'parent-thread',
+        parentTurnId: 'parent-turn',
+        parentTraceId: 'trace-activity',
+        parentToolCallId: 'call-activity',
+        childThreadId: 'child-from-activity',
+        agentPath: '/root/activity-child',
+        spawnedAtMs: 1234,
+      }),
+    ]);
+  });
+});
+
+async function readOwnerMeta(fixture: string): Promise<CodexTranscriptMeta> {
+  const records = await readFixture(fixture);
+  const meta = extractCodexTranscriptMeta(records[0]);
+  if (!meta) throw new Error(`missing owner meta in ${fixture}`);
+  return meta;
+}
+
+async function readParentTurn(): Promise<{
+  turn: CodexExtractedTranscriptTurn;
+  sources: CodexTranscriptSourceRecord[];
+}> {
+  const records = await readFixture(PARENT_FIXTURE);
+  const meta = extractCodexTranscriptMeta(records[0]);
+  const turn = extractCodexPartialTurn(
+    records,
+    meta,
+    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    'parent-turn-1',
+  );
+  if (!turn) throw new Error('parent fixture turn was not extracted');
+  return {
+    turn,
+    sources: records.map((record, index) => ({ startOffset: index, endOffset: index + 1, record })),
+  };
+}
+
+async function readFixture(fixture: string): Promise<Record<string, unknown>[]> {
+  return (await fs.readFile(path.join(FIXTURE_DIR, fixture), 'utf8'))
+    .trimEnd()
+    .split('\n')
+    .map(line => JSON.parse(line) as Record<string, unknown>);
+}
+
+function childMeta(overrides: {
+  threadId: string;
+  createdAtMs?: number;
+  agentPath?: string;
+  depth?: number;
+}): CodexTranscriptMeta {
+  return {
+    threadId: overrides.threadId,
+    rootSessionId: 'root-session',
+    threadSource: 'subagent',
+    parentThreadId: 'parent-thread',
+    depth: overrides.depth ?? 1,
+    createdAtMs: overrides.createdAtMs ?? 30,
+    ...(overrides.agentPath ? { agentPath: overrides.agentPath } : {}),
+    provider: 'openai',
+  };
+}
+
+function spawn(overrides: Partial<CodexSpawnDescriptor> & Pick<CodexSpawnDescriptor, 'parentToolCallId'>): CodexSpawnDescriptor {
+  return {
+    parentThreadId: 'parent-thread',
+    parentTurnId: 'parent-turn',
+    parentTraceId: 'parent-trace',
+    spawnedAtMs: 10,
+    ...overrides,
+  };
+}
+
+function turnWithSpawn(): CodexExtractedTranscriptTurn {
+  return {
+    sessionId: 'parent-thread',
+    transcriptTurnId: 'parent-turn',
+    provider: 'openai',
+    model: 'gpt-test',
+    status: 'completed',
+    startedAtMs: 1,
+    terminalAtMs: 2,
+    promptReady: true,
+    inputMessages: [],
+    steps: [{
+      startedAtMs: 1,
+      responseAtMs: 2,
+      hasResponseEvidence: true,
+      completedAtMs: 2,
+      reasoning: [],
+      tools: [{
+        callId: 'call-activity',
+        name: 'spawn_agent',
+        input: { task_name: 'activity-child' },
+        startedAtMs: 1,
+      }],
+    }],
+    unmatchedTokenUsages: [],
+  };
+}

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -1954,6 +1954,12 @@ describe('CodexTranscriptInput', () => {
         finish_reason: 'stop',
       }],
     });
+    expect(responses[0]?.['agent.codex.turn_status']).toBeUndefined();
+    expect(entries).toContainEqual(expect.objectContaining({
+      'event.name': 'other',
+      'agent.codex.turn_status': 'completed',
+      'gen_ai.turn.end': true,
+    }));
     const finalRequest = entries.find(entry => (
       entry['event.name'] === 'llm.request'
       && entry['gen_ai.step.id'] === 'session-1:turn-1:s3'

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -549,6 +549,27 @@ describe('CodexTranscriptInput', () => {
     await waitFor(() => Boolean(transcriptCheckpoint(first.stateStore, parentTranscript)?.pendingFusion));
     await first.input.stop();
 
+    const parentKey = `codex-transcript:${parentTranscript}`;
+    const persisted = first.stateStore.get(parentKey);
+    const codexTranscript = structuredClone(persisted.extra?.codexTranscript) as Record<string, unknown>;
+    const rejectedSpawn = {
+      parentToolCallId: 'call-rejected-before-restart',
+      parentTraceId: 'stale-trace',
+      spawnedAtMs: 1,
+      taskName: 'fixture_child',
+    };
+    const pendingFusion = codexTranscript.pendingFusion as { children: unknown[] };
+    const activeTurn = codexTranscript.activeTurn as { subagentSpawns: unknown[] };
+    Object.assign(pendingFusion.children[0] as object, { childThreadId: CHILD_FIXTURES[0].threadId });
+    Object.assign(activeTurn.subagentSpawns[0] as object, { childThreadId: CHILD_FIXTURES[0].threadId });
+    pendingFusion.children.push(rejectedSpawn);
+    activeTurn.subagentSpawns.push(rejectedSpawn);
+    first.stateStore.update(parentKey, {
+      lastOffset: persisted.lastOffset,
+      extra: { ...(persisted.extra ?? {}), codexTranscript },
+    });
+    await first.stateStore.save();
+
     for (const fixture of CHILD_FIXTURES) {
       const text = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, fixture.name), 'utf8');
       await writeTranscriptNamed(first.sessionDir, fixture.name, text);
@@ -609,6 +630,40 @@ describe('CodexTranscriptInput', () => {
       pendingSubagent: {
         turnId: 'child-turn-1',
       },
+    });
+  });
+
+  it('skips copied parent terminals whose line timestamps were rewritten at fork time', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-rewritten-time-'));
+    tempDirs.push(root);
+    const { input, sessionDir, stateStore } = await createInput(root);
+    const fixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, CHILD_FIXTURE_NAME), 'utf8');
+    const parentTurnId = '019fdb63-2fc6-7491-9895-8c8f86a8bcab';
+    const childTurnId = '019fdb63-714b-7c72-9c8c-c2e40d9c9111';
+    const lines = fixture.trimEnd().split('\n').map((line, index) => {
+      const parsed = JSON.parse(line) as { timestamp: string; payload: Record<string, unknown> };
+      if (index === 0) {
+        parsed.timestamp = '2026-08-07T08:42:35.146Z';
+        parsed.payload.timestamp = parsed.timestamp;
+        parsed.payload.id = '019fdb63-710a-7131-978c-6a6ee744fff9';
+      }
+      if (index >= 1 && index <= 8) parsed.timestamp = '2026-08-07T08:42:35.204Z';
+      return JSON.stringify(parsed)
+        .replaceAll('parent-turn-1', parentTurnId)
+        .replaceAll('child-turn-1', childTurnId);
+    });
+    const transcript = await writeTranscriptNamed(
+      sessionDir,
+      CHILD_FIXTURE_NAME,
+      lines.join('\n') + '\n',
+    );
+
+    await waitFor(() => Boolean(transcriptCheckpoint(stateStore, transcript)?.pendingSubagent));
+    await input.stop();
+
+    expect(transcriptCheckpoint(stateStore, transcript)).toMatchObject({
+      pendingSubagent: { turnId: childTurnId },
+      activeTurn: { turnId: childTurnId },
     });
   });
 

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -369,14 +369,15 @@ describe('CodexTranscriptInput', () => {
     }));
   });
 
-  it('uses the owning child meta instead of copied parent meta in a forked rollout', async () => {
+  it('holds the parent terminal and fuses completed child rollouts into the parent turn', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-owner-'));
     tempDirs.push(root);
     const { input, entries, sessionDir, stateStore } = await createInput(root);
     const parentFixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, PARENT_FIXTURE_NAME), 'utf8');
 
-    await writeTranscriptNamed(sessionDir, PARENT_FIXTURE_NAME, parentFixture);
-    await waitFor(() => responsesForTurn(entries, 'parent-turn-1').length === 1);
+    const parentTranscript = await writeTranscriptNamed(sessionDir, PARENT_FIXTURE_NAME, parentFixture);
+    await waitFor(() => Boolean(transcriptCheckpoint(stateStore, parentTranscript)?.pendingFusion));
+    expect(globalProcessedTurnIds(stateStore)).not.toContain('parent-turn-1');
     const childTranscripts = new Map<string, string>();
     for (const fixture of CHILD_FIXTURES) {
       const text = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, fixture.name), 'utf8');
@@ -392,19 +393,37 @@ describe('CodexTranscriptInput', () => {
         entry['agent.codex.transcript_turn_id'] === fixture.turnId);
       expect(childEntries.length).toBeGreaterThan(0);
       expect(new Set(childEntries.map(entry => entry['gen_ai.session.id']))).toEqual(
-        new Set([fixture.threadId]),
+        new Set(['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa']),
       );
       expect(new Set(childEntries.map(entry => entry['gen_ai.agent.id']))).toEqual(
         new Set([fixture.threadId]),
       );
       expect(new Set(childEntries.map(entry => entry['gen_ai.turn.id']))).toEqual(
-        new Set([`${fixture.threadId}:${fixture.turnId}`]),
+        new Set(['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa:parent-turn-1']),
       );
       expect(transcriptCheckpoint(stateStore, childTranscripts.get(fixture.threadId)!)).toMatchObject({
         ownerSessionMetaOffset: 0,
       });
-      expect(childEntries.every(entry => entry['gen_ai.agent.scope'] === undefined)).toBe(true);
+      expect(childEntries.every(entry => entry['gen_ai.agent.scope'] === 'subagent')).toBe(true);
+      expect(childEntries.every(entry => entry['gen_ai.agent.depth'] === 1)).toBe(true);
+      expect(new Set(childEntries.map(entry => entry['gen_ai.subagent.parent_tool_call.id']))).toEqual(
+        new Set([`call-subagent-${CHILD_FIXTURES.indexOf(fixture) + 1}`]),
+      );
+      const parentTool = entries.find(entry => (
+        entry['event.name'] === 'tool.call'
+        && entry['gen_ai.tool.call.id'] === `call-subagent-${CHILD_FIXTURES.indexOf(fixture) + 1}`
+      ));
+      const childRoot = childEntries.find(entry => entry['event.name'] === 'other');
+      expect(childRoot?.parent_span_id).toBe(parentTool?.span_id);
     }
+    expect(globalProcessedTurnIds(stateStore)).toEqual(expect.arrayContaining([
+      'parent-turn-1',
+      ...CHILD_FIXTURES.map(fixture => fixture.turnId),
+    ]));
+    expect(transcriptCheckpoint(stateStore, parentTranscript)).toMatchObject({
+      pendingFusion: null,
+      activeTurn: null,
+    });
     expect(input.getSubagentLinkSnapshot()).toMatchObject({
       detectedChildren: 4,
       detectedSpawns: 4,
@@ -418,6 +437,136 @@ describe('CodexTranscriptInput', () => {
         confidence: 'agent_path',
       })),
     });
+  });
+
+  it('does not attach new children to a historical spawn in a long parent rollout', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-history-'));
+    tempDirs.push(root);
+    const { input, sessionDir, stateStore } = await createDormantInput(root);
+    const parentFixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, PARENT_FIXTURE_NAME), 'utf8');
+    const [sessionMeta, ...currentTurn] = parentFixture.trimEnd().split('\n');
+    const historicalTurn = [
+      record('2026-08-07T01:00:00.000Z', 'turn_context', {
+        turn_id: 'historical-parent-turn', model: 'gpt-test', cwd: '/tmp/codex-subagent-fixture',
+      }),
+      record('2026-08-07T01:00:01.000Z', 'event_msg', {
+        type: 'task_started', turn_id: 'historical-parent-turn',
+      }),
+      record('2026-08-07T01:00:02.000Z', 'response_item', {
+        type: 'function_call',
+        call_id: 'call-historical-subagent',
+        name: 'spawn_agent',
+        arguments: JSON.stringify({ task_name: 'stale_child', message: 'redacted' }),
+      }),
+      record('2026-08-07T01:00:03.000Z', 'response_item', {
+        type: 'function_call_output',
+        call_id: 'call-historical-subagent',
+        output: JSON.stringify({ task_name: '/root/stale_child' }),
+      }),
+      record('2026-08-07T01:00:04.000Z', 'event_msg', {
+        type: 'task_complete', turn_id: 'historical-parent-turn', last_agent_message: 'delegated',
+      }),
+    ];
+    const parentTranscript = await writeTranscriptNamed(
+      sessionDir,
+      PARENT_FIXTURE_NAME,
+      [sessionMeta, ...historicalTurn, ...currentTurn].join('\n') + '\n',
+    );
+
+    for (const fixture of CHILD_FIXTURES) {
+      const text = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, fixture.name), 'utf8');
+      const childTranscript = await writeTranscriptNamed(sessionDir, fixture.name, text);
+      await processTranscriptOnce(input, childTranscript);
+    }
+    await processTranscriptOnce(input, parentTranscript);
+
+    expect(transcriptCheckpoint(stateStore, parentTranscript)).toMatchObject({
+      pendingFusion: {
+        turnId: 'parent-turn-1',
+        children: CHILD_FIXTURES.map((_, index) => expect.objectContaining({
+          parentToolCallId: `call-subagent-${index + 1}`,
+        })),
+      },
+    });
+    expect(input.getSubagentLinkSnapshot().links).toEqual(expect.arrayContaining(
+      CHILD_FIXTURES.map((fixture, index) => expect.objectContaining({
+        childThreadId: fixture.threadId,
+        parentTurnId: 'parent-turn-1',
+        parentToolCallId: `call-subagent-${index + 1}`,
+      })),
+    ));
+  });
+
+  it('accepts child terminals before the parent terminal, including turn_aborted', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-child-first-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, stateStore } = await createInput(root);
+    const parentFixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, PARENT_FIXTURE_NAME), 'utf8');
+    const parentLines = parentFixture.trimEnd().split('\n');
+    const parentTerminal = parentLines.pop()!;
+    const parentTranscript = await writeTranscriptNamed(
+      sessionDir,
+      PARENT_FIXTURE_NAME,
+      parentLines.join('\n') + '\n',
+    );
+    await waitFor(() => input.getSubagentLinkSnapshot().detectedSpawns === 4);
+
+    const childTranscripts: string[] = [];
+    for (const [index, fixture] of CHILD_FIXTURES.entries()) {
+      let text = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, fixture.name), 'utf8');
+      if (index === 0) {
+        const lines = text.trimEnd().split('\n');
+        const terminal = JSON.parse(lines.at(-1)!) as { payload: Record<string, unknown> };
+        terminal.payload.type = 'turn_aborted';
+        delete terminal.payload.last_agent_message;
+        terminal.payload.reason = 'interrupted';
+        lines[lines.length - 1] = JSON.stringify(terminal);
+        text = lines.join('\n') + '\n';
+      }
+      childTranscripts.push(await writeTranscriptNamed(sessionDir, fixture.name, text));
+    }
+    await waitFor(() => childTranscripts.every(transcript =>
+      Boolean(transcriptCheckpoint(stateStore, transcript)?.pendingSubagent)));
+    expect(entries.some(entry => entry['gen_ai.agent.scope'] === 'subagent')).toBe(false);
+
+    await fs.appendFile(parentTranscript, parentTerminal + '\n', 'utf8');
+    await waitFor(() => CHILD_FIXTURES.every(fixture =>
+      responsesForTurn(entries, fixture.turnId).length === 1));
+    await input.stop();
+
+    const abortedEntries = entries.filter(entry =>
+      entry['agent.codex.transcript_turn_id'] === 'child-turn-1');
+    expect(abortedEntries.some(entry => entry['agent.codex.turn_status'] === 'interrupted')).toBe(true);
+    expect(transcriptCheckpoint(stateStore, parentTranscript)).toMatchObject({ pendingFusion: null });
+  });
+
+  it('recovers a persisted parent fusion when child rollouts appear before restart', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-restart-'));
+    tempDirs.push(root);
+    const first = await createInput(root);
+    const parentFixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, PARENT_FIXTURE_NAME), 'utf8');
+    const parentTranscript = await writeTranscriptNamed(first.sessionDir, PARENT_FIXTURE_NAME, parentFixture);
+    await waitFor(() => Boolean(transcriptCheckpoint(first.stateStore, parentTranscript)?.pendingFusion));
+    await first.input.stop();
+
+    for (const fixture of CHILD_FIXTURES) {
+      const text = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, fixture.name), 'utf8');
+      await writeTranscriptNamed(first.sessionDir, fixture.name, text);
+    }
+
+    const restarted = await createInput(root);
+    await waitFor(() => CHILD_FIXTURES.every(fixture =>
+      responsesForTurn(restarted.entries, fixture.turnId).length === 1));
+    await restarted.input.stop();
+
+    expect(transcriptCheckpoint(restarted.stateStore, parentTranscript)).toMatchObject({
+      pendingFusion: null,
+      activeTurn: null,
+    });
+    expect(restarted.entries.filter(entry => entry['gen_ai.agent.scope'] === 'subagent').length)
+      .toBeGreaterThan(0);
+    expect(restarted.entries.every(entry => entry['gen_ai.session.id'] === 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'))
+      .toBe(true);
   });
 
   it('rebuilds owning metadata instead of trusting a legacy latest-meta checkpoint', async () => {
@@ -449,16 +598,17 @@ describe('CodexTranscriptInput', () => {
     await persistedState.save();
 
     const recovered = await createInput(root);
-    await waitFor(() => responsesForTurn(recovered.entries, 'child-turn-1').length === 1);
+    await waitFor(() => Boolean(
+      transcriptCheckpoint(recovered.stateStore, childTranscript)?.pendingSubagent,
+    ));
     await recovered.input.stop();
 
-    const childEntries = recovered.entries.filter(entry =>
-      entry['agent.codex.transcript_turn_id'] === 'child-turn-1');
-    expect(new Set(childEntries.map(entry => entry['gen_ai.agent.id']))).toEqual(
-      new Set(['bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb']),
-    );
+    expect(responsesForTurn(recovered.entries, 'child-turn-1')).toHaveLength(0);
     expect(transcriptCheckpoint(recovered.stateStore, childTranscript)).toMatchObject({
       ownerSessionMetaOffset: 0,
+      pendingSubagent: {
+        turnId: 'child-turn-1',
+      },
     });
   });
 

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -4,10 +4,20 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { DEFAULT_RESOURCE_ENV_FIELD_MAP } from '../../../../assets/hooks/shared/resource-context.mjs';
 import { StateStore } from '../../../../src/checkpoints/state-store.js';
+import { extractCodexTranscriptMeta } from '../../../../src/inputs/codex-transcript/codex-transcript-extractor.js';
 import { CodexTranscriptInput } from '../../../../src/inputs/codex-transcript/codex-transcript-input.js';
 import type { AgentActivityEntry, JsonValue } from '../../../../src/types/index.js';
 
 const tempDirs: string[] = [];
+const SUBAGENT_FIXTURE_DIR = path.resolve(process.cwd(), 'tests/fixtures/codex-subagent');
+const PARENT_FIXTURE_NAME = 'rollout-2026-08-07T10-00-00-aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa.jsonl';
+const CHILD_FIXTURE_NAME = 'rollout-2026-08-07T10-00-04-bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb.jsonl';
+const CHILD_FIXTURES = [
+  { name: CHILD_FIXTURE_NAME, threadId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', turnId: 'child-turn-1' },
+  { name: 'rollout-2026-08-07T10-00-05-cccccccc-cccc-4ccc-8ccc-cccccccccccc.jsonl', threadId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc', turnId: 'child-turn-2' },
+  { name: 'rollout-2026-08-07T10-00-06-dddddddd-dddd-4ddd-8ddd-dddddddddddd.jsonl', threadId: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd', turnId: 'child-turn-3' },
+  { name: 'rollout-2026-08-07T10-00-07-eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee.jsonl', threadId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee', turnId: 'child-turn-4' },
+] as const;
 
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
@@ -342,6 +352,101 @@ function globalProcessedTurnIds(stateStore: StateStore): string[] {
 }
 
 describe('CodexTranscriptInput', () => {
+  it('extracts the single-level subagent relationship from owning session metadata', async () => {
+    const fixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, CHILD_FIXTURE_NAME), 'utf8');
+    const firstRecord = JSON.parse(fixture.split('\n')[0]) as Record<string, unknown>;
+
+    expect(extractCodexTranscriptMeta(firstRecord)).toEqual(expect.objectContaining({
+      threadId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+      rootSessionId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      threadSource: 'subagent',
+      parentThreadId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      depth: 1,
+      agentPath: '/root/fixture_child',
+      agentNickname: 'FixtureChild',
+      provider: 'openai',
+    }));
+  });
+
+  it('uses the owning child meta instead of copied parent meta in a forked rollout', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-owner-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, stateStore } = await createInput(root);
+    const parentFixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, PARENT_FIXTURE_NAME), 'utf8');
+
+    await writeTranscriptNamed(sessionDir, PARENT_FIXTURE_NAME, parentFixture);
+    await waitFor(() => responsesForTurn(entries, 'parent-turn-1').length === 1);
+    const childTranscripts = new Map<string, string>();
+    for (const fixture of CHILD_FIXTURES) {
+      const text = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, fixture.name), 'utf8');
+      childTranscripts.set(fixture.threadId, await writeTranscriptNamed(sessionDir, fixture.name, text));
+    }
+    await waitFor(() => CHILD_FIXTURES.every(fixture =>
+      responsesForTurn(entries, fixture.turnId).length === 1));
+    await input.stop();
+
+    expect(responsesForTurn(entries, 'parent-turn-1')).toHaveLength(1);
+    for (const fixture of CHILD_FIXTURES) {
+      const childEntries = entries.filter(entry =>
+        entry['agent.codex.transcript_turn_id'] === fixture.turnId);
+      expect(childEntries.length).toBeGreaterThan(0);
+      expect(new Set(childEntries.map(entry => entry['gen_ai.session.id']))).toEqual(
+        new Set([fixture.threadId]),
+      );
+      expect(new Set(childEntries.map(entry => entry['gen_ai.agent.id']))).toEqual(
+        new Set([fixture.threadId]),
+      );
+      expect(new Set(childEntries.map(entry => entry['gen_ai.turn.id']))).toEqual(
+        new Set([`${fixture.threadId}:${fixture.turnId}`]),
+      );
+      expect(transcriptCheckpoint(stateStore, childTranscripts.get(fixture.threadId)!)).toMatchObject({
+        ownerSessionMetaOffset: 0,
+      });
+    }
+  });
+
+  it('rebuilds owning metadata instead of trusting a legacy latest-meta checkpoint', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-migration-'));
+    tempDirs.push(root);
+    const sessionDir = path.join(root, 'sessions');
+    const childFixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, CHILD_FIXTURE_NAME), 'utf8');
+    const childLines = childFixture.trimEnd().split('\n');
+    const childTranscript = await writeTranscriptNamed(sessionDir, CHILD_FIXTURE_NAME, childFixture);
+    const stat = await fs.stat(childTranscript);
+    const copiedParentEndOffset = Buffer.byteLength(childLines.slice(0, 9).join('\n') + '\n');
+    const copiedParentMetaOffset = Buffer.byteLength(childLines[0] + '\n');
+    const persistedState = new StateStore(path.join(root, 'input-state.json'));
+    await persistedState.load();
+    persistedState.update(`codex-transcript:${childTranscript}`, {
+      lastOffset: copiedParentEndOffset,
+      extra: {
+        codexTranscript: {
+          inode: stat.ino,
+          scanOffset: copiedParentEndOffset,
+          activeTurn: null,
+          pendingTerminal: null,
+          // This is the pre-fix shape and deliberately points at parent meta.
+          latestSessionMetaOffset: copiedParentMetaOffset,
+          emittedTerminalTurnIds: ['parent-turn-1'],
+        },
+      },
+    });
+    await persistedState.save();
+
+    const recovered = await createInput(root);
+    await waitFor(() => responsesForTurn(recovered.entries, 'child-turn-1').length === 1);
+    await recovered.input.stop();
+
+    const childEntries = recovered.entries.filter(entry =>
+      entry['agent.codex.transcript_turn_id'] === 'child-turn-1');
+    expect(new Set(childEntries.map(entry => entry['gen_ai.agent.id']))).toEqual(
+      new Set(['bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb']),
+    );
+    expect(transcriptCheckpoint(recovered.stateStore, childTranscript)).toMatchObject({
+      ownerSessionMetaOffset: 0,
+    });
+  });
+
   it('emits a terminal LLM pair with zero usage for a completed turn without output', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-empty-completed-'));
     tempDirs.push(root);

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -234,7 +234,10 @@ function controlOnlyAbortedTurn(sessionId: string, turnId: string, start: string
   ];
 }
 
-async function createInput(root: string, pollIntervalMs = 10): Promise<{
+async function createInput(
+  root: string,
+  pollIntervalMs = 10,
+): Promise<{
   input: CodexTranscriptInput;
   entries: AgentActivityEntry[];
   batches: AgentActivityEntry[][];
@@ -337,6 +340,11 @@ async function processTranscriptOnce(input: CodexTranscriptInput, transcript: st
   return (input as unknown as { processFile(filePath: string): Promise<number> }).processFile(transcript);
 }
 
+async function finalizeSubagentFusions(input: CodexTranscriptInput): Promise<number> {
+  return (input as unknown as { finalizeReadySubagentFusions(): Promise<number> })
+    .finalizeReadySubagentFusions();
+}
+
 function transcriptCheckpoint(
   stateStore: StateStore,
   transcript: string,
@@ -369,25 +377,65 @@ describe('CodexTranscriptInput', () => {
     }));
   });
 
+  it('bounds reported subagent link fingerprints by evicting the oldest child', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-link-cap-'));
+    tempDirs.push(root);
+    const { input } = await createDormantInput(root);
+    const internals = input as unknown as {
+      reportedSubagentLinks: Map<string, string>;
+      subagentLinker: { registerChild(meta: ReturnType<typeof extractCodexTranscriptMeta>): void };
+      reportSubagentLinks(): void;
+    };
+    for (let index = 0; index < 10_000; index++) {
+      internals.reportedSubagentLinks.set(`old-child-${index}`, 'orphan::parent_not_found');
+    }
+    internals.subagentLinker.registerChild({
+      threadId: 'new-child',
+      rootSessionId: 'parent-thread',
+      threadSource: 'subagent',
+      parentThreadId: 'parent-thread',
+      depth: 1,
+      provider: 'openai',
+    });
+
+    internals.reportSubagentLinks();
+    await input.stop();
+
+    expect(internals.reportedSubagentLinks).toHaveLength(10_000);
+    expect(internals.reportedSubagentLinks.has('old-child-0')).toBe(false);
+    expect(internals.reportedSubagentLinks.has('new-child')).toBe(true);
+  });
+
   it('holds the parent terminal and fuses completed child rollouts into the parent turn', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-owner-'));
     tempDirs.push(root);
     const { input, entries, sessionDir, stateStore } = await createInput(root);
     const parentFixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, PARENT_FIXTURE_NAME), 'utf8');
 
-    const parentTranscript = await writeTranscriptNamed(sessionDir, PARENT_FIXTURE_NAME, parentFixture);
-    await waitFor(() => Boolean(transcriptCheckpoint(stateStore, parentTranscript)?.pendingFusion));
-    expect(globalProcessedTurnIds(stateStore)).not.toContain('parent-turn-1');
+    const parentLines = parentFixture.trimEnd().split('\n');
+    const parentTerminal = parentLines.pop()!;
+    const parentTranscript = await writeTranscriptNamed(
+      sessionDir,
+      PARENT_FIXTURE_NAME,
+      parentLines.join('\n') + '\n',
+    );
+    await waitFor(() => input.getSubagentLinkSnapshot().detectedSpawns === 4);
     const childTranscripts = new Map<string, string>();
     for (const fixture of CHILD_FIXTURES) {
       const text = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, fixture.name), 'utf8');
       childTranscripts.set(fixture.threadId, await writeTranscriptNamed(sessionDir, fixture.name, text));
     }
+    await waitFor(() => [...childTranscripts.values()].every(transcript =>
+      Boolean(transcriptCheckpoint(stateStore, transcript)?.pendingSubagent)));
+    expect(globalProcessedTurnIds(stateStore)).not.toContain('parent-turn-1');
+    expect(CHILD_FIXTURES.every(fixture => responsesForTurn(entries, fixture.turnId).length === 0)).toBe(true);
+
+    await fs.appendFile(parentTranscript, parentTerminal + '\n', 'utf8');
     await waitFor(() => CHILD_FIXTURES.every(fixture =>
       responsesForTurn(entries, fixture.turnId).length === 1));
     await input.stop();
 
-    expect(responsesForTurn(entries, 'parent-turn-1')).toHaveLength(1);
+    expect(responsesForTurn(entries, 'parent-turn-1')).toHaveLength(2);
     for (const fixture of CHILD_FIXTURES) {
       const childEntries = entries.filter(entry =>
         entry['agent.codex.transcript_turn_id'] === fixture.turnId);
@@ -481,12 +529,8 @@ describe('CodexTranscriptInput', () => {
     await processTranscriptOnce(input, parentTranscript);
 
     expect(transcriptCheckpoint(stateStore, parentTranscript)).toMatchObject({
-      pendingFusion: {
-        turnId: 'parent-turn-1',
-        children: CHILD_FIXTURES.map((_, index) => expect.objectContaining({
-          parentToolCallId: `call-subagent-${index + 1}`,
-        })),
-      },
+      pendingFusion: null,
+      activeTurn: null,
     });
     expect(input.getSubagentLinkSnapshot().links).toEqual(expect.arrayContaining(
       CHILD_FIXTURES.map((fixture, index) => expect.objectContaining({
@@ -497,7 +541,7 @@ describe('CodexTranscriptInput', () => {
     ));
   });
 
-  it('accepts child terminals before the parent terminal, including turn_aborted', async () => {
+  it('captures child terminals before the parent terminal and keeps scanning later child turns', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-child-first-'));
     tempDirs.push(root);
     const { input, entries, sessionDir, stateStore } = await createInput(root);
@@ -527,7 +571,33 @@ describe('CodexTranscriptInput', () => {
     }
     await waitFor(() => childTranscripts.every(transcript =>
       Boolean(transcriptCheckpoint(stateStore, transcript)?.pendingSubagent)));
-    expect(entries.some(entry => entry['gen_ai.agent.scope'] === 'subagent')).toBe(false);
+    for (const [index, transcript] of childTranscripts.entries()) {
+      const childStat = await fs.stat(transcript);
+      expect(transcriptCheckpoint(stateStore, transcript)).toMatchObject({
+        scanOffset: childStat.size,
+        pendingSubagent: {
+          parentTurnId: 'parent-turn-1',
+          parentToolCallId: `call-subagent-${index + 1}`,
+          confidence: 'agent_path',
+          activeTurn: { turnId: CHILD_FIXTURES[index]!.turnId },
+        },
+        activeTurn: null,
+      });
+    }
+    expect(CHILD_FIXTURES.every(fixture => responsesForTurn(entries, fixture.turnId).length === 0)).toBe(true);
+
+    const followupLines = simpleCompletedTurn(
+      CHILD_FIXTURES[0].threadId,
+      'child-followup-turn',
+      'follow up after the captured child terminal',
+      'followup complete',
+      10,
+      2,
+      '2026-08-07T02:02:00.000Z',
+    ).slice(1);
+    await fs.appendFile(childTranscripts[0]!, followupLines.join('\n') + '\n', 'utf8');
+    await waitFor(() => responsesForTurn(entries, 'child-followup-turn').length === 1);
+    expect(transcriptCheckpoint(stateStore, childTranscripts[0]!).pendingSubagent).not.toBeNull();
 
     await fs.appendFile(parentTranscript, parentTerminal + '\n', 'utf8');
     await waitFor(() => CHILD_FIXTURES.every(fixture =>
@@ -537,7 +607,345 @@ describe('CodexTranscriptInput', () => {
     const abortedEntries = entries.filter(entry =>
       entry['agent.codex.transcript_turn_id'] === 'child-turn-1');
     expect(abortedEntries.some(entry => entry['agent.codex.turn_status'] === 'interrupted')).toBe(true);
+    expect(abortedEntries.every(entry => entry['gen_ai.agent.scope'] === 'subagent')).toBe(true);
     expect(transcriptCheckpoint(stateStore, parentTranscript)).toMatchObject({ pendingFusion: null });
+  });
+
+  it('forces a reliably linked active child to finalize when the parent reaches task_complete', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-parent-barrier-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
+    const parentFixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, PARENT_FIXTURE_NAME), 'utf8');
+    const parentLines = parentFixture.trimEnd().split('\n');
+    const parentTerminal = parentLines.pop()!;
+    const parentTranscript = await writeTranscriptNamed(
+      sessionDir,
+      PARENT_FIXTURE_NAME,
+      parentLines.join('\n') + '\n',
+    );
+    await processTranscriptOnce(input, parentTranscript);
+
+    const childFixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, CHILD_FIXTURE_NAME), 'utf8');
+    const childLines = childFixture.trimEnd().split('\n');
+    childLines.pop();
+    const childTranscript = await writeTranscriptNamed(
+      sessionDir,
+      CHILD_FIXTURE_NAME,
+      childLines.join('\n') + '\n',
+    );
+    await processTranscriptOnce(input, childTranscript);
+
+    const childStat = await fs.stat(childTranscript);
+    expect(responsesForTurn(entries, 'child-turn-1')).toHaveLength(0);
+    expect(transcriptCheckpoint(stateStore, childTranscript)).toMatchObject({
+      scanOffset: childStat.size,
+      pendingSubagent: null,
+      activeTurn: {
+        turnId: 'child-turn-1',
+        emittedStepCount: 0,
+      },
+    });
+
+    await fs.appendFile(parentTranscript, parentTerminal + '\n', 'utf8');
+    await processTranscriptOnce(input, parentTranscript);
+    expect(transcriptCheckpoint(stateStore, parentTranscript).pendingFusion).not.toBeNull();
+
+    await finalizeSubagentFusions(input);
+
+    expect(responsesForTurn(entries, 'child-turn-1')).toHaveLength(1);
+    expect(responsesForTurn(entries, 'child-turn-1')[0]).toMatchObject({
+      'gen_ai.agent.scope': 'subagent',
+      'gen_ai.subagent.parent_tool_call.id': 'call-subagent-1',
+      'agent.codex.turn_status': 'interrupted',
+    });
+    expect(responsesForTurn(entries, 'parent-turn-1')).toHaveLength(2);
+    expect(transcriptCheckpoint(stateStore, childTranscript)).toMatchObject({
+      activeTurn: null,
+      pendingSubagent: null,
+      emittedTerminalTurnIds: ['child-turn-1'],
+    });
+    expect(transcriptCheckpoint(stateStore, parentTranscript)).toMatchObject({
+      activeTurn: null,
+      pendingFusion: null,
+    });
+  });
+
+  it('releases the parent when a reliable child cannot be rebuilt and emits that child independently later', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-missing-child-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
+    const parentFixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, PARENT_FIXTURE_NAME), 'utf8');
+    const parentLines = parentFixture.trimEnd().split('\n');
+    const parentTerminal = parentLines.pop()!;
+    const parentTranscript = await writeTranscriptNamed(
+      sessionDir,
+      PARENT_FIXTURE_NAME,
+      parentLines.join('\n') + '\n',
+    );
+    await processTranscriptOnce(input, parentTranscript);
+
+    const childFixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, CHILD_FIXTURE_NAME), 'utf8');
+    const childLines = childFixture.trimEnd().split('\n');
+    const childTranscript = await writeTranscriptNamed(
+      sessionDir,
+      CHILD_FIXTURE_NAME,
+      childLines[0]! + '\n',
+    );
+    await processTranscriptOnce(input, childTranscript);
+
+    await fs.appendFile(parentTranscript, parentTerminal + '\n', 'utf8');
+    await processTranscriptOnce(input, parentTranscript);
+    expect(transcriptCheckpoint(stateStore, parentTranscript).pendingFusion).not.toBeNull();
+
+    await finalizeSubagentFusions(input);
+
+    expect(responsesForTurn(entries, 'parent-turn-1')).toHaveLength(2);
+    expect(transcriptCheckpoint(stateStore, parentTranscript)).toMatchObject({
+      activeTurn: null,
+      pendingFusion: null,
+    });
+
+    await fs.appendFile(childTranscript, childLines.slice(1).join('\n') + '\n', 'utf8');
+    await processTranscriptOnce(input, childTranscript);
+
+    expect(responsesForTurn(entries, 'child-turn-1')).toHaveLength(1);
+    expect(responsesForTurn(entries, 'child-turn-1')[0]).not.toHaveProperty('gen_ai.agent.scope', 'subagent');
+    expect(transcriptCheckpoint(stateStore, childTranscript)).toMatchObject({
+      activeTurn: null,
+      pendingSubagent: null,
+    });
+  });
+
+  it('emits an orphan child as an independent trace instead of holding its rollout', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-orphan-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
+    const childFixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, CHILD_FIXTURE_NAME), 'utf8');
+    const childTranscript = await writeTranscriptNamed(sessionDir, CHILD_FIXTURE_NAME, childFixture);
+
+    await processTranscriptOnce(input, childTranscript);
+
+    expect(responsesForTurn(entries, 'child-turn-1')).toHaveLength(1);
+    expect(responsesForTurn(entries, 'child-turn-1')[0]).toMatchObject({
+      'gen_ai.session.id': CHILD_FIXTURES[0].threadId,
+    });
+    expect(transcriptCheckpoint(stateStore, childTranscript)).toMatchObject({
+      pendingSubagent: null,
+      activeTurn: null,
+    });
+  });
+
+  it('does not treat followup_task as a new child lifecycle that requires fusion', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-followup-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
+    const parentFixture = (await fs.readFile(
+      path.join(SUBAGENT_FIXTURE_DIR, PARENT_FIXTURE_NAME),
+      'utf8',
+    )).replaceAll('"name":"spawn_agent"', '"name":"followup_task"');
+    const parentTranscript = await writeTranscriptNamed(sessionDir, PARENT_FIXTURE_NAME, parentFixture);
+    const childFixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, CHILD_FIXTURE_NAME), 'utf8');
+    const childTranscript = await writeTranscriptNamed(sessionDir, CHILD_FIXTURE_NAME, childFixture);
+
+    await processTranscriptOnce(input, parentTranscript);
+    await processTranscriptOnce(input, childTranscript);
+
+    expect(responsesForTurn(entries, 'parent-turn-1')).toHaveLength(1);
+    expect(responsesForTurn(entries, 'child-turn-1')).toHaveLength(1);
+    expect(transcriptCheckpoint(stateStore, parentTranscript)).toMatchObject({ pendingFusion: null });
+    expect(transcriptCheckpoint(stateStore, childTranscript)).toMatchObject({ pendingSubagent: null });
+  });
+
+  it('degrades an ambiguous repeated agent path to an independent child trace', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-ambiguous-path-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
+    const parentFixture = (await fs.readFile(
+      path.join(SUBAGENT_FIXTURE_DIR, PARENT_FIXTURE_NAME),
+      'utf8',
+    )).trimEnd().split('\n')
+      .filter(line => !line.includes('call-subagent-3') && !line.includes('call-subagent-4'))
+      .map(line => line.replaceAll('fixture_child_2', 'fixture_child'))
+      .join('\n') + '\n';
+    const parentTranscript = await writeTranscriptNamed(sessionDir, PARENT_FIXTURE_NAME, parentFixture);
+    const childFixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, CHILD_FIXTURE_NAME), 'utf8');
+    const childTranscript = await writeTranscriptNamed(sessionDir, CHILD_FIXTURE_NAME, childFixture);
+
+    await processTranscriptOnce(input, parentTranscript);
+    await processTranscriptOnce(input, childTranscript);
+
+    expect(responsesForTurn(entries, 'child-turn-1')).toHaveLength(1);
+    expect(transcriptCheckpoint(stateStore, childTranscript)).toMatchObject({
+      pendingSubagent: null,
+      activeTurn: null,
+    });
+    expect(input.getSubagentLinkSnapshot().links).toContainEqual(expect.objectContaining({
+      childThreadId: CHILD_FIXTURES[0].threadId,
+      confidence: 'orphan',
+      orphanReason: 'ambiguous_agent_path',
+    }));
+  });
+
+  it('releases a captured agent_path candidate if a later spawn makes the path ambiguous', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-late-ambiguity-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
+    const parentFixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, PARENT_FIXTURE_NAME), 'utf8');
+    const parentLines = parentFixture.trimEnd().split('\n')
+      .filter(line => (
+        !line.includes('call-subagent-2')
+        && !line.includes('call-subagent-3')
+        && !line.includes('call-subagent-4')
+        && !line.includes('"type":"task_complete"')
+      ));
+    const parentTranscript = await writeTranscriptNamed(
+      sessionDir,
+      PARENT_FIXTURE_NAME,
+      parentLines.join('\n') + '\n',
+    );
+    await processTranscriptOnce(input, parentTranscript);
+
+    const childFixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, CHILD_FIXTURE_NAME), 'utf8');
+    const childTranscript = await writeTranscriptNamed(sessionDir, CHILD_FIXTURE_NAME, childFixture);
+    await processTranscriptOnce(input, childTranscript);
+    expect(transcriptCheckpoint(stateStore, childTranscript)).toMatchObject({
+      pendingSubagent: {
+        parentToolCallId: 'call-subagent-1',
+        confidence: 'agent_path',
+      },
+    });
+
+    await fs.appendFile(parentTranscript, [
+      record('2026-08-07T02:00:07.000Z', 'response_item', {
+        type: 'function_call',
+        call_id: 'call-subagent-late',
+        name: 'spawn_agent',
+        arguments: JSON.stringify({ task_name: 'fixture_child', message: 'redacted' }),
+      }),
+      record('2026-08-07T02:00:08.000Z', 'response_item', {
+        type: 'function_call_output',
+        call_id: 'call-subagent-late',
+        output: JSON.stringify({ task_name: '/root/fixture_child' }),
+      }),
+      record('2026-08-07T02:00:09.000Z', 'event_msg', tokenUsage(120, 12)),
+    ].join('\n') + '\n', 'utf8');
+    await processTranscriptOnce(input, parentTranscript);
+    await processTranscriptOnce(input, childTranscript);
+
+    expect(input.getSubagentLinkSnapshot().links).toContainEqual(expect.objectContaining({
+      childThreadId: CHILD_FIXTURES[0].threadId,
+      confidence: 'orphan',
+      orphanReason: 'ambiguous_agent_path',
+    }));
+    expect(responsesForTurn(entries, 'child-turn-1')).toHaveLength(1);
+    expect(transcriptCheckpoint(stateStore, childTranscript)).toMatchObject({ pendingSubagent: null });
+  });
+
+  it('uses explicit child ids and parentToolCallId to keep repeated paths as distinct candidates', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-explicit-identity-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
+    const originalParent = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, PARENT_FIXTURE_NAME), 'utf8');
+    const parentLines = originalParent.trimEnd().split('\n');
+    const parentTerminal = parentLines.pop()!;
+    const reducedParent = parentLines
+      .filter(line => !line.includes('call-subagent-3') && !line.includes('call-subagent-4'))
+      .map(line => line.replaceAll('fixture_child_2', 'fixture_child'));
+    reducedParent.splice(reducedParent.length - 1, 0,
+      record('2026-08-07T02:00:04.400Z', 'event_msg', {
+        type: 'sub_agent_activity',
+        kind: 'started',
+        event_id: 'call-subagent-1',
+        agent_thread_id: CHILD_FIXTURES[0].threadId,
+        agent_path: '/root/fixture_child',
+        occurred_at_ms: Date.parse('2026-08-07T02:00:04.400Z'),
+      }),
+      record('2026-08-07T02:00:04.450Z', 'event_msg', {
+        type: 'sub_agent_activity',
+        kind: 'started',
+        event_id: 'call-subagent-2',
+        agent_thread_id: CHILD_FIXTURES[1].threadId,
+        agent_path: '/root/fixture_child',
+        occurred_at_ms: Date.parse('2026-08-07T02:00:04.450Z'),
+      }),
+    );
+    const parentTranscript = await writeTranscriptNamed(
+      sessionDir,
+      PARENT_FIXTURE_NAME,
+      reducedParent.join('\n') + '\n',
+    );
+    await processTranscriptOnce(input, parentTranscript);
+
+    const childTranscripts: string[] = [];
+    for (const [index, fixture] of CHILD_FIXTURES.slice(0, 2).entries()) {
+      let childText = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, fixture.name), 'utf8');
+      if (index === 1) childText = childText.replaceAll('/root/fixture_child_2', '/root/fixture_child');
+      const transcript = await writeTranscriptNamed(sessionDir, fixture.name, childText);
+      childTranscripts.push(transcript);
+      await processTranscriptOnce(input, transcript);
+    }
+
+    expect(transcriptCheckpoint(stateStore, childTranscripts[0]!)).toMatchObject({
+      pendingSubagent: {
+        parentToolCallId: 'call-subagent-1',
+        confidence: 'explicit_id',
+      },
+    });
+    expect(transcriptCheckpoint(stateStore, childTranscripts[1]!)).toMatchObject({
+      pendingSubagent: {
+        parentToolCallId: 'call-subagent-2',
+        confidence: 'explicit_id',
+      },
+    });
+
+    await fs.appendFile(parentTranscript, parentTerminal + '\n', 'utf8');
+    await processTranscriptOnce(input, parentTranscript);
+    expect((transcriptCheckpoint(stateStore, parentTranscript).pendingFusion as { children: unknown[] }).children)
+      .toHaveLength(2);
+    await finalizeSubagentFusions(input);
+
+    expect(responsesForTurn(entries, CHILD_FIXTURES[0].turnId)).toHaveLength(1);
+    expect(responsesForTurn(entries, CHILD_FIXTURES[1].turnId)).toHaveLength(1);
+    expect(new Set(entries
+      .filter(entry => entry['gen_ai.agent.scope'] === 'subagent')
+      .map(entry => entry['gen_ai.subagent.parent_tool_call.id'])))
+      .toEqual(new Set(['call-subagent-1', 'call-subagent-2']));
+  });
+
+  it('keeps time_order links diagnostic-only and emits the child independently', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-time-order-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
+    const parentFixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, PARENT_FIXTURE_NAME), 'utf8');
+    const parentLines = parentFixture.trimEnd().split('\n');
+    parentLines.pop();
+    const parentTranscript = await writeTranscriptNamed(
+      sessionDir,
+      PARENT_FIXTURE_NAME,
+      parentLines.join('\n') + '\n',
+    );
+    await processTranscriptOnce(input, parentTranscript);
+    const childFixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, CHILD_FIXTURE_NAME), 'utf8');
+    const childLines = childFixture.trimEnd().split('\n').map((line, index) => {
+      if (index !== 0) return line;
+      const meta = JSON.parse(line) as { payload: Record<string, unknown> };
+      const source = meta.payload.source as { subagent: { thread_spawn: Record<string, unknown> } };
+      delete source.subagent.thread_spawn.agent_path;
+      return JSON.stringify(meta);
+    });
+    const childTranscript = await writeTranscriptNamed(
+      sessionDir,
+      CHILD_FIXTURE_NAME,
+      childLines.join('\n') + '\n',
+    );
+    await processTranscriptOnce(input, childTranscript);
+
+    expect(input.getSubagentLinkSnapshot().links).toContainEqual(expect.objectContaining({
+      childThreadId: CHILD_FIXTURES[0].threadId,
+      confidence: 'time_order',
+    }));
+    expect(responsesForTurn(entries, 'child-turn-1')).toHaveLength(1);
+    expect(transcriptCheckpoint(stateStore, childTranscript)).toMatchObject({ pendingSubagent: null });
   });
 
   it('recovers a persisted parent fusion when child rollouts appear before restart', async () => {
@@ -545,35 +953,25 @@ describe('CodexTranscriptInput', () => {
     tempDirs.push(root);
     const first = await createInput(root);
     const parentFixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, PARENT_FIXTURE_NAME), 'utf8');
-    const parentTranscript = await writeTranscriptNamed(first.sessionDir, PARENT_FIXTURE_NAME, parentFixture);
-    await waitFor(() => Boolean(transcriptCheckpoint(first.stateStore, parentTranscript)?.pendingFusion));
-    await first.input.stop();
-
-    const parentKey = `codex-transcript:${parentTranscript}`;
-    const persisted = first.stateStore.get(parentKey);
-    const codexTranscript = structuredClone(persisted.extra?.codexTranscript) as Record<string, unknown>;
-    const rejectedSpawn = {
-      parentToolCallId: 'call-rejected-before-restart',
-      parentTraceId: 'stale-trace',
-      spawnedAtMs: 1,
-      taskName: 'fixture_child',
-    };
-    const pendingFusion = codexTranscript.pendingFusion as { children: unknown[] };
-    const activeTurn = codexTranscript.activeTurn as { subagentSpawns: unknown[] };
-    Object.assign(pendingFusion.children[0] as object, { childThreadId: CHILD_FIXTURES[0].threadId });
-    Object.assign(activeTurn.subagentSpawns[0] as object, { childThreadId: CHILD_FIXTURES[0].threadId });
-    pendingFusion.children.push(rejectedSpawn);
-    activeTurn.subagentSpawns.push(rejectedSpawn);
-    first.stateStore.update(parentKey, {
-      lastOffset: persisted.lastOffset,
-      extra: { ...(persisted.extra ?? {}), codexTranscript },
-    });
-    await first.stateStore.save();
-
+    const parentLines = parentFixture.trimEnd().split('\n');
+    const parentTerminal = parentLines.pop()!;
+    const parentTranscript = await writeTranscriptNamed(
+      first.sessionDir,
+      PARENT_FIXTURE_NAME,
+      parentLines.join('\n') + '\n',
+    );
+    await waitFor(() => first.input.getSubagentLinkSnapshot().detectedSpawns === 4);
     for (const fixture of CHILD_FIXTURES) {
       const text = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, fixture.name), 'utf8');
       await writeTranscriptNamed(first.sessionDir, fixture.name, text);
     }
+    await waitFor(() => CHILD_FIXTURES.every(fixture => {
+      const transcript = path.join(first.sessionDir, '2026', '06', '24', fixture.name);
+      return Boolean(transcriptCheckpoint(first.stateStore, transcript)?.pendingSubagent);
+    }));
+    await first.input.stop();
+    await first.stateStore.save();
+    await fs.appendFile(parentTranscript, parentTerminal + '\n', 'utf8');
 
     const restarted = await createInput(root);
     await waitFor(() => CHILD_FIXTURES.every(fixture =>
@@ -619,24 +1017,21 @@ describe('CodexTranscriptInput', () => {
     await persistedState.save();
 
     const recovered = await createInput(root);
-    await waitFor(() => Boolean(
-      transcriptCheckpoint(recovered.stateStore, childTranscript)?.pendingSubagent,
-    ));
+    await waitFor(() => responsesForTurn(recovered.entries, 'child-turn-1').length === 1);
     await recovered.input.stop();
 
-    expect(responsesForTurn(recovered.entries, 'child-turn-1')).toHaveLength(0);
+    expect(responsesForTurn(recovered.entries, 'child-turn-1')).toHaveLength(1);
     expect(transcriptCheckpoint(recovered.stateStore, childTranscript)).toMatchObject({
       ownerSessionMetaOffset: 0,
-      pendingSubagent: {
-        turnId: 'child-turn-1',
-      },
+      pendingSubagent: null,
+      activeTurn: null,
     });
   });
 
   it('skips copied parent terminals whose line timestamps were rewritten at fork time', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-rewritten-time-'));
     tempDirs.push(root);
-    const { input, sessionDir, stateStore } = await createInput(root);
+    const { input, entries, sessionDir, stateStore } = await createInput(root);
     const fixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, CHILD_FIXTURE_NAME), 'utf8');
     const parentTurnId = '019fdb63-2fc6-7491-9895-8c8f86a8bcab';
     const childTurnId = '019fdb63-714b-7c72-9c8c-c2e40d9c9111';
@@ -658,12 +1053,96 @@ describe('CodexTranscriptInput', () => {
       lines.join('\n') + '\n',
     );
 
-    await waitFor(() => Boolean(transcriptCheckpoint(stateStore, transcript)?.pendingSubagent));
+    await waitFor(() => responsesForTurn(entries, childTurnId).length === 1);
     await input.stop();
 
     expect(transcriptCheckpoint(stateStore, transcript)).toMatchObject({
-      pendingSubagent: { turnId: childTurnId },
-      activeTurn: { turnId: childTurnId },
+      pendingSubagent: null,
+      activeTurn: null,
+    });
+  });
+
+  it('uses exact parent turn ownership when child metadata has no creation timestamp', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-turn-owner-'));
+    tempDirs.push(root);
+    const { input, entries, sessionDir, stateStore } = await createInput(root);
+    const parentThreadId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const childThreadId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    const parentTurnId = 'copied-parent-turn';
+    const childTurnId = 'owned-child-turn';
+    const parentMeta = record('2026-08-07T02:00:00.000Z', 'session_meta', {
+      id: parentThreadId,
+      session_id: parentThreadId,
+      source: 'vscode',
+      thread_source: 'user',
+      model_provider: 'openai',
+    });
+    await writeTranscriptNamed(sessionDir, PARENT_FIXTURE_NAME, [
+      parentMeta,
+      record('2026-08-07T02:00:01.000Z', 'turn_context', {
+        turn_id: parentTurnId, model: 'gpt-test',
+      }),
+      record('2026-08-07T02:00:02.000Z', 'event_msg', {
+        type: 'task_started', turn_id: parentTurnId,
+      }),
+    ].join('\n') + '\n');
+
+    const childMeta = JSON.stringify({
+      type: 'session_meta',
+      payload: {
+        id: childThreadId,
+        session_id: parentThreadId,
+        source: {
+          subagent: {
+            thread_spawn: {
+              parent_thread_id: parentThreadId,
+              depth: 1,
+              agent_path: '/root/fixture_child',
+            },
+          },
+        },
+        thread_source: 'subagent',
+        model_provider: 'openai',
+        multi_agent_version: 'v2',
+      },
+    });
+    const childTranscript = await writeTranscriptNamed(sessionDir, CHILD_FIXTURE_NAME, [
+      childMeta,
+      parentMeta,
+      record('2026-08-07T02:00:03.000Z', 'turn_context', {
+        turn_id: parentTurnId, model: 'gpt-test',
+      }),
+      record('2026-08-07T02:00:04.000Z', 'event_msg', {
+        type: 'task_started', turn_id: parentTurnId,
+      }),
+      record('2026-08-07T02:00:05.000Z', 'event_msg', {
+        type: 'task_complete', turn_id: parentTurnId,
+      }),
+      record('2026-08-07T02:00:06.000Z', 'turn_context', {
+        turn_id: childTurnId, model: 'gpt-test',
+      }),
+      record('2026-08-07T02:00:07.000Z', 'event_msg', {
+        type: 'task_started', turn_id: childTurnId,
+      }),
+      record('2026-08-07T02:00:08.000Z', 'response_item', {
+        type: 'message', role: 'user', content: [{ type: 'input_text', text: 'child task' }],
+      }),
+      record('2026-08-07T02:00:09.000Z', 'event_msg', {
+        type: 'agent_message', message: 'child done', phase: 'final',
+      }),
+      record('2026-08-07T02:00:10.000Z', 'event_msg', {
+        type: 'task_complete', turn_id: childTurnId,
+      }),
+    ].join('\n') + '\n');
+
+    await waitFor(() => responsesForTurn(entries, childTurnId).length === 1);
+    await input.stop();
+
+    expect(responsesForTurn(entries, parentTurnId)).toHaveLength(0);
+    expect(responsesForTurn(entries, childTurnId)).toHaveLength(1);
+    expect(transcriptCheckpoint(stateStore, childTranscript)).toMatchObject({
+      activeTurn: null,
+      pendingTerminal: null,
     });
   });
 

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -409,12 +409,12 @@ describe('CodexTranscriptInput', () => {
       expect(new Set(childEntries.map(entry => entry['gen_ai.subagent.parent_tool_call.id']))).toEqual(
         new Set([`call-subagent-${CHILD_FIXTURES.indexOf(fixture) + 1}`]),
       );
-      const parentTool = entries.find(entry => (
-        entry['event.name'] === 'tool.call'
-        && entry['gen_ai.tool.call.id'] === `call-subagent-${CHILD_FIXTURES.indexOf(fixture) + 1}`
-      ));
-      const childRoot = childEntries.find(entry => entry['event.name'] === 'other');
-      expect(childRoot?.parent_span_id).toBe(parentTool?.span_id);
+      expect(childEntries.some(entry => entry['event.name'] === 'other')).toBe(false);
+      expect(childEntries.find(entry => entry['event.name'] === 'llm.request')).toEqual(
+        expect.objectContaining({
+          'gen_ai.input.messages': expect.any(Array),
+        }),
+      );
     }
     expect(globalProcessedTurnIds(stateStore)).toEqual(expect.arrayContaining([
       'parent-turn-1',

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -362,6 +362,7 @@ describe('CodexTranscriptInput', () => {
       threadSource: 'subagent',
       parentThreadId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       depth: 1,
+      createdAtMs: Date.parse('2026-08-07T02:00:04.100Z'),
       agentPath: '/root/fixture_child',
       agentNickname: 'FixtureChild',
       provider: 'openai',
@@ -402,7 +403,21 @@ describe('CodexTranscriptInput', () => {
       expect(transcriptCheckpoint(stateStore, childTranscripts.get(fixture.threadId)!)).toMatchObject({
         ownerSessionMetaOffset: 0,
       });
+      expect(childEntries.every(entry => entry['gen_ai.agent.scope'] === undefined)).toBe(true);
     }
+    expect(input.getSubagentLinkSnapshot()).toMatchObject({
+      detectedChildren: 4,
+      detectedSpawns: 4,
+      linkedChildren: 4,
+      orphanChildren: 0,
+      links: CHILD_FIXTURES.map((fixture, index) => expect.objectContaining({
+        childThreadId: fixture.threadId,
+        parentThreadId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        parentTurnId: 'parent-turn-1',
+        parentToolCallId: `call-subagent-${index + 1}`,
+        confidence: 'agent_path',
+      })),
+    });
   });
 
   it('rebuilds owning metadata instead of trusting a legacy latest-meta checkpoint', async () => {


### PR DESCRIPTION
## Summary

- select the session metadata owned by each Codex rollout instead of copied parent metadata
- preserve subagent thread, root session, parent, depth, path, nickname, and role metadata
- rebuild legacy metadata checkpoints with a bounded rollout-header scan
- execute formal depth-one subagent trace fusion; this is no longer a shadow-only path
- key each spawn lifecycle by `parentToolCallId`, so repeated `agent_path` values remain distinct candidates
- allow only `explicit_id` and unambiguous `agent_path` links to execute fusion
- retain `time_order` links for diagnostics only; they never capture a child or delay/fuse a parent
- degrade orphaned, ambiguous, invalidated, and unmatched children to independent traces
- mark captured child terminals as consumed but not independently emitted while advancing their rollout checkpoint
- close cancelled Codex responses with `gen_ai.turn.end: true`
- add redacted fixtures and restart/fallback coverage for one parent and multiple single-level subagents

Multi-level subagent fusion remains intentionally out of scope.

## Fusion state machine

1. **`activeTurn`** — parent and child records are collected incrementally. Parent turns retain observed `spawn_agent` descriptors keyed by `parentToolCallId`.
2. **`pendingSubagent`** — a child terminal with a reliable candidate is consumed and its `scanOffset` advances. Its complete active-turn snapshot and exact parent spawn identity are persisted, but it is not emitted as an independent trace. Later turns in that rollout can still be scanned.
3. **`pendingFusion`** — parent `task_complete` is the direct-child lifecycle barrier. The terminal range and reliable candidates are persisted only as crash-safe staging while the current collection cycle processes child files.
4. **ready/finalize** — captured children are rebuilt from `pendingSubagent`. A reliably linked un-emitted `activeTurn` without a terminal is force-closed as interrupted. Missing or unsafe-to-rebuild children are degraded instead of delaying the parent. Available child entries are emitted under the parent trace before the parent terminal.

There is no wall-clock fusion timeout because `pendingFusion` is not a long-running wait state. Parent `task_complete` causes same-cycle finalize or independent degradation.

## Reliable fusion confidence

- **`explicit_id`**: exactly one spawn explicitly names the child thread id.
- **`agent_path`**: the child path matches exactly one available spawn.
- **`time_order`**: diagnostic-only and never eligible for fusion.
- **`orphan`**: never eligible for fusion.

`agent_path` is metadata, not spawn identity. Candidate ownership and deduplication use `parentToolCallId`.

## Independent-trace degradation

- A child terminal without a reliable candidate is emitted immediately as an independent trace.
- A captured child whose candidate becomes ambiguous or no longer matches its exact spawn identity is rebuilt from its checkpoint and emitted once independently.
- A pending parent that loses all reliable candidates is rebuilt, emitted independently, and advances its offset.
- A reliable child without a terminal is force-rebuilt as interrupted when the parent completes; if rebuilding is unsafe, the parent still completes and the child falls back to the independent path.
- `followup_task` does not create a new child lifecycle.
- Aborted children follow the same ownership and fallback rules.

## Checkpoint and upgrade compatibility

`CodexTranscriptCheckpoint` now uses:

- `scanOffset`: next unread byte; advances past a captured child terminal.
- `activeTurn`: current incremental turn state and parent spawn descriptors.
- `pendingSubagent`: consumed/not-independently-emitted child terminal, including `turnId`, parent thread/turn/trace ids, `parentToolCallId`, reliable confidence, terminal range, and the saved active-turn snapshot.
- `pendingFusion`: held parent terminal plus reliable child candidates.
- `pendingTerminal`: persisted terminal that could not yet be parsed and must be retried.
- `emittedTerminalTurnIds`: bounded per-rollout duplicate protection, supplemented by the global terminal registry.
- `ownerSessionMetaOffset`: the rollout's own metadata location rather than copied parent metadata.

Legacy `pendingSubagent` checkpoints did not persist a reliable spawn identity and retained the child `activeTurn` at the top level. They are migrated to normal independent `pendingTerminal` recovery instead of being fused unsafely. Legacy metadata checkpoints without `ownerSessionMetaOffset` use a bounded header scan.


## Testing

- `npm run typecheck`
- Codex linker/input/converter and OTLP concurrent-subagent tests: 73 passed
- full suite: 2569 passed; one pre-existing OpenClaw minimum-version deployment assertion remains unrelated to this change
- `npm run build`
- `git diff --check`


