### PR TITLE
docs: sync supported agent matrices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,14 +49,20 @@
 |-------|----|---------|---------|-----------|---------|
 | Qoder IDE | `qoder` | Hook | `BaseIdeInput` | `inputs/qoder/` | `agents.d/qoder.json` |
 | Qoder CN | `qoder-cn` | Hook | `BaseIdeInput` / `BaseSqliteInput` | `inputs/qoder-cn*/` | `agents.d/qoder-cn.json` |
+| Qoder for JetBrains | `qoder-jetbrains` | Detection-only（复用 Qoder 采集） | 复用 Qoder Input | `inputs/qoder*/` | `agents.d/qoder-jetbrains.json` |
 | Qoder Work | `qoder-work` | Hook | `BaseSqliteInput` / `BaseHookInput` | `inputs/qoder-work*/` | `agents.d/qoder-work.json` |
 | Qoder Work CN | `qoder-work-cn` | Hook | `BaseHookInput` / `BaseSessionInput` | `inputs/qoder-work*/` | `agents.d/qoder-work-cn.json` |
 | Qoder CLI | `qoder` | Hook | `BaseHookInput` / `BaseSessionInput` | `inputs/qoder-cli*/` | `agents.d/qoder.json` |
 | Cursor | `cursor` | Hook | `BaseHookInput` | `inputs/cursor-hook/` | `agents.d/cursor.json` |
-| Claude Code | `claude-code` | Plugin-Probe | `BaseHookInput` | `inputs/claude-code-log/` | `agents.d/claude-code.json` |
-| Codex | `codex` | Plugin-Probe | `BaseHookInput` | `inputs/codex-log/` | `agents.d/codex.json` |
-| OpenCode | `opencode` | Plugin-Probe | `BaseHookInput` | `inputs/opencode-log/` | `agents.d/opencode.json` |
-| Pi Coding Agent | `pi-coding-agent` | Extension Inject | `BaseHookInput` | `inputs/pi-coding-agent-log/` | `agents.d/pi-coding-agent.json` |
+| Cursor CLI | `cursor-cli` | 复用 Cursor Hook | `BaseHookInput` | `inputs/cursor-hook/` | `agents.d/cursor-cli.json` |
+| Claude Code | `claude-code` | Hook | `BaseHookInput` | `inputs/claude-code-log/` | `agents.d/claude-code.json` |
+| Codex | `codex` | Hook | `BaseInput` | `inputs/codex-transcript/` | `agents.d/codex.json` |
+| Kiro CLI | `kiro-cli` | Hook | `BaseHookInput` / `BaseInput` | `inputs/kiro-cli-*/` | `agents.d/kiro-cli.json` |
+| OpenCode | `opencode` | Plugin-Inject | `BaseHookInput` | `inputs/opencode-log/` | `agents.d/opencode.json` |
+| MiMo Code | `mimo-code` | Plugin-Inject | `BaseHookInput` | `inputs/mimo-code-log/` | `agents.d/mimo-code.json` |
+| Hermes Agent | `hermes-agent` | Directory-Plugin | `BaseSessionInput` | `inputs/hermes-log/` | `agents.d/hermes-agent.json` |
+| OpenClaw | `openclaw` | Plugin-Inject | `BaseHookInput` | `inputs/openclaw-plugin/` | `agents.d/openclaw.json` |
+| Pi Coding Agent | `pi-coding-agent` | Plugin-Inject（Extension） | `BaseHookInput` | `inputs/pi-coding-agent-log/` | `agents.d/pi-coding-agent.json` |
 | Qwen Code CLI | `qwen-code-cli` | Hook | `BaseHookInput` | `inputs/qwen-code-cli-log/` | `agents.d/qwen-code-cli.json` |
 | WorkBuddy | `workbuddy` | Hook | `BaseInput`（Hook/文件唤醒 + 本地 transcript 30 秒轮询兜底） | `inputs/workbuddy/` | `agents.d/workbuddy.json` |
 | Wukong | `wukong` | CLI API Polling | `BaseInput` | `inputs/wukong/` | N/A |

--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ Pilot is designed to answer practical questions:
 | Claude Code   | Hook                      | Yes          | Yes        | Yes         | Yes                       |
 | Codex         | Hook                      | Yes          | Yes        | Yes         | Yes                       |
 | Cursor        | Hook                      | Yes          | Yes        | Yes         | Yes                       |
-| Kiro CLI      | Hook / session polling    | Yes          | Yes        | No          | Yes                       |
+| Cursor CLI    | Shared Cursor hook        | Yes          | Yes        | Yes         | Yes                       |
 | Hermes Agent  | Native directory plugin   | Yes          | Yes        | Yes         | Yes                       |
+| Kiro CLI      | Hook / session polling    | Yes          | Yes        | No          | Yes                       |
+| MiMo Code     | Plugin injection          | Yes          | Yes        | Yes         | Yes                       |
 | OpenClaw      | Plugin injection          | Yes          | Yes        | Yes         | Yes                       |
 | OpenCode      | Plugin injection          | Yes          | Yes        | Yes         | Yes                       |
 | Pi Coding Agent | Extension injection     | Yes          | Yes        | Yes         | Yes                       |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -42,7 +42,10 @@ Pilot 主要帮助回答这些问题：
 | Claude Code | Hook | Yes | Yes | Yes | Yes |
 | Codex | Hook | Yes | Yes | Yes | Yes |
 | Cursor | Hook | Yes | Yes | Yes | Yes |
+| Cursor CLI | 复用 Cursor Hook | Yes | Yes | Yes | Yes |
+| Hermes Agent | 原生目录插件 | Yes | Yes | Yes | Yes |
 | Kiro CLI | Hook / session 轮询 | Yes | Yes | No | Yes |
+| MiMo Code | 插件注入 | Yes | Yes | Yes | Yes |
 | OpenClaw | 插件注入 | Yes | Yes | Yes | Yes |
 | OpenCode | 插件注入 | Yes | Yes | Yes | Yes |
 | Pi Coding Agent | Extension 注入 | Yes | Yes | Yes | Yes |

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -6,14 +6,19 @@ Use this guide to choose which AI coding agents Pilot should collect from and wh
 
 ## Supported Agent IDs
 
-Use these IDs in installer options, `agent-control.json`, and `config.json`.
+These IDs identify the supported integrations. Most can be used in installer
+options, `agent-control.json`, and `config.json`; shared integrations and output
+type differences are called out in the notes.
 
 | Agent | ID | Notes |
 |-------|----|-------|
 | Claude Code | `claude-code` | Hook integration. |
 | Codex | `codex` | Hook integration. |
 | Cursor | `cursor` | Hook integration. |
+| Cursor CLI | `cursor-cli` | Detected and emitted as `cursor-cli`, but reuses Cursor's installed Hook/input pipeline rather than deploying an independent Hook. Use `cursor-cli` for an output-specific content policy. |
+| Hermes Agent | `hermes-agent` | Native directory plugin and local session-file collection. Output records use `gen_ai.agent.type=hermes`. |
 | Kiro CLI | `kiro-cli` | Hook integration with delayed local SQLite/session collection. Token usage is not exposed by the source. |
+| MiMo Code | `mimo-code` | Plugin injection; captures LLM, tool, and token lifecycle events. |
 | OpenClaw | `openclaw` | Plugin injection for OpenClaw 2026.5.12 or later. Captures native LLM, ReAct, tool, token, error, and cancellation events. |
 | OpenCode | `opencode` | Plugin injection. |
 | Pi Coding Agent | `pi-coding-agent` | Pi Extension injection; captures LLM and tool lifecycle events. |
@@ -24,7 +29,7 @@ Use these IDs in installer options, `agent-control.json`, and `config.json`.
 | Qoder Work | `qoder-work` | Hook and local data sources. |
 | Qoder Work CN | `qoder-work-cn` | Hook and local data sources. |
 | Qwen Code CLI | `qwen-code-cli` | Hook integration; parses qwen-code transcript JSONL on Stop. |
-| Wukong | `wukong` | CLI API polling via local `wukong-cli`. |
+| Wukong | `wukong` | Runtime auto-discovery and CLI API polling via local `wukong-cli`; it is not an `agents.d` installer selection. |
 | WorkBuddy | `workbuddy` | Structural Hook/file wakeups with a 30-second local transcript polling fallback. Verified on WorkBuddy Desktop 5.2.6 for macOS and 5.3.5.0 for Windows 11. |
 
 The Windows verification used an installed Pilot package, resolved Node from the

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -25,8 +25,11 @@ LoongSuite Pilot runs on a developer machine and collects telemetry from support
 | Claude Code | Hook | Yes | Yes | Yes | Yes |
 | Codex | Hook | Yes | Yes | Yes | Yes |
 | Cursor | Hook | Yes | Yes | Yes | Yes |
-| Kiro CLI | Hook / local session polling | Yes | Yes | No | Yes |
+| Cursor CLI | Shared Cursor hook | Yes | Yes | Yes | Yes |
 | Hermes Agent | Native directory plugin | Yes | Yes | Yes | Yes |
+| Kiro CLI | Hook / local session polling | Yes | Yes | No | Yes |
+| MiMo Code | Plugin injection | Yes | Yes | Yes | Yes |
+| OpenClaw | Plugin injection | Yes | Yes | Yes | Yes |
 | OpenCode | Plugin injection | Yes | Yes | Yes | Yes |
 | Pi Coding Agent | Extension injection | Yes | Yes | Yes | Yes |
 | Qoder | Hook | Yes | Yes | Yes | Yes |
@@ -38,6 +41,8 @@ LoongSuite Pilot runs on a developer machine and collects telemetry from support
 | Qwen Code CLI | Hook | Yes | Yes | Yes | Yes |
 | Wukong | CLI API polling | Yes | Yes | Yes | Yes |
 | WorkBuddy | Hook wakeup + local transcript watch/poll fallback | Yes | Yes | Yes | Yes |
+
+OpenClaw integration requires OpenClaw 2026.5.12 or later.
 
 ### Documented Windows Agent Support
 

--- a/docs/zh-CN/agents.md
+++ b/docs/zh-CN/agents.md
@@ -6,14 +6,18 @@
 
 ## 支持的 Agent ID
 
-这些 ID 可用于安装参数、`agent-control.json` 和 `config.json`。
+这些 ID 用于标识受支持的集成。大多数 ID 可直接用于安装参数、
+`agent-control.json` 和 `config.json`；复用采集链路或输出类型不同的情况会在说明中标出。
 
 | Agent | ID | 说明 |
 |-------|----|------|
 | Claude Code | `claude-code` | Hook 集成。 |
 | Codex | `codex` | Hook 集成。 |
 | Cursor | `cursor` | Hook 集成。 |
+| Cursor CLI | `cursor-cli` | 独立检测并输出为 `cursor-cli`，但复用 Cursor 已安装的 Hook/Input 链路，不会独立部署另一套 Hook；输出内容策略使用 `cursor-cli`。 |
+| Hermes Agent | `hermes-agent` | 原生目录插件和本地 session 文件采集；输出记录使用 `gen_ai.agent.type=hermes`。 |
 | Kiro CLI | `kiro-cli` | Hook 集成，并延迟采集本地 SQLite/session 数据；源端暂不提供 Token 用量。 |
+| MiMo Code | `mimo-code` | 插件注入，采集 LLM、工具和 Token 生命周期事件。 |
 | OpenClaw | `openclaw` | 注入插件，支持 OpenClaw 2026.5.12 及以上稳定版本；采集原生 LLM、ReAct、工具、Token、错误和取消事件。 |
 | OpenCode | `opencode` | 插件注入。 |
 | Pi Coding Agent | `pi-coding-agent` | 注入 Pi Extension，采集 LLM 与工具生命周期事件。 |
@@ -24,7 +28,7 @@
 | Qoder Work | `qoder-work` | Hook 和本地数据源。 |
 | Qoder Work CN | `qoder-work-cn` | Hook 和本地数据源。 |
 | Qwen Code CLI | `qwen-code-cli` | Hook 集成；Stop 时解析 qwen-code transcript JSONL。 |
-| Wukong | `wukong` | 通过本地 `wukong-cli` 进行 CLI API 轮询。 |
+| Wukong | `wukong` | 运行时自动发现并通过本地 `wukong-cli` 进行 CLI API 轮询；它不是 `agents.d` 安装选择项。 |
 | WorkBuddy | `workbuddy` | 结构化 Hook 和文件变化触发即时采集，本地 transcript 每 30 秒轮询兜底；已在 macOS WorkBuddy Desktop 5.2.6 和 Windows 11 WorkBuddy Desktop 5.3.5.0 验证。 |
 
 Windows 验证使用安装后的 Pilot 产物，在 `PATH` 中没有 Node 的情况下从安装器固定的

--- a/docs/zh-CN/overview.md
+++ b/docs/zh-CN/overview.md
@@ -25,8 +25,11 @@ LoongSuite Pilot 运行在开发者本机，用于采集支持的 AI Coding Agen
 | Claude Code | Hook | Yes | Yes | Yes | Yes |
 | Codex | Hook | Yes | Yes | Yes | Yes |
 | Cursor | Hook | Yes | Yes | Yes | Yes |
-| Kiro CLI | Hook / 本地 session 轮询 | Yes | Yes | No | Yes |
+| Cursor CLI | 复用 Cursor Hook | Yes | Yes | Yes | Yes |
 | Hermes Agent | 原生目录插件 | Yes | Yes | Yes | Yes |
+| Kiro CLI | Hook / 本地 session 轮询 | Yes | Yes | No | Yes |
+| MiMo Code | 插件注入 | Yes | Yes | Yes | Yes |
+| OpenClaw | 插件注入 | Yes | Yes | Yes | Yes |
 | OpenCode | 插件注入 | Yes | Yes | Yes | Yes |
 | Pi Coding Agent | Extension 注入 | Yes | Yes | Yes | Yes |
 | Qoder | Hook | Yes | Yes | Yes | Yes |
@@ -38,6 +41,8 @@ LoongSuite Pilot 运行在开发者本机，用于采集支持的 AI Coding Agen
 | Qwen Code CLI | Hook | Yes | Yes | Yes | Yes |
 | Wukong | CLI API 轮询 | Yes | Yes | Yes | Yes |
 | WorkBuddy | Hook 唤醒 + 本地 transcript 监听/轮询兜底 | Yes | Yes | Yes | Yes |
+
+OpenClaw 集成要求 OpenClaw 2026.5.12 或更高版本。
 
 ### Windows Agent 明确支持情况
 


### PR DESCRIPTION
## Summary

- synchronize the English and Chinese agent support matrices with the current definitions and runtime wiring
- add or clarify Cursor CLI, Hermes Agent, MiMo Code, OpenClaw, and other supported variants where documentation had drifted
- align agent IDs, output identities, deployment modes, and input paths in the agent reference and developer navigation

## Why

The support matrix is duplicated across the README, overview, and agent reference pages. Those copies had drifted from the implementation: several fully wired agents were missing from some pages, and the developer matrix still described older deployment modes or paths.

## Scope and impact

- documentation-only change; no runtime behavior is modified
- keeps the explicit Windows support table unchanged because there is no new installed-product validation to justify expanding it
- makes the four general support matrices use the same 19 logical agent variants and order

## Validation

- verified the four general matrices contain the same 19 agents in the same order
- verified all 17 agents.d definitions are represented, accounting for shared aliases
- verified Cursor CLI, Hermes, MiMo, and OpenClaw identity details in both English and Chinese agent reference pages
- git diff --check
- pre-commit and pre-push hooks passed