### PR TITLE
ci: scan pull requests for leaked secrets

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,106 @@
+name: Secret Scan
+
+on:
+  pull_request:
+    branches: [master, main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: secret-scan-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  secret-scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GITLEAKS_VERSION: 8.30.1
+      GITLEAKS_LINUX_X64_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+    steps:
+      - name: Check out the pull request
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate the commit range
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          git cat-file -e "${BASE_SHA}^{commit}"
+          git cat-file -e "${HEAD_SHA}^{commit}"
+          echo "Scanning pull request commits ${BASE_SHA}..${HEAD_SHA}"
+
+      - name: Install the pinned Gitleaks CLI
+        run: |
+          set -euo pipefail
+          archive="${RUNNER_TEMP}/gitleaks.tar.gz"
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
+            --output "${archive}" "${url}"
+          echo "${GITLEAKS_LINUX_X64_SHA256}  ${archive}" | sha256sum --check --status
+          tar -xzf "${archive}" -C "${RUNNER_TEMP}" gitleaks
+          chmod 0755 "${RUNNER_TEMP}/gitleaks"
+          "${RUNNER_TEMP}/gitleaks" version
+          echo "GITLEAKS_BIN=${RUNNER_TEMP}/gitleaks" >> "${GITHUB_ENV}"
+
+      - name: Load the trusted scanner configuration
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          config_path="${RUNNER_TEMP}/gitleaks.toml"
+          ignore_path="${RUNNER_TEMP}/gitleaksignore"
+
+          if git cat-file -e "${BASE_SHA}:.gitleaks.toml" 2>/dev/null; then
+            git show "${BASE_SHA}:.gitleaks.toml" > "${config_path}"
+          else
+            echo "::warning::The base branch has no Gitleaks configuration; using the pull request configuration for bootstrap."
+            cp .gitleaks.toml "${config_path}"
+          fi
+
+          # Never honor a .gitleaksignore file supplied by the pull request.
+          : > "${ignore_path}"
+          echo "GITLEAKS_CONFIG=${config_path}" >> "${GITHUB_ENV}"
+          echo "GITLEAKS_IGNORE=${ignore_path}" >> "${GITHUB_ENV}"
+
+      - name: Scan pull request commits for secrets
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          set +e
+          "${GITLEAKS_BIN}" git . \
+            --config "${GITLEAKS_CONFIG}" \
+            --gitleaks-ignore-path "${GITLEAKS_IGNORE}" \
+            --ignore-gitleaks-allow \
+            --log-opts="${BASE_SHA}..${HEAD_SHA}" \
+            --max-archive-depth=1 \
+            --max-decode-depth=1 \
+            --redact=100 \
+            --exit-code=2 \
+            --verbose \
+            --no-banner
+          scan_status=$?
+          set -e
+
+          case "${scan_status}" in
+            0)
+              echo "No secrets were detected in the pull request commits."
+              ;;
+            2)
+              echo "::error::Potential secrets were detected. Remove and rotate them before merging."
+              exit 2
+              ;;
+            *)
+              echo "::error::Gitleaks failed with exit code ${scan_status}; failing closed."
+              exit "${scan_status}"
+              ;;
+          esac

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,59 @@
+title = "LoongSuite Pilot secret scanning"
+
+[extend]
+useDefault = true
+
+# The built-in Alibaba Secret Key rule requires the word "alibaba" near the
+# value. This project-specific rule also covers the names used by Alibaba Cloud
+# SDKs and LoongSuite configuration without weakening the entropy requirement.
+[[rules]]
+id = "loongsuite-alibaba-access-key-secret"
+description = "Detected a potential Alibaba Cloud AccessKey Secret."
+regex = '''(?i)[\w.-]{0,50}?(?:alibaba[_\-.]?cloud[_\-.]?access[_\-.]?key[_\-.]?secret|access[_\-.]?key[_\-.]?secret|accesskeysecret)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{30})(?:[\x60'"\s;,}]|\\[nr]|$)'''
+secretGroup = 1
+entropy = 3.0
+keywords = [
+  "alibaba_cloud_access_key_secret",
+  "alibaba-cloud-access-key-secret",
+  "access_key_secret",
+  "access-key-secret",
+  "accesskeysecret",
+]
+
+[[rules.allowlists]]
+description = "Documented non-secret placeholders for Alibaba Cloud credentials."
+stopwords = [
+  "example",
+  "sample",
+  "dummy",
+  "placeholder",
+  "changeme",
+  "youraccesskeysecret",
+  "your_access_key_secret",
+]
+
+# License keys do not have a universal provider prefix. Require a recognized
+# assignment name, a literal-looking value, and sufficient entropy. Exact
+# provider-specific rules can be added as their formats become known.
+[[rules]]
+id = "loongsuite-license-key"
+description = "Detected a potential hard-coded software license or activation key."
+regex = '''(?i)[\w.-]{0,50}?(?:license[_\-.]?key|licensekey|activation[_\-.]?(?:key|code)|activationkey|activationcode)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([a-z0-9][a-z0-9._=\-]{15,199})(?:[\x60'"\s;,}]|\\[nr]|$)'''
+secretGroup = 1
+entropy = 3.3
+keywords = [
+  "license",
+  "activation",
+]
+
+[[rules.allowlists]]
+description = "Documented non-secret placeholders for license keys."
+stopwords = [
+  "example",
+  "sample",
+  "dummy",
+  "placeholder",
+  "changeme",
+  "your-license-key",
+  "your_license_key",
+]

--- a/scripts/security/test-gitleaks-rules.sh
+++ b/scripts/security/test-gitleaks-rules.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+GITLEAKS_BIN="${GITLEAKS_BIN:-gitleaks}"
+CONFIG_PATH="${1:-.gitleaks.toml}"
+LEAK_EXIT=42
+
+if [ ! -x "${GITLEAKS_BIN}" ]; then
+  echo "Gitleaks binary is not executable: ${GITLEAKS_BIN}" >&2
+  exit 1
+fi
+
+if [ ! -f "${CONFIG_PATH}" ]; then
+  echo "Gitleaks configuration does not exist: ${CONFIG_PATH}" >&2
+  exit 1
+fi
+
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "${TEST_ROOT}"' EXIT
+
+IGNORE_PATH="${TEST_ROOT}/gitleaksignore"
+: > "${IGNORE_PATH}"
+
+part_one='aB3dE5fG7hJ9kL'
+part_two='2mN4pQ6rS8tV0xYz'
+access_key_secret="${part_one}${part_two}"
+id_marker='I'
+access_key_id="LTA${id_marker}a1B2c3D4e5F6g7H8i9J0"
+license_part_one='LIC-aB3dE5fG7hJ9'
+license_part_two='kL2mN4pQ6rS8tV0xYz'
+license_key="${license_part_one}${license_part_two}"
+
+run_scan() {
+  local mode="$1"
+  local target="$2"
+  local rule="$3"
+  shift 3
+
+  set +e
+  "${GITLEAKS_BIN}" "${mode}" "${target}" \
+    --config "${CONFIG_PATH}" \
+    --gitleaks-ignore-path "${IGNORE_PATH}" \
+    --ignore-gitleaks-allow \
+    --enable-rule "${rule}" \
+    --redact=100 \
+    --exit-code="${LEAK_EXIT}" \
+    --no-banner \
+    "$@" > "${TEST_ROOT}/scan.log" 2>&1
+  local status=$?
+  set -e
+  return "${status}"
+}
+
+expect_finding() {
+  local name="$1"
+  shift
+
+  local status
+  if run_scan "$@"; then
+    status=0
+  else
+    status=$?
+  fi
+
+  if [ "${status}" -eq 0 ]; then
+    echo "FAIL: ${name}: expected a finding but the scan passed" >&2
+    return 1
+  fi
+  if [ "${status}" -ne "${LEAK_EXIT}" ]; then
+    echo "FAIL: ${name}: scanner returned ${status}, expected ${LEAK_EXIT}" >&2
+    sed -n '1,80p' "${TEST_ROOT}/scan.log" >&2
+    return 1
+  fi
+  echo "PASS: ${name}"
+}
+
+expect_clean() {
+  local name="$1"
+  shift
+
+  local status
+  if run_scan "$@"; then
+    status=0
+  else
+    status=$?
+  fi
+
+  if [ "${status}" -ne 0 ]; then
+    echo "FAIL: ${name}: scanner returned ${status}, expected 0" >&2
+    sed -n '1,80p' "${TEST_ROOT}/scan.log" >&2
+    return 1
+  fi
+  echo "PASS: ${name}"
+}
+
+positive_dir="${TEST_ROOT}/positive"
+negative_dir="${TEST_ROOT}/negative"
+allow_comment_dir="${TEST_ROOT}/allow-comment"
+mkdir -p "${positive_dir}" "${negative_dir}" "${allow_comment_dir}"
+
+printf 'const accessKeyId = "%s";\n' "${access_key_id}" > "${positive_dir}/access-key-id.js"
+printf 'ALIBABA_CLOUD_ACCESS_KEY_SECRET="%s"\n' "${access_key_secret}" > "${positive_dir}/access-key-secret.env"
+printf 'licenseKey: "%s"\n' "${license_key}" > "${positive_dir}/license-key.yml"
+
+printf '%s\n' \
+  'const accessKeyId = process.env.ALIBABA_CLOUD_ACCESS_KEY_ID;' \
+  'const accessKeySecret = process.env.ALIBABA_CLOUD_ACCESS_KEY_SECRET;' \
+  'const licenseKey = "example-license-key";' \
+  'activationCode: "your-license-key"' > "${negative_dir}/placeholders.txt"
+
+printf 'licenseKey: "%s" # gitleaks:allow\n' "${license_key}" > "${allow_comment_dir}/license-key.yml"
+
+expect_finding "Alibaba AccessKey ID" dir "${positive_dir}/access-key-id.js" alibaba-access-key-id
+expect_finding "Alibaba AccessKey Secret" dir "${positive_dir}/access-key-secret.env" loongsuite-alibaba-access-key-secret
+expect_finding "license key" dir "${positive_dir}/license-key.yml" loongsuite-license-key
+expect_finding "inline allow comment is ignored" dir "${allow_comment_dir}" loongsuite-license-key
+expect_clean "environment references and placeholders" dir "${negative_dir}" loongsuite-license-key
+
+history_repo="${TEST_ROOT}/history-repo"
+mkdir -p "${history_repo}"
+git -C "${history_repo}" init -q
+git -C "${history_repo}" config user.name "Secret Scan Test"
+git -C "${history_repo}" config user.email "secret-scan@example.invalid"
+printf 'safe\n' > "${history_repo}/fixture.txt"
+git -C "${history_repo}" add fixture.txt
+git -C "${history_repo}" commit -qm "base"
+history_base="$(git -C "${history_repo}" rev-parse HEAD)"
+printf 'const accessKeyId = "%s";\n' "${access_key_id}" > "${history_repo}/fixture.txt"
+git -C "${history_repo}" commit -qam "add secret"
+printf 'safe again\n' > "${history_repo}/fixture.txt"
+git -C "${history_repo}" commit -qam "remove secret"
+expect_finding \
+  "secret removed later in the pull request" \
+  git "${history_repo}" alibaba-access-key-id \
+  --log-opts="${history_base}..HEAD"
+
+existing_repo="${TEST_ROOT}/existing-repo"
+mkdir -p "${existing_repo}"
+git -C "${existing_repo}" init -q
+git -C "${existing_repo}" config user.name "Secret Scan Test"
+git -C "${existing_repo}" config user.email "secret-scan@example.invalid"
+printf 'const accessKeyId = "%s";\n' "${access_key_id}" > "${existing_repo}/existing.js"
+git -C "${existing_repo}" add existing.js
+git -C "${existing_repo}" commit -qm "existing base secret"
+existing_base="$(git -C "${existing_repo}" rev-parse HEAD)"
+printf 'safe pull request change\n' > "${existing_repo}/safe.txt"
+git -C "${existing_repo}" add safe.txt
+git -C "${existing_repo}" commit -qm "safe change"
+expect_clean \
+  "pre-existing base finding is outside the pull request range" \
+  git "${existing_repo}" alibaba-access-key-id \
+  --log-opts="${existing_base}..HEAD"
+
+echo "All Gitleaks rule tests passed."


### PR DESCRIPTION
## Summary

- add a dedicated pull-request secret scanning workflow using pinned Gitleaks 8.30.1 artifacts and checksum verification
- scan the complete PR commit range with redacted output and fail-closed behavior
- extend the default rules for Alibaba Cloud AccessKey Secrets and software license keys
- prevent PR-supplied ignore files and inline allow comments from bypassing the check
- add executable rule tests for positive, negative, history, and baseline scenarios

## Validation

- Gitleaks rule test suite: passed
- Actionlint 1.7.12: passed
- Bash syntax check: passed
- Gitleaks scan of origin/main..HEAD: passed