### PR TITLE
chore(installer): prefix node deps OSS path with loongsuite-pilot/

### DIFF
--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -77,8 +77,8 @@ $PERMANENT_DIR = Join-Path $CACHE_DIR "package"
 $_OSS_BASE_URL = "https://loongcollector-community-edition.oss-cn-shanghai.aliyuncs.com/loongsuite-pilot"
 # Managed Node.js runtime + prebuilt node_modules (downloaded from OSS at install time)
 if ($env:LOONGSUITE_PILOT_NODE_VERSION) { $script:NODE_VERSION = $env:LOONGSUITE_PILOT_NODE_VERSION } else { $script:NODE_VERSION = "22.22.2" }
-if ($env:LOONGSUITE_PILOT_NODE_DEPS_URL) { $script:NODE_DEPS_BASE = $env:LOONGSUITE_PILOT_NODE_DEPS_URL } else { $script:NODE_DEPS_BASE = "https://aliyun-observability-release-cn-shanghai.oss-cn-shanghai.aliyuncs.com/deps/node" }
-if ($env:LOONGSUITE_PILOT_NODE_MODULES_URL) { $script:NODE_MODULES_BASE = $env:LOONGSUITE_PILOT_NODE_MODULES_URL } else { $script:NODE_MODULES_BASE = "https://aliyun-observability-release-cn-shanghai.oss-cn-shanghai.aliyuncs.com/deps/node-modules" }
+if ($env:LOONGSUITE_PILOT_NODE_DEPS_URL) { $script:NODE_DEPS_BASE = $env:LOONGSUITE_PILOT_NODE_DEPS_URL } else { $script:NODE_DEPS_BASE = "https://aliyun-observability-release-cn-shanghai.oss-cn-shanghai.aliyuncs.com/loongsuite-pilot/deps/node" }
+if ($env:LOONGSUITE_PILOT_NODE_MODULES_URL) { $script:NODE_MODULES_BASE = $env:LOONGSUITE_PILOT_NODE_MODULES_URL } else { $script:NODE_MODULES_BASE = "https://aliyun-observability-release-cn-shanghai.oss-cn-shanghai.aliyuncs.com/loongsuite-pilot/deps/node-modules" }
 
 
 # ============================================================

--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -38,8 +38,8 @@ DEFAULT_DATA_DIR="$HOME/.loongsuite-pilot"
 _OSS_BASE_URL="https://loongcollector-community-edition.oss-cn-shanghai.aliyuncs.com/loongsuite-pilot"
 # Managed Node.js runtime + prebuilt node_modules (downloaded from OSS at install time)
 NODE_VERSION="${LOONGSUITE_PILOT_NODE_VERSION:-22.22.2}"
-NODE_DEPS_BASE="${LOONGSUITE_PILOT_NODE_DEPS_URL:-https://aliyun-observability-release-cn-shanghai.oss-cn-shanghai.aliyuncs.com/deps/node}"
-NODE_MODULES_BASE="${LOONGSUITE_PILOT_NODE_MODULES_URL:-https://aliyun-observability-release-cn-shanghai.oss-cn-shanghai.aliyuncs.com/deps/node-modules}"
+NODE_DEPS_BASE="${LOONGSUITE_PILOT_NODE_DEPS_URL:-https://aliyun-observability-release-cn-shanghai.oss-cn-shanghai.aliyuncs.com/loongsuite-pilot/deps/node}"
+NODE_MODULES_BASE="${LOONGSUITE_PILOT_NODE_MODULES_URL:-https://aliyun-observability-release-cn-shanghai.oss-cn-shanghai.aliyuncs.com/loongsuite-pilot/deps/node-modules}"
 
 
 # ============================================================


### PR DESCRIPTION
## What

Change the default download base URL for the managed Node.js runtime and prebuilt `node_modules` in the installers:

```
- https://aliyun-observability-release-cn-shanghai.oss-cn-shanghai.aliyuncs.com/deps/node(-modules)
+ https://aliyun-observability-release-cn-shanghai.oss-cn-shanghai.aliyuncs.com/loongsuite-pilot/deps/node(-modules)
```

## Why

Namespace the node-deps artifacts under `loongsuite-pilot/` in the OSS bucket, keeping them grouped with the rest of the project's release objects.

## Scope

- `deploy/installer-opensource.sh` — `NODE_DEPS_BASE` / `NODE_MODULES_BASE` defaults
- `deploy/installer-opensource.ps1` — `$script:NODE_DEPS_BASE` / `$script:NODE_MODULES_BASE` defaults

Both remain overridable via `LOONGSUITE_PILOT_NODE_DEPS_URL` / `LOONGSUITE_PILOT_NODE_MODULES_URL`.

> Note: the OSS objects must be published under the new prefix before this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)