### PR TITLE
fix(hook,installer): make hooks parseable under sh and npm runnable with the managed runtime

### DIFF
--- a/assets/hooks/claude-code-loongsuite-pilot-hook.sh
+++ b/assets/hooks/claude-code-loongsuite-pilot-hook.sh
@@ -120,12 +120,23 @@ if [[ -z "$NODE_BIN" ]]; then
   # prefer node-v22.9.0 over node-v22.22.2.
   candidates=()
   runtime_dir="$(dirname "$NODE_PIN_FILE")/runtime"
-  while IFS= read -r d; do
-    [[ -n "$d" ]] && candidates+=("$d/bin/node")
-  done < <(for d in "$runtime_dir"/node-v*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)
-  while IFS= read -r d; do
-    [[ -n "$d" ]] && candidates+=("$d/bin/node")
-  done < <(for d in "$HOME/.nvm/versions/node"/*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)
+  # Appends "<dir>/bin/node" for each newline-separated dir in $1, newest first.
+  # Herestring rather than `done < <(...)`: agents inject this hook as a bare path,
+  # so the interpreter is up to each runtime, and `sh <script>` bypasses the shebang.
+  # macOS /bin/sh is bash in POSIX mode, which rejects process substitution but still
+  # accepts <<<. A pipe would run candidates+= in a subshell and lose it.
+  # The list arrives as an argument so a non-zero glob/pipeline status cannot leak
+  # into `set -e`, and the empty case returns early because <<<"" still yields one
+  # blank line.
+  add_node_bin_candidates() {
+    local list="$1" d
+    [[ -n "$list" ]] || return 0
+    while IFS= read -r d; do
+      if [[ -n "$d" ]]; then candidates+=("$d/bin/node"); fi
+    done <<<"$list"
+  }
+  add_node_bin_candidates "$(for d in "$runtime_dir"/node-v*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)"
+  add_node_bin_candidates "$(for d in "$HOME/.nvm/versions/node"/*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)"
   candidates+=(
     "$HOME/.volta/bin/node"
     "$HOME/.fnm/aliases/default/bin/node"

--- a/assets/hooks/codex-loongsuite-pilot-hook.sh
+++ b/assets/hooks/codex-loongsuite-pilot-hook.sh
@@ -109,12 +109,23 @@ if [[ -z "$NODE_BIN" ]]; then
   # prefer node-v22.9.0 over node-v22.22.2.
   candidates=()
   runtime_dir="$(dirname "$NODE_PIN_FILE")/runtime"
-  while IFS= read -r d; do
-    [[ -n "$d" ]] && candidates+=("$d/bin/node")
-  done < <(for d in "$runtime_dir"/node-v*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)
-  while IFS= read -r d; do
-    [[ -n "$d" ]] && candidates+=("$d/bin/node")
-  done < <(for d in "$HOME/.nvm/versions/node"/*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)
+  # Appends "<dir>/bin/node" for each newline-separated dir in $1, newest first.
+  # Herestring rather than `done < <(...)`: agents inject this hook as a bare path,
+  # so the interpreter is up to each runtime, and `sh <script>` bypasses the shebang.
+  # macOS /bin/sh is bash in POSIX mode, which rejects process substitution but still
+  # accepts <<<. A pipe would run candidates+= in a subshell and lose it.
+  # The list arrives as an argument so a non-zero glob/pipeline status cannot leak
+  # into `set -e`, and the empty case returns early because <<<"" still yields one
+  # blank line.
+  add_node_bin_candidates() {
+    local list="$1" d
+    [[ -n "$list" ]] || return 0
+    while IFS= read -r d; do
+      if [[ -n "$d" ]]; then candidates+=("$d/bin/node"); fi
+    done <<<"$list"
+  }
+  add_node_bin_candidates "$(for d in "$runtime_dir"/node-v*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)"
+  add_node_bin_candidates "$(for d in "$HOME/.nvm/versions/node"/*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)"
   candidates+=(
     "$HOME/.volta/bin/node"
     "$HOME/.fnm/aliases/default/bin/node"

--- a/assets/hooks/cursor-loongsuite-pilot-hook.sh
+++ b/assets/hooks/cursor-loongsuite-pilot-hook.sh
@@ -101,12 +101,23 @@ if [[ -z "$NODE_BIN" ]]; then
   # prefer node-v22.9.0 over node-v22.22.2.
   candidates=()
   runtime_dir="$(dirname "$NODE_PIN_FILE")/runtime"
-  while IFS= read -r d; do
-    [[ -n "$d" ]] && candidates+=("$d/bin/node")
-  done < <(for d in "$runtime_dir"/node-v*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)
-  while IFS= read -r d; do
-    [[ -n "$d" ]] && candidates+=("$d/bin/node")
-  done < <(for d in "$HOME/.nvm/versions/node"/*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)
+  # Appends "<dir>/bin/node" for each newline-separated dir in $1, newest first.
+  # Herestring rather than `done < <(...)`: agents inject this hook as a bare path,
+  # so the interpreter is up to each runtime, and `sh <script>` bypasses the shebang.
+  # macOS /bin/sh is bash in POSIX mode, which rejects process substitution but still
+  # accepts <<<. A pipe would run candidates+= in a subshell and lose it.
+  # The list arrives as an argument so a non-zero glob/pipeline status cannot leak
+  # into `set -e`, and the empty case returns early because <<<"" still yields one
+  # blank line.
+  add_node_bin_candidates() {
+    local list="$1" d
+    [[ -n "$list" ]] || return 0
+    while IFS= read -r d; do
+      if [[ -n "$d" ]]; then candidates+=("$d/bin/node"); fi
+    done <<<"$list"
+  }
+  add_node_bin_candidates "$(for d in "$runtime_dir"/node-v*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)"
+  add_node_bin_candidates "$(for d in "$HOME/.nvm/versions/node"/*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)"
   candidates+=(
     "$HOME/.volta/bin/node"
     "$HOME/.fnm/aliases/default/bin/node"

--- a/assets/hooks/kiro-cli-loongsuite-pilot-hook.sh
+++ b/assets/hooks/kiro-cli-loongsuite-pilot-hook.sh
@@ -110,12 +110,23 @@ if [[ -z "$NODE_BIN" ]]; then
   # prefer node-v22.9.0 over node-v22.22.2.
   candidates=()
   runtime_dir="$(dirname "$NODE_PIN_FILE")/runtime"
-  while IFS= read -r d; do
-    [[ -n "$d" ]] && candidates+=("$d/bin/node")
-  done < <(for d in "$runtime_dir"/node-v*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)
-  while IFS= read -r d; do
-    [[ -n "$d" ]] && candidates+=("$d/bin/node")
-  done < <(for d in "$HOME/.nvm/versions/node"/*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)
+  # Appends "<dir>/bin/node" for each newline-separated dir in $1, newest first.
+  # Herestring rather than `done < <(...)`: agents inject this hook as a bare path,
+  # so the interpreter is up to each runtime, and `sh <script>` bypasses the shebang.
+  # macOS /bin/sh is bash in POSIX mode, which rejects process substitution but still
+  # accepts <<<. A pipe would run candidates+= in a subshell and lose it.
+  # The list arrives as an argument so a non-zero glob/pipeline status cannot leak
+  # into `set -e`, and the empty case returns early because <<<"" still yields one
+  # blank line.
+  add_node_bin_candidates() {
+    local list="$1" d
+    [[ -n "$list" ]] || return 0
+    while IFS= read -r d; do
+      if [[ -n "$d" ]]; then candidates+=("$d/bin/node"); fi
+    done <<<"$list"
+  }
+  add_node_bin_candidates "$(for d in "$runtime_dir"/node-v*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)"
+  add_node_bin_candidates "$(for d in "$HOME/.nvm/versions/node"/*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)"
   candidates+=(
     "$HOME/.volta/bin/node"
     "$HOME/.fnm/aliases/default/bin/node"

--- a/assets/hooks/qoder-loongsuite-pilot-hook.sh
+++ b/assets/hooks/qoder-loongsuite-pilot-hook.sh
@@ -91,12 +91,23 @@ if [[ -z "$NODE_BIN" ]]; then
   # prefer node-v22.9.0 over node-v22.22.2.
   candidates=()
   runtime_dir="$(dirname "$NODE_PIN_FILE")/runtime"
-  while IFS= read -r d; do
-    [[ -n "$d" ]] && candidates+=("$d/bin/node")
-  done < <(for d in "$runtime_dir"/node-v*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)
-  while IFS= read -r d; do
-    [[ -n "$d" ]] && candidates+=("$d/bin/node")
-  done < <(for d in "$HOME/.nvm/versions/node"/*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)
+  # Appends "<dir>/bin/node" for each newline-separated dir in $1, newest first.
+  # Herestring rather than `done < <(...)`: agents inject this hook as a bare path,
+  # so the interpreter is up to each runtime, and `sh <script>` bypasses the shebang.
+  # macOS /bin/sh is bash in POSIX mode, which rejects process substitution but still
+  # accepts <<<. A pipe would run candidates+= in a subshell and lose it.
+  # The list arrives as an argument so a non-zero glob/pipeline status cannot leak
+  # into `set -e`, and the empty case returns early because <<<"" still yields one
+  # blank line.
+  add_node_bin_candidates() {
+    local list="$1" d
+    [[ -n "$list" ]] || return 0
+    while IFS= read -r d; do
+      if [[ -n "$d" ]]; then candidates+=("$d/bin/node"); fi
+    done <<<"$list"
+  }
+  add_node_bin_candidates "$(for d in "$runtime_dir"/node-v*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)"
+  add_node_bin_candidates "$(for d in "$HOME/.nvm/versions/node"/*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)"
   candidates+=(
     "$HOME/.volta/bin/node"
     "$HOME/.fnm/aliases/default/bin/node"

--- a/assets/hooks/qodercn-loongsuite-pilot-hook.sh
+++ b/assets/hooks/qodercn-loongsuite-pilot-hook.sh
@@ -90,12 +90,23 @@ if [[ -z "$NODE_BIN" ]]; then
   # prefer node-v22.9.0 over node-v22.22.2.
   candidates=()
   runtime_dir="$(dirname "$NODE_PIN_FILE")/runtime"
-  while IFS= read -r d; do
-    [[ -n "$d" ]] && candidates+=("$d/bin/node")
-  done < <(for d in "$runtime_dir"/node-v*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)
-  while IFS= read -r d; do
-    [[ -n "$d" ]] && candidates+=("$d/bin/node")
-  done < <(for d in "$HOME/.nvm/versions/node"/*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)
+  # Appends "<dir>/bin/node" for each newline-separated dir in $1, newest first.
+  # Herestring rather than `done < <(...)`: agents inject this hook as a bare path,
+  # so the interpreter is up to each runtime, and `sh <script>` bypasses the shebang.
+  # macOS /bin/sh is bash in POSIX mode, which rejects process substitution but still
+  # accepts <<<. A pipe would run candidates+= in a subshell and lose it.
+  # The list arrives as an argument so a non-zero glob/pipeline status cannot leak
+  # into `set -e`, and the empty case returns early because <<<"" still yields one
+  # blank line.
+  add_node_bin_candidates() {
+    local list="$1" d
+    [[ -n "$list" ]] || return 0
+    while IFS= read -r d; do
+      if [[ -n "$d" ]]; then candidates+=("$d/bin/node"); fi
+    done <<<"$list"
+  }
+  add_node_bin_candidates "$(for d in "$runtime_dir"/node-v*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)"
+  add_node_bin_candidates "$(for d in "$HOME/.nvm/versions/node"/*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)"
   candidates+=(
     "$HOME/.volta/bin/node"
     "$HOME/.fnm/aliases/default/bin/node"

--- a/assets/hooks/qoderwork-loongsuite-pilot-hook.sh
+++ b/assets/hooks/qoderwork-loongsuite-pilot-hook.sh
@@ -90,12 +90,23 @@ if [[ -z "$NODE_BIN" ]]; then
   # prefer node-v22.9.0 over node-v22.22.2.
   candidates=()
   runtime_dir="$(dirname "$NODE_PIN_FILE")/runtime"
-  while IFS= read -r d; do
-    [[ -n "$d" ]] && candidates+=("$d/bin/node")
-  done < <(for d in "$runtime_dir"/node-v*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)
-  while IFS= read -r d; do
-    [[ -n "$d" ]] && candidates+=("$d/bin/node")
-  done < <(for d in "$HOME/.nvm/versions/node"/*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)
+  # Appends "<dir>/bin/node" for each newline-separated dir in $1, newest first.
+  # Herestring rather than `done < <(...)`: agents inject this hook as a bare path,
+  # so the interpreter is up to each runtime, and `sh <script>` bypasses the shebang.
+  # macOS /bin/sh is bash in POSIX mode, which rejects process substitution but still
+  # accepts <<<. A pipe would run candidates+= in a subshell and lose it.
+  # The list arrives as an argument so a non-zero glob/pipeline status cannot leak
+  # into `set -e`, and the empty case returns early because <<<"" still yields one
+  # blank line.
+  add_node_bin_candidates() {
+    local list="$1" d
+    [[ -n "$list" ]] || return 0
+    while IFS= read -r d; do
+      if [[ -n "$d" ]]; then candidates+=("$d/bin/node"); fi
+    done <<<"$list"
+  }
+  add_node_bin_candidates "$(for d in "$runtime_dir"/node-v*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)"
+  add_node_bin_candidates "$(for d in "$HOME/.nvm/versions/node"/*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)"
   candidates+=(
     "$HOME/.volta/bin/node"
     "$HOME/.fnm/aliases/default/bin/node"

--- a/assets/hooks/qoderworkcn-loongsuite-pilot-hook.sh
+++ b/assets/hooks/qoderworkcn-loongsuite-pilot-hook.sh
@@ -90,12 +90,23 @@ if [[ -z "$NODE_BIN" ]]; then
   # prefer node-v22.9.0 over node-v22.22.2.
   candidates=()
   runtime_dir="$(dirname "$NODE_PIN_FILE")/runtime"
-  while IFS= read -r d; do
-    [[ -n "$d" ]] && candidates+=("$d/bin/node")
-  done < <(for d in "$runtime_dir"/node-v*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)
-  while IFS= read -r d; do
-    [[ -n "$d" ]] && candidates+=("$d/bin/node")
-  done < <(for d in "$HOME/.nvm/versions/node"/*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)
+  # Appends "<dir>/bin/node" for each newline-separated dir in $1, newest first.
+  # Herestring rather than `done < <(...)`: agents inject this hook as a bare path,
+  # so the interpreter is up to each runtime, and `sh <script>` bypasses the shebang.
+  # macOS /bin/sh is bash in POSIX mode, which rejects process substitution but still
+  # accepts <<<. A pipe would run candidates+= in a subshell and lose it.
+  # The list arrives as an argument so a non-zero glob/pipeline status cannot leak
+  # into `set -e`, and the empty case returns early because <<<"" still yields one
+  # blank line.
+  add_node_bin_candidates() {
+    local list="$1" d
+    [[ -n "$list" ]] || return 0
+    while IFS= read -r d; do
+      if [[ -n "$d" ]]; then candidates+=("$d/bin/node"); fi
+    done <<<"$list"
+  }
+  add_node_bin_candidates "$(for d in "$runtime_dir"/node-v*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)"
+  add_node_bin_candidates "$(for d in "$HOME/.nvm/versions/node"/*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)"
   candidates+=(
     "$HOME/.volta/bin/node"
     "$HOME/.fnm/aliases/default/bin/node"

--- a/assets/hooks/qwen-code-cli-loongsuite-pilot-hook.sh
+++ b/assets/hooks/qwen-code-cli-loongsuite-pilot-hook.sh
@@ -120,12 +120,23 @@ if [[ -z "$NODE_BIN" ]]; then
   # prefer node-v22.9.0 over node-v22.22.2.
   candidates=()
   runtime_dir="$(dirname "$NODE_PIN_FILE")/runtime"
-  while IFS= read -r d; do
-    [[ -n "$d" ]] && candidates+=("$d/bin/node")
-  done < <(for d in "$runtime_dir"/node-v*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)
-  while IFS= read -r d; do
-    [[ -n "$d" ]] && candidates+=("$d/bin/node")
-  done < <(for d in "$HOME/.nvm/versions/node"/*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)
+  # Appends "<dir>/bin/node" for each newline-separated dir in $1, newest first.
+  # Herestring rather than `done < <(...)`: agents inject this hook as a bare path,
+  # so the interpreter is up to each runtime, and `sh <script>` bypasses the shebang.
+  # macOS /bin/sh is bash in POSIX mode, which rejects process substitution but still
+  # accepts <<<. A pipe would run candidates+= in a subshell and lose it.
+  # The list arrives as an argument so a non-zero glob/pipeline status cannot leak
+  # into `set -e`, and the empty case returns early because <<<"" still yields one
+  # blank line.
+  add_node_bin_candidates() {
+    local list="$1" d
+    [[ -n "$list" ]] || return 0
+    while IFS= read -r d; do
+      if [[ -n "$d" ]]; then candidates+=("$d/bin/node"); fi
+    done <<<"$list"
+  }
+  add_node_bin_candidates "$(for d in "$runtime_dir"/node-v*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)"
+  add_node_bin_candidates "$(for d in "$HOME/.nvm/versions/node"/*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)"
   candidates+=(
     "$HOME/.volta/bin/node"
     "$HOME/.fnm/aliases/default/bin/node"

--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -476,6 +476,16 @@ ensure_node_modules() {
     rm -rf "$tmp"
     return 0
 }
+
+run_npm() {
+    # npm shipped with the managed runtime is a symlink to npm-cli.js, whose
+    # `#!/usr/bin/env node` shebang resolves node through PATH. The runtime's bin dir
+    # is not on PATH, so calling "$NPM_BIN" directly dies with
+    # "env: node: No such file or directory" on hosts without a system node — exactly
+    # the hosts the managed runtime exists for. Mirrors the .ps1 npm fallback, which
+    # already prepends the node dir.
+    PATH="$(dirname "$NODE_BIN"):$PATH" "$NPM_BIN" "$@"
+}
 # <<< managed-node-runtime <<<
 
 check_deps() {
@@ -538,8 +548,8 @@ check_deps() {
         exit 1
     fi
 
-    msg "    ✅ node $("$NODE_BIN" --version)  npm $("$NPM_BIN" --version)" \
-        "    ✅ node $("$NODE_BIN" --version)  npm $("$NPM_BIN" --version)"
+    msg "    ✅ node $("$NODE_BIN" --version)  npm $(run_npm --version)" \
+        "    ✅ node $("$NODE_BIN" --version)  npm $(run_npm --version)"
     msg "    node pinned: $NODE_BIN" "    node pinned: $NODE_BIN"
     echo ""
 }
@@ -871,7 +881,7 @@ deploy_package() {
     else
         msg "    ⚠️ 预编译 node_modules 不可用，回退 npm install" \
             "    ⚠️ Prebuilt node_modules unavailable, falling back to npm install"
-        if ! (cd "$PERMANENT_DIR" && "$NPM_BIN" install --production --no-optional 2>&1 | tail -1); then
+        if ! (cd "$PERMANENT_DIR" && run_npm install --production --no-optional 2>&1 | tail -1); then
             msg "    ❌ 依赖安装失败" "    ❌ Dependency installation failed"
             return 1
         fi

--- a/tests/unit/deploy/managed-node-wiring.test.mjs
+++ b/tests/unit/deploy/managed-node-wiring.test.mjs
@@ -49,6 +49,16 @@ describe('sh installer variants wire the managed node runtime', () => {
       expect(sh).toContain('ensure_node_modules "$modules_ver"');
       expect(sh).toContain('install --production --no-optional');
     });
+    it.skipIf(!present)(`${f} runs npm with the node bin dir on PATH`, () => {
+      // npm from the managed runtime is a symlink to npm-cli.js, whose
+      // `#!/usr/bin/env node` shebang needs node on PATH. Calling "$NPM_BIN"
+      // directly breaks the npm install fallback on hosts without a system node.
+      expect(sh).toMatch(/run_npm\(\)\s*\{/);
+      expect(sh).toContain('PATH="$(dirname "$NODE_BIN"):$PATH" "$NPM_BIN" "$@"');
+      expect(sh).toContain('run_npm install --production --no-optional');
+      expect(sh).not.toContain('"$NPM_BIN" install');
+      expect(sh).not.toContain('npm $("$NPM_BIN" --version)');
+    });
     it.skipIf(!present)(`${f} prints an explicit notice before the npm install fallback`, () => {
       const noticePos = sh.indexOf('预编译 node_modules 不可用，回退 npm install');
       const npmPos = sh.indexOf('install --production --no-optional');
@@ -92,6 +102,14 @@ describe('ps1 installer variants wire the managed node runtime', () => {
     it.skipIf(!present)(`${f} keeps npm install as the node_modules fallback`, () => {
       expect(ps1).toContain('Ensure-NodeModules $modulesVer');
       expect(ps1).toMatch(/install --omit=dev/);
+    });
+    it.skipIf(!present)(`${f} prepends the node dir to PATH for the npm fallback`, () => {
+      // Windows counterpart of run_npm in the sh installers.
+      const fallback = ps1.slice(ps1.indexOf('Prebuilt node_modules unavailable'));
+      const pathPos = fallback.indexOf('$env:PATH = "$nodeDir;$env:PATH"');
+      const npmPos = fallback.search(/install --omit=dev/);
+      expect(pathPos).toBeGreaterThan(-1);
+      expect(npmPos).toBeGreaterThan(pathPos);
     });
     it.skipIf(!present)(`${f} prints an explicit notice before the npm install fallback`, () => {
       const noticePos = ps1.indexOf('预编译 node_modules 不可用，回退 npm install');

--- a/tests/unit/hooks/shared/hook-posix-parse.test.mjs
+++ b/tests/unit/hooks/shared/hook-posix-parse.test.mjs
@@ -1,0 +1,52 @@
+// POSIX-mode parse guard for the hook shell scripts.
+//
+// The hooks carry a `#!/usr/bin/env bash` shebang, but agents do not always honour
+// it — some invoke the hook through `sh <script>` or an `sh -c` wrapper. On macOS
+// /bin/sh is bash in POSIX mode, which parses `[[ ]]`, `=~` and `<<<` but *rejects*
+// process substitution. A `done < <(...)` in the node fallback therefore made every
+// hook die with "syntax error near unexpected token `<'" before doing any work.
+//
+// These tests parse each shipped hook under both plain bash and bash --posix so that
+// class of breakage cannot reach users again.
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const HOOK_DIR = 'assets/hooks';
+const HOOKS = readdirSync(resolve(HOOK_DIR))
+  .filter(f => f.endsWith('.sh'))
+  .sort();
+
+// Sanity check: the list is discovered, so a new hook is covered automatically.
+it('discovers the hook scripts to check', () => {
+  expect(HOOKS.length).toBeGreaterThanOrEqual(9);
+});
+
+describe.each(HOOKS)('%s', (hook) => {
+  const path = resolve(HOOK_DIR, hook);
+
+  it('parses under bash', () => {
+    const r = spawnSync('bash', ['-n', path], { encoding: 'utf-8' });
+    expect(r.stderr.trim(), r.stderr).toBe('');
+    expect(r.status).toBe(0);
+  });
+
+  it('parses under bash --posix (how /bin/sh runs it)', () => {
+    const r = spawnSync('bash', ['--posix', '-n', path], { encoding: 'utf-8' });
+    expect(r.stderr.trim(), r.stderr).toBe('');
+    expect(r.status).toBe(0);
+  });
+
+  it('uses no process substitution', () => {
+    // Comments may mention the construct; only real code is a problem, and any real
+    // occurrence would already fail the --posix parse above. This keeps the intent
+    // explicit and the failure message obvious.
+    const code = readFileSync(path, 'utf-8')
+      .split('\n')
+      .filter(l => !l.trim().startsWith('#'))
+      .join('\n');
+    expect(code).not.toMatch(/<\s*\(/);
+    expect(code).not.toMatch(/>\s*\(/);
+  });
+});

--- a/tests/unit/hooks/shared/node-version-sort.test.mjs
+++ b/tests/unit/hooks/shared/node-version-sort.test.mjs
@@ -14,6 +14,14 @@ const fnMatch = sh.match(/sort_version_dirs_desc\(\) \{[\s\S]*?\n\}\n/);
 if (!fnMatch) throw new Error('sort_version_dirs_desc not found in hook script');
 const SORT_FN = fnMatch[0];
 
+// The real candidate-collection code from the shipped hook, so the end-to-end test
+// exercises what users run instead of a copy that can drift.
+const helperMatch = sh.match(/  add_node_bin_candidates\(\) \{[\s\S]*?\n  \}\n/);
+if (!helperMatch) throw new Error('add_node_bin_candidates not found in hook script');
+const ADD_FN = helperMatch[0];
+const RUNTIME_CALL = sh.split('\n').find(l => l.includes('add_node_bin_candidates "$(for d in "$runtime_dir"'));
+if (!RUNTIME_CALL) throw new Error('runtime add_node_bin_candidates call not found in hook script');
+
 // node-v22.9.0 vs node-v22.22.2 is the regression case: lexicographic order
 // (and a plain reverse glob) prefers the older 22.9.0.
 const EXPECTED = ['node-v24.1.0-darwin-arm64', 'node-v22.22.2', 'node-v22.9.0', 'node-v18.20.0'];
@@ -49,26 +57,53 @@ describe('sort_version_dirs_desc (hook.sh fallback)', () => {
       .toEqual(EXPECTED);
   });
 
-  it('selects the newest runtime dir end-to-end in the fallback glob loop', () => {
-    const tmp = mkdtempSync(resolve(tmpdir(), 'hook-sort-'));
-    try {
-      for (const d of EXPECTED) mkdirSync(resolve(tmp, 'runtime', d, 'bin'), { recursive: true });
-      const body = `
+  // Both shells matter: hooks carry a bash shebang but are sometimes launched via
+  // `sh`, and bash in POSIX mode rejects process substitution.
+  for (const shell of [['bash'], ['bash', '--posix']]) {
+    it(`selects the newest runtime dir end-to-end in the fallback glob loop (${shell.join(' ')})`, () => {
+      const tmp = mkdtempSync(resolve(tmpdir(), 'hook-sort-'));
+      try {
+        for (const d of EXPECTED) mkdirSync(resolve(tmp, 'runtime', d, 'bin'), { recursive: true });
+        const body = `
+set -euo pipefail
 ${SORT_FN}
 candidates=()
 runtime_dir="$1/runtime"
-while IFS= read -r d; do
-  [[ -n "$d" ]] && candidates+=("$d/bin/node")
-done < <(for d in "$runtime_dir"/node-v*; do [[ -d "$d" ]] && printf '%s\\n' "$d"; done | sort_version_dirs_desc)
+${ADD_FN}
+${RUNTIME_CALL}
 printf '%s\\n' "\${candidates[0]}"
 `;
-      const r = spawnSync('bash', ['-c', body, 'bash', tmp], { encoding: 'utf-8' });
-      if (r.status !== 0) throw new Error(`bash exited ${r.status}\nstderr: ${r.stderr}`);
-      expect(r.stdout.trim()).toBe(resolve(tmp, 'runtime/node-v24.1.0-darwin-arm64/bin/node'));
-    } finally {
-      rmSync(tmp, { recursive: true, force: true });
-    }
-  });
+        const r = spawnSync(shell[0], [...shell.slice(1), '-c', body, 'bash', tmp], { encoding: 'utf-8' });
+        if (r.status !== 0) throw new Error(`${shell.join(' ')} exited ${r.status}\nstderr: ${r.stderr}`);
+        expect(r.stdout.trim()).toBe(resolve(tmp, 'runtime/node-v24.1.0-darwin-arm64/bin/node'));
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it(`survives an empty runtime dir under set -e (${shell.join(' ')})`, () => {
+      // <<<"" still feeds one blank line, so an unguarded loop body would fail and
+      // `set -e` would abort the whole hook before any node was resolved.
+      const tmp = mkdtempSync(resolve(tmpdir(), 'hook-sort-empty-'));
+      try {
+        mkdirSync(resolve(tmp, 'runtime'), { recursive: true });
+        const body = `
+set -euo pipefail
+${SORT_FN}
+candidates=()
+runtime_dir="$1/runtime"
+${ADD_FN}
+${RUNTIME_CALL}
+echo "COUNT=\${#candidates[@]}"
+`;
+        const r = spawnSync(shell[0], [...shell.slice(1), '-c', body, 'bash', tmp], { encoding: 'utf-8' });
+        if (r.status !== 0) throw new Error(`${shell.join(' ')} exited ${r.status}\nstderr: ${r.stderr}`);
+        expect(r.stdout.trim()).toBe('COUNT=0');
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+  }
 });
 
 let pwshAvailable = false;


### PR DESCRIPTION
本 PR 修 #221 遗留的**两个独立缺陷**，都是做真机验证时实测发现的。两者共同点：#221 的目标场景是「用户机器没有可用 node 也能采集」，而这两个缺陷分别让 **hook 侧**和**安装侧**在这个场景下失效。

---

# 缺陷一：hook 在 `sh` 下无法解析（9 个 hook 全断）

#221 引入的托管运行时 fallback，用了**进程替换**把排序后的版本目录读回数组：

```bash
done < <(for d in "$runtime_dir"/node-v*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)
```

hook 头上写着 `#!/usr/bin/env bash`，看起来是安全的。但 **10 个 agent 的 `hookCommand` 全是裸路径**（`agents.d/*.json`），解释器完全由各 agent runtime 决定；`sh <脚本>` 会绕过 shebang，而 macOS 的 `/bin/sh` 是 **bash 3.2 的 POSIX 模式，禁用进程替换**。

结果：hook 在做任何事之前就解析失败退出：

```
/Users/<u>/.loongsuite-pilot/hooks/qoder-loongsuite-pilot-hook.sh: line 96: syntax error near unexpected token `<'
```

**采集不是降级，是完全静默中断。** 真机上由 Qoder IDE 的 Stop hook 触发。

## 为什么之前没暴露

进程替换是 #221 **最后一个提交** `87346d8`（为响应评审 Medium#3「运行期版本字典序误选旧 node」）引入的：

| 提交 | 日期 | `< <(` | `sh -n` |
|---|---|---|---|
| `eb3c884` 初版 managed node | 8/4 | 0 | ✅ |
| `13acc26` win zip 布局 | 8/5 | 0 | ✅ |
| `f3ddd84` CI 可移植性 | 8/5 | 0 | ✅ |
| **`87346d8` 评审整改·数值排序** | **8/7** | **2** | **❌** |

此前的 macOS / Windows 真机验证都在 `f3ddd84` 及之前；`87346d8` 之后只跑了 CI + 自动化 review。

## 改法

换成**命令替换 + herestring**（POSIX 模式的 bash 接受 `<<<`），封成 helper：

```bash
add_node_bin_candidates() {
  local list="$1" d
  [[ -n "$list" ]] || return 0
  while IFS= read -r d; do
    if [[ -n "$d" ]]; then candidates+=("$d/bin/node"); fi
  done <<<"$list"
}
add_node_bin_candidates "$(for d in "$runtime_dir"/node-v*; do [[ -d "$d" ]] && printf '%s\n' "$d"; done | sort_version_dirs_desc)"
```

三个约束都是实测踩出来的：

1. **不能改成管道** —— `candidates+=` 会落进子 shell 丢掉。这正是原作者选进程替换的原因。
2. **`<<<"$empty"` 仍会喂一个空行** —— 循环体执行一次、`[[ -n "$d" ]]` 失败，`set -euo pipefail` 直接把 hook 干掉（第一版改完 `sh -n` 全过但一跑就 `rc=1`）。故 helper 先判空提前返回，且把 `&&` 换成 `if/fi`。
3. **列表当函数参数传，不用变量赋值** —— `var="$(for ...; done | ...)"` 的赋值状态就是命令替换的状态，glob 末项不是目录时 for 返回 1，配合 `pipefail` 会再次触发 `set -e`。

`workbuddy` hook 未被 #221 改动，本 PR 也不涉及。

## 验证

**解析**：10 个 hook 全部通过 `/bin/sh -n`、`bash -n`、`bash --posix -n`。

**运行时 before / after**（`sh <脚本>`，pin 失效走 fallback）：

```
before  rc=2 | line 96: syntax error near unexpected token `<'
after   rc=0 | PROCESSOR_RAN(node v22.22.2)
```

目录里同时放了 `node-v22.9.0` / `node-v22.22.2` / `node-v20.11.1`，结果选中 **22.22.2** —— **#221 那个数值排序修复的效果完整保留**（字典序会误选 22.9.0）。

**五种调用方式定位**（同一文件）：

| 调用方式 | 结果 |
|---|---|
| 走 shebang 直接执行 | 正常 |
| `bash <脚本>` | 正常 |
| `sh -c <路径>` | 正常（shebang 生效）|
| `zsh -c <路径>` | 正常 |
| **`sh <脚本>`** | **失败** |

---

# 缺陷二：托管 runtime 的 npm 跑不起来

`check_deps` 从解析出的 node 推导 npm：

```bash
NPM_BIN="$(dirname "$NODE_BIN")/npm"     # → <runtime>/bin/npm
if [ ! -x "$NPM_BIN" ]; then             # ← 永远为 false
    NPM_BIN=$(command -v npm)            #    「退回系统 npm」这条逃生通道打不开
```

官方 Node.js 分发包里 `bin/npm` 是**软链**，指向 `lib/node_modules/npm/bin/npm-cli.js`，而它的第一行是 `#!/usr/bin/env node` —— **它不认识同目录下的 `bin/node`，只会去 PATH 里找 `node`**。而 installer 从未把 `<runtime>/bin` 加进 PATH。

所以：**托管的是 node，不是 npm 的运行环境。** node 22.22.2 本身完全正常（下载、校验、`--version` 都没问题），坏的是 npm。

在**没有系统 node** 的机器上（正是托管 runtime 存在的意义），每次 npm 调用都 127：

- 依赖 banner 里 `npm <version>` 渲染为空；
- 预编译 node_modules 不可用时走的 `npm install` 回退失败 → `deploy_package` 报「依赖安装失败」并 `return 1` → **安装中止**。

另外那个 `[ ! -x "$NPM_BIN" ]` 兜底之所以失效：`-x` 会跟随软链判断目标，`npm-cli.js` 带执行位 → 为 true → 兜底不触发。这是个假阳性守卫。

## 为什么 Windows 真机验证没发现

`.ps1` 的 npm 回退**本来就** prepend 了 PATH（`$env:PATH = "$nodeDir;$env:PATH"`）；更根本的是 Windows 上 `npm.cmd` 用 `%~dp0node.exe` 相对自身定位 node，不依赖 PATH。所以双端表现不一致，Windows 侧天然不受影响。

## 改法

```bash
run_npm() {
    PATH="$(dirname "$NODE_BIN"):$PATH" "$NPM_BIN" "$@"
}
```

所有 npm 调用点（banner 版本打印 + `npm install` 回退）统一走它，与 `.ps1` 的既有行为对齐。

## 验证

darwin-arm64，用**真实的托管 runtime**，PATH 里刻意不放任何 node：

```
command -v node : <none>
[ -x NPM_BIN ]  : true          <- 兜底守卫的假阳性

A) main 原样: "$NPM_BIN" --version     -> rc=127  env: node: No such file or directory
B) 修复后:    run_npm --version        -> 10.9.7

C) main 原样的 npm install 回退分支     -> 走进「依赖安装失败 / return 1」分支，安装中止
D) 修复后的同一分支                     -> 依赖安装完成
```

C/D 用的是 installer 里**逐字照搬**的那段表达式。

## 严重度补充

需要说清边界，避免夸大：

- **有系统 node 的机器不受影响** —— `env node` 找到系统 node，npm 正常跑。（用系统 node 跑 npm、装出的依赖由托管 node 加载；两个原生模块都是 N-API，跨 Node 大版本 ABI 稳定，所以没问题。）
- **#221 之前，没有系统 node 的机器也装不上** —— 那时 `check_deps` 直接报 `Missing dependency: node` 退出。所以**这不是把原本能用的搞坏了**，而是「#221 想解决的场景，因为这个 npm 缺口实际没解决」；区别在于失败点从第一步后移到依赖安装步，报错从明确的「缺 node」变成难懂的 `env: node: No such file or directory`。
- 触发还需一个前提：预编译 node_modules 不可用（走 npm install 回退）。目前 `loongsuite-pilot/deps/node-modules/<版本>/` 线上尚无产物（`1.1.22`/`1.1.23`/`latest` 均 404），所以**这个前提当下恒为真**。产物发布后触发面会显著收窄，但回退路径仍需修。

---

# 为什么 CI 没拦住 + 新增守卫

**关键点：`bash -n` 在坏版本上是 PASS 的**，只有 `bash --posix -n` 会 FAIL。而 `87346d8` 自带的两个测试都是自我指涉的：

- `managed-node-wiring.test.mjs` 是纯静态字符串断言（断言 `sort_version_dirs_desc()` 存在、`nvm_candidates=` 消失）—— 它在断言「这次改动自己的形状」，从不检查文件能否被解析。
- `node-version-sort.test.mjs` 的端到端用例把 `done < <(...)` **抄进了测试自己的 harness**，再用普通 `bash` 跑 —— 等于「用唯一能跑通的 shell，验证一份代码副本」。改坏 shipped 文件它照样绿。

本 PR 补：

- **新增 `tests/unit/hooks/shared/hook-posix-parse.test.mjs`**：目录自动发现所有 hook（新增 hook 自动纳入），逐个断言 `bash -n` + **`bash --posix -n`** 通过、且无进程替换。用 main 的坏版本实测会被这个守卫拦下。
- **改造 `node-version-sort.test.mjs`**：端到端用例改为从 shipped hook 里**提取真实 helper**（不再抄写），并在 `bash` 与 `bash --posix` 下各跑一遍；另加「空 runtime 目录在 `set -e` 下不退出」用例。
- **`managed-node-wiring.test.mjs` 增加双端 npm 接线断言**：sh 侧必须有 `run_npm` 且不再直调 `"$NPM_BIN"`；ps1 侧必须在 `npm install` 前 prepend PATH。

单测：`tests/unit/hooks/shared/` + `tests/unit/deploy/` → **11 files / 199 passed，37 skipped**（skip 为仅存在于内部仓库的 installer 变体与未安装 pwsh）。

# 影响面 / 建议

缺陷一在当前 `main`（含 #231）上让 9 个 hook 全部 `sh -n` FAIL，任何以 `sh <脚本>` 拉起 hook 的 agent runtime 都会采集全断；缺陷二让 #221 的核心承诺在无系统 node 的机器上不成立。**建议按 hotfix 处理。**
