### PR TITLE
fix(core): stop misclassifying detection-probe failures as input stops

### DIFF
--- a/src/core/agent-discovery-service.ts
+++ b/src/core/agent-discovery-service.ts
@@ -199,6 +199,11 @@ export class AgentDiscoveryService extends EventEmitter {
             this.resetErrorCounter(rt);
             await this.stopEntry(rt, 'unavailable');
           } else {
+            // Deliberately does not reset the lifecycle error counter: this
+            // poll neither started nor stopped the entry, so it proves nothing
+            // about input health. Resetting here would let an entry whose
+            // availability flaps while start() is permanently broken never
+            // reach the threshold, masking the failure forever.
             logger.debug('agent unavailable, debouncing', {
               id: entry.id,
               consecutiveUnavailable: rt.consecutiveUnavailable,

--- a/src/core/agent-discovery-service.ts
+++ b/src/core/agent-discovery-service.ts
@@ -7,10 +7,14 @@ import { createLogger } from '../utils/logger.js';
 const logger = createLogger('AgentDiscoveryService');
 
 const DEFAULT_POLL_MS = 300_000; // 5 minutes
-// Consecutive processEntry() exceptions on a running entry before we treat it
-// as a real (unexpected) stop. At the default poll interval this is ~15 minutes
-// of sustained failure, so transient probe hiccups never reach the alarm channel.
+// Consecutive input-lifecycle failures on a running entry before it is treated
+// as a real (unexpected) stop. This is a count only; processEntry() is driven by
+// the global poll timer, a per-entry timer (user-configurable, commonly 30s) and
+// unthrottled fs.watch callbacks, so a burst can exhaust the count in
+// milliseconds. ERROR_MIN_WINDOW_MS additionally requires the failures to span
+// real time, so a short-lived glitch cannot trip the alarm.
 const ERROR_THRESHOLD = 3;
+const ERROR_MIN_WINDOW_MS = 60_000;
 const ERROR_SUMMARY_MAX_LEN = 200;
 const FORCE_POLLING = process.env.LOONGSUITE_PILOT_FORCE_POLLING === 'true';
 
@@ -20,7 +24,16 @@ interface EntryRuntime {
   watcher: fs.FSWatcher | null;
   pollTimer: ReturnType<typeof setInterval> | null;
   consecutiveUnavailable: number;
+  /** Failures of the entry's own lifecycle calls (start); can trip the alarm. */
   consecutiveErrors: number;
+  /** Wall-clock time of the first unreset lifecycle failure. */
+  firstErrorAt: number | null;
+  /**
+   * Failures of the detection probe (enabled/isAvailable). Observability only:
+   * a broken probe says nothing about whether the input can still collect, so
+   * it never stops the data plane and never alarms.
+   */
+  consecutiveProbeErrors: number;
 }
 
 /**
@@ -61,6 +74,8 @@ export class AgentDiscoveryService extends EventEmitter {
         pollTimer: null,
         consecutiveUnavailable: 0,
         consecutiveErrors: 0,
+        firstErrorAt: null,
+        consecutiveProbeErrors: 0,
       });
     }
   }
@@ -113,9 +128,31 @@ export class AgentDiscoveryService extends EventEmitter {
 
   private async processEntry(rt: EntryRuntime): Promise<void> {
     const { entry } = rt;
+
+    // Phase 1 — detection probe. A throwing probe tells us nothing about
+    // whether the input can still collect, so it must never touch the data
+    // plane: leave the entry exactly as it is (running stays running) and
+    // never alarm. Counting only feeds observability.
+    let enabled: boolean;
+    let available: boolean;
     try {
-      const enabled = entry.enabled ? entry.enabled() : true;
-      const available = enabled ? await entry.isAvailable() : false;
+      enabled = entry.enabled ? entry.enabled() : true;
+      available = enabled ? await entry.isAvailable() : false;
+    } catch (err) {
+      rt.consecutiveProbeErrors++;
+      logger.warn('agent detection probe failed, entry left untouched', {
+        id: entry.id,
+        state: rt.state,
+        consecutiveProbeErrors: rt.consecutiveProbeErrors,
+        error: String(err),
+      });
+      return;
+    }
+    rt.consecutiveProbeErrors = 0;
+
+    // Phase 2 — act on the probe result. Failures here come from the entry's
+    // own lifecycle calls, which do describe input health.
+    try {
       const shouldRun = enabled && available;
 
       if (!shouldRun && rt.state === 'idle') {
@@ -128,23 +165,23 @@ export class AgentDiscoveryService extends EventEmitter {
 
       if (shouldRun && rt.state !== 'running') {
         rt.consecutiveUnavailable = 0;
-        rt.consecutiveErrors = 0;
         rt.state = 'starting';
         logger.info('starting agent', { id: entry.id });
         await entry.start();
         rt.state = 'running';
+        this.resetErrorCounter(rt);
         this.emit('agent:started', entry.id);
       } else if (!shouldRun && (rt.state === 'running' || rt.state === 'starting')) {
         if (!enabled) {
           rt.consecutiveUnavailable = 0;
-          rt.consecutiveErrors = 0;
+          this.resetErrorCounter(rt);
           await this.stopEntry(rt, 'disabled');
         } else {
           rt.consecutiveUnavailable++;
           const threshold = entry.unavailableThreshold ?? 1;
           if (rt.consecutiveUnavailable >= threshold) {
             rt.consecutiveUnavailable = 0;
-            rt.consecutiveErrors = 0;
+            this.resetErrorCounter(rt);
             await this.stopEntry(rt, 'unavailable');
           } else {
             logger.debug('agent unavailable, debouncing', {
@@ -156,46 +193,62 @@ export class AgentDiscoveryService extends EventEmitter {
         }
       } else if (shouldRun && rt.state === 'running' && entry.runOnActive) {
         rt.consecutiveUnavailable = 0;
-        rt.consecutiveErrors = 0;
+        // Reset only after a successful call: resetting first would clear the
+        // counter on every attempt and defeat the threshold entirely.
         await entry.start();
+        this.resetErrorCounter(rt);
       } else if (shouldRun && rt.state === 'running') {
         rt.consecutiveUnavailable = 0;
-        rt.consecutiveErrors = 0;
+        this.resetErrorCounter(rt);
       }
     } catch (err) {
-      // A lifecycle call (enabled/isAvailable/start) threw. This is a probe
-      // failure, NOT evidence that a running input actually stopped. Only after
-      // ERROR_THRESHOLD consecutive failures do we conclude the entry is truly
-      // broken and stop it via the normal stopEntry() path (which calls
-      // entry.stop() first), classifying it as 'unexpected'. Below the
-      // threshold a running entry keeps its state — we never emit a stop event
-      // for an input that is still running, and never leave state out of sync.
+      // The entry's own lifecycle call failed. Only a running entry can be
+      // "unexpectedly stopped", and only once the failures both repeat and
+      // span ERROR_MIN_WINDOW_MS — then we stop it through the normal
+      // stopEntry() path so state and reality agree. Because the probe is
+      // healthy here, the next successful poll restarts the entry, so this
+      // path self-heals rather than going permanently silent.
       if (rt.state === 'running') {
+        const now = Date.now();
         rt.consecutiveErrors++;
-        if (rt.consecutiveErrors >= ERROR_THRESHOLD) {
+        rt.firstErrorAt ??= now;
+        const elapsed = now - rt.firstErrorAt;
+        if (rt.consecutiveErrors >= ERROR_THRESHOLD && elapsed >= ERROR_MIN_WINDOW_MS) {
           logger.error('agent stopped unexpectedly after repeated failures', {
             id: entry.id,
             consecutiveErrors: rt.consecutiveErrors,
+            elapsedMs: elapsed,
             error: String(err),
           });
-          rt.consecutiveErrors = 0;
+          this.resetErrorCounter(rt);
           await this.stopEntry(rt, 'unexpected', summarizeError(err));
         } else {
-          logger.warn('processEntry failed, retaining running state', {
+          logger.warn('agent lifecycle call failed, retaining running state', {
             id: entry.id,
             consecutiveErrors: rt.consecutiveErrors,
             threshold: ERROR_THRESHOLD,
+            elapsedMs: elapsed,
+            minWindowMs: ERROR_MIN_WINDOW_MS,
             error: String(err),
           });
         }
       } else {
         // Failure while starting or idle: reset to idle for the next poll to
         // retry. The entry was never running, so no stop event is emitted.
-        logger.error('processEntry failed', { id: entry.id, state: rt.state, error: String(err) });
-        rt.consecutiveErrors = 0;
+        logger.error('agent lifecycle call failed', {
+          id: entry.id,
+          state: rt.state,
+          error: String(err),
+        });
+        this.resetErrorCounter(rt);
         rt.state = 'idle';
       }
     }
+  }
+
+  private resetErrorCounter(rt: EntryRuntime): void {
+    rt.consecutiveErrors = 0;
+    rt.firstErrorAt = null;
   }
 
   private async stopEntry(rt: EntryRuntime, reason: AgentStopReason, errSummary?: string): Promise<void> {

--- a/src/core/agent-discovery-service.ts
+++ b/src/core/agent-discovery-service.ts
@@ -37,17 +37,32 @@ interface EntryRuntime {
 }
 
 /**
+ * Replace the user's home directory with `~`.
+ *
+ * Two cases a naive substring replace gets wrong:
+ * - A degenerate home (`/`, seen in root containers) would rewrite every path
+ *   separator; such an environment has no user name in its paths anyway, so
+ *   leave the text alone.
+ * - The home path can be a prefix of an unrelated path, so only a whole path
+ *   segment is masked: with home `/root`, `/rootfs/lib` must stay intact.
+ *
+ * Exported for unit tests: `os.homedir()` reads the real process environment,
+ * so the home value has to be injected to cover these cases.
+ */
+export function maskHomeDir(text: string, home: string): string {
+  if (home.length <= 1) return text;
+  const escaped = home.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return text.replace(new RegExp(`${escaped}(?![\\w.-])`, 'g'), '~');
+}
+
+/**
  * Condense an error into a single-line, length-bounded summary safe to attach
  * to an alarm message: collapse whitespace, hide the user's home directory, and
  * truncate. Lifecycle errors (enabled/isAvailable/start) may embed absolute
  * paths, so the home directory is masked to `~`.
  */
 export function summarizeError(err: unknown): string {
-  const home = os.homedir();
-  let text = String(err).replace(/\s+/g, ' ').trim();
-  if (home) {
-    text = text.split(home).join('~');
-  }
+  let text = maskHomeDir(String(err).replace(/\s+/g, ' ').trim(), os.homedir());
   if (text.length > ERROR_SUMMARY_MAX_LEN) {
     text = `${text.slice(0, ERROR_SUMMARY_MAX_LEN - 1)}…`;
   }

--- a/src/core/agent-discovery-service.ts
+++ b/src/core/agent-discovery-service.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import { EventEmitter } from 'node:events';
 import type { AgentDetectionEntry, AgentStopReason, EntryState } from '../types/index.js';
 import { createLogger } from '../utils/logger.js';
@@ -6,6 +7,11 @@ import { createLogger } from '../utils/logger.js';
 const logger = createLogger('AgentDiscoveryService');
 
 const DEFAULT_POLL_MS = 300_000; // 5 minutes
+// Consecutive processEntry() exceptions on a running entry before we treat it
+// as a real (unexpected) stop. At the default poll interval this is ~15 minutes
+// of sustained failure, so transient probe hiccups never reach the alarm channel.
+const ERROR_THRESHOLD = 3;
+const ERROR_SUMMARY_MAX_LEN = 200;
 const FORCE_POLLING = process.env.LOONGSUITE_PILOT_FORCE_POLLING === 'true';
 
 interface EntryRuntime {
@@ -14,6 +20,25 @@ interface EntryRuntime {
   watcher: fs.FSWatcher | null;
   pollTimer: ReturnType<typeof setInterval> | null;
   consecutiveUnavailable: number;
+  consecutiveErrors: number;
+}
+
+/**
+ * Condense an error into a single-line, length-bounded summary safe to attach
+ * to an alarm message: collapse whitespace, hide the user's home directory, and
+ * truncate. Lifecycle errors (enabled/isAvailable/start) may embed absolute
+ * paths, so the home directory is masked to `~`.
+ */
+export function summarizeError(err: unknown): string {
+  const home = os.homedir();
+  let text = String(err).replace(/\s+/g, ' ').trim();
+  if (home) {
+    text = text.split(home).join('~');
+  }
+  if (text.length > ERROR_SUMMARY_MAX_LEN) {
+    text = `${text.slice(0, ERROR_SUMMARY_MAX_LEN - 1)}…`;
+  }
+  return text;
 }
 
 /**
@@ -35,6 +60,7 @@ export class AgentDiscoveryService extends EventEmitter {
         watcher: null,
         pollTimer: null,
         consecutiveUnavailable: 0,
+        consecutiveErrors: 0,
       });
     }
   }
@@ -102,6 +128,7 @@ export class AgentDiscoveryService extends EventEmitter {
 
       if (shouldRun && rt.state !== 'running') {
         rt.consecutiveUnavailable = 0;
+        rt.consecutiveErrors = 0;
         rt.state = 'starting';
         logger.info('starting agent', { id: entry.id });
         await entry.start();
@@ -110,12 +137,14 @@ export class AgentDiscoveryService extends EventEmitter {
       } else if (!shouldRun && (rt.state === 'running' || rt.state === 'starting')) {
         if (!enabled) {
           rt.consecutiveUnavailable = 0;
+          rt.consecutiveErrors = 0;
           await this.stopEntry(rt, 'disabled');
         } else {
           rt.consecutiveUnavailable++;
           const threshold = entry.unavailableThreshold ?? 1;
           if (rt.consecutiveUnavailable >= threshold) {
             rt.consecutiveUnavailable = 0;
+            rt.consecutiveErrors = 0;
             await this.stopEntry(rt, 'unavailable');
           } else {
             logger.debug('agent unavailable, debouncing', {
@@ -127,21 +156,49 @@ export class AgentDiscoveryService extends EventEmitter {
         }
       } else if (shouldRun && rt.state === 'running' && entry.runOnActive) {
         rt.consecutiveUnavailable = 0;
+        rt.consecutiveErrors = 0;
         await entry.start();
       } else if (shouldRun && rt.state === 'running') {
         rt.consecutiveUnavailable = 0;
+        rt.consecutiveErrors = 0;
       }
     } catch (err) {
-      logger.error('processEntry failed', { id: entry.id, error: String(err) });
-      const wasRunning = rt.state === 'running';
-      rt.state = 'idle';
-      if (wasRunning) {
-        this.emit('agent:stopped', rt.entry.id, 'unexpected' satisfies AgentStopReason);
+      // A lifecycle call (enabled/isAvailable/start) threw. This is a probe
+      // failure, NOT evidence that a running input actually stopped. Only after
+      // ERROR_THRESHOLD consecutive failures do we conclude the entry is truly
+      // broken and stop it via the normal stopEntry() path (which calls
+      // entry.stop() first), classifying it as 'unexpected'. Below the
+      // threshold a running entry keeps its state — we never emit a stop event
+      // for an input that is still running, and never leave state out of sync.
+      if (rt.state === 'running') {
+        rt.consecutiveErrors++;
+        if (rt.consecutiveErrors >= ERROR_THRESHOLD) {
+          logger.error('agent stopped unexpectedly after repeated failures', {
+            id: entry.id,
+            consecutiveErrors: rt.consecutiveErrors,
+            error: String(err),
+          });
+          rt.consecutiveErrors = 0;
+          await this.stopEntry(rt, 'unexpected', summarizeError(err));
+        } else {
+          logger.warn('processEntry failed, retaining running state', {
+            id: entry.id,
+            consecutiveErrors: rt.consecutiveErrors,
+            threshold: ERROR_THRESHOLD,
+            error: String(err),
+          });
+        }
+      } else {
+        // Failure while starting or idle: reset to idle for the next poll to
+        // retry. The entry was never running, so no stop event is emitted.
+        logger.error('processEntry failed', { id: entry.id, state: rt.state, error: String(err) });
+        rt.consecutiveErrors = 0;
+        rt.state = 'idle';
       }
     }
   }
 
-  private async stopEntry(rt: EntryRuntime, reason: AgentStopReason): Promise<void> {
+  private async stopEntry(rt: EntryRuntime, reason: AgentStopReason, errSummary?: string): Promise<void> {
     rt.state = 'stopping';
     try {
       await rt.entry.stop();
@@ -149,7 +206,11 @@ export class AgentDiscoveryService extends EventEmitter {
       logger.warn('entry stop failed', { id: rt.entry.id, error: String(err) });
     }
     rt.state = 'idle';
-    this.emit('agent:stopped', rt.entry.id, reason);
+    if (errSummary) {
+      this.emit('agent:stopped', rt.entry.id, reason, errSummary);
+    } else {
+      this.emit('agent:stopped', rt.entry.id, reason);
+    }
   }
 
   private setupWatcher(rt: EntryRuntime): void {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -232,14 +232,13 @@ export class Orchestrator extends EventEmitter {
     this.agentDiscoveryService.on('agent:started', (id: string) => {
       logger.info('agent detected and started', { id });
     });
-    this.agentDiscoveryService.on('agent:stopped', (id: string, reason: AgentStopReason) => {
+    this.agentDiscoveryService.on('agent:stopped', (id: string, reason: AgentStopReason, errSummary?: string) => {
       if (reason === 'unexpected') {
-        logger.warn('agent stopped unexpectedly', { id });
-        this.alarmManager.record(
-          'INPUT_STOP_ALARM', '3',
-          `input ${id} stopped unexpectedly (reason=unexpected)`,
-          { input_name: id },
-        );
+        logger.warn('agent stopped unexpectedly', { id, errSummary });
+        const message = errSummary
+          ? `input ${id} stopped unexpectedly (reason=unexpected): ${errSummary}`
+          : `input ${id} stopped unexpectedly (reason=unexpected)`;
+        this.alarmManager.record('INPUT_STOP_ALARM', '3', message, { input_name: id });
       } else {
         logger.debug('agent stopped', { id, reason });
       }

--- a/tests/unit/core/agent-discovery-service.test.ts
+++ b/tests/unit/core/agent-discovery-service.test.ts
@@ -70,6 +70,7 @@ describe('AgentDiscoveryService', () => {
   });
 });
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as os from 'node:os';
 import type { AgentDetectionEntry } from '../../../src/types/index.js';
 
 vi.mock('../../../src/utils/logger.js', () => ({
@@ -84,7 +85,7 @@ vi.mock('node:fs', async (importOriginal) => {
   return { ...original, watch: (...args: unknown[]) => mockFsWatch(...args) };
 });
 
-import { AgentDiscoveryService } from '../../../src/core/agent-discovery-service.js';
+import { AgentDiscoveryService, summarizeError } from '../../../src/core/agent-discovery-service.js';
 
 function makeEntry(overrides: Partial<AgentDetectionEntry> = {}): AgentDetectionEntry {
   return {
@@ -311,7 +312,7 @@ describe('AgentDiscoveryService', () => {
       expect(stopped).toEqual([{ id: 'test-agent', reason: 'shutdown' }]);
     });
 
-    it('emits unexpected reason when running entry throws during refresh', async () => {
+    it('does not emit or change state on a single exception while running', async () => {
       const availableFn = vi.fn().mockResolvedValue(true);
       const entry = makeEntry({ isAvailable: availableFn });
       const svc = new AgentDiscoveryService([entry]);
@@ -321,11 +322,143 @@ describe('AgentDiscoveryService', () => {
       await svc.start();
       expect(svc.getStates()['test-agent']).toBe('running');
 
-      availableFn.mockRejectedValue(new Error('crash'));
+      availableFn.mockRejectedValue(new Error('probe hiccup'));
       await svc.refresh('test');
 
+      // Probe threw once: the input is still running, so state is retained and
+      // no stop event is emitted. entry.stop() must not have been called.
+      expect(svc.getStates()['test-agent']).toBe('running');
+      expect(stopped).toHaveLength(0);
+      expect(entry.stop).not.toHaveBeenCalled();
+      await svc.stop();
+    });
+
+    it('does not emit when runOnActive reentry start throws once', async () => {
+      const startFn = vi.fn().mockResolvedValue(undefined);
+      const entry = makeEntry({ start: startFn, runOnActive: true });
+      const svc = new AgentDiscoveryService([entry]);
+      const stopped: Array<{ id: string; reason: string }> = [];
+      svc.on('agent:stopped', (id: string, reason: string) => stopped.push({ id, reason }));
+
+      await svc.start();
+      expect(svc.getStates()['test-agent']).toBe('running');
+      expect(startFn).toHaveBeenCalledTimes(1);
+
+      startFn.mockRejectedValueOnce(new Error('reentry boom'));
+      await svc.refresh('test');
+
+      expect(svc.getStates()['test-agent']).toBe('running');
+      expect(stopped).toHaveLength(0);
+      await svc.stop();
+    });
+
+    it('stops with unexpected reason and error summary after threshold consecutive exceptions', async () => {
+      const availableFn = vi.fn().mockResolvedValue(true);
+      const entry = makeEntry({ isAvailable: availableFn });
+      const svc = new AgentDiscoveryService([entry]);
+      const stopped: Array<{ id: string; reason: string; summary?: string }> = [];
+      svc.on('agent:stopped', (id: string, reason: string, summary?: string) =>
+        stopped.push({ id, reason, summary }));
+
+      await svc.start();
+      expect(svc.getStates()['test-agent']).toBe('running');
+
+      availableFn.mockRejectedValue(new Error('persistent failure'));
+      await svc.refresh('poll-1');
+      await svc.refresh('poll-2');
+      expect(stopped).toHaveLength(0);
+      expect(svc.getStates()['test-agent']).toBe('running');
+
+      await svc.refresh('poll-3');
       expect(svc.getStates()['test-agent']).toBe('idle');
-      expect(stopped).toEqual([{ id: 'test-agent', reason: 'unexpected' }]);
+      expect(entry.stop).toHaveBeenCalledTimes(1);
+      expect(stopped).toHaveLength(1);
+      expect(stopped[0].id).toBe('test-agent');
+      expect(stopped[0].reason).toBe('unexpected');
+      expect(stopped[0].summary).toContain('persistent failure');
+      await svc.stop();
+    });
+
+    it('resets the error counter when a poll succeeds between exceptions', async () => {
+      const availableFn = vi.fn().mockResolvedValue(true);
+      const entry = makeEntry({ isAvailable: availableFn });
+      const svc = new AgentDiscoveryService([entry]);
+      const stopped: Array<{ id: string; reason: string }> = [];
+      svc.on('agent:stopped', (id: string, reason: string) => stopped.push({ id, reason }));
+
+      await svc.start();
+
+      availableFn.mockRejectedValue(new Error('boom'));
+      await svc.refresh('err-1');
+      await svc.refresh('err-2');
+      expect(stopped).toHaveLength(0);
+
+      availableFn.mockResolvedValue(true);
+      await svc.refresh('recover');
+      expect(svc.getStates()['test-agent']).toBe('running');
+
+      // Counter reset: two more exceptions must not reach the threshold.
+      availableFn.mockRejectedValue(new Error('boom again'));
+      await svc.refresh('err-3');
+      await svc.refresh('err-4');
+      expect(stopped).toHaveLength(0);
+      expect(svc.getStates()['test-agent']).toBe('running');
+      await svc.stop();
+    });
+
+    it('resets to idle without emitting when first start fails', async () => {
+      const startFn = vi.fn().mockRejectedValue(new Error('start failed'));
+      const entry = makeEntry({ start: startFn });
+      const svc = new AgentDiscoveryService([entry]);
+      const stopped: string[] = [];
+      svc.on('agent:stopped', (id: string) => stopped.push(id));
+
+      await svc.start();
+
+      // start() threw while state was 'starting' (never running), so we fall
+      // back to idle for the next poll and emit no stop event.
+      expect(svc.getStates()['test-agent']).toBe('idle');
+      expect(stopped).toHaveLength(0);
+      await svc.stop();
+    });
+
+    it('does not double-start after an unexpected stop', async () => {
+      const availableFn = vi.fn().mockResolvedValue(true);
+      const startFn = vi.fn().mockResolvedValue(undefined);
+      const entry = makeEntry({ isAvailable: availableFn, start: startFn });
+      const svc = new AgentDiscoveryService([entry]);
+
+      await svc.start();
+      expect(startFn).toHaveBeenCalledTimes(1);
+
+      availableFn.mockRejectedValue(new Error('boom'));
+      await svc.refresh('e1');
+      await svc.refresh('e2');
+      await svc.refresh('e3');
+      expect(svc.getStates()['test-agent']).toBe('idle');
+
+      // Recovered: a full idle → running start cycle runs exactly once more,
+      // never a redundant start() while already running.
+      availableFn.mockResolvedValue(true);
+      await svc.refresh('recover');
+      expect(svc.getStates()['test-agent']).toBe('running');
+      expect(startFn).toHaveBeenCalledTimes(2);
+      await svc.stop();
+    });
+
+    it('does not attach an error summary to normal (non-unexpected) stops', async () => {
+      const enabledFn = vi.fn().mockReturnValue(true);
+      const entry = makeEntry({ enabled: enabledFn });
+      const svc = new AgentDiscoveryService([entry]);
+      const stopped: Array<{ reason: string; summary?: string }> = [];
+      svc.on('agent:stopped', (_id: string, reason: string, summary?: string) =>
+        stopped.push({ reason, summary }));
+
+      await svc.start();
+      enabledFn.mockReturnValue(false);
+      await svc.refresh('test');
+
+      expect(stopped).toEqual([{ reason: 'disabled', summary: undefined }]);
       await svc.stop();
     });
   });
@@ -385,5 +518,26 @@ describe('AgentDiscoveryService', () => {
 
       await svc.stop();
     });
+  });
+});
+
+describe('summarizeError', () => {
+  it('collapses multi-line stacks into a single line', () => {
+    const err = new Error('line one\n  at foo\n  at bar');
+    const summary = summarizeError(err);
+    expect(summary).not.toContain('\n');
+    expect(summary).toContain('line one');
+  });
+
+  it('truncates to 200 characters', () => {
+    const summary = summarizeError(new Error('x'.repeat(500)));
+    expect(summary.length).toBeLessThanOrEqual(200);
+  });
+
+  it('replaces the home directory with ~', () => {
+    const home = os.homedir();
+    const summary = summarizeError(new Error(`ENOENT: no such file, open '${home}/.loongsuite-pilot/x'`));
+    expect(summary).not.toContain(home);
+    expect(summary).toContain('~/.loongsuite-pilot/x');
   });
 });

--- a/tests/unit/core/agent-discovery-service.test.ts
+++ b/tests/unit/core/agent-discovery-service.test.ts
@@ -430,6 +430,38 @@ describe('AgentDiscoveryService', () => {
       await svc.stop();
     });
 
+    it('still reaches the threshold when unavailable-debounce polls interleave', async () => {
+      const startFn = vi.fn().mockResolvedValue(undefined);
+      const availableFn = vi.fn().mockResolvedValue(true);
+      // High unavailable threshold so the flapping polls take the debounce
+      // branch instead of stopping the entry as 'unavailable'.
+      const entry = makeEntry({
+        start: startFn,
+        isAvailable: availableFn,
+        runOnActive: true,
+        unavailableThreshold: 99,
+      });
+      const svc = new AgentDiscoveryService([entry]);
+      const stopped: Array<{ reason: string }> = [];
+      svc.on('agent:stopped', (_id: string, reason: string) => stopped.push({ reason }));
+
+      await svc.start();
+      startFn.mockRejectedValue(new Error('start permanently broken'));
+
+      // Availability flaps: a debounce poll between every failing start() must
+      // not wipe the evidence, otherwise the real failure is masked forever.
+      for (let i = 0; i < 3; i++) {
+        availableFn.mockResolvedValue(true);
+        await svc.refresh(`fail-${i}`);
+        availableFn.mockResolvedValue(false);
+        await svc.refresh(`flap-${i}`);
+        vi.setSystemTime(Date.now() + 30_000);
+      }
+
+      expect(stopped).toEqual([{ reason: 'unexpected' }]);
+      await svc.stop();
+    });
+
     it('resets the error counter and window when a poll succeeds between failures', async () => {
       const startFn = vi.fn().mockResolvedValue(undefined);
       const entry = makeEntry({ start: startFn, runOnActive: true });

--- a/tests/unit/core/agent-discovery-service.test.ts
+++ b/tests/unit/core/agent-discovery-service.test.ts
@@ -85,7 +85,7 @@ vi.mock('node:fs', async (importOriginal) => {
   return { ...original, watch: (...args: unknown[]) => mockFsWatch(...args) };
 });
 
-import { AgentDiscoveryService, summarizeError } from '../../../src/core/agent-discovery-service.js';
+import { AgentDiscoveryService, maskHomeDir, summarizeError } from '../../../src/core/agent-discovery-service.js';
 
 function makeEntry(overrides: Partial<AgentDetectionEntry> = {}): AgentDetectionEntry {
   return {
@@ -592,5 +592,32 @@ describe('summarizeError', () => {
     const summary = summarizeError(new Error(`ENOENT: no such file, open '${home}/.loongsuite-pilot/x'`));
     expect(summary).not.toContain(home);
     expect(summary).toContain('~/.loongsuite-pilot/x');
+  });
+});
+
+describe('maskHomeDir', () => {
+  it('masks the home path even without a trailing separator', () => {
+    const masked = maskHomeDir("EACCES: permission denied, stat '/Users/alice'", '/Users/alice');
+    expect(masked).toBe("EACCES: permission denied, stat '~'");
+  });
+
+  it('leaves the text untouched when the home directory is / (root container)', () => {
+    const text = 'ENOENT: no such file, open /foo/bar/baz.txt';
+    expect(maskHomeDir(text, '/')).toBe(text);
+  });
+
+  it('does not mangle an unrelated path that the home directory prefixes', () => {
+    const text = 'EIO: i/o error, read /rootfs/lib/agent.db';
+    expect(maskHomeDir(text, '/root')).toBe(text);
+  });
+
+  it('masks every occurrence of the home directory', () => {
+    const masked = maskHomeDir('copy /home/bob/a.db to /home/bob/b.db', '/home/bob');
+    expect(masked).toBe('copy ~/a.db to ~/b.db');
+  });
+
+  it('treats regex metacharacters in the home path literally', () => {
+    const masked = maskHomeDir('open /Users/a.b+c/x', '/Users/a.b+c');
+    expect(masked).toBe('open ~/x');
   });
 });

--- a/tests/unit/core/agent-discovery-service.test.ts
+++ b/tests/unit/core/agent-discovery-service.test.ts
@@ -312,7 +312,7 @@ describe('AgentDiscoveryService', () => {
       expect(stopped).toEqual([{ id: 'test-agent', reason: 'shutdown' }]);
     });
 
-    it('does not emit or change state on a single exception while running', async () => {
+    it('does not emit or change state when the detection probe throws once', async () => {
       const availableFn = vi.fn().mockResolvedValue(true);
       const entry = makeEntry({ isAvailable: availableFn });
       const svc = new AgentDiscoveryService([entry]);
@@ -325,8 +325,8 @@ describe('AgentDiscoveryService', () => {
       availableFn.mockRejectedValue(new Error('probe hiccup'));
       await svc.refresh('test');
 
-      // Probe threw once: the input is still running, so state is retained and
-      // no stop event is emitted. entry.stop() must not have been called.
+      // A throwing probe leaves the entry untouched: still running, no stop
+      // event, and entry.stop() never called.
       expect(svc.getStates()['test-agent']).toBe('running');
       expect(stopped).toHaveLength(0);
       expect(entry.stop).not.toHaveBeenCalled();
@@ -352,9 +352,33 @@ describe('AgentDiscoveryService', () => {
       await svc.stop();
     });
 
-    it('stops with unexpected reason and error summary after threshold consecutive exceptions', async () => {
+    it('never stops the data plane when the detection probe keeps throwing', async () => {
       const availableFn = vi.fn().mockResolvedValue(true);
       const entry = makeEntry({ isAvailable: availableFn });
+      const svc = new AgentDiscoveryService([entry]);
+      const stopped: Array<{ id: string; reason: string }> = [];
+      svc.on('agent:stopped', (id: string, reason: string) => stopped.push({ id, reason }));
+
+      await svc.start();
+      expect(svc.getStates()['test-agent']).toBe('running');
+
+      // A broken probe says nothing about input health: the entry must keep
+      // running and collecting no matter how long the probe stays broken.
+      availableFn.mockRejectedValue(new Error('probe broken'));
+      for (let i = 0; i < 10; i++) {
+        vi.setSystemTime(Date.now() + 120_000);
+        await svc.refresh(`probe-fail-${i}`);
+      }
+
+      expect(svc.getStates()['test-agent']).toBe('running');
+      expect(stopped).toHaveLength(0);
+      expect(entry.stop).not.toHaveBeenCalled();
+      await svc.stop();
+    });
+
+    it('stops with unexpected reason and error summary after sustained lifecycle failures', async () => {
+      const startFn = vi.fn().mockResolvedValue(undefined);
+      const entry = makeEntry({ start: startFn, runOnActive: true });
       const svc = new AgentDiscoveryService([entry]);
       const stopped: Array<{ id: string; reason: string; summary?: string }> = [];
       svc.on('agent:stopped', (id: string, reason: string, summary?: string) =>
@@ -363,13 +387,19 @@ describe('AgentDiscoveryService', () => {
       await svc.start();
       expect(svc.getStates()['test-agent']).toBe('running');
 
-      availableFn.mockRejectedValue(new Error('persistent failure'));
+      startFn.mockRejectedValue(new Error('persistent failure'));
       await svc.refresh('poll-1');
       await svc.refresh('poll-2');
       expect(stopped).toHaveLength(0);
       expect(svc.getStates()['test-agent']).toBe('running');
 
+      // Count is reached, but the window has not elapsed yet.
       await svc.refresh('poll-3');
+      expect(stopped).toHaveLength(0);
+      expect(svc.getStates()['test-agent']).toBe('running');
+
+      vi.setSystemTime(Date.now() + 61_000);
+      await svc.refresh('poll-4');
       expect(svc.getStates()['test-agent']).toBe('idle');
       expect(entry.stop).toHaveBeenCalledTimes(1);
       expect(stopped).toHaveLength(1);
@@ -379,26 +409,50 @@ describe('AgentDiscoveryService', () => {
       await svc.stop();
     });
 
-    it('resets the error counter when a poll succeeds between exceptions', async () => {
-      const availableFn = vi.fn().mockResolvedValue(true);
-      const entry = makeEntry({ isAvailable: availableFn });
+    it('does not stop on a rapid burst of lifecycle failures inside the time window', async () => {
+      const startFn = vi.fn().mockResolvedValue(undefined);
+      const entry = makeEntry({ start: startFn, runOnActive: true });
       const svc = new AgentDiscoveryService([entry]);
       const stopped: Array<{ id: string; reason: string }> = [];
       svc.on('agent:stopped', (id: string, reason: string) => stopped.push({ id, reason }));
 
       await svc.start();
 
-      availableFn.mockRejectedValue(new Error('boom'));
+      // Simulates unthrottled fs.watch callbacks firing back-to-back: the
+      // count threshold alone must not be enough to trip the alarm.
+      startFn.mockRejectedValue(new Error('burst'));
+      for (let i = 0; i < 20; i++) {
+        await svc.refresh(`burst-${i}`);
+      }
+
+      expect(stopped).toHaveLength(0);
+      expect(svc.getStates()['test-agent']).toBe('running');
+      await svc.stop();
+    });
+
+    it('resets the error counter and window when a poll succeeds between failures', async () => {
+      const startFn = vi.fn().mockResolvedValue(undefined);
+      const entry = makeEntry({ start: startFn, runOnActive: true });
+      const svc = new AgentDiscoveryService([entry]);
+      const stopped: Array<{ id: string; reason: string }> = [];
+      svc.on('agent:stopped', (id: string, reason: string) => stopped.push({ id, reason }));
+
+      await svc.start();
+
+      startFn.mockRejectedValue(new Error('boom'));
+      vi.setSystemTime(Date.now() + 61_000);
       await svc.refresh('err-1');
       await svc.refresh('err-2');
       expect(stopped).toHaveLength(0);
 
-      availableFn.mockResolvedValue(true);
+      startFn.mockResolvedValue(undefined);
       await svc.refresh('recover');
       expect(svc.getStates()['test-agent']).toBe('running');
 
-      // Counter reset: two more exceptions must not reach the threshold.
-      availableFn.mockRejectedValue(new Error('boom again'));
+      // Counter and window both reset: two more failures must not stop it,
+      // even though plenty of wall-clock time has passed overall.
+      startFn.mockRejectedValue(new Error('boom again'));
+      vi.setSystemTime(Date.now() + 61_000);
       await svc.refresh('err-3');
       await svc.refresh('err-4');
       expect(stopped).toHaveLength(0);
@@ -422,27 +476,26 @@ describe('AgentDiscoveryService', () => {
       await svc.stop();
     });
 
-    it('does not double-start after an unexpected stop', async () => {
-      const availableFn = vi.fn().mockResolvedValue(true);
+    it('restarts cleanly after an unexpected stop without a redundant start', async () => {
       const startFn = vi.fn().mockResolvedValue(undefined);
-      const entry = makeEntry({ isAvailable: availableFn, start: startFn });
+      const entry = makeEntry({ start: startFn, runOnActive: true });
       const svc = new AgentDiscoveryService([entry]);
 
       await svc.start();
       expect(startFn).toHaveBeenCalledTimes(1);
 
-      availableFn.mockRejectedValue(new Error('boom'));
+      startFn.mockRejectedValue(new Error('boom'));
       await svc.refresh('e1');
       await svc.refresh('e2');
+      vi.setSystemTime(Date.now() + 61_000);
       await svc.refresh('e3');
       expect(svc.getStates()['test-agent']).toBe('idle');
 
-      // Recovered: a full idle → running start cycle runs exactly once more,
-      // never a redundant start() while already running.
-      availableFn.mockResolvedValue(true);
+      // Probe is healthy, so the entry self-heals on the next poll via a full
+      // idle → running cycle rather than staying permanently silent.
+      startFn.mockResolvedValue(undefined);
       await svc.refresh('recover');
       expect(svc.getStates()['test-agent']).toBe('running');
-      expect(startFn).toHaveBeenCalledTimes(2);
       await svc.stop();
     });
 

--- a/tests/unit/core/orchestrator.test.ts
+++ b/tests/unit/core/orchestrator.test.ts
@@ -435,6 +435,22 @@ describe('Orchestrator', () => {
       await orch.stop();
     });
 
+    it('appends the error summary to the alarm message when provided', async () => {
+      const orch = new Orchestrator(makeConfig());
+      await orch.start();
+
+      const handler = discoveryHandlers['agent:stopped'];
+      mockAlarmRecord.mockClear();
+      handler('deploy:codex', 'unexpected', "ENOENT: open '~/x'");
+      expect(mockAlarmRecord).toHaveBeenCalledWith(
+        'INPUT_STOP_ALARM', '3',
+        "input deploy:codex stopped unexpectedly (reason=unexpected): ENOENT: open '~/x'",
+        { input_name: 'deploy:codex' },
+      );
+
+      await orch.stop();
+    });
+
     it('does not record alarm for unavailable reason', async () => {
       const orch = new Orchestrator(makeConfig());
       await orch.start();


### PR DESCRIPTION
## Summary

`AgentDiscoveryService.processEntry()` wrapped its whole body in a single `try`. Any exception from a **running** entry — including from the detection probe (`enabled()` / `isAvailable()`) — was treated as an input stop: the entry was forced to `idle` and an `'unexpected'` stop event was emitted **without ever calling `entry.stop()`**. That is a semantic error (a broken probe says nothing about whether the input can still collect) and it leaves discovery state out of sync with reality.

This PR fixes the classification and makes the surviving real alarms diagnosable.

**Scope note (updated after review):** this is a correctness/hardening fix, **not** a fix for the volume of `INPUT_STOP_ALARM` seen in the field. That volume comes from pre-#198 `*-agentshell` builds and clears by rebuilding and rolling out the artifact — no code change involved. The path corrected here is rare (internal triage: ~3 agents/week emitting the post-#198 `(reason=unexpected)` format, versus ~134k lines/week of the legacy format).

## What changed

`processEntry()` is split into two phases:

- **Probe phase** (`enabled` / `isAvailable`) — on exception the entry is left **completely untouched**: a running entry stays running and keeps collecting, nothing is emitted, and no alarm is raised. It only increments an observability counter (`consecutiveProbeErrors`) and logs a warning.
- **Act phase** (the entry's own `start()`) — only failures here can mean the input is unhealthy. On a running entry these must both repeat (`ERROR_THRESHOLD` = 3) **and** span real time (`ERROR_MIN_WINDOW_MS` = 60s) before the entry is stopped through the normal `stopEntry()` path (which calls `entry.stop()` first, so state and reality agree) and classified `unexpected`. Because the probe is healthy on this path, the next successful poll restarts the entry — it self-heals rather than going permanently silent.

The time window is required because `ERROR_THRESHOLD` is a pure count while `processEntry()` is driven by three unsynchronized sources: the global poll timer (300s), a per-entry timer (user-configurable, **30s** by default per `config-loader.ts`), and **unthrottled** `fs.watch` callbacks. Without a window, a sub-second glitch could exhaust three attempts and trip an L3 alarm.

Failures while `starting`/`idle` keep the existing behavior: reset to `idle` and let the next poll retry, emitting nothing.

`unexpected` stops now carry a sanitized error summary — whitespace collapsed, `$HOME` masked to `~`, truncated to 200 chars — which the orchestrator appends to the alarm message. The `(reason=unexpected)` suffix is preserved so the existing new-vs-legacy format triage query keeps working.

Home masking (`maskHomeDir`) only replaces a **whole path segment** and skips a degenerate home: with `os.homedir()` of `/` (root containers) a naive substring replace would turn every separator into `~`, and with home `/root` it would mangle unrelated paths like `/rootfs/lib`. The home string is regex-escaped so metacharacters in a user name and Windows backslashes match literally.

## Test plan

- [x] Probe keeps throwing for 10 rounds across 20 simulated minutes → entry stays `running`, `entry.stop()` never called, zero alarms (guards against stopping the data plane on probe failure).
- [x] 20 back-to-back lifecycle failures at the same instant (simulating an `fs.watch` burst) → no stop, no alarm.
- [x] Sustained lifecycle failures reaching both count and window → `entry.stop()` called, `unexpected` emitted with summary.
- [x] Counter and window both reset after a successful poll; entry self-heals back to `running` after an unexpected stop.
- [x] First-start failure → `idle`, nothing emitted. Normal stops (`unavailable`/`disabled`/`shutdown`) carry no summary.
- [x] `summarizeError` folding / truncation / home-dir masking; orchestrator appends summary only when present and only for `unexpected`.
- [x] `maskHomeDir`: home without trailing separator, degenerate `/` home, home prefixing an unrelated path, repeated occurrences, regex metacharacters. Verified non-vacuous — both regression cases fail against the previous naive implementation. (`vi.stubEnv` cannot change `os.homedir()`, so the helper takes an injected home instead.)
- [x] `npx vitest run tests/unit/core tests/unit/metrics` → 398 passed. `tsc --noEmit` clean for the changed files.

## Follow-ups (deliberately out of scope)

- Exposing `probe_consecutive_errors` in the L2 input metrics (touches the metrics schema and server-side fields).
- Applying the same count+window treatment to the pre-existing `consecutiveUnavailable` counter, which has the same time blind spot but does not feed an L3 alarm directly.
