### PR TITLE
feat(qoder-cn): 标记 qoder-cn IDE 的 turn 起止事件

### DIFF
--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -1225,17 +1225,25 @@ function finalizeRecords(records, cwd) {
   return records;
 }
 
+// Variants whose records are committed one complete turn at a time, so the
+// batch boundaries coincide with the turn boundaries. qoder-cli is excluded:
+// its transcript may commit several turns in one batch.
+const TURN_BOUNDARY_VARIANTS = new Set(['qoder', 'qoder-cn']);
+
 /**
- * Mark the turn's opening and closing event (qoder IDE only).
+ * Mark the turn's opening and closing event (qoder / qoder-cn IDE only).
  *
  * The records of one turn arrive in emission order, so the first one is the
  * user-input `other` event and the turn closes with its last `llm.response`.
  * The event-log contract allows exactly one start and one end per turn, so the
  * flags are only ever set to true and never stamped on the events in between.
+ * A turn without any `llm.response` (interrupted before the model replied)
+ * falls back to closing on its last record, which keeps the single-end
+ * guarantee intact.
  */
 export function markTurnBoundaries(records) {
   if (records.length === 0) return records;
-  if (records[0]['gen_ai.agent.type'] !== 'qoder') return records;
+  if (!TURN_BOUNDARY_VARIANTS.has(records[0]['gen_ai.agent.type'])) return records;
 
   records[0]['gen_ai.turn.start'] = true;
 

--- a/tests/unit/hooks/qoder-turn-boundary.test.mjs
+++ b/tests/unit/hooks/qoder-turn-boundary.test.mjs
@@ -87,8 +87,8 @@ function writeTranscript(rows) {
   fs.writeFileSync(transcriptPath, rows.map(row => JSON.stringify(row)).join('\n') + '\n');
 }
 
-function runProcessor() {
-  return spawnSync('node', [PROCESSOR, '--agent-id', 'qoder', '--log-prefix', 'qoder'], {
+function runProcessor(agentId = 'qoder') {
+  return spawnSync('node', [PROCESSOR, '--agent-id', agentId, '--log-prefix', agentId], {
     input: JSON.stringify({
       session_id: 'session-ide',
       transcript_path: transcriptPath,
@@ -100,8 +100,8 @@ function runProcessor() {
   });
 }
 
-function readHistory() {
-  const historyDir = path.join(dataDir, 'logs', 'qoder', 'history');
+function readHistory(agentId = 'qoder') {
+  const historyDir = path.join(dataDir, 'logs', agentId, 'history');
   if (!fs.existsSync(historyDir)) return [];
   return fs.readdirSync(historyDir)
     .filter(file => file.endsWith('.jsonl'))
@@ -134,6 +134,31 @@ describe('qoder-hook-processor turn boundary markers', () => {
 
     // Both markers share one turn, and the events in between carry neither.
     expect(starts[0]['gen_ai.turn.id']).toBe(ends[0]['gen_ai.turn.id']);
+    for (const record of records.slice(1, -1)) {
+      expect(record['gen_ai.turn.start']).toBeUndefined();
+      expect(record['gen_ai.turn.end']).toBeUndefined();
+    }
+  });
+
+  it('marks a qoder-cn turn the same way', () => {
+    writeTranscript(ideTurnRows());
+
+    expect(runProcessor('qoder-cn').status).toBe(0);
+    const records = readHistory('qoder-cn');
+    expect(records.length).toBeGreaterThan(0);
+    expect(new Set(records.map(r => r['gen_ai.agent.type']))).toEqual(new Set(['qoder-cn']));
+
+    const starts = records.filter(r => r['gen_ai.turn.start'] === true);
+    const ends = records.filter(r => r['gen_ai.turn.end'] === true);
+    expect(starts).toHaveLength(1);
+    expect(ends).toHaveLength(1);
+
+    expect(starts[0]['event.name']).toBe('other');
+    expect(records[0]).toBe(starts[0]);
+    expect(ends[0]['event.name']).toBe('llm.response');
+    expect(records[records.length - 1]).toBe(ends[0]);
+    expect(starts[0]['gen_ai.turn.id']).toBe(ends[0]['gen_ai.turn.id']);
+
     for (const record of records.slice(1, -1)) {
       expect(record['gen_ai.turn.start']).toBeUndefined();
       expect(record['gen_ai.turn.end']).toBeUndefined();


### PR DESCRIPTION
## 背景

#219 让 qoder IDE 在一个 turn 的首条 user 输入事件上打 `gen_ai.turn.start`、在最后一条 `llm.response` 上打 `gen_ai.turn.end`。qoder-cn 走的是同一个 `assets/hooks/qoder-hook-processor.mjs`（`qodercn-loongsuite-pilot-hook.sh` 只是带 `--agent-id qoder-cn` 转发），但 `markTurnBoundaries` 的变体判断写死了 `=== 'qoder'`，所以 qoder-cn 的事件流一直缺这两个字段。

## 为什么 qoder-cn 可以直接复用同一套标记逻辑

`markTurnBoundaries` 的前提是「一个提交批次 == 一个完整 turn」，qoder-cn 恰好满足：

- `processTranscript` 的 Phase 2.5 对 `agentId === 'qoder-cn'` 做了 Stop 门禁——progress 里没有 `Stop` 就直接返回，因此 `UserPromptSubmit` / `PreToolUse` / `PostToolUse` 三个回调不会产出任何记录；
- `selectTurnSegmentsForCollection` 对 qoder-cn 恒返回 `turnSegments.slice(-1)`，即每次提交只输出最新一个 turn。

所以 qoder-cn 每次提交都只包含一个 turn，`records[0]` 就是该 turn 的 user 输入事件，末条 `llm.response` 就是收尾事件，和 qoder IDE 完全同构。

qoder-cli 仍然不标记：它一个批次可能提交多个 turn，`records[0]` 不能代表 turn 边界。

## 改动

- `assets/hooks/qoder-hook-processor.mjs`：把变体判断从单值比较改为 `TURN_BOUNDARY_VARIANTS`（`qoder` / `qoder-cn`）集合，并补注释说明为什么排除 qoder-cli。
- 顺手补齐 #219 review 里 @ralf0131 提到的兜底语义：在 JSDoc 里写明「turn 内没有任何 `llm.response`（例如模型回复前被中断）时收尾标记落到末条记录」，仍然满足每 turn 唯一 start / 唯一 end 的契约。

## 验证

`tests/unit/hooks/qoder-turn-boundary.test.mjs` 新增 qoder-cn 用例（把 `runProcessor` / `readHistory` 参数化到 agent id），断言：唯一 start 落在 `event.name=other` 的首条记录、唯一 end 落在末条 `llm.response`、两者共享同一个 `gen_ai.turn.id`、中间事件都不带标记。

```
✓ tests/unit/hooks/qoder-turn-boundary.test.mjs (3 tests)
  ✓ marks the user input as turn start and the final llm.response as turn end
  ✓ marks a qoder-cn turn the same way
  ✓ leaves qoder-cli turns unmarked
```

回归确认新用例是有效的：临时回退 processor 改动后，新用例在 `expect(starts).toHaveLength(1)` 处失败（实际 0），其余两条仍通过。

同时跑了 `qoder-hook-processor-cold-start`、`qoder-hook-processor-retry`、`hook-processor-line-records` 共 48 条用例全部通过。
