### PR TITLE
fix(updater): abort activation when pinning the managed node runtime fails

### DIFF
--- a/src/metrics/alarm-manager.ts
+++ b/src/metrics/alarm-manager.ts
@@ -19,7 +19,8 @@ export type AlarmType =
   | 'DEGRADED_STARTUP_ALARM'
   | 'UPDATER_NOT_RUNNING_ALARM'
   | 'BROKEN_VERSION_POINTER_ALARM'
-  | 'INVALID_NODE_BIN_ALARM';
+  | 'INVALID_NODE_BIN_ALARM'
+  | 'UPDATER_NODE_PIN_ALARM';
 
 export interface AlarmContext {
   input_name?: string;

--- a/src/updater/updater-metrics.ts
+++ b/src/updater/updater-metrics.ts
@@ -28,7 +28,8 @@ export type UpdaterEventType =
   | 'deployed'
   | 'collector_restarted'
   | 'update_failure'
-  | 'updater_stopped_max_failures';
+  | 'updater_stopped_max_failures'
+  | 'managed_node_pin_failed';
 
 export interface UpdaterEvent {
   event_type: UpdaterEventType;
@@ -37,6 +38,8 @@ export interface UpdaterEvent {
   latest_version?: string;
   error?: string;
   consecutive_failures?: number;
+  node_bin?: string;
+  pin?: string;
   user_id: string;
   ip: string;
   __time__: number;

--- a/src/updater/updater.ts
+++ b/src/updater/updater.ts
@@ -606,7 +606,11 @@ export class Updater {
         await this.syncInstalledScripts(targetDir);
         // Repoint the CLI wrapper at the managed runtime only after activation, so
         // the collector/updater restart (and any future launch) runs on it. Skipped
-        // when we fell back to system node, preserving the existing pin.
+        // when we fell back to system node, preserving the existing pin. When the
+        // managed runtime was adopted, pinNodeRuntime throws on failure so we roll the
+        // pointers back below: the activated version's node_modules are ABI-tied to the
+        // managed node, and leaving the pin on the old node would crash-loop the
+        // collector on mismatched native addons with no self-heal.
         if (managedNodeBin) {
           await this.pinNodeRuntime(managedNodeBin);
         }
@@ -882,7 +886,26 @@ export class Updater {
       await this.writePointerFile(this.paths.nodePinFile, nodeBin);
       logger.info('pinned managed node runtime', { nodeBin, pin: this.paths.nodePinFile });
     } catch (err) {
-      logger.warn('failed to pin managed node runtime', { error: String(err) });
+      // The freshly activated version ships node_modules compiled against the managed
+      // node ABI. If the CLI wrapper cannot be repointed at that runtime, the collector
+      // restarts on the old (system) node and crash-loops on ABI-mismatched native
+      // addons — a state the version-only self-heal cannot detect or repair. Surface it
+      // (event + alarm) and rethrow so the caller rolls the pointers back to the
+      // previous, ABI-consistent install rather than marking the upgrade successful.
+      void this.metrics?.writeEvent('managed_node_pin_failed', {
+        error: String(err),
+        node_bin: nodeBin,
+        pin: this.paths.nodePinFile,
+      });
+      void this.metrics?.writeAlarm(
+        'UPDATER_NODE_PIN_ALARM', '2',
+        `failed to pin managed node runtime at ${this.paths.nodePinFile}: ${String(err)}`,
+      );
+      logger.error('failed to pin managed node runtime, aborting activation', {
+        error: String(err),
+        pin: this.paths.nodePinFile,
+      });
+      throw err;
     }
   }
 

--- a/tests/unit/updater/updater.test.ts
+++ b/tests/unit/updater/updater.test.ts
@@ -399,6 +399,89 @@ describe('Updater', () => {
       expect(execCommands).not.toContain('npm');
     });
 
+    it('rolls pointers back when pinning the managed node runtime fails', async () => {
+      const expOs = process.platform === 'win32' ? 'win' : process.platform;
+      const expArch = process.arch;
+      const supported = ['darwin', 'linux', 'win'].includes(expOs)
+        && ['x64', 'arch'].includes(expArch === 'arm64' ? 'arch' : expArch)
+        && !(expOs === 'win' && expArch === 'arm64');
+      // On an unsupported host the managed runtime is never adopted, so there is no
+      // pin step to fail; the ABI-consistency hazard this guards does not arise.
+      if (!supported) return;
+
+      const nodeArchive = `node-v22.22.2-${expOs}-${expArch}.${expOs === 'win' ? 'zip' : 'tar.gz'}`;
+      const modulesArchive = `node-modules-${expOs}-${expArch}.tar.gz`;
+      const nodeLeaf = expOs === 'win' ? 'node.exe' : 'node';
+
+      mockFetch
+        .mockResolvedValueOnce(makeResponseJson(makeManifest()))  // manifest
+        .mockResolvedValueOnce(makeResponseStream())              // package
+        .mockResolvedValueOnce(makeResponseStream())              // node archive
+        .mockResolvedValueOnce(makeResponseStream())              // node SHASUMS
+        .mockResolvedValueOnce(makeResponseStream())              // modules archive
+        .mockResolvedValueOnce(makeResponseStream());             // modules SHASUMS
+      mockComputeSha256.mockResolvedValue('SHA');
+
+      mockFsReaddir.mockImplementation((dir: string) => {
+        if (dir.includes('download-tmp')) return Promise.resolve(['loongsuite-pilot']);
+        return Promise.resolve([]);
+      });
+      mockFsStat.mockResolvedValue({ isDirectory: () => true });
+      mockFsAccess.mockImplementation((p: string) => {
+        if (p.includes('postinstall.js')) return Promise.reject(new Error('ENOENT'));
+        if (p.includes('package.json')) return Promise.resolve();
+        if (p.includes('dist/index.js')) return Promise.resolve();
+        if (p.includes('dist/updater/index.js')) return Promise.resolve();
+        if (p.includes('collector-daemon.js')) return Promise.resolve();
+        if (p.includes('updater-daemon.js')) return Promise.resolve();
+        if (p.includes('loongsuite-pilot.')) return Promise.resolve();
+        if (p.includes('/runtime/') && p.endsWith(`/${nodeLeaf}`)) return Promise.resolve();
+        if (p.includes('.pilot-nm-') && p.endsWith('node_modules')) return Promise.resolve();
+        return Promise.reject(new Error('ENOENT'));
+      });
+      mockFsReadFile.mockImplementation((filePath: string) => {
+        if (String(filePath).includes('SHASUMS256')) {
+          return Promise.resolve(`SHA  ${nodeArchive}\nSHA  ${modulesArchive}\n` as unknown as string);
+        }
+        if (String(filePath).endsWith('/current')) return Promise.resolve('1.0.1_aaa\n' as unknown as string);
+        if (String(filePath).endsWith('/previous')) return Promise.resolve('1.0.0_zzz\n' as unknown as string);
+        if (String(filePath).endsWith('/VERSION')) return Promise.resolve('version=1.0.1\ngit_commit=aaa\n' as unknown as string);
+        if (String(filePath).includes('/scripts/')) {
+          return Promise.resolve(Buffer.from('script') as unknown as string);
+        }
+        return Promise.reject(new Error('ENOENT'));
+      });
+      // The managed runtime is adopted, but repointing the CLI wrapper fails.
+      mockFsWriteFile.mockImplementation((filePath: string) => {
+        if (String(filePath).includes('node-bin.tmp')) {
+          return Promise.reject(new Error('EACCES: pin dir not writable'));
+        }
+        return Promise.resolve();
+      });
+
+      const updater = new Updater(makeConfig(), tmpDir);
+      await updater.check();
+
+      // The pin was attempted (managed runtime adopted)...
+      expect(mockFsWriteFile).toHaveBeenCalledWith(
+        expect.stringContaining('node-bin.tmp'),
+        expect.any(String),
+      );
+      // ...and because it failed, the previous pointers were restored instead of
+      // leaving the new (managed-ABI) version active on the old system-node pin.
+      expect(mockFsWriteFile).toHaveBeenCalledWith(
+        expect.stringContaining('/current.tmp'),
+        '1.0.1_aaa\n',
+      );
+      expect(mockFsWriteFile).toHaveBeenCalledWith(
+        expect.stringContaining('/previous.tmp'),
+        '1.0.0_zzz\n',
+      );
+      // The upgrade must not report success: no collector restart was executed.
+      const execCommands = mockExecFile.mock.calls.map((c: unknown[]) => String(c[0]));
+      expect(execCommands).not.toContain('npm');
+    });
+
     it('syncs installed scripts after switching the current pointer', async () => {
       setupForDownload();
       mockFsAccess.mockImplementation((p: string) => {


### PR DESCRIPTION
## 背景

跟进 #234(`feat(updater): adopt managed Node.js runtime + prebuilt node_modules`)代码评审中的 Medium 意见 —— pin 失败被静默吞没、误报升级成功的原子性缺口。

## 问题

采用托管 Node.js 运行时后,被激活版本的 `node_modules` 是按托管 node(v22.22.2)的 ABI 预编译的。原实现中:

- `pinNodeRuntime` 吞掉所有异常(仅 `logger.warn`)且不 rethrow;
- 调用点其后**无条件** `activated = true`。

于是「node_modules 已按托管 node ABI 编译,但 `node-bin` pin 未能重定向」这一不一致状态被标记为升级成功。此时启动器 `resolve_node()` 兜底只校验 `major>=18`、不校验 ABI,collector 重启时 `require('sqlite3')` 因 `NODE_MODULE_VERSION` 不匹配而加载失败 → **崩溃循环**;version-only 的 self-heal 无法检测或修复,更新流程也无对应告警、fleet 层不可见。

## 修复

让 `pinNodeRuntime` 在失败时:

1. 发出 `managed_node_pin_failed` metrics 事件 + `UPDATER_NODE_PIN_ALARM` 告警(fleet 可见);
2. **rethrow**,从而复用 `fs.rename` 之后已存在的 activation `try/catch` —— 回滚指针(`restorePointers`)到上一个 ABI 一致的安装,而不是把升级标记为成功。

不新增回滚代码,与既有 post-rename 错误处理(如 `syncInstalledScripts` 失败)保持一致。

## 改动

- `src/updater/updater.ts` — pin 失败发事件/告警并 rethrow;调用点注释说明新行为
- `src/updater/updater-metrics.ts` — 新增 `managed_node_pin_failed` 事件类型 + `node_bin`/`pin` 字段
- `src/metrics/alarm-manager.ts` — 新增 `UPDATER_NODE_PIN_ALARM` 告警类型
- `tests/unit/updater/updater.test.ts` — 回归用例:托管 node 采用后 pin 写失败 → 断言指针被 `restorePointers` 回滚

## 验证

- `npx tsc --noEmit` 通过
- `npx vitest run tests/unit/updater/updater.test.ts` — 43/43 通过(含新增回归用例)

🤖 Generated with [Claude Code](https://claude.com/claude-code)