### PR TITLE
fix(codex): drop copied history prefix in forked rollouts

### DIFF
--- a/agents.d/codex.json
+++ b/agents.d/codex.json
@@ -8,7 +8,7 @@
   },
   "hook": {
     "settingsPath": "~/.codex/hooks.json",
-    "events": ["SessionStart", "UserPromptSubmit", "Stop"],
+    "events": ["SessionStart", "UserPromptSubmit", "SubagentStart", "SubagentStop", "Stop"],
     "retiredEvents": ["PreToolUse", "PostToolUse", "PostToolUseFailure"],
     "hookCommand": "$PILOT_DATA/hooks/codex-loongsuite-pilot-hook.sh",
     "format": "nested",

--- a/assets/hooks/codex-hook-processor.mjs
+++ b/assets/hooks/codex-hook-processor.mjs
@@ -116,7 +116,7 @@ function writeTurnSpanContext(input) {
   });
 }
 
-function writeWakeupMarker(input) {
+function writeWakeupMarker(input, hookEvent) {
   const sessionId = typeof input.session_id === 'string' ? input.session_id : '';
   if (!sessionId) return;
   const configuredCodexHome = typeof process.env.CODEX_HOME === 'string'
@@ -128,12 +128,31 @@ function writeWakeupMarker(input) {
   recordUpstreamContextOnce({ agentId: AGENT_ID, sessionId, dataDir: pilotDataDir() });
 
   const directory = path.join(pilotDataDir(), 'state', 'codex', 'transcript-wakeups');
+  const marker = path.join(directory, `${safePathPart(sessionId)}.json`);
+  let initialTurnId = '';
+  try {
+    const existing = JSON.parse(fs.readFileSync(marker, 'utf8'));
+    if (existing && typeof existing.initial_turn_id === 'string') {
+      initialTurnId = existing.initial_turn_id;
+    }
+  } catch {
+    // The first Hook for a session has no existing marker.
+  }
+  if (
+    !initialTurnId
+    && (hookEvent === 'user-prompt-submit' || hookEvent === 'subagent-start')
+    && typeof input.turn_id === 'string'
+  ) {
+    initialTurnId = input.turn_id;
+  }
   const payload = {
     session_id: sessionId,
     ...(typeof input.turn_id === 'string' && input.turn_id ? { turn_id: input.turn_id } : {}),
+    ...(initialTurnId ? { initial_turn_id: initialTurnId } : {}),
     ...(typeof input.transcript_path === 'string' && input.transcript_path
       ? { transcript_path: input.transcript_path }
       : {}),
+    hook_event: hookEvent,
     codex_home: codexHome,
     session_dir: path.join(codexHome, 'sessions'),
     ...RESOURCE_ATTRIBUTE_FIELDS,
@@ -147,21 +166,43 @@ function writeWakeupMarker(input) {
   });
 }
 
+function normalizedHookInput(input, subcommand) {
+  if (subcommand !== 'subagent-start' && subcommand !== 'subagent-stop') return input;
+  const childSessionId = typeof input.agent_id === 'string' ? input.agent_id : '';
+  const childTranscriptPath = subcommand === 'subagent-stop'
+    ? input.agent_transcript_path
+    : input.transcript_path;
+  return {
+    ...input,
+    session_id: childSessionId,
+    ...(typeof childTranscriptPath === 'string' && childTranscriptPath
+      ? { transcript_path: childTranscriptPath }
+      : {}),
+  };
+}
+
 function main() {
   const subcommand = (process.argv[2] || '').trim();
   try {
     if (
       subcommand === 'session-start'
       || subcommand === 'user-prompt-submit'
+      || subcommand === 'subagent-start'
+      || subcommand === 'subagent-stop'
       || subcommand === 'stop'
     ) {
-      const input = tryReadStdin();
-      if (subcommand === 'user-prompt-submit' || subcommand === 'stop') {
+      const input = normalizedHookInput(tryReadStdin(), subcommand);
+      if (
+        subcommand === 'user-prompt-submit'
+        || subcommand === 'subagent-start'
+        || subcommand === 'subagent-stop'
+        || subcommand === 'stop'
+      ) {
         // Persist invocation attributes before publishing the wakeup so the
         // asynchronous transcript reader cannot observe the turn first.
         writeTurnSpanContext(input);
       }
-      writeWakeupMarker(input);
+      writeWakeupMarker(input, subcommand);
     }
   } finally {
     process.stdout.write('{}\n');

--- a/assets/hooks/codex-hook-processor.mjs
+++ b/assets/hooks/codex-hook-processor.mjs
@@ -130,25 +130,41 @@ function writeWakeupMarker(input, hookEvent) {
   const directory = path.join(pilotDataDir(), 'state', 'codex', 'transcript-wakeups');
   const marker = path.join(directory, `${safePathPart(sessionId)}.json`);
   let initialTurnId = '';
+  let recoveryTurnId = '';
   try {
     const existing = JSON.parse(fs.readFileSync(marker, 'utf8'));
     if (existing && typeof existing.initial_turn_id === 'string') {
       initialTurnId = existing.initial_turn_id;
+    }
+    if (existing && typeof existing.recovery_turn_id === 'string') {
+      recoveryTurnId = existing.recovery_turn_id;
     }
   } catch {
     // The first Hook for a session has no existing marker.
   }
   if (
     !initialTurnId
+    && !recoveryTurnId
     && (hookEvent === 'user-prompt-submit' || hookEvent === 'subagent-start')
     && typeof input.turn_id === 'string'
   ) {
     initialTurnId = input.turn_id;
   }
+  if (
+    (hookEvent === 'stop' || hookEvent === 'subagent-stop')
+    && typeof input.turn_id === 'string'
+    && input.turn_id
+  ) {
+    // A terminal Hook proves this turn belongs to the rollout, but it may be a
+    // later turn when the corresponding Start Hook was missed. Keep it as
+    // recovery evidence rather than overwriting the exact initial anchor.
+    recoveryTurnId = input.turn_id;
+  }
   const payload = {
     session_id: sessionId,
     ...(typeof input.turn_id === 'string' && input.turn_id ? { turn_id: input.turn_id } : {}),
     ...(initialTurnId ? { initial_turn_id: initialTurnId } : {}),
+    ...(recoveryTurnId ? { recovery_turn_id: recoveryTurnId } : {}),
     ...(typeof input.transcript_path === 'string' && input.transcript_path
       ? { transcript_path: input.transcript_path }
       : {}),

--- a/assets/hooks/codex-loongsuite-pilot-hook.sh
+++ b/assets/hooks/codex-loongsuite-pilot-hook.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 #   $PILOT_DATA/hooks/codex-loongsuite-pilot-hook.sh <subcommand>
 #
 # Subcommand 与 Codex hook event 一一对应:
-#   session-start / user-prompt-submit / pre-tool-use / post-tool-use / stop
+#   session-start / user-prompt-submit / subagent-start / subagent-stop / stop
 #
 # Fail-open 原则: 任何错误都输出 "{}" 并 exit 0,不阻塞宿主 agent。
 

--- a/assets/skills/loongsuite-pilot-ops/references/codex-diagnostics.md
+++ b/assets/skills/loongsuite-pilot-ops/references/codex-diagnostics.md
@@ -36,7 +36,7 @@ codex                    # 启动 TUI
 
 或者：如果存在任何 `Untrusted` / `Modified` hook，**`codex` 启动时会自动弹出 "Hooks need review" 对话框**——这是最常见的发现入口，无需手工查询。
 
-我们的 5 个 hook（`SessionStart` / `UserPromptSubmit` / `PreToolUse` / `PostToolUse` / `Stop`）应当全部为 **`Trusted`** 或 **`Managed`**。
+我们的 5 个 hook（`SessionStart` / `UserPromptSubmit` / `SubagentStart` / `SubagentStop` / `Stop`）应当全部为 **`Trusted`** 或 **`Managed`**。
 
 | 状态 | 含义 | 处理 |
 |------|------|------|

--- a/src/deployment/codex-trust-writer.ts
+++ b/src/deployment/codex-trust-writer.ts
@@ -232,7 +232,6 @@ export interface InstalledTrustOpts {
   hooksJsonAbsPath: string;
   locations: Record<string, InstalledCodexHookLocation>;
   marker: string;
-  forceBypass?: boolean;
 }
 
 interface LegacyTrustOpts {
@@ -242,7 +241,6 @@ interface LegacyTrustOpts {
   eventToCommand: Record<string, string>;
   eventToGroupIndex: Record<string, number>;
   marker: string;
-  forceBypass?: boolean;
 }
 
 type TrustOpts = InstalledTrustOpts | LegacyTrustOpts;
@@ -268,7 +266,6 @@ function normalizeTrustOpts(opts: TrustOpts): InstalledTrustOpts {
     hooksJsonAbsPath: opts.hooksJsonAbsPath,
     locations,
     marker: opts.marker,
-    ...(opts.forceBypass !== undefined ? { forceBypass: opts.forceBypass } : {}),
   };
 }
 
@@ -292,11 +289,11 @@ export function verifyTrustHashes(rawOpts: TrustOpts): VerifyResult {
   const content = fs.readFileSync(opts.configPath, 'utf-8');
   const actual = new Map(parseTrustSections(content).map(section => [section.key, section.hash]));
   const mismatches: string[] = [];
-  const bypassPresent = /^\s*bypass_hook_trust\s*=\s*true\s*$/m.test(content);
-  if (opts.forceBypass && !bypassPresent) {
-    mismatches.push('missing bypass_hook_trust = true');
-  } else if (!opts.forceBypass && bypassPresent) {
-    mismatches.push('unexpected bypass_hook_trust = true');
+  // Pilot briefly wrote this as an emergency bypass, but Codex only supports
+  // bypassing trust via the per-invocation --dangerously-bypass-hook-trust flag.
+  // Treat the unsupported legacy field as repairable state so deployment removes it.
+  if (/^\s*bypass_hook_trust\s*=/m.test(content)) {
+    mismatches.push('unsupported config field bypass_hook_trust');
   }
   for (const [key, hash] of expectedTrustState(opts)) {
     const current = actual.get(key);
@@ -341,7 +338,6 @@ export function writeTrustedHashes(rawOpts: TrustOpts): boolean {
   content = removeExactTrustSections(content, exactKeys);
 
   const lines: string[] = [begin];
-  if (opts.forceBypass) lines.push('bypass_hook_trust = true', '');
   for (const [key, hash] of expected) {
     lines.push(`[hooks.state.${encodeTomlBasicString(key)}]`);
     const enabled = enabledByKey.get(key);
@@ -376,7 +372,7 @@ export function removeTrustBlock(
   return true;
 }
 
-/** Remove exact position-based trust entries without touching the active block markers or bypass. */
+/** Remove exact position-based trust entries without touching the active block markers. */
 export function removeTrustStateKeys(
   configPath: string,
   ownedHookStateKeys: readonly string[],

--- a/src/deployment/codex-trust-writer.ts
+++ b/src/deployment/codex-trust-writer.ts
@@ -292,7 +292,10 @@ export function verifyTrustHashes(rawOpts: TrustOpts): VerifyResult {
   const content = fs.readFileSync(opts.configPath, 'utf-8');
   const actual = new Map(parseTrustSections(content).map(section => [section.key, section.hash]));
   const mismatches: string[] = [];
-  if (!opts.forceBypass && /^\s*bypass_hook_trust\s*=\s*true\s*$/m.test(content)) {
+  const bypassPresent = /^\s*bypass_hook_trust\s*=\s*true\s*$/m.test(content);
+  if (opts.forceBypass && !bypassPresent) {
+    mismatches.push('missing bypass_hook_trust = true');
+  } else if (!opts.forceBypass && bypassPresent) {
     mismatches.push('unexpected bypass_hook_trust = true');
   }
   for (const [key, hash] of expectedTrustState(opts)) {
@@ -313,7 +316,7 @@ export function writeTrustedHashes(rawOpts: TrustOpts): boolean {
   const existing = fs.existsSync(opts.configPath)
     ? fs.readFileSync(opts.configPath, 'utf-8')
     : '';
-  if (!opts.forceBypass && verifyTrustHashes(opts).valid) return false;
+  if (verifyTrustHashes(opts).valid) return false;
 
   const begin = `# BEGIN ${opts.marker} trust`;
   const end = `# END ${opts.marker} trust`;
@@ -353,24 +356,32 @@ export function writeTrustedHashes(rawOpts: TrustOpts): boolean {
 export function removeTrustBlock(
   configPath: string,
   marker: string,
-  _hooksJsonAbsPath?: string,
-  _hookEvents?: readonly string[],
+  ownedHookStateKeys: readonly string[] = [],
 ): boolean {
   if (!fs.existsSync(configPath)) return false;
   const before = fs.readFileSync(configPath, 'utf-8');
   const begin = `# BEGIN ${marker} trust`;
   const end = `# END ${marker} trust`;
-  const beginIndex = before.indexOf(begin);
-  const endIndex = before.indexOf(end, beginIndex + begin.length);
-  const owned = new Set<string>();
-  if (beginIndex !== -1 && endIndex !== -1) {
-    for (const section of parseTrustSections(before.slice(beginIndex, endIndex))) owned.add(section.key);
-  }
+  const owned = new Set(ownedHookStateKeys);
   let content = before.split('\n')
     .filter(line => line.trim() !== begin && line.trim() !== end)
     .filter(line => !/^\s*bypass_hook_trust\s*=/.test(line))
     .join('\n');
   content = removeExactTrustSections(content, owned).replace(/\n{3,}/g, '\n\n').trimEnd() + '\n';
+  if (content === before) return false;
+  fs.writeFileSync(configPath, content, 'utf-8');
+  return true;
+}
+
+/** Remove exact position-based trust entries without touching the active block markers or bypass. */
+export function removeTrustStateKeys(
+  configPath: string,
+  ownedHookStateKeys: readonly string[],
+): boolean {
+  if (!fs.existsSync(configPath) || ownedHookStateKeys.length === 0) return false;
+  const before = fs.readFileSync(configPath, 'utf-8');
+  const content = removeExactTrustSections(before, new Set(ownedHookStateKeys))
+    .replace(/\n{3,}/g, '\n\n');
   if (content === before) return false;
   fs.writeFileSync(configPath, content, 'utf-8');
   return true;

--- a/src/deployment/codex-trust-writer.ts
+++ b/src/deployment/codex-trust-writer.ts
@@ -327,7 +327,10 @@ export function writeTrustedHashes(rawOpts: TrustOpts): boolean {
   const exactKeys = new Set(expected.keys());
   const enabledByKey = new Map(
     parseTrustSections(existing)
-      .filter(section => exactKeys.has(section.key) && section.enabledLine)
+      .filter(section => (
+        section.enabledLine !== undefined
+        && expected.get(section.key) === section.hash
+      ))
       .map(section => [section.key, section.enabledLine!]),
   );
 

--- a/src/deployment/codex-trust-writer.ts
+++ b/src/deployment/codex-trust-writer.ts
@@ -1,34 +1,7 @@
-/**
- * codex-trust-writer.ts — Codex hook trust hash 写入 / 校验。
- *
- * 移植自 codex-plugin .../src/trust.ts,改 ESM TypeScript + 新增能力:
- *   - verifyTrustHashes() 自洽性检查(Q8 决策)
- *   - EVENT_KEY_MAP 扩展到 10 个事件(为未来 codex 全事件兼容留余地)
- *   - forceBypass 应急通道(R4):写 bypass_hook_trust = true 顶层字段
- *   - marker 名从外部传入(不再硬编码 "otel-codex-hook")
- *
- * 算法核心(对齐 codex-rs/config/src/fingerprint.rs):
- *   computeHookTrustHash(eventName, command):
- *     identity = NormalizedHookIdentity {
- *       event_name,
- *       hooks: [{ type:"command", command, timeout:600, async:false }]
- *     }
- *     SHA-256(canonical_json(identity)) → "sha256:<hex>"
- *
- * Trust block 结构:
- *     # BEGIN <marker> trust
- *     bypass_hook_trust = true   # 仅 forceBypass=true 时
- *     [hooks.state."<hooks.json>:<event>:0:0"]
- *     trusted_hash = "sha256:..."
- *     ...
- *     # END <marker> trust
- */
-
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 
-/** 已知 Codex hook 事件 → snake_case label。 */
-const EVENT_KEY_MAP: Record<string, string> = {
+export const CODEX_HOOK_EVENT_KEYS: Record<string, string> = {
   PreToolUse: 'pre_tool_use',
   PermissionRequest: 'permission_request',
   PostToolUse: 'post_tool_use',
@@ -36,11 +9,54 @@ const EVENT_KEY_MAP: Record<string, string> = {
   PreCompact: 'pre_compact',
   PostCompact: 'post_compact',
   SessionStart: 'session_start',
+  SessionEnd: 'session_end',
   UserPromptSubmit: 'user_prompt_submit',
   SubagentStart: 'subagent_start',
   SubagentStop: 'subagent_stop',
   Stop: 'stop',
 };
+
+const MATCHER_EVENTS = new Set([
+  'PreToolUse',
+  'PermissionRequest',
+  'PostToolUse',
+  'PreCompact',
+  'PostCompact',
+  'SessionStart',
+  'SessionEnd',
+  'SubagentStart',
+  'SubagentStop',
+]);
+
+const ADDITIONAL_CONTEXT_EVENTS = new Set([
+  'PreToolUse',
+  'PostToolUse',
+  'SessionStart',
+  'UserPromptSubmit',
+  'SubagentStart',
+]);
+
+const DEFAULT_ADDITIONAL_CONTEXT_LIMIT = 2_500;
+
+export interface InstalledCodexCommandHandler {
+  type: 'command';
+  command: string;
+  commandWindows?: string;
+  timeout?: number;
+  async?: boolean;
+  statusMessage?: string;
+  additionalContextLimit?: number;
+}
+
+/** Exact location and source config of one handler in the installed hooks.json. */
+export interface InstalledCodexHookLocation {
+  eventName: string;
+  eventKey: string;
+  groupIndex: number;
+  handlerIndex: number;
+  matcher?: string;
+  handler: InstalledCodexCommandHandler;
+}
 
 function canonicalJson(value: unknown): unknown {
   if (value === null || value === undefined) return value;
@@ -56,65 +72,98 @@ function canonicalJson(value: unknown): unknown {
 }
 
 function versionForToml(obj: unknown): string {
-  const canonical = canonicalJson(obj);
-  const serialized = JSON.stringify(canonical);
+  const serialized = JSON.stringify(canonicalJson(obj));
   const hex = crypto.createHash('sha256').update(serialized, 'utf-8').digest('hex');
   return `sha256:${hex}`;
 }
 
-/**
- * 计算单个 hook 的 trust hash。
- * 对齐 codex-rs `command_hook_hash`(见 hooks/src/engine/discovery.rs)。
- *
- * NormalizedHookIdentity { event_name, #[flatten] group: MatcherGroup }
- * MatcherGroup { matcher: Option<String>, hooks: Vec<HookHandlerConfig> }
- *   matcher = None → TOML 中字段缺失
- * HookHandlerConfig::Command { type:"command", command, timeout_sec:Some(600), async:false, status_message:None, command_windows:None }
- *   timeout_sec serde rename "timeout";command_windows / status_message 缺省时跳过
- */
-export function computeHookTrustHash(eventName: string, command: string): string {
-  const eventKey = EVENT_KEY_MAP[eventName];
-  if (!eventKey) throw new Error(`Unknown hook event: ${eventName}`);
-
-  const identity: Record<string, unknown> = {
-    event_name: eventKey,
-    // matcher: None → 缺失字段
-    hooks: [
-      {
-        type: 'command',
-        command,
-        timeout: 600,
-        async: false,
-        // status_message: None / command_windows: None → 缺失字段
-      },
-    ],
-  };
-  return versionForToml(identity);
+function normalizedTimeout(eventName: string, configured: number | undefined): number {
+  if (eventName === 'SessionEnd') {
+    return Math.min(3, Math.max(1, configured ?? 1));
+  }
+  return Math.max(1, configured ?? 600);
 }
 
-/**
- * 构建 trust state key。
- *
- * key 格式: `<hooks.json 绝对路径>:<event_label>:<group_index>:<handler_index>`
- *
- * group_index = hook 在 hooks.json 中的数组位置(0-based),由调用方传入。
- * 如果其他第三方 hook(如 r2c)排在前面,pilot 的 hook 会在 1、2... 的位置。
- * handler_index 目前固定 0(每个 group 只有一个 handler)。
- */
+/** Mirror Codex discovery.rs handler normalization before trust hashing. */
+function normalizeInstalledHandler(
+  location: InstalledCodexHookLocation,
+  platform: NodeJS.Platform,
+): Record<string, unknown> {
+  const source = location.handler;
+  const command = platform === 'win32'
+    ? source.commandWindows ?? source.command
+    : source.command;
+  const normalized: Record<string, unknown> = {
+    type: 'command',
+    command,
+    timeout: normalizedTimeout(location.eventName, source.timeout),
+    async: source.async ?? false,
+  };
+  if (source.statusMessage !== undefined) normalized.statusMessage = source.statusMessage;
+  if (
+    ADDITIONAL_CONTEXT_EVENTS.has(location.eventName)
+    && source.additionalContextLimit !== undefined
+    && source.additionalContextLimit !== DEFAULT_ADDITIONAL_CONTEXT_LIMIT
+  ) {
+    normalized.additionalContextLimit = source.additionalContextLimit;
+  }
+  return normalized;
+}
+
+/** Compute the hash from the actual installed group and handler. */
+export function computeInstalledHookTrustHash(
+  location: InstalledCodexHookLocation,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const expectedKey = CODEX_HOOK_EVENT_KEYS[location.eventName];
+  if (!expectedKey || expectedKey !== location.eventKey) {
+    throw new Error(`Unknown or inconsistent hook event: ${location.eventName}`);
+  }
+  const matcher = MATCHER_EVENTS.has(location.eventName) ? location.matcher : undefined;
+  return versionForToml({
+    event_name: location.eventKey,
+    ...(matcher !== undefined ? { matcher } : {}),
+    hooks: [normalizeInstalledHandler(location, platform)],
+  });
+}
+
+/** Compatibility helper for callers that only need Codex's default command identity. */
+export function computeHookTrustHash(
+  eventName: string,
+  command: string,
+  matcher?: string,
+): string {
+  const eventKey = CODEX_HOOK_EVENT_KEYS[eventName];
+  if (!eventKey) throw new Error(`Unknown hook event: ${eventName}`);
+  return computeInstalledHookTrustHash({
+    eventName,
+    eventKey,
+    groupIndex: 0,
+    handlerIndex: 0,
+    ...(matcher !== undefined ? { matcher } : {}),
+    handler: { type: 'command', command },
+  });
+}
+
+export function installedHookStateKey(
+  hooksJsonAbsPath: string,
+  location: InstalledCodexHookLocation,
+): string {
+  return `${hooksJsonAbsPath}:${location.eventKey}:${location.groupIndex}:${location.handlerIndex}`;
+}
+
 export function hookStateKey(
   hooksJsonAbsPath: string,
   eventName: string,
-  groupIndex: number = 0,
+  groupIndex = 0,
+  handlerIndex = 0,
 ): string {
-  const eventKey = EVENT_KEY_MAP[eventName];
+  const eventKey = CODEX_HOOK_EVENT_KEYS[eventName];
   if (!eventKey) throw new Error(`Unknown hook event: ${eventName}`);
-  return `${hooksJsonAbsPath}:${eventKey}:${groupIndex}:0`;
+  return `${hooksJsonAbsPath}:${eventKey}:${groupIndex}:${handlerIndex}`;
 }
 
 function encodeTomlBasicString(value: string): string {
-  // JSON escaping is compatible with TOML basic strings for absolute paths.
-  // Windows backslashes must be doubled or `\u` in `C:\Users\...` is parsed
-  // as the beginning of a TOML Unicode escape.
   return JSON.stringify(value);
 }
 
@@ -128,289 +177,206 @@ function decodeTomlBasicString(value: string): string | null {
 }
 
 function tomlKeyCandidates(value: string): string[] {
-  const candidates: string[] = [];
   const decoded = decodeTomlBasicString(value);
-  if (decoded !== null) candidates.push(decoded);
+  const raw = value.startsWith('"') && value.endsWith('"') ? value.slice(1, -1) : null;
+  return [...new Set([decoded, raw].filter((candidate): candidate is string => candidate !== null))];
+}
 
-  // Older Windows builds interpolated C:\... directly into a TOML basic
-  // string. Keep the raw body as a cleanup-only candidate so a subsequent
-  // deployment can remove that invalid section and repair config.toml.
-  if (value.startsWith('"') && value.endsWith('"')) {
-    candidates.push(value.slice(1, -1));
+interface ParsedTrustSection {
+  key: string;
+  hash?: string;
+  enabledLine?: string;
+}
+
+function parseTrustSections(content: string): ParsedTrustSection[] {
+  const lines = content.split('\n');
+  const sections: ParsedTrustSection[] = [];
+  const header = /^\s*\[hooks\.state\.("(?:\\.|[^"\\])*")\]\s*$/;
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i]!.match(header);
+    if (!match) continue;
+    const key = tomlKeyCandidates(match[1]!)[0];
+    if (key === undefined) continue;
+    const section: ParsedTrustSection = { key };
+    for (let j = i + 1; j < lines.length && !/^\s*\[/.test(lines[j]!); j++) {
+      const hash = lines[j]!.match(/^\s*trusted_hash\s*=\s*"([^"]+)"/);
+      if (hash) section.hash = hash[1];
+      if (/^\s*enabled\s*=/.test(lines[j]!)) section.enabledLine = lines[j]!.trim();
+    }
+    sections.push(section);
   }
-  return [...new Set(candidates)];
+  return sections;
 }
 
-interface ParsedTrustHash {
-  key: string;     // 完整 hook state key,如 "/abs/hooks.json:session_start:0:0"
-  hash: string;    // sha256:xxx
-}
-
-/**
- * 从 config.toml content 中提取所有 [hooks.state."..."].trusted_hash 条目。
- * 仅按 marker BEGIN/END 包裹的 block 内提取。
- */
-function parseTrustBlock(content: string, marker: string): ParsedTrustHash[] {
-  const begin = `# BEGIN ${marker} trust`;
-  const end = `# END ${marker} trust`;
-  const beginIdx = content.indexOf(begin);
-  const endIdx = content.indexOf(end);
-  if (beginIdx === -1 || endIdx === -1 || endIdx <= beginIdx) return [];
-
-  const block = content.slice(beginIdx, endIdx);
-  const out: ParsedTrustHash[] = [];
-  const sectionRe = /\[hooks\.state\.("(?:\\.|[^"\\])*")\]\s*\n\s*trusted_hash\s*=\s*"([^"]+)"/g;
-  let m: RegExpExecArray | null;
-  while ((m = sectionRe.exec(block)) !== null) {
-    const key = decodeTomlBasicString(m[1]!);
-    if (key !== null) out.push({ key, hash: m[2]! });
-  }
-  return out;
-}
-
-/**
- * 移除老版本插件留下的"裸" [hooks.state."<hooksJsonAbsPath>:<event>:<group>:0"] 段。
- * 不在 marker 块内,但 path/event 匹配 + handler=0 → pilot 拥有的 slot,清掉。
- * 匹配任意 group index(老插件可能在 :0:0,新 pilot 可能在 :1:0 等)。
- */
-function removeStaleTrustState(
-  content: string,
-  hooksJsonAbsPath: string,
-  hookEvents: readonly string[],
-): string {
-  const ownedEventKeys = new Set(
-    hookEvents.map((event) => {
-      const eventKey = EVENT_KEY_MAP[event];
-      if (!eventKey) throw new Error(`Unknown hook event: ${event}`);
-      return eventKey;
-    }),
-  );
-
+function removeExactTrustSections(content: string, keys: ReadonlySet<string>): string {
+  if (keys.size === 0) return content;
   const lines = content.split('\n');
   const out: string[] = [];
+  const header = /^\s*\[hooks\.state\.("(?:\\.|[^"\\])*")\]\s*$/;
   let skipping = false;
-
-  const sectionHeader = /^\s*\[hooks\.state\.("(?:\\.|[^"\\])*")\]\s*$/;
-  const anyHeader = /^\s*\[/;
-
-  const isOwnedKey = (key: string): boolean => {
-    // key 格式: "<path>:<event>:<group>:<handler>"
-    const lastColon = key.lastIndexOf(':');
-    if (lastColon === -1) return false;
-    const handlerPart = key.slice(lastColon + 1);
-    const rest = key.slice(0, lastColon);
-    const groupColon = rest.lastIndexOf(':');
-    if (groupColon === -1) return false;
-    const groupPart = rest.slice(groupColon + 1);
-    const eventStart = rest.slice(0, groupColon);
-    const eventColon = eventStart.lastIndexOf(':');
-    if (eventColon === -1) return false;
-    const eventKey = eventStart.slice(eventColon + 1);
-    const pathPart = eventStart.slice(0, eventColon);
-
-    return (
-      pathPart === hooksJsonAbsPath &&
-      ownedEventKeys.has(eventKey) &&
-      handlerPart === '0'
-    );
-  };
-
   for (const line of lines) {
-    const headerMatch = line.match(sectionHeader);
-    if (headerMatch) {
-      skipping = tomlKeyCandidates(headerMatch[1]!).some(isOwnedKey);
-      if (skipping) continue;
-      out.push(line);
+    const match = line.match(header);
+    if (match) {
+      skipping = tomlKeyCandidates(match[1]!).some(key => keys.has(key));
+      if (!skipping) out.push(line);
       continue;
     }
-    if (anyHeader.test(line)) {
-      // 任何其他 table header 终止跳过区
-      skipping = false;
-      out.push(line);
-      continue;
-    }
-    if (skipping) continue;
-    out.push(line);
+    if (/^\s*\[/.test(line)) skipping = false;
+    if (!skipping) out.push(line);
   }
-
-  let result = out.join('\n');
-  result = result.replace(/\n{3,}/g, '\n\n');
-  return result;
+  return out.join('\n').replace(/\n{3,}/g, '\n\n');
 }
 
-export interface WriteTrustedHashesOpts {
-  configPath: string;            // ~/.codex/config.toml
-  hooksJsonAbsPath: string;      // ~/.codex/hooks.json 绝对路径
-  hookEvents: readonly string[]; // 要写 trust 的 event 列表(如 ["SessionStart", ...])
-  /**
-   * event → 实际写入 hooks.json 的完整 command 字符串。
-   * trust hash 算法必须用相同字符串,否则 codex 端校验失败。
-   */
+export interface InstalledTrustOpts {
+  configPath: string;
+  hooksJsonAbsPath: string;
+  locations: Record<string, InstalledCodexHookLocation>;
+  marker: string;
+  forceBypass?: boolean;
+}
+
+interface LegacyTrustOpts {
+  configPath: string;
+  hooksJsonAbsPath: string;
+  hookEvents: readonly string[];
   eventToCommand: Record<string, string>;
-  /**
-   * event → hooks.json 中实际的 group index(0-based 数组位置)。
-   * 当其他第三方 hook 排在前面时,pilot 的 hook 可能在 1、2... 位置。
-   * 由 HookStrategy.writeCodexTrust 从 hooks.json 回读提供。
-   */
   eventToGroupIndex: Record<string, number>;
-  marker: string;                // BEGIN/END marker 名(如 "otel-codex-hook")
-  forceBypass?: boolean;         // R4 应急:写 bypass_hook_trust = true
+  marker: string;
+  forceBypass?: boolean;
+}
+
+type TrustOpts = InstalledTrustOpts | LegacyTrustOpts;
+
+function normalizeTrustOpts(opts: TrustOpts): InstalledTrustOpts {
+  if ('locations' in opts) return opts;
+  const locations: Record<string, InstalledCodexHookLocation> = {};
+  for (const eventName of opts.hookEvents) {
+    const eventKey = CODEX_HOOK_EVENT_KEYS[eventName];
+    const command = opts.eventToCommand[eventName];
+    if (!eventKey) throw new Error(`Unknown hook event: ${eventName}`);
+    if (!command) throw new Error(`Missing eventToCommand[${eventName}]`);
+    locations[eventName] = {
+      eventName,
+      eventKey,
+      groupIndex: opts.eventToGroupIndex[eventName] ?? 0,
+      handlerIndex: 0,
+      handler: { type: 'command', command },
+    };
+  }
+  return {
+    configPath: opts.configPath,
+    hooksJsonAbsPath: opts.hooksJsonAbsPath,
+    locations,
+    marker: opts.marker,
+    ...(opts.forceBypass !== undefined ? { forceBypass: opts.forceBypass } : {}),
+  };
+}
+
+function expectedTrustState(opts: InstalledTrustOpts): Map<string, string> {
+  const expected = new Map<string, string>();
+  for (const location of Object.values(opts.locations)) {
+    expected.set(
+      installedHookStateKey(opts.hooksJsonAbsPath, location),
+      computeInstalledHookTrustHash(location),
+    );
+  }
+  return expected;
+}
+
+/** Exact deterministic verification against the installed hooks.json locations. */
+export function verifyTrustHashes(rawOpts: TrustOpts): VerifyResult {
+  const opts = normalizeTrustOpts(rawOpts);
+  if (!fs.existsSync(opts.configPath)) {
+    return { valid: false, mismatches: ['config.toml missing'] };
+  }
+  const content = fs.readFileSync(opts.configPath, 'utf-8');
+  const actual = new Map(parseTrustSections(content).map(section => [section.key, section.hash]));
+  const mismatches: string[] = [];
+  if (!opts.forceBypass && /^\s*bypass_hook_trust\s*=\s*true\s*$/m.test(content)) {
+    mismatches.push('unexpected bypass_hook_trust = true');
+  }
+  for (const [key, hash] of expectedTrustState(opts)) {
+    const current = actual.get(key);
+    if (current === undefined) mismatches.push(`missing key=${key}`);
+    else if (current !== hash) mismatches.push(`hash mismatch key=${key} (expected=${hash}, got=${current})`);
+  }
+  return { valid: mismatches.length === 0, mismatches };
 }
 
 /**
- * 写入 trust block(幂等):
- *   1. 清已有 BEGIN/END 块
- *   2. 清裸的 [hooks.state."<owned>"] 残留(老插件残留)
- *   3. 写新 BEGIN/END 块(forceBypass=true 时块顶含 bypass_hook_trust = true)
- *
- * 注意 command 字符串与 hook 注册到 hooks.json 时一致:`bash <entryPath> <subcommand>`
+ * Upsert only Pilot's exact current keys. Marker position is never used to
+ * infer ownership, so unrelated hook state survives Codex TOML reserialization.
+ * Returns false when the trust state is already correct and no file was written.
  */
-export function writeTrustedHashes(opts: WriteTrustedHashesOpts): void {
-  const { configPath, hooksJsonAbsPath, hookEvents, eventToCommand, eventToGroupIndex, marker, forceBypass } = opts;
+export function writeTrustedHashes(rawOpts: TrustOpts): boolean {
+  const opts = normalizeTrustOpts(rawOpts);
+  const existing = fs.existsSync(opts.configPath)
+    ? fs.readFileSync(opts.configPath, 'utf-8')
+    : '';
+  if (!opts.forceBypass && verifyTrustHashes(opts).valid) return false;
 
-  let content = '';
-  if (fs.existsSync(configPath)) {
-    content = fs.readFileSync(configPath, 'utf-8');
-  }
+  const begin = `# BEGIN ${opts.marker} trust`;
+  const end = `# END ${opts.marker} trust`;
+  const expected = expectedTrustState(opts);
+  // Never infer ownership from marker position: Codex may reserialize TOML and
+  // move the END comment past unrelated third-party sections. Until persisted
+  // owned-key metadata is introduced, only touch the exact current Pilot keys.
+  const exactKeys = new Set(expected.keys());
+  const enabledByKey = new Map(
+    parseTrustSections(existing)
+      .filter(section => exactKeys.has(section.key) && section.enabledLine)
+      .map(section => [section.key, section.enabledLine!]),
+  );
 
-  const TRUST_BEGIN = `# BEGIN ${marker} trust`;
-  const TRUST_END = `# END ${marker} trust`;
-
-  // Step 1: 删 BEGIN/END marker 注释行(仅删注释行本身,不按范围删,
-  // 因为 codex 桌面版会重新序列化 TOML,导致 END marker 位移,范围删会误伤用户数据)
-  content = content.split('\n')
-    .filter((line) => line.trim() !== TRUST_BEGIN && line.trim() !== TRUST_END)
+  let content = existing.split('\n')
+    .filter(line => line.trim() !== begin && line.trim() !== end)
+    .filter(line => !/^\s*bypass_hook_trust\s*=/.test(line))
     .join('\n');
+  content = removeExactTrustSections(content, exactKeys);
 
-  // Step 1b: 删 bypass_hook_trust 行(上次 forceBypass 留下的)
-  content = content.split('\n')
-    .filter((line) => !/^\s*bypass_hook_trust\s*=/.test(line))
-    .join('\n');
-
-  // Step 2: 清所有 owned [hooks.state."<our path>:<our event>:<any group>:0"] section
-  content = removeStaleTrustState(content, hooksJsonAbsPath, hookEvents);
-
-  // Step 3: 写新块
-  const lines: string[] = [TRUST_BEGIN];
-  if (forceBypass) {
-    lines.push('bypass_hook_trust = true');
-    lines.push('');
-  }
-  for (const event of hookEvents) {
-    const command = eventToCommand[event];
-    if (!command) throw new Error(`Missing eventToCommand[${event}]`);
-    const groupIndex = eventToGroupIndex[event] ?? 0;
-    const hash = computeHookTrustHash(event, command);
-    const key = hookStateKey(hooksJsonAbsPath, event, groupIndex);
+  const lines: string[] = [begin];
+  if (opts.forceBypass) lines.push('bypass_hook_trust = true', '');
+  for (const [key, hash] of expected) {
     lines.push(`[hooks.state.${encodeTomlBasicString(key)}]`);
-    lines.push(`trusted_hash = "${hash}"`);
-    lines.push('');
+    const enabled = enabledByKey.get(key);
+    if (enabled) lines.push(enabled);
+    lines.push(`trusted_hash = "${hash}"`, '');
   }
-  lines.push(TRUST_END);
-
+  lines.push(end);
   const separator = !content || content.endsWith('\n') ? '' : '\n';
-  let out = content + separator + '\n' + lines.join('\n') + '\n';
-  out = out.replace(/\n{3,}/g, '\n\n');
-  fs.writeFileSync(configPath, out, 'utf-8');
+  const output = `${content}${separator}\n${lines.join('\n')}\n`.replace(/\n{3,}/g, '\n\n');
+  if (output === existing) return false;
+  fs.writeFileSync(opts.configPath, output, 'utf-8');
+  return true;
 }
 
-/**
- * 删除 pilot 写入的 trust 条目(uninstall / 卸载场景)。
- *
- * 策略:逐条精确删除,不依赖 BEGIN/END 范围(codex 桌面版会重新序列化 TOML,
- * 导致 END marker 位移,范围删除会误伤 marker 之间的用户数据)。
- *
- * 删除顺序:
- *   1. 删 `# BEGIN <marker> trust` 和 `# END <marker> trust` 注释行
- *   2. 删 `bypass_hook_trust = true` 行(forceBypass 应急开关)
- *   3. 逐条删 `[hooks.state."<hooksJsonAbsPath>:<owned_event>:<any_group>:0"]` section
- *
- * @param hooksJsonAbsPath 不传时退化为只删 marker 注释行(兼容老的 installer 调用)
- * @param hookEvents 不传时退化为只删 marker 注释行
- */
 export function removeTrustBlock(
   configPath: string,
   marker: string,
-  hooksJsonAbsPath?: string,
-  hookEvents?: readonly string[],
+  _hooksJsonAbsPath?: string,
+  _hookEvents?: readonly string[],
 ): boolean {
   if (!fs.existsSync(configPath)) return false;
-  let content = fs.readFileSync(configPath, 'utf-8');
-  const before = content;
-
-  const TRUST_BEGIN = `# BEGIN ${marker} trust`;
-  const TRUST_END = `# END ${marker} trust`;
-
-  // Step 1: 删 BEGIN/END marker 注释行(仅删注释行本身,不删中间内容)
-  content = content.split('\n')
-    .filter((line) => line.trim() !== TRUST_BEGIN && line.trim() !== TRUST_END)
-    .join('\n');
-
-  // Step 2: 删 bypass_hook_trust 行(如存在)
-  content = content.split('\n')
-    .filter((line) => !/^\s*bypass_hook_trust\s*=/.test(line))
-    .join('\n');
-
-  // Step 3: 逐条删 [hooks.state."<owned>"] section
-  if (hooksJsonAbsPath && hookEvents) {
-    content = removeStaleTrustState(content, hooksJsonAbsPath, hookEvents);
+  const before = fs.readFileSync(configPath, 'utf-8');
+  const begin = `# BEGIN ${marker} trust`;
+  const end = `# END ${marker} trust`;
+  const beginIndex = before.indexOf(begin);
+  const endIndex = before.indexOf(end, beginIndex + begin.length);
+  const owned = new Set<string>();
+  if (beginIndex !== -1 && endIndex !== -1) {
+    for (const section of parseTrustSections(before.slice(beginIndex, endIndex))) owned.add(section.key);
   }
-
-  content = content.replace(/\n{3,}/g, '\n\n').trimEnd() + '\n';
-
+  let content = before.split('\n')
+    .filter(line => line.trim() !== begin && line.trim() !== end)
+    .filter(line => !/^\s*bypass_hook_trust\s*=/.test(line))
+    .join('\n');
+  content = removeExactTrustSections(content, owned).replace(/\n{3,}/g, '\n\n').trimEnd() + '\n';
   if (content === before) return false;
   fs.writeFileSync(configPath, content, 'utf-8');
   return true;
 }
 
-export interface VerifyTrustHashesOpts {
-  configPath: string;
-  hooksJsonAbsPath: string;
-  hookEvents: readonly string[];
-  /** event → 实际写入 hooks.json 的完整 command 字符串(与 writeTrustedHashes 一致)。 */
-  eventToCommand: Record<string, string>;
-  /** event → hooks.json 中实际的 group index(与 writeTrustedHashes 一致)。 */
-  eventToGroupIndex: Record<string, number>;
-  marker: string;
-}
-
 export interface VerifyResult {
   valid: boolean;
   mismatches: string[];
-}
-
-/**
- * 自洽性检查 (Q8):重新 parse config.toml,把每条 trust state 与本地重算的 hash 对比。
- * 仅校验 pilot 自己写入的(BEGIN/END 块内的)条目。
- *
- * 用途: deploy 后立即调用,确认我们写入正确(防止 string 拼接错位等);失败时 logger.error。
- *       不直接阻塞 deploy(让 hook-watchdog 活性检查再次触发 redeploy 兜底)。
- */
-export function verifyTrustHashes(opts: VerifyTrustHashesOpts): VerifyResult {
-  const { configPath, hooksJsonAbsPath, hookEvents, eventToCommand, eventToGroupIndex, marker } = opts;
-  if (!fs.existsSync(configPath)) {
-    return { valid: false, mismatches: ['config.toml missing'] };
-  }
-  const content = fs.readFileSync(configPath, 'utf-8');
-  const parsed = parseTrustBlock(content, marker);
-  const parsedMap = new Map(parsed.map((p) => [p.key, p.hash]));
-
-  const mismatches: string[] = [];
-  for (const event of hookEvents) {
-    const command = eventToCommand[event];
-    if (!command) {
-      mismatches.push(`event=${event} missing command mapping`);
-      continue;
-    }
-    const groupIndex = eventToGroupIndex[event] ?? 0;
-    const expectedKey = hookStateKey(hooksJsonAbsPath, event, groupIndex);
-    const expectedHash = computeHookTrustHash(event, command);
-    const actualHash = parsedMap.get(expectedKey);
-    if (!actualHash) {
-      mismatches.push(`event=${event} missing key=${expectedKey}`);
-    } else if (actualHash !== expectedHash) {
-      mismatches.push(`event=${event} hash mismatch (expected=${expectedHash}, got=${actualHash})`);
-    }
-  }
-  return { valid: mismatches.length === 0, mismatches };
 }

--- a/src/deployment/hook-strategy.ts
+++ b/src/deployment/hook-strategy.ts
@@ -19,6 +19,9 @@ import {
 import { detectAgent } from './detect-utils.js';
 import { createLogger } from '../utils/logger.js';
 import {
+  CODEX_HOOK_EVENT_KEYS,
+  type InstalledCodexCommandHandler,
+  type InstalledCodexHookLocation,
   writeTrustedHashes,
   removeTrustBlock,
   verifyTrustHashes,
@@ -156,23 +159,21 @@ export class HookStrategy implements DeployStrategy {
   private async needsTrustRepairForCodex(def: AgentDefinition): Promise<boolean> {
     const cfg = def.hook?.trustToml;
     if (!cfg || !def.hook) return false;
-
-    const hookCommand = resolveHome(def.hook.hookCommand);
-    const eventToCommand: Record<string, string> = {};
-    for (const event of def.hook.events) {
-      eventToCommand[event] = formatHookCommand(
-        hookCommand, event, def.hook.eventSubcommand, def.id,
-      );
+    try {
+      const locations = await this.resolveInstalledCodexHooks(def);
+      return !verifyTrustHashes({
+        configPath: resolveHome(cfg.configPath),
+        hooksJsonAbsPath: path.resolve(resolveHome(def.hook.settingsPath)),
+        locations,
+        marker: cfg.marker,
+      }).valid;
+    } catch (err) {
+      logger.warn('could not resolve installed Codex hooks for trust verification', {
+        agentId: def.id,
+        error: String(err),
+      });
+      return true;
     }
-    const eventToGroupIndex = await this.resolveGroupIndices(def);
-    return !verifyTrustHashes({
-      configPath: resolveHome(cfg.configPath),
-      hooksJsonAbsPath: path.resolve(resolveHome(def.hook.settingsPath)),
-      hookEvents: def.hook.events,
-      eventToCommand,
-      eventToGroupIndex,
-      marker: cfg.marker,
-    }).valid;
   }
 
   async deploy(def: AgentDefinition): Promise<DeployResult> {
@@ -288,25 +289,12 @@ export class HookStrategy implements DeployStrategy {
     const cfg = def.hook!.trustToml!;
     const configPath = resolveHome(cfg.configPath);
     const hooksJsonAbsPath = path.resolve(resolveHome(def.hook!.settingsPath));
-    const hookCommand = resolveHome(def.hook!.hookCommand);
+    const locations = await this.resolveInstalledCodexHooks(def);
 
-    // 构建 event → 实际写入 hooks.json 的完整 command(与 buildHookDefinitions 一致)
-    const eventToCmd: Record<string, string> = {};
-    for (const ev of def.hook!.events) {
-      eventToCmd[ev] = formatHookCommand(hookCommand, ev, def.hook!.eventSubcommand, def.id);
-    }
-
-    // 回读 hooks.json,算出每个 event 中 pilot hook 的实际 group index。
-    // 当其他第三方 hook(如 r2c)排在前面时,pilot 的 hook 会被 push 到后面的位置。
-    // trust hash 的 key 必须用实际 index,否则 codex 端校验失败(静默 Untrusted)。
-    const eventToGroupIndex = await this.resolveGroupIndices(def);
-
-    writeTrustedHashes({
+    const changed = writeTrustedHashes({
       configPath,
       hooksJsonAbsPath,
-      hookEvents: def.hook!.events,
-      eventToCommand: eventToCmd,
-      eventToGroupIndex,
+      locations,
       marker: cfg.marker,
       forceBypass: process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS === '1',
     });
@@ -318,9 +306,7 @@ export class HookStrategy implements DeployStrategy {
     const verify = verifyTrustHashes({
       configPath,
       hooksJsonAbsPath,
-      hookEvents: def.hook!.events,
-      eventToCommand: eventToCmd,
-      eventToGroupIndex,
+      locations,
       marker: cfg.marker,
     });
     if (!verify.valid) {
@@ -329,7 +315,7 @@ export class HookStrategy implements DeployStrategy {
         mismatches: verify.mismatches,
       });
     } else {
-      logger.info('codex trust hash verified', { agentId: def.id });
+      logger.info('codex trust block self-check passed', { agentId: def.id, changed });
     }
   }
 
@@ -364,45 +350,69 @@ export class HookStrategy implements DeployStrategy {
     return allOk;
   }
 
-  /**
-   * 回读 hooks.json,找到 pilot hook command 在每个 event 数组中的实际 group index。
-   * 支持 nested format({hooks:[{command}]}) 和 flat format({command})两种结构。
-   */
-  private async resolveGroupIndices(def: AgentDefinition): Promise<Record<string, number>> {
-    const result: Record<string, number> = {};
+  /** Resolve each exact installed Pilot handler. Ambiguity is unsafe for trust. */
+  private async resolveInstalledCodexHooks(
+    def: AgentDefinition,
+  ): Promise<Record<string, InstalledCodexHookLocation>> {
+    const result: Record<string, InstalledCodexHookLocation> = {};
     const hookCommand = resolveHome(def.hook!.hookCommand);
-
-    try {
-      const settings = await readJsonFile<Record<string, unknown>>(def.hook!.settingsPath);
-      const hooks = (settings as any)?.hooks;
-      if (!hooks || typeof hooks !== 'object') {
-        return result;
-      }
-
-      for (const event of def.hook!.events) {
-        const arr = hooks[event];
-        if (!Array.isArray(arr)) continue;
-        const cmd = formatHookCommand(hookCommand, event, def.hook!.eventSubcommand, def.id);
-        for (let i = 0; i < arr.length; i++) {
-          const entry = arr[i];
-          // nested: {hooks: [{command}]}
-          if (Array.isArray(entry?.hooks)) {
-            if (entry.hooks.some((h: any) => h.command === cmd)) {
-              result[event] = i;
-              break;
-            }
-          }
-          // flat: {command}
-          if (entry?.command === cmd) {
-            result[event] = i;
-            break;
-          }
-        }
-      }
-    } catch {
-      // 读取失败时 fallback 全 0(首次安装、无其他 hook 时是对的)
+    const settingsPath = resolveHome(def.hook!.settingsPath);
+    const settings = await readJsonFile<Record<string, unknown>>(settingsPath);
+    const hooks = (settings as { hooks?: Record<string, unknown> } | null)?.hooks;
+    if (!hooks || typeof hooks !== 'object') {
+      throw new Error(`installed hooks object missing: ${settingsPath}`);
     }
 
+    for (const eventName of def.hook!.events) {
+      const eventKey = CODEX_HOOK_EVENT_KEYS[eventName];
+      if (!eventKey) throw new Error(`Unknown hook event: ${eventName}`);
+      const groups = hooks[eventName];
+      if (!Array.isArray(groups)) throw new Error(`installed hook event missing: ${eventName}`);
+      const command = formatHookCommand(
+        hookCommand, eventName, def.hook!.eventSubcommand, def.id,
+      );
+      const matches: InstalledCodexHookLocation[] = [];
+      groups.forEach((rawGroup, groupIndex) => {
+        if (!rawGroup || typeof rawGroup !== 'object') return;
+        const group = rawGroup as Record<string, unknown>;
+        const handlers = Array.isArray(group.hooks) ? group.hooks : [group];
+        handlers.forEach((rawHandler, handlerIndex) => {
+          if (!rawHandler || typeof rawHandler !== 'object') return;
+          const handler = rawHandler as Record<string, unknown>;
+          if (handler.command !== command) return;
+          if (handler.type !== undefined && handler.type !== 'command') return;
+          const installed: InstalledCodexCommandHandler = {
+            type: 'command',
+            command,
+            ...(typeof handler.commandWindows === 'string'
+              ? { commandWindows: handler.commandWindows }
+              : typeof handler.command_windows === 'string'
+                ? { commandWindows: handler.command_windows }
+                : {}),
+            ...(typeof handler.timeout === 'number' ? { timeout: handler.timeout } : {}),
+            ...(typeof handler.async === 'boolean' ? { async: handler.async } : {}),
+            ...(typeof handler.statusMessage === 'string' ? { statusMessage: handler.statusMessage } : {}),
+            ...(typeof handler.additionalContextLimit === 'number'
+              ? { additionalContextLimit: handler.additionalContextLimit }
+              : {}),
+          };
+          matches.push({
+            eventName,
+            eventKey,
+            groupIndex,
+            handlerIndex: Array.isArray(group.hooks) ? handlerIndex : 0,
+            ...(typeof group.matcher === 'string' ? { matcher: group.matcher } : {}),
+            handler: installed,
+          });
+        });
+      });
+      if (matches.length !== 1) {
+        throw new Error(
+          `expected exactly one installed Pilot handler for ${eventName}; found ${matches.length}`,
+        );
+      }
+      result[eventName] = matches[0]!;
+    }
     return result;
   }
 

--- a/src/deployment/hook-strategy.ts
+++ b/src/deployment/hook-strategy.ts
@@ -159,6 +159,7 @@ export class HookStrategy implements DeployStrategy {
   private async needsTrustRepairForCodex(def: AgentDefinition): Promise<boolean> {
     const cfg = def.hook?.trustToml;
     if (!cfg || !def.hook) return false;
+    const forceBypass = process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS === '1';
     try {
       const locations = await this.resolveInstalledCodexHooks(def);
       return !verifyTrustHashes({
@@ -166,6 +167,7 @@ export class HookStrategy implements DeployStrategy {
         hooksJsonAbsPath: path.resolve(resolveHome(def.hook.settingsPath)),
         locations,
         marker: cfg.marker,
+        forceBypass,
       }).valid;
     } catch (err) {
       logger.warn('could not resolve installed Codex hooks for trust verification', {
@@ -242,14 +244,7 @@ export class HookStrategy implements DeployStrategy {
       // Codex 类 hook 需要写 trust hash 到 config.toml(forceBypass 应急通道由 pilot
       // config.json 的 agents.<id>.trust.forceBypass 控制 — 后续可由 hook-watchdog 读取)
       if (hookConfig.trustToml) {
-        try {
-          await this.writeCodexTrust(def);
-        } catch (err) {
-          logger.error('codex trust write failed (deploy continues)', {
-            agentId: def.id,
-            error: String(err),
-          });
-        }
+        await this.writeCodexTrust(def);
       }
 
       logger.info('hooks deployed', { agentId: def.id, events: hookConfig.events.length });
@@ -270,7 +265,8 @@ export class HookStrategy implements DeployStrategy {
 
   /**
    * 写 Codex trust hash + 立即自洽性校验(Q8)。
-   * 校验失败仅记 logger.error,不阻塞 deploy(让 hook-watchdog 活性检查兜底重试)。
+   * 定位、写入或本地校验失败时必须阻止 deploy 成功，避免产生“hook 存在但不可执行”
+   * 的静默部署状态。
    *
    * 注:command 字符串必须与 HookManager.installHook 写入 hooks.json 时一致,否则 hash 对不上。
    * HookManager nested format 写入的 command 就是原始 def.hook.hookCommand + 末尾空格 + subcommand
@@ -290,17 +286,18 @@ export class HookStrategy implements DeployStrategy {
     const configPath = resolveHome(cfg.configPath);
     const hooksJsonAbsPath = path.resolve(resolveHome(def.hook!.settingsPath));
     const locations = await this.resolveInstalledCodexHooks(def);
+    const forceBypass = process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS === '1';
 
     const changed = writeTrustedHashes({
       configPath,
       hooksJsonAbsPath,
       locations,
       marker: cfg.marker,
-      forceBypass: process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS === '1',
+      forceBypass,
     });
 
-    if (process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS === '1') {
-      logger.warn('Codex trust bypass enabled via LOONGSUITE_PILOT_CODEX_FORCE_BYPASS — hook trust verification is DISABLED', { agentId: def.id });
+    if (forceBypass) {
+      logger.warn('Codex trust enforcement bypass enabled via LOONGSUITE_PILOT_CODEX_FORCE_BYPASS', { agentId: def.id });
     }
 
     const verify = verifyTrustHashes({
@@ -308,15 +305,12 @@ export class HookStrategy implements DeployStrategy {
       hooksJsonAbsPath,
       locations,
       marker: cfg.marker,
+      forceBypass,
     });
     if (!verify.valid) {
-      logger.error('codex trust hash verification failed', {
-        agentId: def.id,
-        mismatches: verify.mismatches,
-      });
-    } else {
-      logger.info('codex trust block self-check passed', { agentId: def.id, changed });
+      throw new Error(`codex trust hash verification failed: ${verify.mismatches.join('; ')}`);
     }
+    logger.info('codex trust block self-check passed', { agentId: def.id, changed });
   }
 
   async undeploy(def: AgentDefinition): Promise<boolean> {

--- a/src/deployment/hook-strategy.ts
+++ b/src/deployment/hook-strategy.ts
@@ -161,7 +161,6 @@ export class HookStrategy implements DeployStrategy {
   private async needsTrustRepairForCodex(def: AgentDefinition): Promise<boolean> {
     const cfg = def.hook?.trustToml;
     if (!cfg || !def.hook) return false;
-    const forceBypass = process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS === '1';
     try {
       const locations = await this.resolveInstalledCodexHooks(def);
       return !verifyTrustHashes({
@@ -169,7 +168,6 @@ export class HookStrategy implements DeployStrategy {
         hooksJsonAbsPath: path.resolve(resolveHome(def.hook.settingsPath)),
         locations,
         marker: cfg.marker,
-        forceBypass,
       }).valid;
     } catch (err) {
       logger.warn('could not resolve installed Codex hooks for trust verification', {
@@ -262,8 +260,9 @@ export class HookStrategy implements DeployStrategy {
         }
       }
 
-      // Codex 类 hook 需要写 trust hash 到 config.toml(forceBypass 应急通道由 pilot
-      // config.json 的 agents.<id>.trust.forceBypass 控制 — 后续可由 hook-watchdog 读取)
+      // Codex 类 hook 需要写 trust hash 到 config.toml。
+      // Hook trust bypass 仅是 Codex 进程级 CLI 参数，不是合法的 config.toml 字段；
+      // Pilot 不拥有 Codex 启动入口，因此这里不能提供 bypass 通道。
       if (hookConfig.trustToml) {
         await this.writeCodexTrust(def);
       }
@@ -307,26 +306,19 @@ export class HookStrategy implements DeployStrategy {
     const configPath = resolveHome(cfg.configPath);
     const hooksJsonAbsPath = path.resolve(resolveHome(def.hook!.settingsPath));
     const locations = await this.resolveInstalledCodexHooks(def);
-    const forceBypass = process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS === '1';
 
     const changed = writeTrustedHashes({
       configPath,
       hooksJsonAbsPath,
       locations,
       marker: cfg.marker,
-      forceBypass,
     });
-
-    if (forceBypass) {
-      logger.warn('Codex trust enforcement bypass enabled via LOONGSUITE_PILOT_CODEX_FORCE_BYPASS', { agentId: def.id });
-    }
 
     const verify = verifyTrustHashes({
       configPath,
       hooksJsonAbsPath,
       locations,
       marker: cfg.marker,
-      forceBypass,
     });
     if (!verify.valid) {
       throw new Error(`codex trust hash verification failed: ${verify.mismatches.join('; ')}`);

--- a/src/deployment/hook-strategy.ts
+++ b/src/deployment/hook-strategy.ts
@@ -22,8 +22,10 @@ import {
   CODEX_HOOK_EVENT_KEYS,
   type InstalledCodexCommandHandler,
   type InstalledCodexHookLocation,
+  installedHookStateKey,
   writeTrustedHashes,
   removeTrustBlock,
+  removeTrustStateKeys,
   verifyTrustHashes,
 } from './codex-trust-writer.js';
 
@@ -201,6 +203,27 @@ export class HookStrategy implements DeployStrategy {
       }
 
       const retiredHookDefs = this.buildRetiredHookDefinitions(def);
+      let retiredTrustKeys: string[] = [];
+      if (hookConfig.trustToml && retiredHookDefs.length > 0) {
+        try {
+          const retiredEvents = retiredHookDefs.map(
+            definition => definition.hookJsonPath.at(-1)!,
+          );
+          const locations = await this.resolveInstalledCodexHooks(def, retiredEvents, true);
+          const hooksJsonAbsPath = path.resolve(resolveHome(hookConfig.settingsPath));
+          retiredTrustKeys = Object.values(locations).map(
+            location => installedHookStateKey(hooksJsonAbsPath, location),
+          );
+        } catch (err) {
+          // Cleanup must be conservative: if ownership cannot be proven from the
+          // installed handler, leave stale state behind rather than deleting a
+          // third-party hook's position-based trust entry.
+          logger.warn('could not resolve retired Codex hook trust ownership', {
+            agentId: def.id,
+            error: String(err),
+          });
+        }
+      }
       for (const retiredHookDef of retiredHookDefs) {
         const removed = await this.hookManager.uninstallHook(retiredHookDef);
         if (!removed) {
@@ -209,11 +232,9 @@ export class HookStrategy implements DeployStrategy {
       }
       if (hookConfig.trustToml && retiredHookDefs.length > 0) {
         const trust = hookConfig.trustToml;
-        removeTrustBlock(
+        removeTrustStateKeys(
           resolveHome(trust.configPath),
-          trust.marker,
-          path.resolve(resolveHome(hookConfig.settingsPath)),
-          retiredHookDefs.map(definition => definition.hookJsonPath.at(-1)!),
+          retiredTrustKeys,
         );
       }
 
@@ -320,6 +341,22 @@ export class HookStrategy implements DeployStrategy {
     // firing, since current events don't cover them.
     const retiredHookDefs = this.buildRetiredHookDefinitions(def);
     const hookDefs = [...this.buildHookDefinitions(def), ...retiredHookDefs];
+    let ownedTrustKeys: string[] = [];
+    if (def.hook?.trustToml) {
+      try {
+        const events = hookDefs.map(hookDef => hookDef.hookJsonPath.at(-1)!);
+        const locations = await this.resolveInstalledCodexHooks(def, events, true);
+        const hooksJsonAbsPath = path.resolve(resolveHome(def.hook.settingsPath));
+        ownedTrustKeys = Object.values(locations).map(
+          location => installedHookStateKey(hooksJsonAbsPath, location),
+        );
+      } catch (err) {
+        logger.warn('could not resolve Codex hook trust ownership before undeploy', {
+          agentId: def.id,
+          error: String(err),
+        });
+      }
+    }
     let allOk = true;
     for (const hookDef of hookDefs) {
       const ok = await this.hookManager.uninstallHook(hookDef);
@@ -330,12 +367,7 @@ export class HookStrategy implements DeployStrategy {
       try {
         const cfg = def.hook.trustToml;
         const configPath = resolveHome(cfg.configPath);
-        const hooksJsonAbsPath = path.resolve(resolveHome(def.hook.settingsPath));
-        const retiredEvents = retiredHookDefs.map(d => d.hookJsonPath.at(-1) as string);
-        removeTrustBlock(configPath, cfg.marker, hooksJsonAbsPath, [
-          ...def.hook.events,
-          ...retiredEvents,
-        ]);
+        removeTrustBlock(configPath, cfg.marker, ownedTrustKeys);
       } catch (err) {
         logger.warn('codex trust cleanup failed (non-blocking)', { error: String(err) });
       }
@@ -347,6 +379,8 @@ export class HookStrategy implements DeployStrategy {
   /** Resolve each exact installed Pilot handler. Ambiguity is unsafe for trust. */
   private async resolveInstalledCodexHooks(
     def: AgentDefinition,
+    eventNames: readonly string[] = def.hook!.events,
+    allowMissing = false,
   ): Promise<Record<string, InstalledCodexHookLocation>> {
     const result: Record<string, InstalledCodexHookLocation> = {};
     const hookCommand = resolveHome(def.hook!.hookCommand);
@@ -357,11 +391,14 @@ export class HookStrategy implements DeployStrategy {
       throw new Error(`installed hooks object missing: ${settingsPath}`);
     }
 
-    for (const eventName of def.hook!.events) {
+    for (const eventName of eventNames) {
       const eventKey = CODEX_HOOK_EVENT_KEYS[eventName];
       if (!eventKey) throw new Error(`Unknown hook event: ${eventName}`);
       const groups = hooks[eventName];
-      if (!Array.isArray(groups)) throw new Error(`installed hook event missing: ${eventName}`);
+      if (!Array.isArray(groups)) {
+        if (allowMissing) continue;
+        throw new Error(`installed hook event missing: ${eventName}`);
+      }
       const command = formatHookCommand(
         hookCommand, eventName, def.hook!.eventSubcommand, def.id,
       );
@@ -400,6 +437,7 @@ export class HookStrategy implements DeployStrategy {
           });
         });
       });
+      if (matches.length === 0 && allowMissing) continue;
       if (matches.length !== 1) {
         throw new Error(
           `expected exactly one installed Pilot handler for ${eventName}; found ${matches.length}`,

--- a/src/inputs/codex-transcript/codex-transcript-extractor.ts
+++ b/src/inputs/codex-transcript/codex-transcript-extractor.ts
@@ -23,6 +23,12 @@ export function extractCodexTranscriptMeta(record: Record<string, unknown>): Cod
   const subagent = asRecord(source?.subagent);
   const threadSpawn = asRecord(subagent?.thread_spawn);
   const parentThreadId = stringValue(threadSpawn?.parent_thread_id);
+  // First-party fork/resume lineage marker written at the top-level of the
+  // session_meta payload. Present for both subagent spawns and Desktop
+  // resume/fork, and is the most reliable trigger for "this file begins with a
+  // copied ancestor-history prefix". Subagent copies also expose
+  // parent_thread_id via thread_spawn; user resume/fork exposes only this.
+  const forkedFromId = stringValue(payload.forked_from_id);
   const agentPath = stringValue(threadSpawn?.agent_path);
   const agentNickname = stringValue(threadSpawn?.agent_nickname);
   const agentRole = stringValue(threadSpawn?.agent_role);
@@ -46,6 +52,7 @@ export function extractCodexTranscriptMeta(record: Record<string, unknown>): Cod
     rootSessionId: stringValue(payload.session_id) ?? threadId,
     threadSource,
     ...(parentThreadId ? { parentThreadId } : {}),
+    ...(forkedFromId ? { forkedFromId } : {}),
     depth,
     ...(Number.isFinite(createdAtMs) ? { createdAtMs } : {}),
     ...(agentPath ? { agentPath } : {}),

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -32,7 +32,7 @@ import {
   type CodexPendingFusionChild,
   type CodexPendingFusionTurn,
   type CodexPendingSubagentTurn,
-  type CodexCopiedPrefixProbe,
+  type CodexForkBootstrap,
   type CodexPendingTerminalTurn,
   type CodexTranscriptInputContext,
   type CodexTranscriptCheckpoint,
@@ -56,12 +56,6 @@ const MAX_EMIT_BATCH_BYTES = 1024 * 1024;
 const MAX_PERSISTED_INPUT_CONTEXT_BYTES = 1024 * 1024;
 const MAX_TERMINALS_PER_FILE_CYCLE = 100;
 const MAX_SCAN_BYTES_PER_FILE_CYCLE = 16 * 1024 * 1024;
-/**
- * Upper bound on how far the copied-prefix probe reads before giving up.
- * Reaching it means the expected boundary marker never arrived, so the rollout
- * is collected from the start instead of being withheld indefinitely.
- */
-const MAX_COPIED_PREFIX_PROBE_BYTES = 512 * 1024 * 1024;
 // Dynamic roots come from user-local Hook markers. Keep discovery bounded so
 // stale task homes cannot turn every polling cycle into an unbounded walk.
 const MAX_WAKEUP_MARKERS_FOR_DISCOVERY = 256;
@@ -133,6 +127,11 @@ interface DiscoveredSessionFile {
 interface DynamicDirectoryWalkBudget {
   remainingDirectories: number;
   remainingRolloutFiles: number;
+}
+
+interface CodexWakeupMarker {
+  initialTurnId?: string;
+  hookEvent?: string;
 }
 
 interface ParentTurnIndex {
@@ -322,63 +321,65 @@ export class CodexTranscriptInput extends BaseInput {
       : undefined;
     if (ownerMeta?.depth === 0) this.registerPersistedSubagentSpawns(checkpoint, ownerMeta.threadId);
 
-    // Fork/resume/subagent rollouts begin with a verbatim copy of ancestor
-    // history that must never be emitted (it re-reports the ancestor's events
-    // or, post owner-session fix, spawns ghost turns). Probe for the end of that
-    // prefix before collecting anything, then start collection right after it.
-    //
-    // Probing runs on its own offset and never advances the collection offset:
-    // if the probe is later abandoned, collection still starts from the top so
-    // the range is reported rather than silently dropped. Gated on a first-party
-    // fork/child indicator, so normal user sessions are never probed.
+    // A fork/subagent rollout starts with copied ancestor history. Its lifecycle
+    // Hook supplies the exact first turn owned by this rollout, so keep normal
+    // collection parked at offset zero until that task_started record appears.
+    // The independent search offset makes this safe when the Hook fires before
+    // Codex finishes appending the copied prefix or the new turn.
     const hasCopiedPrefix = ownerMeta != null && (
       ownerMeta.forkedFromId != null
       || ownerMeta.parentThreadId != null
       || ownerMeta.threadSource === 'subagent'
     );
-    const probe = checkpoint.copiedPrefixProbe;
     if (
       hasCopiedPrefix
-      && probe?.settled !== true
       && checkpoint.scanOffset === 0
       && checkpoint.activeTurn === null
       && checkpoint.pendingTerminal === null
     ) {
-      const probeStart = probe?.scanOffset ?? 0;
-      const result = await probeCopiedPrefix(
-        filePath,
-        ownerMeta!.threadId,
-        probeStart,
-        stat.size,
-        probe?.sawForeignMeta ?? false,
-      );
+      const marker = await this.readWakeupMarker(ownerMeta!.threadId, filePath);
+      const markerTurnId = marker?.initialTurnId;
+      let bootstrap: CodexForkBootstrap = checkpoint.forkBootstrap ?? { searchOffset: 0 };
+      if (markerTurnId && bootstrap.turnId !== markerTurnId) {
+        bootstrap = { turnId: markerTurnId, searchOffset: 0 };
+      }
+      checkpoint.forkBootstrap = bootstrap;
       checkpointChanged = true;
-      if (result.kind === 'found') {
-        this.logger.info('skipped copied fork/subagent history prefix', {
-          transcriptPath: filePath,
-          skippedBytes: result.endOffset,
-          threadSource: ownerMeta!.threadSource,
-          forkedFromId: ownerMeta!.forkedFromId,
-          parentThreadId: ownerMeta!.parentThreadId,
-        });
-        checkpoint.scanOffset = result.endOffset;
-        checkpoint.copiedPrefixProbe = { scanOffset: result.endOffset, sawForeignMeta: true, settled: true };
-      } else if (result.kind === 'absent') {
-        // No prefix to drop: leave the collection offset at the start.
-        checkpoint.copiedPrefixProbe = { scanOffset: probeStart, sawForeignMeta: false, settled: true };
-      } else if (result.nextOffset >= MAX_COPIED_PREFIX_PROBE_BYTES) {
-        // The expected marker never arrived. Stop probing and collect from the
-        // start: duplicate reporting is recoverable, dropped data is not.
-        this.logger.warn('copied history prefix boundary not found within limit; collecting from start', {
-          transcriptPath: filePath,
-          probedBytes: result.nextOffset,
-        });
-        checkpoint.copiedPrefixProbe = { scanOffset: result.nextOffset, sawForeignMeta: true, settled: true };
-      } else {
-        // Boundary lies beyond this cycle: remember how far the probe read and
-        // continue next cycle without collecting or emitting anything.
-        checkpoint.copiedPrefixProbe = { scanOffset: result.nextOffset, sawForeignMeta: true };
+      if (!bootstrap.turnId) {
         this.saveCheckpoint(key, checkpoint);
+        return 0;
+      }
+
+      const located = await findTurnStartOffset(
+        filePath,
+        bootstrap.turnId,
+        bootstrap.searchOffset,
+        stat.size,
+      );
+      if (located.startOffset === null) {
+        checkpoint.forkBootstrap = {
+          turnId: bootstrap.turnId,
+          searchOffset: located.nextOffset,
+        };
+        this.saveCheckpoint(key, checkpoint);
+        return 0;
+      }
+
+      checkpoint.scanOffset = located.startOffset;
+      checkpoint.forkBootstrap = undefined;
+      this.logger.info('anchored fork/subagent rollout at its first owned turn', {
+        transcriptPath: filePath,
+        turnId: bootstrap.turnId,
+        skippedBytes: located.startOffset,
+        hookEvent: marker?.hookEvent,
+        threadSource: ownerMeta!.threadSource,
+        forkedFromId: ownerMeta!.forkedFromId,
+        parentThreadId: ownerMeta!.parentThreadId,
+      });
+      // The start Hook only establishes the checkpoint. A later terminal Hook
+      // or the regular poll performs the existing incremental scan.
+      this.saveCheckpoint(key, checkpoint);
+      if (marker?.hookEvent === 'user-prompt-submit' || marker?.hookEvent === 'subagent-start') {
         return 0;
       }
     }
@@ -1454,6 +1455,39 @@ export class CodexTranscriptInput extends BaseInput {
     return resourceAttributes;
   }
 
+  private async readWakeupMarker(
+    sessionId: string,
+    transcriptPath: string,
+  ): Promise<CodexWakeupMarker | undefined> {
+    const markerPath = path.join(this.wakeupDir, `${safeWakeupSessionPart(sessionId)}.json`);
+    let record: Record<string, unknown> | null = null;
+    try {
+      record = asRecord(JSON.parse(await fs.readFile(markerPath, 'utf8')));
+    } catch {
+      return undefined;
+    }
+    if (!record || stringValue(record.session_id) !== sessionId) return undefined;
+
+    const recordedTranscriptPath = stringValue(record.transcript_path);
+    if (recordedTranscriptPath) {
+      try {
+        const [recordedRealPath, transcriptRealPath] = await Promise.all([
+          fs.realpath(recordedTranscriptPath),
+          fs.realpath(transcriptPath),
+        ]);
+        if (recordedRealPath !== transcriptRealPath) return undefined;
+      } catch {
+        if (path.resolve(recordedTranscriptPath) !== path.resolve(transcriptPath)) return undefined;
+      }
+    }
+    const initialTurnId = stringValue(record.initial_turn_id);
+    const hookEvent = stringValue(record.hook_event);
+    return {
+      ...(initialTurnId ? { initialTurnId } : {}),
+      ...(hookEvent ? { hookEvent } : {}),
+    };
+  }
+
   private async readTurnSpanAttributes(
     sessionId: string,
     turnId: string,
@@ -1821,15 +1855,14 @@ export class CodexTranscriptInput extends BaseInput {
       // so recover them through the normal independent terminal path.
       pendingTerminal ??= newPendingTerminal(subagent.turnId, subagent.terminalEndOffset, 0);
     }
-    const probeRecord = asRecord(value.copiedPrefixProbe);
-    // A probe spanning several cycles must survive restarts, otherwise the rest
-    // of the copied prefix would be collected as if it were real content.
-    const copiedPrefixProbe: CodexCopiedPrefixProbe | null = probeRecord
-      && typeof probeRecord.scanOffset === 'number'
+    const bootstrapRecord = asRecord(value.forkBootstrap);
+    const forkBootstrap: CodexForkBootstrap | null = bootstrapRecord
+      && typeof bootstrapRecord.searchOffset === 'number'
       ? {
-          scanOffset: probeRecord.scanOffset,
-          sawForeignMeta: probeRecord.sawForeignMeta === true,
-          ...(probeRecord.settled === true ? { settled: true } : {}),
+          searchOffset: bootstrapRecord.searchOffset,
+          ...(typeof bootstrapRecord.turnId === 'string'
+            ? { turnId: bootstrapRecord.turnId }
+            : {}),
         }
       : null;
     return {
@@ -1845,7 +1878,7 @@ export class CodexTranscriptInput extends BaseInput {
       ownerSessionMetaOffset: typeof value.ownerSessionMetaOffset === 'number'
         ? value.ownerSessionMetaOffset
         : null,
-      ...(copiedPrefixProbe ? { copiedPrefixProbe } : {}),
+      ...(forkBootstrap ? { forkBootstrap } : {}),
       emittedTerminalTurnIds: Array.isArray(value.emittedTerminalTurnIds)
         ? value.emittedTerminalTurnIds.filter((item): item is string => typeof item === 'string')
           .slice(0, MAX_EMITTED_TERMINAL_TURNS)
@@ -2108,72 +2141,27 @@ async function findOwnerSessionMetaOffset(
   return ownerOffset;
 }
 
-/**
- * Outcome of one probe cycle over a rollout's copied-history prefix.
- *
- * `absent` — no copied prefix (or no boundary exists at all): collect normally.
- * `found` — the prefix ends at `endOffset`; collection starts there.
- * `probing` — the boundary is past this cycle's window; resume from
- *   `nextOffset` on a later cycle without collecting anything.
- */
-type CopiedPrefixProbeResult =
-  | { kind: 'absent' }
-  | { kind: 'found'; endOffset: number }
-  | { kind: 'probing'; nextOffset: number };
-
-/**
- * Probe for the end of a fork/resume/subagent rollout's copied-history prefix.
- *
- * Codex spawns (subagent) and Desktop resume/fork produce a new rollout that
- * begins with a verbatim copy of the ancestor's history, then appends the
- * child's own `thread_settings_applied` marker before any real new turn (see
- * codex-rs `record_initial_history`, ForkPersistence::Copied). The copied
- * region therefore spans from file start up to the first
- * `event_msg/thread_settings_applied`. Emitting it re-reports the ancestor's
- * events (colliding event.id) or, after the owner-session fix, spawns ghost
- * turns; either way it must be dropped.
- *
- * The prefix can exceed one scan window, so probing is resumable via
- * `startOffset` and `foreignMetaConfirmed`. An ancestor session_meta
- * (id != owner) somewhere before the marker is what proves the prefix is real;
- * codex writes it inside the copied history rather than in the header, so the
- * probe must keep reading to find it. Without that evidence, or when EOF is
- * reached with no marker (older codex builds, truncated files), the rollout is
- * collected untouched rather than withheld.
- */
-async function probeCopiedPrefix(
+/** Locate the Hook-provided first task owned by a forked rollout. */
+async function findTurnStartOffset(
   filePath: string,
-  ownerThreadId: string,
+  turnId: string,
   startOffset: number,
   fileSize: number,
-  foreignMetaConfirmed: boolean,
-): Promise<CopiedPrefixProbeResult> {
-  const scanEnd = Math.min(fileSize, startOffset + MAX_SCAN_BYTES_PER_FILE_CYCLE);
-  let sawForeignMeta = foreignMetaConfirmed;
-  let boundaryEndOffset: number | null = null;
-  const { nextOffset } = await scanJsonLines(filePath, startOffset, scanEnd, line => {
+): Promise<{ startOffset: number | null; nextOffset: number }> {
+  let turnStartOffset: number | null = null;
+  const { nextOffset } = await scanJsonLines(filePath, startOffset, fileSize, line => {
     const payload = asRecord(line.record.payload);
-    if (line.record.type === 'session_meta') {
-      const metaId = payload ? stringValue(payload.id) : undefined;
-      if (metaId && ownerThreadId && metaId !== ownerThreadId) sawForeignMeta = true;
-      return undefined;
-    }
-    if (line.record.type === 'event_msg' && payload?.type === 'thread_settings_applied') {
-      // The first settings marker delimits the prefix. Reaching it without
-      // ancestor metadata means there is nothing to drop; either way the probe
-      // stops here, so a mid-stream settings change is never mistaken for it.
-      if (sawForeignMeta) boundaryEndOffset = line.endOffset;
+    if (
+      line.record.type === 'event_msg'
+      && payload?.type === 'task_started'
+      && stringValue(payload.turn_id) === turnId
+    ) {
+      turnStartOffset = line.startOffset;
       return false;
     }
     return undefined;
   });
-  if (boundaryEndOffset !== null) return { kind: 'found', endOffset: boundaryEndOffset };
-  // No ancestor metadata seen so far: no evidence of a copied prefix, so collect
-  // normally instead of withholding the rollout while probing further.
-  if (!sawForeignMeta) return { kind: 'absent' };
-  // Prefix confirmed but no marker: at EOF this rollout simply has none.
-  if (nextOffset >= fileSize) return { kind: 'absent' };
-  return { kind: 'probing', nextOffset };
+  return { startOffset: turnStartOffset, nextOffset };
 }
 
 function selectOwnerSessionMetaOffset(

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -302,16 +302,41 @@ export class CodexTranscriptInput extends BaseInput {
       };
       checkpointChanged = true;
     } else if (checkpoint.inode !== stat.ino) {
-      this.logger.warn('Codex transcript inode changed; applying no-replay baseline', {
-        transcriptPath: filePath,
-        previousInode: checkpoint.inode,
-        currentInode: stat.ino,
-        previousScanOffset: checkpoint.scanOffset,
-        hadForkBootstrap: checkpoint.forkBootstrap !== undefined,
-      });
-      await this.baselineFile(filePath, key);
-      this.saveGlobalProcessedTerminalTurnIds();
-      return 0;
+      if (checkpoint.forkBootstrap) {
+        this.logger.warn('Codex fork transcript inode changed before owned history was consumed; restarting bootstrap', {
+          transcriptPath: filePath,
+          previousInode: checkpoint.inode,
+          currentInode: stat.ino,
+          previousScanOffset: checkpoint.scanOffset,
+          previousSearchOffset: checkpoint.forkBootstrap.searchOffset,
+        });
+        checkpoint = {
+          inode: stat.ino,
+          scanOffset: 0,
+          activeTurn: null,
+          pendingTerminal: null,
+          pendingFusion: null,
+          pendingSubagent: null,
+          ownerSessionMetaOffset: null,
+          emittedTerminalTurnIds: checkpoint.emittedTerminalTurnIds,
+          forkBootstrap: {
+            ...checkpoint.forkBootstrap,
+            searchOffset: 0,
+          },
+        };
+        checkpointChanged = true;
+      } else {
+        this.logger.warn('Codex transcript inode changed; applying no-replay baseline', {
+          transcriptPath: filePath,
+          previousInode: checkpoint.inode,
+          currentInode: stat.ino,
+          previousScanOffset: checkpoint.scanOffset,
+          hadForkBootstrap: false,
+        });
+        await this.baselineFile(filePath, key);
+        this.saveGlobalProcessedTerminalTurnIds();
+        return 0;
+      }
     }
 
     if (checkpoint.ownerSessionMetaOffset === null) {
@@ -412,7 +437,14 @@ export class CodexTranscriptInput extends BaseInput {
       }
 
       checkpoint.scanOffset = located.startOffset;
-      checkpoint.forkBootstrap = undefined;
+      // Retain the recovery evidence until the owned range actually advances.
+      // A Start Hook intentionally returns after anchoring, so clearing this
+      // state here would make an intervening inode replacement baseline the
+      // copied prefix and permanently lose the already-written child turn.
+      checkpoint.forkBootstrap = {
+        ...bootstrap,
+        searchOffset: located.startOffset,
+      };
       this.logger.info('anchored fork/subagent rollout at its first owned turn', {
         transcriptPath: filePath,
         turnId: located.turnId,
@@ -431,6 +463,8 @@ export class CodexTranscriptInput extends BaseInput {
       }
     }
 
+    const forkBootstrapAtOwnedScanStart = checkpoint.forkBootstrap;
+    const ownedScanStartOffset = checkpoint.scanOffset;
     let emittedCount = 0;
     let processedTerminalCount = 0;
     if (
@@ -703,6 +737,13 @@ export class CodexTranscriptInput extends BaseInput {
       if (blocked || terminalTurnId === null) break;
     }
 
+    if (
+      forkBootstrapAtOwnedScanStart
+      && checkpoint.scanOffset > ownedScanStartOffset
+    ) {
+      checkpoint.forkBootstrap = undefined;
+      checkpointChanged = true;
+    }
     if (checkpointChanged) this.saveCheckpoint(key, checkpoint);
     this.saveGlobalProcessedTerminalTurnIds();
     return emittedCount;
@@ -975,8 +1016,9 @@ export class CodexTranscriptInput extends BaseInput {
         continue;
       }
       const checkpoint = this.readCheckpoint(this.stateKey(filePath));
-      const ownerOffset = checkpoint?.ownerSessionMetaOffset
-        ?? await findOwnerSessionMetaOffset(filePath, stat.size);
+      const ownerOffset = checkpoint?.inode === stat.ino
+        ? checkpoint.ownerSessionMetaOffset ?? await findOwnerSessionMetaOffset(filePath, stat.size)
+        : await findOwnerSessionMetaOffset(filePath, stat.size);
       if (ownerOffset === null) continue;
       const record = await readJsonLineAt(filePath, ownerOffset);
       const meta = record ? extractCodexTranscriptMeta(record) : null;

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -26,8 +26,6 @@ import {
   sessionIdFromTranscriptPath,
 } from './codex-transcript-extractor.js';
 import {
-  MAX_EMITTED_TERMINAL_TURNS,
-  MAX_GLOBAL_EMITTED_TERMINAL_TURNS,
   type CodexActiveTranscriptTurn,
   type CodexPendingFusionChild,
   type CodexPendingFusionTurn,
@@ -36,7 +34,6 @@ import {
   type CodexPendingTerminalTurn,
   type CodexTranscriptInputContext,
   type CodexTranscriptCheckpoint,
-  type CodexTranscriptGlobalState,
   type CodexTranscriptMeta,
   type CodexTranscriptSourceRange,
 } from './codex-transcript-types.js';
@@ -135,14 +132,6 @@ interface CodexWakeupMarker {
   hookEvent?: string;
 }
 
-interface ParentTurnIndex {
-  filePath: string;
-  inode: number;
-  scanOffset: number;
-  complete: boolean;
-  turnIds: Set<string>;
-}
-
 export interface CodexTranscriptInputOptions extends InputOptions {
   sessionDir?: string;
   wakeupDir?: string;
@@ -158,13 +147,8 @@ export class CodexTranscriptInput extends BaseInput {
   private readonly wakeupDir: string;
   private readonly spanContextDir: string;
   private wakeupWatcher: FSWatcher | null = null;
-  private processedTerminalTurnIdsLoaded = false;
-  private processedTerminalTurnIdsDirty = false;
-  private processedTerminalTurnIds = new Set<string>();
-  private processedTerminalTurnIdOrder: string[] = [];
   private readonly subagentLinker = new CodexSubagentLinker();
   private readonly reportedSubagentLinks = new Map<string, string>();
-  private readonly parentTurnIndexes = new Map<string, ParentTurnIndex>();
   private lastSubagentLinkSummary = '';
   private lastWakeupMarkerCleanupAtMs = 0;
   private lastSpanContextCleanupAtMs = 0;
@@ -187,7 +171,7 @@ export class CodexTranscriptInput extends BaseInput {
   }
 
   protected override async onStart(): Promise<void> {
-    this.loadGlobalProcessedTerminalTurnIds();
+    this.discardLegacyGlobalTurnRegistry();
     const discovered = await this.discoverSessionFiles();
     await this.indexDiscoveredTranscriptOwners(discovered);
     for (const { filePath, baselineOnStart } of discovered) {
@@ -197,10 +181,14 @@ export class CodexTranscriptInput extends BaseInput {
         && meta.parentThreadId !== undefined
         && this.hasPendingFusionForParent(meta.parentThreadId);
       if (baselineOnStart && !neededByPendingFusion && !this.readCheckpoint(key)) {
-        await this.baselineFile(filePath, key);
+        const hasCopiedPrefix = hasCopiedHistoryPrefix(meta);
+        if (hasCopiedPrefix) {
+          await this.parkForkBaseline(filePath, key);
+        } else {
+          await this.baselineFile(filePath, key);
+        }
       }
     }
-    this.saveGlobalProcessedTerminalTurnIds();
     await Promise.all([
       fs.mkdir(this.wakeupDir, { recursive: true }),
       fs.mkdir(this.spanContextDir, { recursive: true }),
@@ -287,6 +275,12 @@ export class CodexTranscriptInput extends BaseInput {
       return 0;
     }
     const key = this.stateKey(filePath);
+    // onStart()/collect() index the current inode before processFile(). Keep
+    // this lookup ahead of inode recovery: forkBootstrap is intentionally
+    // cleared after owned data advances, while the owner meta remains the
+    // durable proof that every replacement still starts with copied history.
+    const indexedOwnerMeta = this.transcriptMetaByPath.get(filePath) ?? null;
+    const hasIndexedCopiedPrefix = hasCopiedHistoryPrefix(indexedOwnerMeta);
     let checkpoint = this.readCheckpoint(key);
     let checkpointChanged = false;
     if (!checkpoint) {
@@ -298,17 +292,17 @@ export class CodexTranscriptInput extends BaseInput {
         pendingFusion: null,
         pendingSubagent: null,
         ownerSessionMetaOffset: null,
-        emittedTerminalTurnIds: [],
       };
       checkpointChanged = true;
     } else if (checkpoint.inode !== stat.ino) {
-      if (checkpoint.forkBootstrap) {
+      const forkBootstrap = checkpoint.forkBootstrap;
+      if (hasIndexedCopiedPrefix && forkBootstrap?.state === 'live-pending') {
         this.logger.warn('Codex fork transcript inode changed before owned history was consumed; restarting bootstrap', {
           transcriptPath: filePath,
           previousInode: checkpoint.inode,
           currentInode: stat.ino,
           previousScanOffset: checkpoint.scanOffset,
-          previousSearchOffset: checkpoint.forkBootstrap.searchOffset,
+          previousSearchOffset: forkBootstrap.searchOffset,
         });
         checkpoint = {
           inode: stat.ino,
@@ -318,9 +312,9 @@ export class CodexTranscriptInput extends BaseInput {
           pendingFusion: null,
           pendingSubagent: null,
           ownerSessionMetaOffset: null,
-          emittedTerminalTurnIds: checkpoint.emittedTerminalTurnIds,
           forkBootstrap: {
-            ...checkpoint.forkBootstrap,
+            ...forkBootstrap,
+            state: 'live-pending',
             searchOffset: 0,
           },
         };
@@ -331,10 +325,14 @@ export class CodexTranscriptInput extends BaseInput {
           previousInode: checkpoint.inode,
           currentInode: stat.ino,
           previousScanOffset: checkpoint.scanOffset,
-          hadForkBootstrap: false,
+          hadForkBootstrap: checkpoint.forkBootstrap !== undefined,
+          hasCopiedPrefix: hasIndexedCopiedPrefix,
         });
-        await this.baselineFile(filePath, key);
-        this.saveGlobalProcessedTerminalTurnIds();
+        if (hasIndexedCopiedPrefix) {
+          await this.parkForkBaseline(filePath, key);
+        } else {
+          await this.baselineFile(filePath, key);
+        }
         return 0;
       }
     }
@@ -347,118 +345,18 @@ export class CodexTranscriptInput extends BaseInput {
 
     const ownerMeta = this.transcriptMetaByPath.get(filePath) ?? null;
     const isDirectSubagent = ownerMeta?.threadSource === 'subagent' && ownerMeta.depth === 1;
-    const parentTurnIndex = isDirectSubagent
-      && ownerMeta?.parentThreadId
-      && (checkpoint.scanOffset < stat.size || checkpoint.activeTurn !== null || checkpoint.pendingTerminal !== null)
-      ? await this.refreshParentTurnIndex(ownerMeta.parentThreadId)
-      : undefined;
     if (ownerMeta?.depth === 0) this.registerPersistedSubagentSpawns(checkpoint, ownerMeta.threadId);
 
-    // A fork/subagent rollout starts with copied ancestor history. Prefer the
-    // lifecycle Hook's exact initial turn; when that Hook is unavailable, UUIDv7
-    // causality identifies the earliest turn created after the rollout owner.
-    // A terminal Hook supplies recovery evidence but is not assumed to be the
-    // first turn. Keep normal collection parked at zero until one of these
-    // positive ownership signals is found.
-    const hasCopiedPrefix = ownerMeta != null && (
-      ownerMeta.forkedFromId != null
-      || ownerMeta.parentThreadId != null
-      || ownerMeta.threadSource === 'subagent'
-    );
+    const hasCopiedPrefix = hasCopiedHistoryPrefix(ownerMeta);
     if (
       hasCopiedPrefix
-      && checkpoint.scanOffset === 0
       && checkpoint.activeTurn === null
       && checkpoint.pendingTerminal === null
     ) {
-      const marker = await this.readWakeupMarker(ownerMeta!.threadId, filePath);
-      let bootstrap: CodexForkBootstrap = checkpoint.forkBootstrap ?? { searchOffset: 0 };
-      if (marker?.initialTurnId && bootstrap.initialTurnId !== marker.initialTurnId) {
-        bootstrap = {
-          initialTurnId: marker.initialTurnId,
-          ...(marker.recoveryTurnId ? { recoveryTurnId: marker.recoveryTurnId } : {}),
-          searchOffset: 0,
-        };
-      } else if (
-        marker?.recoveryTurnId
-        && bootstrap.recoveryTurnId !== marker.recoveryTurnId
-      ) {
-        bootstrap = {
-          ...bootstrap,
-          recoveryTurnId: marker.recoveryTurnId,
-          // The newly arrived terminal evidence may already lie before an EOF
-          // reached by an evidence-free UUID probe. Re-scan from the start.
-          searchOffset: bootstrap.initialTurnId ? bootstrap.searchOffset : 0,
-        };
-      }
-      const safeSearchOffset = boundedSearchOffset(bootstrap.searchOffset, stat.size);
-      if (safeSearchOffset !== bootstrap.searchOffset) {
-        this.logger.warn('repaired invalid Codex fork bootstrap search offset', {
-          transcriptPath: filePath,
-          searchOffset: bootstrap.searchOffset,
-          repairedSearchOffset: safeSearchOffset,
-          fileSize: stat.size,
-        });
-        bootstrap = { ...bootstrap, searchOffset: safeSearchOffset };
-      }
-      checkpoint.forkBootstrap = bootstrap;
-      checkpointChanged = true;
-      const searchedNewBytes = bootstrap.searchOffset < stat.size;
-
-      const located = await findTurnStartOffset(
-        filePath,
-        ownerMeta!.threadId,
-        bootstrap.initialTurnId,
-        bootstrap.recoveryTurnId,
-        bootstrap.searchOffset,
-        stat.size,
-      );
-      if (located.startOffset === null) {
-        checkpoint.forkBootstrap = {
-          ...(bootstrap.initialTurnId ? { initialTurnId: bootstrap.initialTurnId } : {}),
-          ...(bootstrap.recoveryTurnId ? { recoveryTurnId: bootstrap.recoveryTurnId } : {}),
-          searchOffset: located.nextOffset,
-        };
-        if (
-          located.nextOffset >= stat.size
-          && searchedNewBytes
-          && !bootstrap.initialTurnId
-          && uuidV7TimestampMs(ownerMeta!.threadId) === undefined
-          && !bootstrap.recoveryTurnId
-        ) {
-          this.logger.warn('Codex fork bootstrap has no usable Hook or UUIDv7 ownership evidence', {
-            transcriptPath: filePath,
-            threadId: ownerMeta!.threadId,
-            searchedBytes: located.nextOffset,
-          });
-        }
+      const prepared = await this.prepareCopiedTranscript(filePath, stat.size, ownerMeta!, checkpoint);
+      checkpointChanged ||= prepared.changed;
+      if (!prepared.ready) {
         this.saveCheckpoint(key, checkpoint);
-        return 0;
-      }
-
-      checkpoint.scanOffset = located.startOffset;
-      // Retain the recovery evidence until the owned range actually advances.
-      // A Start Hook intentionally returns after anchoring, so clearing this
-      // state here would make an intervening inode replacement baseline the
-      // copied prefix and permanently lose the already-written child turn.
-      checkpoint.forkBootstrap = {
-        ...bootstrap,
-        searchOffset: located.startOffset,
-      };
-      this.logger.info('anchored fork/subagent rollout at its first owned turn', {
-        transcriptPath: filePath,
-        turnId: located.turnId,
-        anchorKind: located.anchorKind,
-        skippedBytes: located.startOffset,
-        hookEvent: marker?.hookEvent,
-        threadSource: ownerMeta!.threadSource,
-        forkedFromId: ownerMeta!.forkedFromId,
-        parentThreadId: ownerMeta!.parentThreadId,
-      });
-      // The start Hook only establishes the checkpoint. A later terminal Hook
-      // or the regular poll performs the existing incremental scan.
-      this.saveCheckpoint(key, checkpoint);
-      if (marker?.hookEvent === 'user-prompt-submit' || marker?.hookEvent === 'subagent-start') {
         return 0;
       }
     }
@@ -475,7 +373,6 @@ export class CodexTranscriptInput extends BaseInput {
         checkpoint.pendingTerminal.turnId,
         checkpoint.activeTurn.startedAtMs,
         ownerMeta?.createdAtMs,
-        parentTurnIndex,
       )
     ) {
       checkpoint.activeTurn = null;
@@ -530,7 +427,6 @@ export class CodexTranscriptInput extends BaseInput {
     processedTerminalCount += pendingResult.processedTerminalCount;
     if (pendingResult.blocked) {
       if (checkpointChanged) this.saveCheckpoint(key, checkpoint);
-      this.saveGlobalProcessedTerminalTurnIds();
       return emittedCount;
     }
 
@@ -591,16 +487,6 @@ export class CodexTranscriptInput extends BaseInput {
       let blocked = false;
 
       if (checkpoint.activeTurn && nextScanOffset > checkpoint.activeTurn.startOffset) {
-        if (terminalTurnId && checkpoint.emittedTerminalTurnIds.includes(terminalTurnId)) {
-          checkpoint.activeTurn = null;
-          checkpoint.pendingTerminal = null;
-          processedTerminalCount++;
-        } else if (terminalTurnId && this.isGloballyProcessedTerminalTurn(terminalTurnId)) {
-          this.rememberProcessedTerminalTurnId(checkpoint, terminalTurnId);
-          checkpoint.activeTurn = null;
-          checkpoint.pendingTerminal = null;
-          processedTerminalCount++;
-        } else {
           if (
             isDirectSubagent
             && terminalTurnId
@@ -608,7 +494,6 @@ export class CodexTranscriptInput extends BaseInput {
               terminalTurnId,
               checkpoint.activeTurn.startedAtMs,
               ownerMeta?.createdAtMs,
-              parentTurnIndex,
             )
           ) {
             // Forked child rollouts contain copied parent history after their
@@ -723,13 +608,10 @@ export class CodexTranscriptInput extends BaseInput {
               });
               blocked = true;
             } else if (!checkpoint.pendingFusion) {
-              this.rememberProcessedTerminalTurnId(checkpoint, terminalTurnId);
-              this.rememberGlobalProcessedTerminalTurnId(terminalTurnId);
               checkpoint.activeTurn = null;
               checkpoint.pendingTerminal = null;
               processedTerminalCount++;
             }
-          }
         }
       }
 
@@ -745,7 +627,6 @@ export class CodexTranscriptInput extends BaseInput {
       checkpointChanged = true;
     }
     if (checkpointChanged) this.saveCheckpoint(key, checkpoint);
-    this.saveGlobalProcessedTerminalTurnIds();
     return emittedCount;
   }
 
@@ -762,12 +643,6 @@ export class CodexTranscriptInput extends BaseInput {
     if (checkpoint.activeTurn?.turnId !== pending.turnId) {
       checkpoint.pendingTerminal = null;
       return { blocked: false, emittedCount: 0, processedTerminalCount: 0 };
-    }
-    if (this.isGloballyProcessedTerminalTurn(pending.turnId)) {
-      this.rememberProcessedTerminalTurnId(checkpoint, pending.turnId);
-      checkpoint.activeTurn = null;
-      checkpoint.pendingTerminal = null;
-      return { blocked: false, emittedCount: 0, processedTerminalCount: 1 };
     }
     const recovered = await this.recoverTurnSegment(filePath, checkpoint, pending.terminalEndOffset, true);
     if (recovered.kind === 'unparseable') {
@@ -791,8 +666,6 @@ export class CodexTranscriptInput extends BaseInput {
     }
 
     const emittedCount = this.emitEntryBatches(recovered.entries);
-    this.rememberProcessedTerminalTurnId(checkpoint, pending.turnId);
-    this.rememberGlobalProcessedTerminalTurnId(pending.turnId);
     checkpoint.activeTurn = null;
     checkpoint.pendingTerminal = null;
     return { blocked: false, emittedCount, processedTerminalCount: 1 };
@@ -1029,67 +902,6 @@ export class CodexTranscriptInput extends BaseInput {
     }
   }
 
-  /**
-   * Build an incremental ownership index for the exact parent rollout named by
-   * a depth-one child's session_meta. An exact turn-id hit is positive evidence
-   * of copied parent history; a miss is authoritative only after this snapshot
-   * has been scanned to a stable EOF.
-   */
-  private async refreshParentTurnIndex(parentThreadId: string): Promise<ParentTurnIndex | undefined> {
-    const filePath = this.transcriptPathByThreadId.get(parentThreadId);
-    if (!filePath) return undefined;
-    const meta = this.transcriptMetaByPath.get(filePath);
-    if (!meta || meta.threadId !== parentThreadId || meta.depth !== 0) return undefined;
-
-    let stat;
-    try {
-      stat = await fs.stat(filePath);
-    } catch {
-      return undefined;
-    }
-
-    let index = this.parentTurnIndexes.get(parentThreadId);
-    if (
-      !index
-      || index.filePath !== filePath
-      || index.inode !== stat.ino
-      || index.scanOffset > stat.size
-    ) {
-      index = {
-        filePath,
-        inode: stat.ino,
-        scanOffset: 0,
-        complete: false,
-        turnIds: new Set<string>(),
-      };
-      this.parentTurnIndexes.set(parentThreadId, index);
-    }
-
-    if (index.scanOffset < stat.size) {
-      const scan = await scanJsonLines(filePath, index.scanOffset, stat.size, line => {
-        const payload = asRecord(line.record.payload);
-        if (!payload) return;
-        const turnId = turnIdForStart(line.record, payload)
-          ?? terminalTurnIdFor(line.record, payload);
-        if (turnId) index!.turnIds.add(turnId);
-      });
-      index.scanOffset = scan.nextOffset;
-    }
-
-    // Re-stat after scanning so a concurrent parent append cannot turn a stale
-    // EOF snapshot into an authoritative negative ownership decision.
-    try {
-      const current = await fs.stat(filePath);
-      index.complete = current.ino === index.inode && index.scanOffset >= current.size;
-    } catch {
-      index.complete = false;
-    }
-    this.parentTurnIndexes.delete(parentThreadId);
-    this.parentTurnIndexes.set(parentThreadId, index);
-    trimOldestMap(this.parentTurnIndexes, MAX_LINK_DESCRIPTORS);
-    return index;
-  }
-
   private registerPersistedSubagentSpawns(
     checkpoint: CodexTranscriptCheckpoint,
     parentThreadId: string,
@@ -1180,8 +992,7 @@ export class CodexTranscriptInput extends BaseInput {
       if (
         checkpoint
         && !captured
-        && checkpoint.activeTurn === null
-        && checkpoint.emittedTerminalTurnIds.length > 0
+        && isChildCollectionSettled(checkpoint)
       ) continue;
       reliable.push({ ...child, childThreadId: link.childThreadId });
     }
@@ -1221,8 +1032,6 @@ export class CodexTranscriptInput extends BaseInput {
     }
 
     const emittedCount = this.emitEntryBatches(recovered.entries);
-    this.rememberProcessedTerminalTurnId(checkpoint, pending.turnId);
-    this.rememberGlobalProcessedTerminalTurnId(pending.turnId);
     checkpoint.activeTurn = null;
     checkpoint.pendingTerminal = null;
     return { emittedCount, processedTerminalCount: 1 };
@@ -1254,8 +1063,6 @@ export class CodexTranscriptInput extends BaseInput {
       return { emittedCount: 0, processedTerminalCount: 0 };
     }
     const emittedCount = this.emitEntryBatches(recovered.entries);
-    this.rememberProcessedTerminalTurnId(checkpoint, captured.turnId);
-    this.rememberGlobalProcessedTerminalTurnId(captured.turnId);
     checkpoint.pendingSubagent = null;
     return { emittedCount, processedTerminalCount: 1 };
   }
@@ -1368,8 +1175,6 @@ export class CodexTranscriptInput extends BaseInput {
 
       for (const output of childOutputs) {
         emittedCount += this.emitEntryBatches(output.entries);
-        this.rememberProcessedTerminalTurnId(output.checkpoint, output.turnId);
-        this.rememberGlobalProcessedTerminalTurnId(output.turnId);
         if (
           output.source === 'captured-terminal'
           && output.checkpoint.pendingSubagent?.parentToolCallId === output.parentToolCallId
@@ -1385,13 +1190,10 @@ export class CodexTranscriptInput extends BaseInput {
         this.saveCheckpoint(this.stateKey(output.path), output.checkpoint);
       }
       emittedCount += this.emitEntryBatches(parentRecovered.entries);
-      this.rememberProcessedTerminalTurnId(parentCheckpoint, pending.turnId);
-      this.rememberGlobalProcessedTerminalTurnId(pending.turnId);
       parentCheckpoint.activeTurn = null;
       parentCheckpoint.pendingFusion = null;
       this.saveCheckpoint(parentKey, parentCheckpoint);
     }
-    this.saveGlobalProcessedTerminalTurnIds();
     return emittedCount;
   }
 
@@ -1653,6 +1455,230 @@ export class CodexTranscriptInput extends BaseInput {
     return Object.keys(spanAttributes).length > 0 ? spanAttributes : undefined;
   }
 
+  /**
+   * Prepare the normal scan range for a rollout that starts with copied history.
+   * The method owns the complete bootstrap state machine so processFile only
+   * needs to distinguish ready-to-scan from waiting-for-more-evidence.
+   */
+  private async prepareCopiedTranscript(
+    filePath: string,
+    fileSize: number,
+    ownerMeta: CodexTranscriptMeta,
+    checkpoint: CodexTranscriptCheckpoint,
+  ): Promise<{ ready: boolean; changed: boolean }> {
+    // A newly discovered live fork must not enter the normal scanner until its
+    // first positively-owned turn is located.
+    if (checkpoint.scanOffset === 0 && checkpoint.forkBootstrap === undefined) {
+      checkpoint.forkBootstrap = {
+        state: 'live-pending',
+        searchOffset: 0,
+      };
+    }
+
+    const current = checkpoint.forkBootstrap;
+    if (!current) return { ready: true, changed: false };
+    if (current.state === 'baseline-tail') {
+      const rebuilt = await this.rebuildForkBaselineTail(filePath, checkpoint);
+      return { ready: rebuilt, changed: true };
+    }
+
+    // Prefer the lifecycle Hook's exact initial turn. UUIDv7 causality is the
+    // fallback; a terminal Hook is recovery evidence, not necessarily turn one.
+    const marker = await this.readWakeupMarker(ownerMeta.threadId, filePath);
+    let bootstrap: CodexForkBootstrap = current;
+    if (marker?.initialTurnId && bootstrap.initialTurnId !== marker.initialTurnId) {
+      bootstrap = {
+        state: bootstrap.state,
+        initialTurnId: marker.initialTurnId,
+        ...(marker.recoveryTurnId ? { recoveryTurnId: marker.recoveryTurnId } : {}),
+        searchOffset: 0,
+      };
+    } else if (
+      marker?.recoveryTurnId
+      && bootstrap.recoveryTurnId !== marker.recoveryTurnId
+    ) {
+      bootstrap = {
+        ...bootstrap,
+        recoveryTurnId: marker.recoveryTurnId,
+        // The terminal evidence may lie before an EOF reached by an earlier
+        // evidence-free UUID probe, so restart that probe from the beginning.
+        searchOffset: bootstrap.initialTurnId ? bootstrap.searchOffset : 0,
+      };
+    }
+
+    const safeSearchOffset = boundedSearchOffset(bootstrap.searchOffset, fileSize);
+    if (safeSearchOffset !== bootstrap.searchOffset) {
+      this.logger.warn('repaired invalid Codex fork bootstrap search offset', {
+        transcriptPath: filePath,
+        searchOffset: bootstrap.searchOffset,
+        repairedSearchOffset: safeSearchOffset,
+        fileSize,
+      });
+      bootstrap = { ...bootstrap, searchOffset: safeSearchOffset };
+    }
+    checkpoint.forkBootstrap = bootstrap;
+    const searchedNewBytes = bootstrap.searchOffset < fileSize;
+
+    const located = await findTurnStartOffset(
+      filePath,
+      ownerMeta.threadId,
+      bootstrap.initialTurnId,
+      bootstrap.recoveryTurnId,
+      bootstrap.searchOffset,
+      fileSize,
+    );
+    if (located.startOffset === null) {
+      checkpoint.forkBootstrap = {
+        state: bootstrap.state,
+        ...(bootstrap.initialTurnId ? { initialTurnId: bootstrap.initialTurnId } : {}),
+        ...(bootstrap.recoveryTurnId ? { recoveryTurnId: bootstrap.recoveryTurnId } : {}),
+        searchOffset: located.nextOffset,
+      };
+      if (
+        located.nextOffset >= fileSize
+        && searchedNewBytes
+        && !bootstrap.initialTurnId
+        && uuidV7TimestampMs(ownerMeta.threadId) === undefined
+        && !bootstrap.recoveryTurnId
+      ) {
+        this.logger.warn('Codex fork bootstrap has no usable Hook or UUIDv7 ownership evidence', {
+          transcriptPath: filePath,
+          threadId: ownerMeta.threadId,
+          searchedBytes: located.nextOffset,
+        });
+      }
+      return { ready: false, changed: true };
+    }
+
+    const previousScanOffset = checkpoint.scanOffset;
+    if (bootstrap.state === 'baseline-search' && located.startOffset < previousScanOffset) {
+      checkpoint.forkBootstrap = {
+        state: 'baseline-tail',
+        ...(bootstrap.initialTurnId ? { initialTurnId: bootstrap.initialTurnId } : {}),
+        ...(bootstrap.recoveryTurnId ? { recoveryTurnId: bootstrap.recoveryTurnId } : {}),
+        searchOffset: located.startOffset,
+      };
+      this.logger.info('located owned history below Codex fork baseline; rebuilding active tail', {
+        transcriptPath: filePath,
+        turnId: located.turnId,
+        anchorKind: located.anchorKind,
+        ownedStartOffset: located.startOffset,
+        baselineOffset: previousScanOffset,
+      });
+      const rebuilt = await this.rebuildForkBaselineTail(filePath, checkpoint);
+      return { ready: rebuilt, changed: true };
+    }
+
+    checkpoint.scanOffset = Math.max(previousScanOffset, located.startOffset);
+    // Keep live evidence until owned bytes advance. If the inode changes before
+    // then, recovery must restart from zero instead of applying a no-replay baseline.
+    checkpoint.forkBootstrap = previousScanOffset < located.startOffset
+      ? {
+          state: 'live-pending',
+          ...(bootstrap.initialTurnId ? { initialTurnId: bootstrap.initialTurnId } : {}),
+          ...(bootstrap.recoveryTurnId ? { recoveryTurnId: bootstrap.recoveryTurnId } : {}),
+          searchOffset: located.startOffset,
+        }
+      : undefined;
+    this.logger.info('anchored fork/subagent rollout at its first owned turn', {
+      transcriptPath: filePath,
+      turnId: located.turnId,
+      anchorKind: located.anchorKind,
+      skippedBytes: located.startOffset,
+      hookEvent: marker?.hookEvent,
+      threadSource: ownerMeta.threadSource,
+      forkedFromId: ownerMeta.forkedFromId,
+      parentThreadId: ownerMeta.parentThreadId,
+    });
+    const startHookOnly = previousScanOffset < located.startOffset
+      && (marker?.hookEvent === 'user-prompt-submit' || marker?.hookEvent === 'subagent-start');
+    return { ready: !startHookOnly, changed: true };
+  }
+
+  private async parkForkBaseline(
+    filePath: string,
+    key: string,
+  ): Promise<void> {
+    let stat;
+    try {
+      stat = await fs.stat(filePath);
+    } catch {
+      return;
+    }
+    const scanOffset = await lastCompleteJsonlOffset(filePath, stat.size);
+    const ownerSessionMetaOffset = await findOwnerSessionMetaOffset(filePath, scanOffset);
+    this.saveCheckpoint(key, {
+      inode: stat.ino,
+      scanOffset,
+      activeTurn: null,
+      pendingTerminal: null,
+      pendingFusion: null,
+      pendingSubagent: null,
+      ownerSessionMetaOffset,
+      forkBootstrap: {
+        state: 'baseline-search',
+        searchOffset: 0,
+      },
+    });
+  }
+
+  private async rebuildForkBaselineTail(
+    filePath: string,
+    checkpoint: CodexTranscriptCheckpoint,
+  ): Promise<boolean> {
+    const bootstrap = checkpoint.forkBootstrap;
+    if (!bootstrap || bootstrap.state !== 'baseline-tail') return true;
+
+    const baselineEnd = checkpoint.scanOffset;
+    const searchOffset = boundedSearchOffset(bootstrap.searchOffset, baselineEnd);
+    const scanEnd = Math.min(baselineEnd, searchOffset + MAX_SCAN_BYTES_PER_FILE_CYCLE);
+    let candidate = bootstrap.tailCandidate
+      ? cloneActiveTurn(bootstrap.tailCandidate)
+      : null;
+    const processLine = (line: JsonLine): void => {
+      const payload = asRecord(line.record.payload);
+      if (!payload || line.record.type === 'session_meta') return;
+      const turnId = turnIdForStart(line.record, payload);
+      if (turnId) {
+        if (!candidate || candidate.turnId !== turnId) {
+          candidate = createActiveTurn(
+            turnId,
+            line.startOffset,
+            timestampMs(line.record, Date.now()),
+            true,
+          );
+        }
+        updateActiveTurnMetadata(candidate, line.record, payload);
+        return;
+      }
+      if (terminalTurnIdFor(line.record, payload) === candidate?.turnId) candidate = null;
+    };
+
+    let scan = await scanJsonLines(filePath, searchOffset, scanEnd, processLine);
+    if (scan.nextOffset === searchOffset && scanEnd < baselineEnd) {
+      scan = await scanJsonLines(filePath, searchOffset, baselineEnd, line => {
+        processLine(line);
+        return false;
+      });
+    }
+
+    if (scan.nextOffset < baselineEnd) {
+      checkpoint.forkBootstrap = {
+        ...bootstrap,
+        searchOffset: scan.nextOffset,
+        ...(candidate ? { tailCandidate: candidate } : { tailCandidate: undefined }),
+      };
+      return false;
+    }
+
+    if (candidate) {
+      candidate.startOffset = baselineEnd;
+      checkpoint.activeTurn = candidate;
+    }
+    checkpoint.forkBootstrap = undefined;
+    return true;
+  }
+
   private async baselineFile(filePath: string, key: string): Promise<void> {
     let stat;
     try {
@@ -1662,7 +1688,6 @@ export class CodexTranscriptInput extends BaseInput {
     }
     let ownerSessionMetaOffset: number | null = null;
     let activeTurn: CodexActiveTranscriptTurn | null = null;
-    const completedTurnIds: string[] = [];
     const { nextOffset } = await scanJsonLines(filePath, 0, stat.size, line => {
       const payload = asRecord(line.record.payload);
       if (!payload) return;
@@ -1684,24 +1709,19 @@ export class CodexTranscriptInput extends BaseInput {
       }
       const terminalTurnId = terminalTurnIdFor(line.record, payload);
       if (terminalTurnId === activeTurn?.turnId) {
-        completedTurnIds.push(terminalTurnId);
         activeTurn = null;
       }
     });
     const baselineActiveTurn = activeTurn as CodexActiveTranscriptTurn | null;
-    if (baselineActiveTurn) {
-      baselineActiveTurn.startOffset = nextOffset;
-    }
-    for (const turnId of completedTurnIds) this.rememberGlobalProcessedTerminalTurnId(turnId);
+    if (baselineActiveTurn) baselineActiveTurn.startOffset = nextOffset;
     this.saveCheckpoint(key, {
       inode: stat.ino,
       scanOffset: nextOffset,
-      activeTurn,
+      activeTurn: baselineActiveTurn,
       pendingTerminal: null,
       pendingFusion: null,
       pendingSubagent: null,
       ownerSessionMetaOffset,
-      emittedTerminalTurnIds: [],
     });
   }
 
@@ -1959,11 +1979,25 @@ export class CodexTranscriptInput extends BaseInput {
       pendingTerminal ??= newPendingTerminal(subagent.turnId, subagent.terminalEndOffset, 0);
     }
     const bootstrapRecord = asRecord(value.forkBootstrap);
+    const bootstrapTailCandidate = parseActiveTranscriptTurn(bootstrapRecord?.tailCandidate);
+    const bootstrapState = bootstrapRecord?.state === 'baseline-tail'
+      ? 'baseline-tail' as const
+      : bootstrapRecord?.state === 'baseline-search'
+        ? 'baseline-search' as const
+        : bootstrapRecord?.state === 'live-pending'
+          ? 'live-pending' as const
+          // Migrate the mode/phase representation used by development builds.
+          : bootstrapRecord?.phase === 'rebuild-owned-tail'
+            ? 'baseline-tail' as const
+            : bootstrapRecord?.mode === 'baseline'
+              ? 'baseline-search' as const
+              : 'live-pending' as const;
     const forkBootstrap: CodexForkBootstrap | null = bootstrapRecord
       && typeof bootstrapRecord.searchOffset === 'number'
       && Number.isFinite(bootstrapRecord.searchOffset)
       && bootstrapRecord.searchOffset >= 0
       ? {
+          state: bootstrapState,
           searchOffset: bootstrapRecord.searchOffset,
           ...(typeof bootstrapRecord.initialTurnId === 'string'
             ? { initialTurnId: bootstrapRecord.initialTurnId }
@@ -1973,6 +2007,9 @@ export class CodexTranscriptInput extends BaseInput {
               : {}),
           ...(typeof bootstrapRecord.recoveryTurnId === 'string'
             ? { recoveryTurnId: bootstrapRecord.recoveryTurnId }
+            : {}),
+          ...(bootstrapState === 'baseline-tail' && bootstrapTailCandidate
+            ? { tailCandidate: bootstrapTailCandidate }
             : {}),
         }
       : null;
@@ -1990,10 +2027,6 @@ export class CodexTranscriptInput extends BaseInput {
         ? value.ownerSessionMetaOffset
         : null,
       ...(forkBootstrap ? { forkBootstrap } : {}),
-      emittedTerminalTurnIds: Array.isArray(value.emittedTerminalTurnIds)
-        ? value.emittedTerminalTurnIds.filter((item): item is string => typeof item === 'string')
-          .slice(0, MAX_EMITTED_TERMINAL_TURNS)
-        : [],
     };
   }
 
@@ -2008,78 +2041,11 @@ export class CodexTranscriptInput extends BaseInput {
     });
   }
 
-  private loadGlobalProcessedTerminalTurnIds(): void {
-    if (this.processedTerminalTurnIdsLoaded) return;
-    this.processedTerminalTurnIdsLoaded = true;
-
-    const global = this.readGlobalState();
-    const hasPersistedGlobalState = global.emittedTerminalTurnIds.length > 0;
-    for (const turnId of global.emittedTerminalTurnIds) {
-      if (this.processedTerminalTurnIds.has(turnId)) continue;
-      this.processedTerminalTurnIds.add(turnId);
-      this.processedTerminalTurnIdOrder.push(turnId);
-    }
-
-    if (hasPersistedGlobalState) return;
-    for (const key of this.stateStore.keys()) {
-      if (!key.startsWith(`${this.id}:`)) continue;
-      const raw = this.stateStore.get(key).extra?.codexTranscript;
-      const value = asRecord(raw);
-      const emittedTerminalTurnIds = Array.isArray(value?.emittedTerminalTurnIds)
-        ? value.emittedTerminalTurnIds
-        : [];
-      for (const turnId of emittedTerminalTurnIds) {
-        if (typeof turnId === 'string') this.rememberGlobalProcessedTerminalTurnId(turnId);
-      }
-    }
-  }
-
-  private readGlobalState(): CodexTranscriptGlobalState {
-    const raw = this.stateStore.get(this.id).extra?.codexTranscriptGlobal;
-    const value = asRecord(raw);
-    return {
-      emittedTerminalTurnIds: Array.isArray(value?.emittedTerminalTurnIds)
-        ? value.emittedTerminalTurnIds
-          .filter((item): item is string => typeof item === 'string')
-          .slice(0, MAX_GLOBAL_EMITTED_TERMINAL_TURNS)
-        : [],
-    };
-  }
-
-  private saveGlobalProcessedTerminalTurnIds(): void {
-    if (!this.processedTerminalTurnIdsDirty) return;
+  private discardLegacyGlobalTurnRegistry(): void {
     const current = this.stateStore.get(this.id);
-    this.stateStore.update(this.id, {
-      lastOffset: this.processedTerminalTurnIdOrder.length,
-      extra: {
-        ...(current.extra ?? {}),
-        codexTranscriptGlobal: {
-          emittedTerminalTurnIds: this.processedTerminalTurnIdOrder,
-        },
-      },
-    });
-    this.processedTerminalTurnIdsDirty = false;
-  }
-
-  private isGloballyProcessedTerminalTurn(turnId: string): boolean {
-    this.loadGlobalProcessedTerminalTurnIds();
-    return this.processedTerminalTurnIds.has(turnId);
-  }
-
-  private rememberProcessedTerminalTurnId(checkpoint: CodexTranscriptCheckpoint, turnId: string): void {
-    checkpoint.emittedTerminalTurnIds = [turnId, ...checkpoint.emittedTerminalTurnIds.filter(id => id !== turnId)]
-      .slice(0, MAX_EMITTED_TERMINAL_TURNS);
-  }
-
-  private rememberGlobalProcessedTerminalTurnId(turnId: string, markDirty = true): void {
-    if (this.processedTerminalTurnIds.has(turnId)) return;
-    this.processedTerminalTurnIds.add(turnId);
-    this.processedTerminalTurnIdOrder.unshift(turnId);
-    while (this.processedTerminalTurnIdOrder.length > MAX_GLOBAL_EMITTED_TERMINAL_TURNS) {
-      const removed = this.processedTerminalTurnIdOrder.pop();
-      if (removed) this.processedTerminalTurnIds.delete(removed);
-    }
-    if (markDirty) this.processedTerminalTurnIdsDirty = true;
+    if (!current.extra || !('codexTranscriptGlobal' in current.extra)) return;
+    const { codexTranscriptGlobal: _discarded, ...extra } = current.extra;
+    this.stateStore.set(this.id, { ...current, extra });
   }
 }
 
@@ -2169,6 +2135,30 @@ async function readJsonLines(filePath: string, startOffset: number, endOffset: n
     items.push(line);
   });
   return { items, nextOffset };
+}
+
+async function lastCompleteJsonlOffset(filePath: string, fileSize: number): Promise<number> {
+  if (fileSize <= 0) return 0;
+  const handle = await fs.open(filePath, 'r');
+  try {
+    const lastByte = Buffer.alloc(1);
+    if ((await handle.read(lastByte, 0, 1, fileSize - 1)).bytesRead === 1 && lastByte[0] === 0x0a) {
+      return fileSize;
+    }
+    let position = fileSize;
+    while (position > 0) {
+      const length = Math.min(READ_CHUNK_SIZE, position);
+      position -= length;
+      const chunk = Buffer.alloc(length);
+      const { bytesRead } = await handle.read(chunk, 0, length, position);
+      if (bytesRead <= 0) break;
+      const newline = chunk.subarray(0, bytesRead).lastIndexOf(0x0a);
+      if (newline >= 0) return position + newline + 1;
+    }
+    return 0;
+  } finally {
+    await handle.close();
+  }
 }
 
 async function scanJsonLines(
@@ -2506,24 +2496,31 @@ function mergePendingFusionChildren(
   return [...merged.values()];
 }
 
-function classifyParentTurnOwnership(
-  turnId: string,
-  index: ParentTurnIndex | undefined,
-): 'copied' | 'child' | 'unknown' {
-  if (!index) return 'unknown';
-  if (index.turnIds.has(turnId)) return 'copied';
-  return index.complete ? 'child' : 'unknown';
+function hasCopiedHistoryPrefix(
+  meta: CodexTranscriptMeta | null | undefined,
+): boolean {
+  return meta != null && (
+    meta.forkedFromId != null
+    || meta.parentThreadId != null
+    || meta.threadSource === 'subagent'
+  );
+}
+
+/** Child completion is derived from the existing scan state, not a second lifecycle flag. */
+function isChildCollectionSettled(checkpoint: CodexTranscriptCheckpoint): boolean {
+  return checkpoint.scanOffset > 0
+    && checkpoint.forkBootstrap === undefined
+    && checkpoint.activeTurn === null
+    && checkpoint.pendingTerminal === null
+    && checkpoint.pendingSubagent === null;
 }
 
 function shouldSkipCopiedParentTurn(
   turnId: string,
   observedStartedAtMs: number,
   ownerCreatedAtMs: number | undefined,
-  index: ParentTurnIndex | undefined,
 ): boolean {
-  const ownership = classifyParentTurnOwnership(turnId, index);
-  if (ownership === 'copied') return true;
-  if (ownership === 'child' || ownerCreatedAtMs === undefined) return false;
+  if (ownerCreatedAtMs === undefined) return false;
   return isCopiedParentTurnByTime(turnId, observedStartedAtMs, ownerCreatedAtMs);
 }
 

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -32,6 +32,7 @@ import {
   type CodexPendingFusionChild,
   type CodexPendingFusionTurn,
   type CodexPendingSubagentTurn,
+  type CodexCopiedPrefixProbe,
   type CodexPendingTerminalTurn,
   type CodexTranscriptInputContext,
   type CodexTranscriptCheckpoint,
@@ -55,6 +56,12 @@ const MAX_EMIT_BATCH_BYTES = 1024 * 1024;
 const MAX_PERSISTED_INPUT_CONTEXT_BYTES = 1024 * 1024;
 const MAX_TERMINALS_PER_FILE_CYCLE = 100;
 const MAX_SCAN_BYTES_PER_FILE_CYCLE = 16 * 1024 * 1024;
+/**
+ * Upper bound on how far the copied-prefix probe reads before giving up.
+ * Reaching it means the expected boundary marker never arrived, so the rollout
+ * is collected from the start instead of being withheld indefinitely.
+ */
+const MAX_COPIED_PREFIX_PROBE_BYTES = 512 * 1024 * 1024;
 // Dynamic roots come from user-local Hook markers. Keep discovery bounded so
 // stale task homes cannot turn every polling cycle into an unbounded walk.
 const MAX_WAKEUP_MARKERS_FOR_DISCOVERY = 256;
@@ -317,33 +324,62 @@ export class CodexTranscriptInput extends BaseInput {
 
     // Fork/resume/subagent rollouts begin with a verbatim copy of ancestor
     // history that must never be emitted (it re-reports the ancestor's events
-    // or, post owner-session fix, spawns ghost turns). On the file's first scan
-    // (fresh checkpoint, nothing consumed yet), advance the offset past that
-    // copied prefix using codex's own boundary marker. Gated on a first-party
-    // fork/child indicator so normal user sessions are never touched, and
-    // fail-open: no boundary found -> skip nothing.
+    // or, post owner-session fix, spawns ghost turns). Probe for the end of that
+    // prefix before collecting anything, then start collection right after it.
+    //
+    // Probing runs on its own offset and never advances the collection offset:
+    // if the probe is later abandoned, collection still starts from the top so
+    // the range is reported rather than silently dropped. Gated on a first-party
+    // fork/child indicator, so normal user sessions are never probed.
     const hasCopiedPrefix = ownerMeta != null && (
       ownerMeta.forkedFromId != null
       || ownerMeta.parentThreadId != null
       || ownerMeta.threadSource === 'subagent'
     );
+    const probe = checkpoint.copiedPrefixProbe;
     if (
       hasCopiedPrefix
+      && probe?.settled !== true
       && checkpoint.scanOffset === 0
       && checkpoint.activeTurn === null
       && checkpoint.pendingTerminal === null
     ) {
-      const prefixEnd = await findCopiedPrefixEndOffset(filePath, ownerMeta!.threadId, stat.size);
-      if (prefixEnd !== null && prefixEnd > 0) {
-        this.logger.info('skipping copied fork/subagent history prefix', {
+      const probeStart = probe?.scanOffset ?? 0;
+      const result = await probeCopiedPrefix(
+        filePath,
+        ownerMeta!.threadId,
+        probeStart,
+        stat.size,
+        probe?.sawForeignMeta ?? false,
+      );
+      checkpointChanged = true;
+      if (result.kind === 'found') {
+        this.logger.info('skipped copied fork/subagent history prefix', {
           transcriptPath: filePath,
-          skippedBytes: prefixEnd,
+          skippedBytes: result.endOffset,
           threadSource: ownerMeta!.threadSource,
           forkedFromId: ownerMeta!.forkedFromId,
           parentThreadId: ownerMeta!.parentThreadId,
         });
-        checkpoint.scanOffset = prefixEnd;
-        checkpointChanged = true;
+        checkpoint.scanOffset = result.endOffset;
+        checkpoint.copiedPrefixProbe = { scanOffset: result.endOffset, sawForeignMeta: true, settled: true };
+      } else if (result.kind === 'absent') {
+        // No prefix to drop: leave the collection offset at the start.
+        checkpoint.copiedPrefixProbe = { scanOffset: probeStart, sawForeignMeta: false, settled: true };
+      } else if (result.nextOffset >= MAX_COPIED_PREFIX_PROBE_BYTES) {
+        // The expected marker never arrived. Stop probing and collect from the
+        // start: duplicate reporting is recoverable, dropped data is not.
+        this.logger.warn('copied history prefix boundary not found within limit; collecting from start', {
+          transcriptPath: filePath,
+          probedBytes: result.nextOffset,
+        });
+        checkpoint.copiedPrefixProbe = { scanOffset: result.nextOffset, sawForeignMeta: true, settled: true };
+      } else {
+        // Boundary lies beyond this cycle: remember how far the probe read and
+        // continue next cycle without collecting or emitting anything.
+        checkpoint.copiedPrefixProbe = { scanOffset: result.nextOffset, sawForeignMeta: true };
+        this.saveCheckpoint(key, checkpoint);
+        return 0;
       }
     }
 
@@ -1785,6 +1821,17 @@ export class CodexTranscriptInput extends BaseInput {
       // so recover them through the normal independent terminal path.
       pendingTerminal ??= newPendingTerminal(subagent.turnId, subagent.terminalEndOffset, 0);
     }
+    const probeRecord = asRecord(value.copiedPrefixProbe);
+    // A probe spanning several cycles must survive restarts, otherwise the rest
+    // of the copied prefix would be collected as if it were real content.
+    const copiedPrefixProbe: CodexCopiedPrefixProbe | null = probeRecord
+      && typeof probeRecord.scanOffset === 'number'
+      ? {
+          scanOffset: probeRecord.scanOffset,
+          sawForeignMeta: probeRecord.sawForeignMeta === true,
+          ...(probeRecord.settled === true ? { settled: true } : {}),
+        }
+      : null;
     return {
       inode: value.inode,
       scanOffset: value.scanOffset,
@@ -1798,6 +1845,7 @@ export class CodexTranscriptInput extends BaseInput {
       ownerSessionMetaOffset: typeof value.ownerSessionMetaOffset === 'number'
         ? value.ownerSessionMetaOffset
         : null,
+      ...(copiedPrefixProbe ? { copiedPrefixProbe } : {}),
       emittedTerminalTurnIds: Array.isArray(value.emittedTerminalTurnIds)
         ? value.emittedTerminalTurnIds.filter((item): item is string => typeof item === 'string')
           .slice(0, MAX_EMITTED_TERMINAL_TURNS)
@@ -2061,7 +2109,20 @@ async function findOwnerSessionMetaOffset(
 }
 
 /**
- * Locate the end of a fork/resume/subagent rollout's copied-history prefix.
+ * Outcome of one probe cycle over a rollout's copied-history prefix.
+ *
+ * `absent` — no copied prefix (or no boundary exists at all): collect normally.
+ * `found` — the prefix ends at `endOffset`; collection starts there.
+ * `probing` — the boundary is past this cycle's window; resume from
+ *   `nextOffset` on a later cycle without collecting anything.
+ */
+type CopiedPrefixProbeResult =
+  | { kind: 'absent' }
+  | { kind: 'found'; endOffset: number }
+  | { kind: 'probing'; nextOffset: number };
+
+/**
+ * Probe for the end of a fork/resume/subagent rollout's copied-history prefix.
  *
  * Codex spawns (subagent) and Desktop resume/fork produce a new rollout that
  * begins with a verbatim copy of the ancestor's history, then appends the
@@ -2072,22 +2133,25 @@ async function findOwnerSessionMetaOffset(
  * events (colliding event.id) or, after the owner-session fix, spawns ghost
  * turns; either way it must be dropped.
  *
- * Returns the end offset of that first `thread_settings_applied` (i.e. the
- * offset where the child's own content begins), but only when a foreign
- * session_meta (id != owner) was observed before it — the positive signal that
- * a copied prefix actually exists. Returns null when there is no copied prefix
- * or no boundary marker is found within the byte budget, so callers fail open
- * (skip nothing) rather than risk dropping real data.
+ * The prefix can exceed one scan window, so probing is resumable via
+ * `startOffset` and `foreignMetaConfirmed`. An ancestor session_meta
+ * (id != owner) somewhere before the marker is what proves the prefix is real;
+ * codex writes it inside the copied history rather than in the header, so the
+ * probe must keep reading to find it. Without that evidence, or when EOF is
+ * reached with no marker (older codex builds, truncated files), the rollout is
+ * collected untouched rather than withheld.
  */
-async function findCopiedPrefixEndOffset(
+async function probeCopiedPrefix(
   filePath: string,
   ownerThreadId: string,
-  endOffset: number,
-): Promise<number | null> {
-  const scanEnd = Math.min(endOffset, MAX_SCAN_BYTES_PER_FILE_CYCLE);
-  let sawForeignMeta = false;
+  startOffset: number,
+  fileSize: number,
+  foreignMetaConfirmed: boolean,
+): Promise<CopiedPrefixProbeResult> {
+  const scanEnd = Math.min(fileSize, startOffset + MAX_SCAN_BYTES_PER_FILE_CYCLE);
+  let sawForeignMeta = foreignMetaConfirmed;
   let boundaryEndOffset: number | null = null;
-  await scanJsonLines(filePath, 0, scanEnd, line => {
+  const { nextOffset } = await scanJsonLines(filePath, startOffset, scanEnd, line => {
     const payload = asRecord(line.record.payload);
     if (line.record.type === 'session_meta') {
       const metaId = payload ? stringValue(payload.id) : undefined;
@@ -2095,15 +2159,21 @@ async function findCopiedPrefixEndOffset(
       return undefined;
     }
     if (line.record.type === 'event_msg' && payload?.type === 'thread_settings_applied') {
-      // The first settings marker delimits the copied prefix. A mid-stream
-      // settings change (a later marker) is in real content and must not match,
-      // so stop the scan here.
+      // The first settings marker delimits the prefix. Reaching it without
+      // ancestor metadata means there is nothing to drop; either way the probe
+      // stops here, so a mid-stream settings change is never mistaken for it.
       if (sawForeignMeta) boundaryEndOffset = line.endOffset;
       return false;
     }
     return undefined;
   });
-  return boundaryEndOffset;
+  if (boundaryEndOffset !== null) return { kind: 'found', endOffset: boundaryEndOffset };
+  // No ancestor metadata seen so far: no evidence of a copied prefix, so collect
+  // normally instead of withholding the rollout while probing further.
+  if (!sawForeignMeta) return { kind: 'absent' };
+  // Prefix confirmed but no marker: at EOF this rollout simply has none.
+  if (nextOffset >= fileSize) return { kind: 'absent' };
+  return { kind: 'probing', nextOffset };
 }
 
 function selectOwnerSessionMetaOffset(

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -131,6 +131,7 @@ interface DynamicDirectoryWalkBudget {
 
 interface CodexWakeupMarker {
   initialTurnId?: string;
+  recoveryTurnId?: string;
   hookEvent?: string;
 }
 
@@ -301,6 +302,13 @@ export class CodexTranscriptInput extends BaseInput {
       };
       checkpointChanged = true;
     } else if (checkpoint.inode !== stat.ino) {
+      this.logger.warn('Codex transcript inode changed; applying no-replay baseline', {
+        transcriptPath: filePath,
+        previousInode: checkpoint.inode,
+        currentInode: stat.ino,
+        previousScanOffset: checkpoint.scanOffset,
+        hadForkBootstrap: checkpoint.forkBootstrap !== undefined,
+      });
       await this.baselineFile(filePath, key);
       this.saveGlobalProcessedTerminalTurnIds();
       return 0;
@@ -321,11 +329,12 @@ export class CodexTranscriptInput extends BaseInput {
       : undefined;
     if (ownerMeta?.depth === 0) this.registerPersistedSubagentSpawns(checkpoint, ownerMeta.threadId);
 
-    // A fork/subagent rollout starts with copied ancestor history. Its lifecycle
-    // Hook supplies the exact first turn owned by this rollout, so keep normal
-    // collection parked at offset zero until that task_started record appears.
-    // The independent search offset makes this safe when the Hook fires before
-    // Codex finishes appending the copied prefix or the new turn.
+    // A fork/subagent rollout starts with copied ancestor history. Prefer the
+    // lifecycle Hook's exact initial turn; when that Hook is unavailable, UUIDv7
+    // causality identifies the earliest turn created after the rollout owner.
+    // A terminal Hook supplies recovery evidence but is not assumed to be the
+    // first turn. Keep normal collection parked at zero until one of these
+    // positive ownership signals is found.
     const hasCopiedPrefix = ownerMeta != null && (
       ownerMeta.forkedFromId != null
       || ownerMeta.parentThreadId != null
@@ -338,29 +347,66 @@ export class CodexTranscriptInput extends BaseInput {
       && checkpoint.pendingTerminal === null
     ) {
       const marker = await this.readWakeupMarker(ownerMeta!.threadId, filePath);
-      const markerTurnId = marker?.initialTurnId;
       let bootstrap: CodexForkBootstrap = checkpoint.forkBootstrap ?? { searchOffset: 0 };
-      if (markerTurnId && bootstrap.turnId !== markerTurnId) {
-        bootstrap = { turnId: markerTurnId, searchOffset: 0 };
+      if (marker?.initialTurnId && bootstrap.initialTurnId !== marker.initialTurnId) {
+        bootstrap = {
+          initialTurnId: marker.initialTurnId,
+          ...(marker.recoveryTurnId ? { recoveryTurnId: marker.recoveryTurnId } : {}),
+          searchOffset: 0,
+        };
+      } else if (
+        marker?.recoveryTurnId
+        && bootstrap.recoveryTurnId !== marker.recoveryTurnId
+      ) {
+        bootstrap = {
+          ...bootstrap,
+          recoveryTurnId: marker.recoveryTurnId,
+          // The newly arrived terminal evidence may already lie before an EOF
+          // reached by an evidence-free UUID probe. Re-scan from the start.
+          searchOffset: bootstrap.initialTurnId ? bootstrap.searchOffset : 0,
+        };
+      }
+      const safeSearchOffset = boundedSearchOffset(bootstrap.searchOffset, stat.size);
+      if (safeSearchOffset !== bootstrap.searchOffset) {
+        this.logger.warn('repaired invalid Codex fork bootstrap search offset', {
+          transcriptPath: filePath,
+          searchOffset: bootstrap.searchOffset,
+          repairedSearchOffset: safeSearchOffset,
+          fileSize: stat.size,
+        });
+        bootstrap = { ...bootstrap, searchOffset: safeSearchOffset };
       }
       checkpoint.forkBootstrap = bootstrap;
       checkpointChanged = true;
-      if (!bootstrap.turnId) {
-        this.saveCheckpoint(key, checkpoint);
-        return 0;
-      }
+      const searchedNewBytes = bootstrap.searchOffset < stat.size;
 
       const located = await findTurnStartOffset(
         filePath,
-        bootstrap.turnId,
+        ownerMeta!.threadId,
+        bootstrap.initialTurnId,
+        bootstrap.recoveryTurnId,
         bootstrap.searchOffset,
         stat.size,
       );
       if (located.startOffset === null) {
         checkpoint.forkBootstrap = {
-          turnId: bootstrap.turnId,
+          ...(bootstrap.initialTurnId ? { initialTurnId: bootstrap.initialTurnId } : {}),
+          ...(bootstrap.recoveryTurnId ? { recoveryTurnId: bootstrap.recoveryTurnId } : {}),
           searchOffset: located.nextOffset,
         };
+        if (
+          located.nextOffset >= stat.size
+          && searchedNewBytes
+          && !bootstrap.initialTurnId
+          && uuidV7TimestampMs(ownerMeta!.threadId) === undefined
+          && !bootstrap.recoveryTurnId
+        ) {
+          this.logger.warn('Codex fork bootstrap has no usable Hook or UUIDv7 ownership evidence', {
+            transcriptPath: filePath,
+            threadId: ownerMeta!.threadId,
+            searchedBytes: located.nextOffset,
+          });
+        }
         this.saveCheckpoint(key, checkpoint);
         return 0;
       }
@@ -369,7 +415,8 @@ export class CodexTranscriptInput extends BaseInput {
       checkpoint.forkBootstrap = undefined;
       this.logger.info('anchored fork/subagent rollout at its first owned turn', {
         transcriptPath: filePath,
-        turnId: bootstrap.turnId,
+        turnId: located.turnId,
+        anchorKind: located.anchorKind,
         skippedBytes: located.startOffset,
         hookEvent: marker?.hookEvent,
         threadSource: ownerMeta!.threadSource,
@@ -1475,15 +1522,29 @@ export class CodexTranscriptInput extends BaseInput {
           fs.realpath(recordedTranscriptPath),
           fs.realpath(transcriptPath),
         ]);
-        if (recordedRealPath !== transcriptRealPath) return undefined;
+        if (recordedRealPath !== transcriptRealPath) {
+          this.logger.warn('Codex wakeup transcript path differs from discovered session file; accepting session anchor', {
+            sessionId,
+            recordedTranscriptPath,
+            transcriptPath,
+          });
+        }
       } catch {
-        if (path.resolve(recordedTranscriptPath) !== path.resolve(transcriptPath)) return undefined;
+        if (path.resolve(recordedTranscriptPath) !== path.resolve(transcriptPath)) {
+          this.logger.warn('Codex wakeup transcript path could not be canonicalized; accepting session anchor', {
+            sessionId,
+            recordedTranscriptPath,
+            transcriptPath,
+          });
+        }
       }
     }
     const initialTurnId = stringValue(record.initial_turn_id);
+    const recoveryTurnId = stringValue(record.recovery_turn_id);
     const hookEvent = stringValue(record.hook_event);
     return {
       ...(initialTurnId ? { initialTurnId } : {}),
+      ...(recoveryTurnId ? { recoveryTurnId } : {}),
       ...(hookEvent ? { hookEvent } : {}),
     };
   }
@@ -1858,10 +1919,18 @@ export class CodexTranscriptInput extends BaseInput {
     const bootstrapRecord = asRecord(value.forkBootstrap);
     const forkBootstrap: CodexForkBootstrap | null = bootstrapRecord
       && typeof bootstrapRecord.searchOffset === 'number'
+      && Number.isFinite(bootstrapRecord.searchOffset)
+      && bootstrapRecord.searchOffset >= 0
       ? {
           searchOffset: bootstrapRecord.searchOffset,
-          ...(typeof bootstrapRecord.turnId === 'string'
-            ? { turnId: bootstrapRecord.turnId }
+          ...(typeof bootstrapRecord.initialTurnId === 'string'
+            ? { initialTurnId: bootstrapRecord.initialTurnId }
+            : typeof bootstrapRecord.turnId === 'string'
+              // Migrate checkpoints written by the first Hook-anchor version.
+              ? { initialTurnId: bootstrapRecord.turnId }
+              : {}),
+          ...(typeof bootstrapRecord.recoveryTurnId === 'string'
+            ? { recoveryTurnId: bootstrapRecord.recoveryTurnId }
             : {}),
         }
       : null;
@@ -2141,27 +2210,72 @@ async function findOwnerSessionMetaOffset(
   return ownerOffset;
 }
 
-/** Locate the Hook-provided first task owned by a forked rollout. */
+type ForkAnchorKind = 'initial-hook' | 'uuidv7' | 'terminal-recovery';
+
+/** Locate the first positively-owned turn of a forked rollout in one bounded window. */
 async function findTurnStartOffset(
   filePath: string,
-  turnId: string,
+  ownerThreadId: string,
+  initialTurnId: string | undefined,
+  recoveryTurnId: string | undefined,
   startOffset: number,
   fileSize: number,
-): Promise<{ startOffset: number | null; nextOffset: number }> {
+): Promise<{
+  startOffset: number | null;
+  nextOffset: number;
+  turnId?: string;
+  anchorKind?: ForkAnchorKind;
+}> {
   let turnStartOffset: number | null = null;
-  const { nextOffset } = await scanJsonLines(filePath, startOffset, fileSize, line => {
+  let matchedTurnId: string | undefined;
+  let anchorKind: ForkAnchorKind | undefined;
+  const safeStart = boundedSearchOffset(startOffset, fileSize);
+  const scanEnd = Math.min(fileSize, safeStart + MAX_SCAN_BYTES_PER_FILE_CYCLE);
+  const ownerTimestamp = uuidV7TimestampMs(ownerThreadId);
+  const { nextOffset } = await scanJsonLines(filePath, safeStart, scanEnd, line => {
     const payload = asRecord(line.record.payload);
+    if (!payload) return undefined;
+    const candidateTurnId = turnIdForStart(line.record, payload);
+    if (!candidateTurnId) return undefined;
+
+    if (initialTurnId && candidateTurnId === initialTurnId) {
+      turnStartOffset = line.startOffset;
+      matchedTurnId = candidateTurnId;
+      anchorKind = 'initial-hook';
+      return false;
+    }
+    if (initialTurnId) return undefined;
+
+    const candidateTimestamp = uuidV7TimestampMs(candidateTurnId);
     if (
-      line.record.type === 'event_msg'
-      && payload?.type === 'task_started'
-      && stringValue(payload.turn_id) === turnId
+      ownerTimestamp !== undefined
+      && candidateTimestamp !== undefined
+      && candidateTimestamp >= ownerTimestamp
     ) {
       turnStartOffset = line.startOffset;
+      matchedTurnId = candidateTurnId;
+      anchorKind = 'uuidv7';
+      return false;
+    }
+    if (recoveryTurnId && candidateTurnId === recoveryTurnId) {
+      turnStartOffset = line.startOffset;
+      matchedTurnId = candidateTurnId;
+      anchorKind = 'terminal-recovery';
       return false;
     }
     return undefined;
   });
-  return { startOffset: turnStartOffset, nextOffset };
+  return {
+    startOffset: turnStartOffset,
+    nextOffset,
+    ...(matchedTurnId ? { turnId: matchedTurnId } : {}),
+    ...(anchorKind ? { anchorKind } : {}),
+  };
+}
+
+function boundedSearchOffset(value: number, fileSize: number): number {
+  if (!Number.isFinite(value) || value < 0 || value > fileSize) return 0;
+  return Math.trunc(value);
 }
 
 function selectOwnerSessionMetaOffset(

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -315,6 +315,38 @@ export class CodexTranscriptInput extends BaseInput {
       : undefined;
     if (ownerMeta?.depth === 0) this.registerPersistedSubagentSpawns(checkpoint, ownerMeta.threadId);
 
+    // Fork/resume/subagent rollouts begin with a verbatim copy of ancestor
+    // history that must never be emitted (it re-reports the ancestor's events
+    // or, post owner-session fix, spawns ghost turns). On the file's first scan
+    // (fresh checkpoint, nothing consumed yet), advance the offset past that
+    // copied prefix using codex's own boundary marker. Gated on a first-party
+    // fork/child indicator so normal user sessions are never touched, and
+    // fail-open: no boundary found -> skip nothing.
+    const hasCopiedPrefix = ownerMeta != null && (
+      ownerMeta.forkedFromId != null
+      || ownerMeta.parentThreadId != null
+      || ownerMeta.threadSource === 'subagent'
+    );
+    if (
+      hasCopiedPrefix
+      && checkpoint.scanOffset === 0
+      && checkpoint.activeTurn === null
+      && checkpoint.pendingTerminal === null
+    ) {
+      const prefixEnd = await findCopiedPrefixEndOffset(filePath, ownerMeta!.threadId, stat.size);
+      if (prefixEnd !== null && prefixEnd > 0) {
+        this.logger.info('skipping copied fork/subagent history prefix', {
+          transcriptPath: filePath,
+          skippedBytes: prefixEnd,
+          threadSource: ownerMeta!.threadSource,
+          forkedFromId: ownerMeta!.forkedFromId,
+          parentThreadId: ownerMeta!.parentThreadId,
+        });
+        checkpoint.scanOffset = prefixEnd;
+        checkpointChanged = true;
+      }
+    }
+
     let emittedCount = 0;
     let processedTerminalCount = 0;
     if (
@@ -2026,6 +2058,52 @@ async function findOwnerSessionMetaOffset(
     return undefined;
   });
   return ownerOffset;
+}
+
+/**
+ * Locate the end of a fork/resume/subagent rollout's copied-history prefix.
+ *
+ * Codex spawns (subagent) and Desktop resume/fork produce a new rollout that
+ * begins with a verbatim copy of the ancestor's history, then appends the
+ * child's own `thread_settings_applied` marker before any real new turn (see
+ * codex-rs `record_initial_history`, ForkPersistence::Copied). The copied
+ * region therefore spans from file start up to the first
+ * `event_msg/thread_settings_applied`. Emitting it re-reports the ancestor's
+ * events (colliding event.id) or, after the owner-session fix, spawns ghost
+ * turns; either way it must be dropped.
+ *
+ * Returns the end offset of that first `thread_settings_applied` (i.e. the
+ * offset where the child's own content begins), but only when a foreign
+ * session_meta (id != owner) was observed before it — the positive signal that
+ * a copied prefix actually exists. Returns null when there is no copied prefix
+ * or no boundary marker is found within the byte budget, so callers fail open
+ * (skip nothing) rather than risk dropping real data.
+ */
+async function findCopiedPrefixEndOffset(
+  filePath: string,
+  ownerThreadId: string,
+  endOffset: number,
+): Promise<number | null> {
+  const scanEnd = Math.min(endOffset, MAX_SCAN_BYTES_PER_FILE_CYCLE);
+  let sawForeignMeta = false;
+  let boundaryEndOffset: number | null = null;
+  await scanJsonLines(filePath, 0, scanEnd, line => {
+    const payload = asRecord(line.record.payload);
+    if (line.record.type === 'session_meta') {
+      const metaId = payload ? stringValue(payload.id) : undefined;
+      if (metaId && ownerThreadId && metaId !== ownerThreadId) sawForeignMeta = true;
+      return undefined;
+    }
+    if (line.record.type === 'event_msg' && payload?.type === 'thread_settings_applied') {
+      // The first settings marker delimits the copied prefix. A mid-stream
+      // settings change (a later marker) is in real content and must not match,
+      // so stop the scan here.
+      if (sawForeignMeta) boundaryEndOffset = line.endOffset;
+      return false;
+    }
+    return undefined;
+  });
+  return boundaryEndOffset;
 }
 
 function selectOwnerSessionMetaOffset(

--- a/src/inputs/codex-transcript/codex-transcript-types.ts
+++ b/src/inputs/codex-transcript/codex-transcript-types.ts
@@ -111,7 +111,7 @@ export interface CodexTranscriptCheckpoint {
    * meta therefore misattributes child turns to the parent session.
    */
   ownerSessionMetaOffset: number | null;
-  /** Present until the first owned turn is located from Hook or UUIDv7 evidence. */
+  /** Present until the first owned range is located and actually consumed. */
   forkBootstrap?: CodexForkBootstrap;
   /** Terminal turns already processed by this transcript, including empty control turns. */
   emittedTerminalTurnIds: string[];

--- a/src/inputs/codex-transcript/codex-transcript-types.ts
+++ b/src/inputs/codex-transcript/codex-transcript-types.ts
@@ -86,22 +86,12 @@ export interface CodexPendingTerminalTurn {
   sourceRecordCount?: number;
 }
 
-/**
- * Progress of the copied-history prefix probe for fork/subagent rollouts.
- *
- * The prefix can be larger than one cycle's scan window, so its boundary has to
- * be searched across cycles. The probe deliberately keeps its own offset: the
- * collection offset must not move while probing, otherwise abandoning the probe
- * would leave the skipped range marked as consumed and the data would be lost
- * instead of collected.
- */
-export interface CodexCopiedPrefixProbe {
-  /** How far the probe has read; independent of the collection offset. */
-  scanOffset: number;
-  /** Whether an ancestor session_meta proved a copied prefix exists. */
-  sawForeignMeta: boolean;
-  /** Set once the prefix was skipped, found absent, or abandoned. */
-  settled?: boolean;
+/** Exact first-turn bootstrap for a fork/subagent rollout. */
+export interface CodexForkBootstrap {
+  /** Hook-provided first turn owned by this rollout. */
+  turnId?: string;
+  /** How far the append-only rollout has been searched for that turn. */
+  searchOffset: number;
 }
 
 export interface CodexTranscriptCheckpoint {
@@ -119,8 +109,8 @@ export interface CodexTranscriptCheckpoint {
    * meta therefore misattributes child turns to the parent session.
    */
   ownerSessionMetaOffset: number | null;
-  /** Cross-cycle state of the copied-history prefix probe; see the interface. */
-  copiedPrefixProbe?: CodexCopiedPrefixProbe;
+  /** Present until a lifecycle Hook identifies this rollout's first owned turn. */
+  forkBootstrap?: CodexForkBootstrap;
   /** Terminal turns already processed by this transcript, including empty control turns. */
   emittedTerminalTurnIds: string[];
 }

--- a/src/inputs/codex-transcript/codex-transcript-types.ts
+++ b/src/inputs/codex-transcript/codex-transcript-types.ts
@@ -86,6 +86,24 @@ export interface CodexPendingTerminalTurn {
   sourceRecordCount?: number;
 }
 
+/**
+ * Progress of the copied-history prefix probe for fork/subagent rollouts.
+ *
+ * The prefix can be larger than one cycle's scan window, so its boundary has to
+ * be searched across cycles. The probe deliberately keeps its own offset: the
+ * collection offset must not move while probing, otherwise abandoning the probe
+ * would leave the skipped range marked as consumed and the data would be lost
+ * instead of collected.
+ */
+export interface CodexCopiedPrefixProbe {
+  /** How far the probe has read; independent of the collection offset. */
+  scanOffset: number;
+  /** Whether an ancestor session_meta proved a copied prefix exists. */
+  sawForeignMeta: boolean;
+  /** Set once the prefix was skipped, found absent, or abandoned. */
+  settled?: boolean;
+}
+
 export interface CodexTranscriptCheckpoint {
   inode: number;
   scanOffset: number;
@@ -101,6 +119,8 @@ export interface CodexTranscriptCheckpoint {
    * meta therefore misattributes child turns to the parent session.
    */
   ownerSessionMetaOffset: number | null;
+  /** Cross-cycle state of the copied-history prefix probe; see the interface. */
+  copiedPrefixProbe?: CodexCopiedPrefixProbe;
   /** Terminal turns already processed by this transcript, including empty control turns. */
   emittedTerminalTurnIds: string[];
 }

--- a/src/inputs/codex-transcript/codex-transcript-types.ts
+++ b/src/inputs/codex-transcript/codex-transcript-types.ts
@@ -86,11 +86,13 @@ export interface CodexPendingTerminalTurn {
   sourceRecordCount?: number;
 }
 
-/** Exact first-turn bootstrap for a fork/subagent rollout. */
+/** First-owned-turn bootstrap for a fork/subagent rollout. */
 export interface CodexForkBootstrap {
   /** Hook-provided first turn owned by this rollout. */
-  turnId?: string;
-  /** How far the append-only rollout has been searched for that turn. */
+  initialTurnId?: string;
+  /** Terminal Hook evidence for an owned turn; it may not be the first one. */
+  recoveryTurnId?: string;
+  /** How far the append-only rollout has been searched for an owned turn. */
   searchOffset: number;
 }
 
@@ -109,7 +111,7 @@ export interface CodexTranscriptCheckpoint {
    * meta therefore misattributes child turns to the parent session.
    */
   ownerSessionMetaOffset: number | null;
-  /** Present until a lifecycle Hook identifies this rollout's first owned turn. */
+  /** Present until the first owned turn is located from Hook or UUIDv7 evidence. */
   forkBootstrap?: CodexForkBootstrap;
   /** Terminal turns already processed by this transcript, including empty control turns. */
   emittedTerminalTurnIds: string[];

--- a/src/inputs/codex-transcript/codex-transcript-types.ts
+++ b/src/inputs/codex-transcript/codex-transcript-types.ts
@@ -1,8 +1,5 @@
 import type { JsonValue } from '../../types/index.js';
 
-export const MAX_EMITTED_TERMINAL_TURNS = 100;
-export const MAX_GLOBAL_EMITTED_TERMINAL_TURNS = 10_000;
-
 export type CodexTerminalStatus = 'completed' | 'interrupted';
 
 export interface CodexTranscriptInputContext {
@@ -86,8 +83,7 @@ export interface CodexPendingTerminalTurn {
   sourceRecordCount?: number;
 }
 
-/** First-owned-turn bootstrap for a fork/subagent rollout. */
-export interface CodexForkBootstrap {
+interface CodexForkBootstrapBase {
   /** Hook-provided first turn owned by this rollout. */
   initialTurnId?: string;
   /** Terminal Hook evidence for an owned turn; it may not be the first one. */
@@ -96,8 +92,23 @@ export interface CodexForkBootstrap {
   searchOffset: number;
 }
 
+/** First-owned-turn bootstrap for a fork/subagent rollout. */
+export type CodexForkBootstrap = CodexForkBootstrapBase & (
+  /** A file discovered while Pilot is running; retain until owned bytes advance. */
+  | { state: 'live-pending' }
+  /** A startup no-replay file whose first owned turn has not been located yet. */
+  | { state: 'baseline-search' }
+  /** A bounded no-output rebuild below the startup baseline. */
+  | {
+      state: 'baseline-tail';
+      /** Last unfinished owned candidate reconstructed below the baseline scanOffset. */
+      tailCandidate?: CodexActiveTranscriptTurn;
+    }
+);
+
 export interface CodexTranscriptCheckpoint {
   inode: number;
+  /** No-replay floor and next byte for normal event collection. Never rewound by fork probing. */
   scanOffset: number;
   activeTurn: CodexActiveTranscriptTurn | null;
   pendingTerminal: CodexPendingTerminalTurn | null;
@@ -111,15 +122,8 @@ export interface CodexTranscriptCheckpoint {
    * meta therefore misattributes child turns to the parent session.
    */
   ownerSessionMetaOffset: number | null;
-  /** Present until the first owned range is located and actually consumed. */
+  /** Independent ownership probe; searchOffset never acts as the normal collection cursor. */
   forkBootstrap?: CodexForkBootstrap;
-  /** Terminal turns already processed by this transcript, including empty control turns. */
-  emittedTerminalTurnIds: string[];
-}
-
-export interface CodexTranscriptGlobalState {
-  /** Bounded cross-transcript registry; the persisted name is retained for compatibility. */
-  emittedTerminalTurnIds: string[];
 }
 
 export interface CodexTranscriptMeta {

--- a/src/inputs/codex-transcript/codex-transcript-types.ts
+++ b/src/inputs/codex-transcript/codex-transcript-types.ts
@@ -117,6 +117,8 @@ export interface CodexTranscriptMeta {
   rootSessionId: string;
   threadSource: 'user' | 'subagent' | 'unknown';
   parentThreadId?: string;
+  /** Top-level session_meta.forked_from_id — fork/resume lineage marker. */
+  forkedFromId?: string;
   depth: number;
   createdAtMs?: number;
   agentPath?: string;

--- a/tests/unit/deployment/codex-trust-writer.test.ts
+++ b/tests/unit/deployment/codex-trust-writer.test.ts
@@ -230,7 +230,7 @@ describe('writeTrustedHashes / verifyTrustHashes 闭环', () => {
   });
 
   test('forceBypass=true 时写入 bypass_hook_trust = true', () => {
-    writeTrustedHashes({
+    const opts = {
       configPath,
       hooksJsonAbsPath: '/abs/hooks.json',
       hookEvents: HOOK_EVENTS,
@@ -238,9 +238,54 @@ describe('writeTrustedHashes / verifyTrustHashes 闭环', () => {
       eventToGroupIndex: EVENT_TO_GROUP_0,
       marker: 'otel-codex-hook',
       forceBypass: true,
-    });
+    } as const;
+    writeTrustedHashes(opts);
     const content = fs.readFileSync(configPath, 'utf-8');
     expect(content).toContain('bypass_hook_trust = true');
+    expect(verifyTrustHashes(opts)).toEqual({ valid: true, mismatches: [] });
+  });
+
+  test('forceBypass off -> on 需要触发重写', () => {
+    const base = {
+      configPath,
+      hooksJsonAbsPath: '/abs/hooks.json',
+      hookEvents: HOOK_EVENTS,
+      eventToCommand: EVENT_TO_CMD,
+      eventToGroupIndex: EVENT_TO_GROUP_0,
+      marker: 'otel-codex-hook',
+    } as const;
+    writeTrustedHashes(base);
+
+    const enabled = { ...base, forceBypass: true } as const;
+    expect(verifyTrustHashes(enabled)).toEqual({
+      valid: false,
+      mismatches: ['missing bypass_hook_trust = true'],
+    });
+    expect(writeTrustedHashes(enabled)).toBe(true);
+    expect(fs.readFileSync(configPath, 'utf-8')).toContain('bypass_hook_trust = true');
+    expect(verifyTrustHashes(enabled)).toEqual({ valid: true, mismatches: [] });
+  });
+
+  test('forceBypass on -> off 需要触发重写', () => {
+    const enabled = {
+      configPath,
+      hooksJsonAbsPath: '/abs/hooks.json',
+      hookEvents: HOOK_EVENTS,
+      eventToCommand: EVENT_TO_CMD,
+      eventToGroupIndex: EVENT_TO_GROUP_0,
+      marker: 'otel-codex-hook',
+      forceBypass: true,
+    } as const;
+    writeTrustedHashes(enabled);
+
+    const disabled = { ...enabled, forceBypass: false } as const;
+    expect(verifyTrustHashes(disabled)).toEqual({
+      valid: false,
+      mismatches: ['unexpected bypass_hook_trust = true'],
+    });
+    expect(writeTrustedHashes(disabled)).toBe(true);
+    expect(fs.readFileSync(configPath, 'utf-8')).not.toContain('bypass_hook_trust = true');
+    expect(verifyTrustHashes(disabled)).toEqual({ valid: true, mismatches: [] });
   });
 
   test('幂等重写: 两次 write 不产生重复段', () => {
@@ -296,7 +341,9 @@ describe('writeTrustedHashes / verifyTrustHashes 闭环', () => {
     ].join('\n');
     fs.writeFileSync(configPath, trustAndUserData, 'utf-8');
 
-    const removed = removeTrustBlock(configPath, 'otel-codex-hook', '/abs/hooks.json', HOOK_EVENTS);
+    const removed = removeTrustBlock(configPath, 'otel-codex-hook', [
+      '/abs/hooks.json:session_start:0:0',
+    ]);
     expect(removed).toBe(true);
     const content = fs.readFileSync(configPath, 'utf-8');
     // trust 条目 + marker 都被删
@@ -307,6 +354,31 @@ describe('writeTrustedHashes / verifyTrustHashes 闭环', () => {
     // 用户的 marketplace 数据保留
     expect(content).toContain('[marketplaces.openai-bundled]');
     expect(content).toContain('source_type = "local"');
+  });
+
+  test('removeTrustBlock 不删除 marker 范围内的第三方 hook trust', () => {
+    const pilotKey = '/abs/hooks.json:session_start:0:0';
+    const thirdPartyKey = '/abs/hooks.json:session_start:1:0';
+    fs.writeFileSync(configPath, [
+      '# BEGIN otel-codex-hook trust',
+      `[hooks.state."${pilotKey}"]`,
+      'trusted_hash = "sha256:PILOT"',
+      '',
+      `[hooks.state."${thirdPartyKey}"]`,
+      'enabled = false',
+      'trusted_hash = "sha256:THIRD_PARTY"',
+      '',
+      '# END otel-codex-hook trust',
+    ].join('\n'), 'utf-8');
+
+    removeTrustBlock(configPath, 'otel-codex-hook', [pilotKey]);
+
+    const content = fs.readFileSync(configPath, 'utf-8');
+    expect(content).not.toContain(pilotKey);
+    expect(content).not.toContain('sha256:PILOT');
+    expect(content).toContain(`[hooks.state."${thirdPartyKey}"]`);
+    expect(content).toContain('enabled = false');
+    expect(content).toContain('sha256:THIRD_PARTY');
   });
 
   test('verify 检测 hash 不一致', () => {

--- a/tests/unit/deployment/codex-trust-writer.test.ts
+++ b/tests/unit/deployment/codex-trust-writer.test.ts
@@ -4,7 +4,10 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import {
   computeHookTrustHash,
+  computeInstalledHookTrustHash,
   hookStateKey,
+  installedHookStateKey,
+  type InstalledCodexHookLocation,
   writeTrustedHashes,
   removeTrustBlock,
   verifyTrustHashes,
@@ -56,6 +59,75 @@ describe('codex-trust-writer 算法', () => {
 
   test('未知 event 抛错', () => {
     expect(() => computeHookTrustHash('Unknown', 'cmd')).toThrow(/Unknown hook event/);
+  });
+
+  test('matches Codex hashes for installed matcher-sensitive Pilot hooks', () => {
+    const command = '/Users/yunshen/.loongsuite-pilot/hooks/codex-loongsuite-pilot-hook.sh';
+    expect(computeHookTrustHash('SessionStart', `${command} session-start`, '*')).toBe(
+      'sha256:474a9671344eabd67eeda6fc6dc5c152e22ee474e067ff28885da1230e334512',
+    );
+    expect(computeHookTrustHash('SubagentStart', `${command} subagent-start`, '*')).toBe(
+      'sha256:b35e26cd3fd1c65960cbb8a5b62720743729d447b720a62f4a78bf2bf19edcde',
+    );
+    expect(computeHookTrustHash('SubagentStop', `${command} subagent-stop`, '*')).toBe(
+      'sha256:d7d2dee53aeaca1819c85d2781ef97e6056768187eef9186a1eef8dc3e0dbc91',
+    );
+  });
+
+  test('ignores matcher for UserPromptSubmit and Stop', () => {
+    expect(computeHookTrustHash('UserPromptSubmit', 'cmd', '*')).toBe(
+      computeHookTrustHash('UserPromptSubmit', 'cmd'),
+    );
+    expect(computeHookTrustHash('Stop', 'cmd', '*')).toBe(
+      computeHookTrustHash('Stop', 'cmd'),
+    );
+  });
+
+  test('distinguishes absent, empty, and wildcard matcher for matcher events', () => {
+    const hashes = [
+      computeHookTrustHash('SessionStart', 'cmd'),
+      computeHookTrustHash('SessionStart', 'cmd', ''),
+      computeHookTrustHash('SessionStart', 'cmd', '*'),
+    ];
+    expect(new Set(hashes).size).toBe(3);
+  });
+
+  test('normalizes installed handler fields and uses the real handler index', () => {
+    const base: InstalledCodexHookLocation = {
+      eventName: 'SessionStart',
+      eventKey: 'session_start',
+      groupIndex: 2,
+      handlerIndex: 3,
+      matcher: '*',
+      handler: {
+        type: 'command',
+        command: 'unix-command',
+        commandWindows: 'windows-command',
+        timeout: 0,
+        async: true,
+        statusMessage: 'running',
+        additionalContextLimit: 4_096,
+      },
+    };
+    expect(installedHookStateKey('/abs/hooks.json', base)).toBe(
+      '/abs/hooks.json:session_start:2:3',
+    );
+    expect(computeInstalledHookTrustHash(base, 'linux')).not.toBe(
+      computeInstalledHookTrustHash(base, 'win32'),
+    );
+    expect(computeInstalledHookTrustHash(base, 'linux')).not.toBe(
+      computeInstalledHookTrustHash({
+        ...base,
+        handler: { ...base.handler, statusMessage: undefined },
+      }, 'linux'),
+    );
+    expect(computeInstalledHookTrustHash({
+      ...base,
+      handler: { ...base.handler, additionalContextLimit: 2_500 },
+    }, 'linux')).toBe(computeInstalledHookTrustHash({
+      ...base,
+      handler: { ...base.handler, additionalContextLimit: undefined },
+    }, 'linux'));
   });
 });
 
@@ -304,5 +376,40 @@ describe('writeTrustedHashes / verifyTrustHashes 闭环', () => {
       marker: 'otel-codex-hook',
     });
     expect(result.valid).toBe(true);
+  });
+
+  test('precise installed-key repair preserves third-party state and enabled', () => {
+    const location: InstalledCodexHookLocation = {
+      eventName: 'SubagentStart',
+      eventKey: 'subagent_start',
+      groupIndex: 1,
+      handlerIndex: 1,
+      matcher: '*',
+      handler: { type: 'command', command: 'pilot subagent-start' },
+    };
+    fs.writeFileSync(configPath, [
+      '[hooks.state."/abs/hooks.json:subagent_start:0:0"]',
+      'trusted_hash = "sha256:THIRD_PARTY"',
+      '',
+      '# BEGIN otel-codex-hook trust',
+      '[hooks.state."/abs/hooks.json:subagent_start:1:1"]',
+      'enabled = false',
+      'trusted_hash = "sha256:STALE"',
+      '# END otel-codex-hook trust',
+      '',
+    ].join('\n'));
+    const opts = {
+      configPath,
+      hooksJsonAbsPath: '/abs/hooks.json',
+      locations: { SubagentStart: location },
+      marker: 'otel-codex-hook',
+    };
+
+    expect(writeTrustedHashes(opts)).toBe(true);
+    const repaired = fs.readFileSync(configPath, 'utf8');
+    expect(repaired).toContain('sha256:THIRD_PARTY');
+    expect(repaired).toContain('enabled = false');
+    expect(repaired).not.toContain('sha256:STALE');
+    expect(writeTrustedHashes(opts)).toBe(false);
   });
 });

--- a/tests/unit/deployment/codex-trust-writer.test.ts
+++ b/tests/unit/deployment/codex-trust-writer.test.ts
@@ -450,7 +450,7 @@ describe('writeTrustedHashes / verifyTrustHashes 闭环', () => {
     expect(result.valid).toBe(true);
   });
 
-  test('precise installed-key repair preserves third-party state and enabled', () => {
+  test('does not inherit enabled from a different hook previously at the same key', () => {
     const location: InstalledCodexHookLocation = {
       eventName: 'SubagentStart',
       eventKey: 'subagent_start',
@@ -480,8 +480,40 @@ describe('writeTrustedHashes / verifyTrustHashes 闭环', () => {
     expect(writeTrustedHashes(opts)).toBe(true);
     const repaired = fs.readFileSync(configPath, 'utf8');
     expect(repaired).toContain('sha256:THIRD_PARTY');
-    expect(repaired).toContain('enabled = false');
+    expect(repaired).not.toContain('enabled = false');
     expect(repaired).not.toContain('sha256:STALE');
     expect(writeTrustedHashes(opts)).toBe(false);
+  });
+
+  test('preserves enabled only when key and trusted hash both match Pilot', () => {
+    const location: InstalledCodexHookLocation = {
+      eventName: 'SubagentStart',
+      eventKey: 'subagent_start',
+      groupIndex: 0,
+      handlerIndex: 0,
+      matcher: '*',
+      handler: { type: 'command', command: 'pilot subagent-start' },
+    };
+    const key = installedHookStateKey('/abs/hooks.json', location);
+    const hash = computeInstalledHookTrustHash(location);
+    fs.writeFileSync(configPath, [
+      `[hooks.state."${key}"]`,
+      'enabled = false',
+      `trusted_hash = "${hash}"`,
+      '',
+    ].join('\n'));
+    const opts = {
+      configPath,
+      hooksJsonAbsPath: '/abs/hooks.json',
+      locations: { SubagentStart: location },
+      marker: 'otel-codex-hook',
+      forceBypass: true,
+    };
+
+    expect(writeTrustedHashes(opts)).toBe(true);
+    const repaired = fs.readFileSync(configPath, 'utf8');
+    expect(repaired).toContain('bypass_hook_trust = true');
+    expect(repaired).toContain('enabled = false');
+    expect(repaired).toContain(`trusted_hash = "${hash}"`);
   });
 });

--- a/tests/unit/deployment/codex-trust-writer.test.ts
+++ b/tests/unit/deployment/codex-trust-writer.test.ts
@@ -229,7 +229,7 @@ describe('writeTrustedHashes / verifyTrustHashes 闭环', () => {
     expect(verifyTrustHashes(opts)).toEqual({ valid: true, mismatches: [] });
   });
 
-  test('forceBypass=true 时写入 bypass_hook_trust = true', () => {
+  test('removes the unsupported legacy bypass_hook_trust field', () => {
     const opts = {
       configPath,
       hooksJsonAbsPath: '/abs/hooks.json',
@@ -237,55 +237,17 @@ describe('writeTrustedHashes / verifyTrustHashes 闭环', () => {
       eventToCommand: EVENT_TO_CMD,
       eventToGroupIndex: EVENT_TO_GROUP_0,
       marker: 'otel-codex-hook',
-      forceBypass: true,
     } as const;
     writeTrustedHashes(opts);
-    const content = fs.readFileSync(configPath, 'utf-8');
-    expect(content).toContain('bypass_hook_trust = true');
-    expect(verifyTrustHashes(opts)).toEqual({ valid: true, mismatches: [] });
-  });
+    fs.writeFileSync(configPath, `bypass_hook_trust = true\n${fs.readFileSync(configPath, 'utf-8')}`);
 
-  test('forceBypass off -> on 需要触发重写', () => {
-    const base = {
-      configPath,
-      hooksJsonAbsPath: '/abs/hooks.json',
-      hookEvents: HOOK_EVENTS,
-      eventToCommand: EVENT_TO_CMD,
-      eventToGroupIndex: EVENT_TO_GROUP_0,
-      marker: 'otel-codex-hook',
-    } as const;
-    writeTrustedHashes(base);
-
-    const enabled = { ...base, forceBypass: true } as const;
-    expect(verifyTrustHashes(enabled)).toEqual({
+    expect(verifyTrustHashes(opts)).toEqual({
       valid: false,
-      mismatches: ['missing bypass_hook_trust = true'],
+      mismatches: ['unsupported config field bypass_hook_trust'],
     });
-    expect(writeTrustedHashes(enabled)).toBe(true);
-    expect(fs.readFileSync(configPath, 'utf-8')).toContain('bypass_hook_trust = true');
-    expect(verifyTrustHashes(enabled)).toEqual({ valid: true, mismatches: [] });
-  });
-
-  test('forceBypass on -> off 需要触发重写', () => {
-    const enabled = {
-      configPath,
-      hooksJsonAbsPath: '/abs/hooks.json',
-      hookEvents: HOOK_EVENTS,
-      eventToCommand: EVENT_TO_CMD,
-      eventToGroupIndex: EVENT_TO_GROUP_0,
-      marker: 'otel-codex-hook',
-      forceBypass: true,
-    } as const;
-    writeTrustedHashes(enabled);
-
-    const disabled = { ...enabled, forceBypass: false } as const;
-    expect(verifyTrustHashes(disabled)).toEqual({
-      valid: false,
-      mismatches: ['unexpected bypass_hook_trust = true'],
-    });
-    expect(writeTrustedHashes(disabled)).toBe(true);
+    expect(writeTrustedHashes(opts)).toBe(true);
     expect(fs.readFileSync(configPath, 'utf-8')).not.toContain('bypass_hook_trust = true');
-    expect(verifyTrustHashes(disabled)).toEqual({ valid: true, mismatches: [] });
+    expect(verifyTrustHashes(opts)).toEqual({ valid: true, mismatches: [] });
   });
 
   test('幂等重写: 两次 write 不产生重复段', () => {
@@ -497,6 +459,7 @@ describe('writeTrustedHashes / verifyTrustHashes 闭环', () => {
     const key = installedHookStateKey('/abs/hooks.json', location);
     const hash = computeInstalledHookTrustHash(location);
     fs.writeFileSync(configPath, [
+      'bypass_hook_trust = true',
       `[hooks.state."${key}"]`,
       'enabled = false',
       `trusted_hash = "${hash}"`,
@@ -507,12 +470,11 @@ describe('writeTrustedHashes / verifyTrustHashes 闭环', () => {
       hooksJsonAbsPath: '/abs/hooks.json',
       locations: { SubagentStart: location },
       marker: 'otel-codex-hook',
-      forceBypass: true,
     };
 
     expect(writeTrustedHashes(opts)).toBe(true);
     const repaired = fs.readFileSync(configPath, 'utf8');
-    expect(repaired).toContain('bypass_hook_trust = true');
+    expect(repaired).not.toContain('bypass_hook_trust');
     expect(repaired).toContain('enabled = false');
     expect(repaired).toContain(`trusted_hash = "${hash}"`);
   });

--- a/tests/unit/deployment/hook-strategy.test.ts
+++ b/tests/unit/deployment/hook-strategy.test.ts
@@ -54,7 +54,10 @@ import {
   writeJsonFile,
   writeTextFileAtomic,
 } from '../../../src/utils/fs-utils.js';
-import { verifyTrustHashes } from '../../../src/deployment/codex-trust-writer.js';
+import {
+  verifyTrustHashes,
+  writeTrustedHashes,
+} from '../../../src/deployment/codex-trust-writer.js';
 
 function makeDef(overrides?: Partial<AgentDefinition>): AgentDefinition {
   return {
@@ -251,6 +254,44 @@ describe('HookStrategy', () => {
 
       expect(result).toBe(true);
       expect(verifyTrustHashes).not.toHaveBeenCalled();
+    });
+
+    it('passes forceBypass to trust verification when deciding whether to redeploy', async () => {
+      const previous = process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS;
+      process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS = '1';
+      try {
+        vi.mocked(readJsonFile).mockResolvedValue({
+          hooks: {
+            Stop: [{ hooks: [{ type: 'command', command: '/opt/pilot/hooks/codex-hook.sh stop' }] }],
+          },
+        });
+        vi.mocked(verifyTrustHashes).mockReturnValue({ valid: true, mismatches: [] });
+        mockHookManager.isHookInstalled.mockResolvedValue(true);
+
+        const result = await strategy.needsDeploy(makeDef({
+          id: 'codex',
+          hook: {
+            settingsPath: '/home/.codex/hooks.json',
+            events: ['Stop'],
+            hookCommand: '/opt/pilot/hooks/codex-hook.sh',
+            format: 'nested',
+            eventSubcommand: 'kebab-case',
+            trustToml: {
+              configPath: '/home/.codex/config.toml',
+              trustAlgo: 'v1',
+              marker: 'otel-codex-hook',
+            },
+          },
+        }));
+
+        expect(result).toBe(false);
+        expect(verifyTrustHashes).toHaveBeenCalledWith(expect.objectContaining({
+          forceBypass: true,
+        }));
+      } finally {
+        if (previous === undefined) delete process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS;
+        else process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS = previous;
+      }
     });
 
     it('builds correct hook definitions from agent config', async () => {
@@ -719,6 +760,111 @@ describe('HookStrategy', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('disk error');
+    });
+
+    it('returns failure when Codex trust writing fails', async () => {
+      vi.mocked(readJsonFile).mockResolvedValue({
+        hooks: {
+          Stop: [{ hooks: [{ type: 'command', command: '/opt/pilot/hooks/codex-hook.sh stop' }] }],
+        },
+      });
+      mockHookManager.isHookInstalled.mockResolvedValue(true);
+      vi.mocked(writeTrustedHashes).mockImplementationOnce(() => {
+        throw new Error('trust write failed');
+      });
+
+      const result = await strategy.deploy(makeDef({
+        id: 'codex',
+        hook: {
+          settingsPath: '/home/.codex/hooks.json',
+          events: ['Stop'],
+          hookCommand: '/opt/pilot/hooks/codex-hook.sh',
+          format: 'nested',
+          eventSubcommand: 'kebab-case',
+          trustToml: {
+            configPath: '/home/.codex/config.toml',
+            trustAlgo: 'v1',
+            marker: 'otel-codex-hook',
+          },
+        },
+      }));
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('trust write failed');
+    });
+
+    it('returns failure when Codex trust self-check fails', async () => {
+      vi.mocked(readJsonFile).mockResolvedValue({
+        hooks: {
+          Stop: [{ hooks: [{ type: 'command', command: '/opt/pilot/hooks/codex-hook.sh stop' }] }],
+        },
+      });
+      mockHookManager.isHookInstalled.mockResolvedValue(true);
+      vi.mocked(verifyTrustHashes).mockReturnValueOnce({
+        valid: false,
+        mismatches: ['hash mismatch key=stop'],
+      });
+
+      const result = await strategy.deploy(makeDef({
+        id: 'codex',
+        hook: {
+          settingsPath: '/home/.codex/hooks.json',
+          events: ['Stop'],
+          hookCommand: '/opt/pilot/hooks/codex-hook.sh',
+          format: 'nested',
+          eventSubcommand: 'kebab-case',
+          trustToml: {
+            configPath: '/home/.codex/config.toml',
+            trustAlgo: 'v1',
+            marker: 'otel-codex-hook',
+          },
+        },
+      }));
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('codex trust hash verification failed');
+      expect(result.error).toContain('hash mismatch key=stop');
+    });
+
+    it('passes forceBypass consistently when writing and verifying Codex trust', async () => {
+      const previous = process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS;
+      process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS = '1';
+      try {
+        vi.mocked(readJsonFile).mockResolvedValue({
+          hooks: {
+            Stop: [{ hooks: [{ type: 'command', command: '/opt/pilot/hooks/codex-hook.sh stop' }] }],
+          },
+        });
+        mockHookManager.isHookInstalled.mockResolvedValue(true);
+        vi.mocked(verifyTrustHashes).mockReturnValue({ valid: true, mismatches: [] });
+
+        const result = await strategy.deploy(makeDef({
+          id: 'codex',
+          hook: {
+            settingsPath: '/home/.codex/hooks.json',
+            events: ['Stop'],
+            hookCommand: '/opt/pilot/hooks/codex-hook.sh',
+            format: 'nested',
+            eventSubcommand: 'kebab-case',
+            trustToml: {
+              configPath: '/home/.codex/config.toml',
+              trustAlgo: 'v1',
+              marker: 'otel-codex-hook',
+            },
+          },
+        }));
+
+        expect(result.success).toBe(true);
+        expect(writeTrustedHashes).toHaveBeenCalledWith(expect.objectContaining({
+          forceBypass: true,
+        }));
+        expect(verifyTrustHashes).toHaveBeenCalledWith(expect.objectContaining({
+          forceBypass: true,
+        }));
+      } finally {
+        if (previous === undefined) delete process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS;
+        else process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS = previous;
+      }
     });
   });
 

--- a/tests/unit/deployment/hook-strategy.test.ts
+++ b/tests/unit/deployment/hook-strategy.test.ts
@@ -260,44 +260,6 @@ describe('HookStrategy', () => {
       expect(verifyTrustHashes).not.toHaveBeenCalled();
     });
 
-    it('passes forceBypass to trust verification when deciding whether to redeploy', async () => {
-      const previous = process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS;
-      process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS = '1';
-      try {
-        vi.mocked(readJsonFile).mockResolvedValue({
-          hooks: {
-            Stop: [{ hooks: [{ type: 'command', command: '/opt/pilot/hooks/codex-hook.sh stop' }] }],
-          },
-        });
-        vi.mocked(verifyTrustHashes).mockReturnValue({ valid: true, mismatches: [] });
-        mockHookManager.isHookInstalled.mockResolvedValue(true);
-
-        const result = await strategy.needsDeploy(makeDef({
-          id: 'codex',
-          hook: {
-            settingsPath: '/home/.codex/hooks.json',
-            events: ['Stop'],
-            hookCommand: '/opt/pilot/hooks/codex-hook.sh',
-            format: 'nested',
-            eventSubcommand: 'kebab-case',
-            trustToml: {
-              configPath: '/home/.codex/config.toml',
-              trustAlgo: 'v1',
-              marker: 'otel-codex-hook',
-            },
-          },
-        }));
-
-        expect(result).toBe(false);
-        expect(verifyTrustHashes).toHaveBeenCalledWith(expect.objectContaining({
-          forceBypass: true,
-        }));
-      } finally {
-        if (previous === undefined) delete process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS;
-        else process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS = previous;
-      }
-    });
-
     it('builds correct hook definitions from agent config', async () => {
       mockHookManager.isHookInstalled.mockResolvedValue(true);
       const def = makeDef();
@@ -830,46 +792,6 @@ describe('HookStrategy', () => {
       expect(result.error).toContain('hash mismatch key=stop');
     });
 
-    it('passes forceBypass consistently when writing and verifying Codex trust', async () => {
-      const previous = process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS;
-      process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS = '1';
-      try {
-        vi.mocked(readJsonFile).mockResolvedValue({
-          hooks: {
-            Stop: [{ hooks: [{ type: 'command', command: '/opt/pilot/hooks/codex-hook.sh stop' }] }],
-          },
-        });
-        mockHookManager.isHookInstalled.mockResolvedValue(true);
-        vi.mocked(verifyTrustHashes).mockReturnValue({ valid: true, mismatches: [] });
-
-        const result = await strategy.deploy(makeDef({
-          id: 'codex',
-          hook: {
-            settingsPath: '/home/.codex/hooks.json',
-            events: ['Stop'],
-            hookCommand: '/opt/pilot/hooks/codex-hook.sh',
-            format: 'nested',
-            eventSubcommand: 'kebab-case',
-            trustToml: {
-              configPath: '/home/.codex/config.toml',
-              trustAlgo: 'v1',
-              marker: 'otel-codex-hook',
-            },
-          },
-        }));
-
-        expect(result.success).toBe(true);
-        expect(writeTrustedHashes).toHaveBeenCalledWith(expect.objectContaining({
-          forceBypass: true,
-        }));
-        expect(verifyTrustHashes).toHaveBeenCalledWith(expect.objectContaining({
-          forceBypass: true,
-        }));
-      } finally {
-        if (previous === undefined) delete process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS;
-        else process.env.LOONGSUITE_PILOT_CODEX_FORCE_BYPASS = previous;
-      }
-    });
   });
 
   describe('env injection (settings.env merge)', () => {

--- a/tests/unit/deployment/hook-strategy.test.ts
+++ b/tests/unit/deployment/hook-strategy.test.ts
@@ -41,8 +41,11 @@ vi.mock('../../../src/deployment/codex-trust-writer.js', () => ({
     Stop: 'stop',
     PostToolUse: 'post_tool_use',
   },
+  installedHookStateKey: vi.fn((hooksPath: string, location: { eventKey: string; groupIndex: number; handlerIndex: number }) =>
+    `${hooksPath}:${location.eventKey}:${location.groupIndex}:${location.handlerIndex}`),
   writeTrustedHashes: vi.fn(),
   removeTrustBlock: vi.fn(),
+  removeTrustStateKeys: vi.fn(),
   verifyTrustHashes: vi.fn(() => ({ valid: true, mismatches: [] })),
 }));
 
@@ -55,6 +58,7 @@ import {
   writeTextFileAtomic,
 } from '../../../src/utils/fs-utils.js';
 import {
+  removeTrustBlock,
   verifyTrustHashes,
   writeTrustedHashes,
 } from '../../../src/deployment/codex-trust-writer.js';
@@ -1034,6 +1038,43 @@ describe('HookStrategy', () => {
 
       const result = await strategy.undeploy(makeDef());
       expect(result).toBe(false);
+    });
+
+    it('removes only exact Codex trust keys resolved before uninstall', async () => {
+      vi.mocked(readJsonFile).mockResolvedValue({
+        hooks: {
+          Stop: [
+            { hooks: [{ type: 'command', command: 'third-party' }] },
+            { hooks: [{ type: 'command', command: '/opt/pilot/hooks/codex-hook.sh stop' }] },
+          ],
+        },
+      });
+      mockHookManager.uninstallHook.mockResolvedValue(true);
+      const def = makeDef({
+        id: 'codex',
+        hook: {
+          settingsPath: '/home/.codex/hooks.json',
+          events: ['Stop'],
+          hookCommand: '/opt/pilot/hooks/codex-hook.sh',
+          format: 'nested',
+          eventSubcommand: 'kebab-case',
+          trustToml: {
+            configPath: '/home/.codex/config.toml',
+            trustAlgo: 'v1',
+            marker: 'otel-codex-hook',
+          },
+        },
+      });
+
+      const result = await strategy.undeploy(def);
+
+      expect(result).toBe(true);
+      expect(removeTrustBlock).toHaveBeenCalledWith(
+        '/home/.codex/config.toml',
+        'otel-codex-hook',
+        ['/home/.codex/hooks.json:stop:1:0'],
+      );
+      expect(mockHookManager.uninstallHook).toHaveBeenCalledOnce();
     });
   });
 

--- a/tests/unit/deployment/hook-strategy.test.ts
+++ b/tests/unit/deployment/hook-strategy.test.ts
@@ -33,6 +33,14 @@ vi.mock('../../../src/utils/fs-utils.js', () => ({
 }));
 
 vi.mock('../../../src/deployment/codex-trust-writer.js', () => ({
+  CODEX_HOOK_EVENT_KEYS: {
+    SessionStart: 'session_start',
+    UserPromptSubmit: 'user_prompt_submit',
+    SubagentStart: 'subagent_start',
+    SubagentStop: 'subagent_stop',
+    Stop: 'stop',
+    PostToolUse: 'post_tool_use',
+  },
   writeTrustedHashes: vi.fn(),
   removeTrustBlock: vi.fn(),
   verifyTrustHashes: vi.fn(() => ({ valid: true, mismatches: [] })),
@@ -134,7 +142,11 @@ describe('HookStrategy', () => {
     });
 
     it('returns true when Codex hook exists but its trust state is invalid', async () => {
-      vi.mocked(readJsonFile).mockResolvedValue({ hooks: {} });
+      vi.mocked(readJsonFile).mockResolvedValue({
+        hooks: {
+          Stop: [{ hooks: [{ type: 'command', command: '/opt/pilot/hooks/codex-hook.sh stop' }] }],
+        },
+      });
       vi.mocked(verifyTrustHashes).mockReturnValue({
         valid: false,
         mismatches: ['missing trust state'],
@@ -159,6 +171,86 @@ describe('HookStrategy', () => {
 
       expect(result).toBe(true);
       expect(verifyTrustHashes).toHaveBeenCalledOnce();
+    });
+
+    it('verifies trust with the installed matcher and non-zero group/handler indices', async () => {
+      vi.mocked(readJsonFile).mockResolvedValue({
+        hooks: {
+          SubagentStart: [
+            { matcher: '*', hooks: [{ type: 'command', command: 'third-party' }] },
+            {
+              matcher: '*',
+              hooks: [
+                { type: 'command', command: 'another-handler' },
+                {
+                  type: 'command',
+                  command: '/opt/pilot/hooks/codex-hook.sh subagent-start',
+                  timeout: 12,
+                  async: true,
+                  statusMessage: 'starting',
+                },
+              ],
+            },
+          ],
+        },
+      });
+      vi.mocked(verifyTrustHashes).mockReturnValue({ valid: true, mismatches: [] });
+      mockHookManager.isHookInstalled.mockResolvedValue(true);
+
+      const result = await strategy.needsDeploy(makeDef({
+        id: 'codex',
+        hook: {
+          settingsPath: '/home/.codex/hooks.json',
+          events: ['SubagentStart'],
+          hookCommand: '/opt/pilot/hooks/codex-hook.sh',
+          format: 'nested',
+          eventSubcommand: 'kebab-case',
+          trustToml: {
+            configPath: '/home/.codex/config.toml',
+            trustAlgo: 'v1',
+            marker: 'otel-codex-hook',
+          },
+        },
+      }));
+
+      expect(result).toBe(false);
+      expect(verifyTrustHashes).toHaveBeenCalledWith(expect.objectContaining({
+        locations: {
+          SubagentStart: expect.objectContaining({
+            matcher: '*',
+            groupIndex: 1,
+            handlerIndex: 1,
+            handler: expect.objectContaining({ timeout: 12, async: true, statusMessage: 'starting' }),
+          }),
+        },
+      }));
+    });
+
+    it('refuses ambiguous duplicate installed commands instead of trusting index zero', async () => {
+      const command = '/opt/pilot/hooks/codex-hook.sh stop';
+      vi.mocked(readJsonFile).mockResolvedValue({
+        hooks: { Stop: [{ hooks: [{ type: 'command', command }, { type: 'command', command }] }] },
+      });
+      mockHookManager.isHookInstalled.mockResolvedValue(true);
+
+      const result = await strategy.needsDeploy(makeDef({
+        id: 'codex',
+        hook: {
+          settingsPath: '/home/.codex/hooks.json',
+          events: ['Stop'],
+          hookCommand: '/opt/pilot/hooks/codex-hook.sh',
+          format: 'nested',
+          eventSubcommand: 'kebab-case',
+          trustToml: {
+            configPath: '/home/.codex/config.toml',
+            trustAlgo: 'v1',
+            marker: 'otel-codex-hook',
+          },
+        },
+      }));
+
+      expect(result).toBe(true);
+      expect(verifyTrustHashes).not.toHaveBeenCalled();
     });
 
     it('builds correct hook definitions from agent config', async () => {

--- a/tests/unit/hooks/codex/hook-processor.test.mjs
+++ b/tests/unit/hooks/codex/hook-processor.test.mjs
@@ -52,7 +52,13 @@ describe('codex transcript discovery hook', () => {
   test('deploys early discovery hooks while retiring telemetry-heavy hooks', () => {
     const definition = JSON.parse(fs.readFileSync(AGENT_DEFINITION, 'utf8'));
 
-    expect(definition.hook.events).toEqual(['SessionStart', 'UserPromptSubmit', 'Stop']);
+    expect(definition.hook.events).toEqual([
+      'SessionStart',
+      'UserPromptSubmit',
+      'SubagentStart',
+      'SubagentStop',
+      'Stop',
+    ]);
     expect(definition.hook.retiredEvents).toEqual([
       'PreToolUse',
       'PostToolUse',
@@ -101,6 +107,52 @@ describe('codex transcript discovery hook', () => {
       });
     },
   );
+
+  test('normalizes SubagentStart to the child rollout identity', () => {
+    const childTranscript = '/tmp/rollout-child.jsonl';
+    const result = runHook('subagent-start', {
+      session_id: 'parent-session',
+      agent_id: 'child-session',
+      turn_id: 'child-turn',
+      transcript_path: childTranscript,
+    });
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(fs.readFileSync(markerPath('child-session'), 'utf8'))).toMatchObject({
+      session_id: 'child-session',
+      turn_id: 'child-turn',
+      initial_turn_id: 'child-turn',
+      transcript_path: childTranscript,
+      hook_event: 'subagent-start',
+    });
+    expect(fs.existsSync(markerPath('parent-session'))).toBe(false);
+  });
+
+  test('normalizes SubagentStop and preserves the SubagentStart anchor', () => {
+    const childTranscript = '/tmp/rollout-child.jsonl';
+    runHook('subagent-start', {
+      session_id: 'parent-session',
+      agent_id: 'child-session',
+      turn_id: 'child-turn',
+      transcript_path: childTranscript,
+    });
+    const result = runHook('subagent-stop', {
+      session_id: 'parent-session',
+      agent_id: 'child-session',
+      turn_id: 'child-turn',
+      transcript_path: '/tmp/rollout-parent.jsonl',
+      agent_transcript_path: childTranscript,
+    });
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(fs.readFileSync(markerPath('child-session'), 'utf8'))).toMatchObject({
+      session_id: 'child-session',
+      turn_id: 'child-turn',
+      initial_turn_id: 'child-turn',
+      transcript_path: childTranscript,
+      hook_event: 'subagent-stop',
+    });
+  });
 
   test('writes AgentTeams resource attributes into the wakeup marker', () => {
     const result = runHook('stop', {

--- a/tests/unit/hooks/codex/hook-processor.test.mjs
+++ b/tests/unit/hooks/codex/hook-processor.test.mjs
@@ -149,9 +149,46 @@ describe('codex transcript discovery hook', () => {
       session_id: 'child-session',
       turn_id: 'child-turn',
       initial_turn_id: 'child-turn',
+      recovery_turn_id: 'child-turn',
       transcript_path: childTranscript,
       hook_event: 'subagent-stop',
     });
+  });
+
+  test('records Stop as recovery evidence without claiming it is the initial turn', () => {
+    const result = runHook('stop', {
+      session_id: 'fork-session',
+      turn_id: 'latest-terminal-turn',
+      transcript_path: '/tmp/rollout-fork.jsonl',
+    });
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(fs.readFileSync(markerPath('fork-session'), 'utf8'))).toMatchObject({
+      session_id: 'fork-session',
+      turn_id: 'latest-terminal-turn',
+      recovery_turn_id: 'latest-terminal-turn',
+      hook_event: 'stop',
+    });
+    expect(JSON.parse(fs.readFileSync(markerPath('fork-session'), 'utf8')))
+      .not.toHaveProperty('initial_turn_id');
+  });
+
+  test('does not promote a later UserPromptSubmit after terminal recovery evidence', () => {
+    runHook('stop', {
+      session_id: 'multi-turn-fork',
+      turn_id: 'first-terminal-turn',
+      transcript_path: '/tmp/rollout-multi-turn.jsonl',
+    });
+    runHook('user-prompt-submit', {
+      session_id: 'multi-turn-fork',
+      turn_id: 'later-prompt-turn',
+      transcript_path: '/tmp/rollout-multi-turn.jsonl',
+    });
+
+    const marker = JSON.parse(fs.readFileSync(markerPath('multi-turn-fork'), 'utf8'));
+    expect(marker).not.toHaveProperty('initial_turn_id');
+    expect(marker.recovery_turn_id).toBe('first-terminal-turn');
+    expect(marker.turn_id).toBe('later-prompt-turn');
   });
 
   test('writes AgentTeams resource attributes into the wakeup marker', () => {

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -35,6 +35,11 @@ function record(timestamp: string, type: string, payload: Record<string, unknown
   return JSON.stringify({ timestamp, type, payload });
 }
 
+function uuidV7At(timestamp: string, tail = '000000000001'): string {
+  const hex = Date.parse(timestamp).toString(16).padStart(12, '0');
+  return `${hex.slice(0, 8)}-${hex.slice(8)}-7000-8000-${tail}`;
+}
+
 function tokenUsage(input: number, output: number): Record<string, unknown> {
   return {
     type: 'token_count',
@@ -2827,8 +2832,210 @@ describe('CodexTranscriptInput', () => {
       expect(entries).toHaveLength(0);
       expect(transcriptCheckpoint(stateStore, transcript)).toMatchObject({
         scanOffset: 0,
-        forkBootstrap: { searchOffset: 0 },
+        forkBootstrap: { searchOffset: Buffer.byteLength(await fs.readFile(transcript, 'utf8')) },
       });
+    });
+
+    it('uses UUIDv7 causality to collect a same-millisecond first owned turn without any Hook', async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-uuid-fallback-'));
+      tempDirs.push(root);
+      const { input, entries, sessionDir } = await createDormantInput(root);
+      const parent = uuidV7At('2026-08-05T09:00:00.000Z');
+      const owner = uuidV7At('2026-08-05T10:00:00.000Z', '000000000002');
+      const parentTurn = uuidV7At('2026-08-05T09:30:00.000Z');
+      const firstOwnedTurn = uuidV7At('2026-08-05T10:00:00.000Z', '000000000003');
+      const secondOwnedTurn = uuidV7At('2026-08-05T10:01:00.000Z');
+      const transcript = await writeTranscriptNamed(
+        sessionDir,
+        `rollout-2026-08-05T10-00-00-${owner}.jsonl`,
+        [
+          record('2026-08-05T10:00:00.000Z', 'session_meta', {
+            id: owner, forked_from_id: parent, thread_source: 'user', model_provider: 'openai',
+          }),
+          record('2026-08-05T09:00:00.000Z', 'session_meta', { id: parent, model_provider: 'openai' }),
+          ...turnBlock(parentTurn, '2026-08-05T09:30:00.000Z'),
+          ...turnBlock(firstOwnedTurn, '2026-08-05T10:00:00.010Z'),
+          ...turnBlock(secondOwnedTurn, '2026-08-05T10:01:00.000Z'),
+        ].join('\n') + '\n',
+        { bootstrapFork: false },
+      );
+
+      await processTranscriptOnce(input, transcript);
+
+      expect(responsesForTurn(entries, parentTurn)).toHaveLength(0);
+      expect(responsesForTurn(entries, firstOwnedTurn)).toHaveLength(1);
+      expect(responsesForTurn(entries, secondOwnedTurn)).toHaveLength(1);
+      expect(responsesForTurn(entries, firstOwnedTurn)[0]).toMatchObject({
+        'gen_ai.response.model': 'gpt-5.5',
+        'agent.codex.cwd': '/tmp/p',
+      });
+    });
+
+    it('uses a later Stop turn only as recovery evidence and keeps earlier owned turns', async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-stop-recovery-'));
+      tempDirs.push(root);
+      const { input, entries, sessionDir, wakeupDir } = await createDormantInput(root);
+      const parent = uuidV7At('2026-08-05T09:00:00.000Z', '000000000011');
+      const owner = uuidV7At('2026-08-05T10:00:00.000Z', '000000000012');
+      const parentTurn = uuidV7At('2026-08-05T09:30:00.000Z', '000000000013');
+      const firstOwnedTurn = uuidV7At('2026-08-05T10:00:00.010Z', '000000000014');
+      const latestOwnedTurn = uuidV7At('2026-08-05T10:01:00.000Z', '000000000015');
+      const transcript = await writeTranscriptNamed(
+        sessionDir,
+        `rollout-2026-08-05T10-00-00-${owner}.jsonl`,
+        [
+          record('2026-08-05T10:00:00.000Z', 'session_meta', {
+            id: owner, forked_from_id: parent, thread_source: 'user', model_provider: 'openai',
+          }),
+          ...turnBlock(parentTurn, '2026-08-05T09:30:00.000Z'),
+          ...turnBlock(firstOwnedTurn, '2026-08-05T10:00:00.010Z'),
+          ...turnBlock(latestOwnedTurn, '2026-08-05T10:01:00.000Z'),
+        ].join('\n') + '\n',
+        { bootstrapFork: false },
+      );
+      await writeWakeupMarker(wakeupDir, owner, {
+        session_id: owner,
+        turn_id: latestOwnedTurn,
+        recovery_turn_id: latestOwnedTurn,
+        transcript_path: transcript,
+        hook_event: 'stop',
+      });
+
+      await processTranscriptOnce(input, transcript);
+
+      expect(responsesForTurn(entries, parentTurn)).toHaveLength(0);
+      expect(responsesForTurn(entries, firstOwnedTurn)).toHaveLength(1);
+      expect(responsesForTurn(entries, latestOwnedTurn)).toHaveLength(1);
+    });
+
+    it('accepts a session-matched initial anchor when transcript paths differ', async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-path-soft-check-'));
+      tempDirs.push(root);
+      const { input, entries, sessionDir, wakeupDir } = await createDormantInput(root);
+      const warn = vi.fn();
+      (input as unknown as { logger: { warn: typeof warn } }).logger.warn = warn;
+      const owner = 'cccccccc-0004-4004-8004-000000000004';
+      const currentTurn = 'owned-turn-from-soft-path-anchor';
+      const transcript = await writeTranscriptNamed(
+        sessionDir,
+        `rollout-2026-08-05T10-00-00-${owner}.jsonl`,
+        [
+          record('2026-08-05T10:00:00.000Z', 'session_meta', {
+            id: owner, forked_from_id: 'parent', thread_source: 'user', model_provider: 'openai',
+          }),
+          ...turnBlock('copied-parent-turn', '2026-08-04T10:00:00.000Z'),
+          ...turnBlock(currentTurn, '2026-08-05T10:00:00.010Z'),
+        ].join('\n') + '\n',
+        { bootstrapFork: false },
+      );
+      await writeWakeupMarker(wakeupDir, owner, {
+        session_id: owner,
+        initial_turn_id: currentTurn,
+        transcript_path: path.join(root, 'different-spelling', path.basename(transcript)),
+        hook_event: 'stop',
+      });
+
+      await processTranscriptOnce(input, transcript);
+
+      expect(responsesForTurn(entries, 'copied-parent-turn')).toHaveLength(0);
+      expect(responsesForTurn(entries, currentTurn)).toHaveLength(1);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('accepting session anchor'),
+        expect.objectContaining({ sessionId: owner }),
+      );
+    });
+
+    it('anchors at turn_context when task_started is absent', async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-turn-context-only-'));
+      tempDirs.push(root);
+      const { input, entries, sessionDir, wakeupDir } = await createDormantInput(root);
+      const owner = 'cccccccc-0005-4005-8005-000000000005';
+      const currentTurn = 'turn-context-only-owned-turn';
+      const currentBlock = turnBlock(currentTurn, '2026-08-05T10:00:00.010Z')
+        .filter(line => JSON.parse(line).payload?.type !== 'task_started');
+      const transcript = await writeTranscriptNamed(
+        sessionDir,
+        `rollout-2026-08-05T10-00-00-${owner}.jsonl`,
+        [
+          record('2026-08-05T10:00:00.000Z', 'session_meta', {
+            id: owner, forked_from_id: 'parent', thread_source: 'user', model_provider: 'openai',
+          }),
+          ...turnBlock('copied-parent-turn-with-start', '2026-08-04T10:00:00.000Z'),
+          ...currentBlock,
+        ].join('\n') + '\n',
+        { bootstrapFork: false },
+      );
+      await writeWakeupMarker(wakeupDir, owner, {
+        session_id: owner,
+        initial_turn_id: currentTurn,
+        transcript_path: transcript,
+        hook_event: 'stop',
+      });
+
+      await processTranscriptOnce(input, transcript);
+
+      expect(responsesForTurn(entries, 'copied-parent-turn-with-start')).toHaveLength(0);
+      expect(responsesForTurn(entries, currentTurn)).toHaveLength(1);
+      expect(responsesForTurn(entries, currentTurn)[0]).toMatchObject({
+        'gen_ai.response.model': 'gpt-5.5',
+        'agent.codex.cwd': '/tmp/p',
+      });
+    });
+
+    it('repairs an out-of-range persisted fork search offset', async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-invalid-search-offset-'));
+      tempDirs.push(root);
+      const { input, entries, sessionDir, wakeupDir, stateStore } = await createDormantInput(root);
+      const warn = vi.fn();
+      (input as unknown as { logger: { warn: typeof warn } }).logger.warn = warn;
+      const owner = 'cccccccc-0006-4006-8006-000000000006';
+      const currentTurn = 'owned-turn-after-invalid-offset';
+      const transcript = await writeTranscriptNamed(
+        sessionDir,
+        `rollout-2026-08-05T10-00-00-${owner}.jsonl`,
+        [
+          record('2026-08-05T10:00:00.000Z', 'session_meta', {
+            id: owner, forked_from_id: 'parent', thread_source: 'user', model_provider: 'openai',
+          }),
+          ...turnBlock('copied-before-invalid-offset', '2026-08-04T10:00:00.000Z'),
+          ...turnBlock(currentTurn, '2026-08-05T10:00:00.010Z'),
+        ].join('\n') + '\n',
+        { bootstrapFork: false },
+      );
+      const stat = await fs.stat(transcript);
+      stateStore.update(`codex-transcript:${transcript}`, {
+        lastOffset: 0,
+        extra: {
+          codexTranscript: {
+            inode: stat.ino,
+            scanOffset: 0,
+            activeTurn: null,
+            pendingTerminal: null,
+            pendingFusion: null,
+            pendingSubagent: null,
+            ownerSessionMetaOffset: null,
+            forkBootstrap: {
+              initialTurnId: currentTurn,
+              searchOffset: stat.size + 100,
+            },
+            emittedTerminalTurnIds: [],
+          },
+        },
+      });
+      await writeWakeupMarker(wakeupDir, owner, {
+        session_id: owner,
+        initial_turn_id: currentTurn,
+        transcript_path: transcript,
+        hook_event: 'stop',
+      });
+
+      await processTranscriptOnce(input, transcript);
+
+      expect(responsesForTurn(entries, currentTurn)).toHaveLength(1);
+      expect(warn).toHaveBeenCalledWith(
+        'repaired invalid Codex fork bootstrap search offset',
+        expect.objectContaining({ searchOffset: stat.size + 100, repairedSearchOffset: 0 }),
+      );
     });
 
     it('resumes an exact-turn search when the Hook fires before task_started is appended', async () => {
@@ -2861,10 +3068,10 @@ describe('CodexTranscriptInput', () => {
       await processTranscriptOnce(input, transcript);
       const pending = transcriptCheckpoint(stateStore, transcript) as {
         scanOffset: number;
-        forkBootstrap: { turnId: string; searchOffset: number };
+        forkBootstrap: { initialTurnId: string; searchOffset: number };
       };
       expect(pending.scanOffset).toBe(0);
-      expect(pending.forkBootstrap.turnId).toBe(turnId);
+      expect(pending.forkBootstrap.initialTurnId).toBe(turnId);
       expect(pending.forkBootstrap.searchOffset).toBeGreaterThan(0);
 
       await fs.appendFile(transcript, [
@@ -2983,18 +3190,18 @@ describe('CodexTranscriptInput', () => {
       expect(responsesForTurn(entries, 'parent-turn')).toHaveLength(0);
     });
 
-    it('locates a Hook-anchored turn beyond one normal scan window', async () => {
+    it('locates a Hook-anchored turn across bounded 16 MiB scan windows', async () => {
       const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-big-'));
       tempDirs.push(root);
-      const { input, entries, sessionDir, stateStore } = await createInput(root);
+      const { input, entries, sessionDir, wakeupDir, stateStore } = await createDormantInput(root);
       const child = 'cccccccc-4444-4444-8444-444444444444';
       const ancestor = 'aaaaaaaa-7777-4777-8777-777777777777';
-      // Pad the copied region past one scan window (16 MiB) so the boundary can
-      // only be reached by resuming the probe on a later cycle. Padding uses an
+      // Pad the copied region past two scan windows (32 MiB) so the boundary can
+      // only be reached by resuming the probe across three cycles. Padding uses an
       // unrecognised event type so it never yields entries by itself.
       const filler = 'x'.repeat(64 * 1024);
       const padding: string[] = [];
-      for (let i = 0; i < 280; i++) {
+      for (let i = 0; i < 540; i++) {
         padding.push(record('2026-06-01T00:00:20.000Z', 'event_msg', { type: 'copied_padding', filler }));
       }
       const text = [
@@ -3007,15 +3214,39 @@ describe('CodexTranscriptInput', () => {
         record('2026-08-05T10:00:05.000Z', 'event_msg', { type: 'thread_settings_applied', thread_settings: { model: 'gpt-5.5' } }),
         ...turnBlock('big-child-turn', '2026-08-05T10:00:10.000Z'),
       ].join('\n') + '\n';
-      expect(Buffer.byteLength(text)).toBeGreaterThan(16 * 1024 * 1024);
+      expect(Buffer.byteLength(text)).toBeGreaterThan(32 * 1024 * 1024);
       const transcript = await writeTranscriptNamed(sessionDir, `rollout-2026-08-05T10-00-00-${child}.jsonl`, text);
+      await writeWakeupMarker(wakeupDir, child, {
+        session_id: child,
+        initial_turn_id: 'big-child-turn',
+        transcript_path: transcript,
+        hook_event: 'stop',
+      });
 
-      await waitFor(() => responsesForTurn(entries, 'big-child-turn').length === 1, 15_000);
-      await input.stop();
+      await processTranscriptOnce(input, transcript);
+      const firstOffset = ((transcriptCheckpoint(stateStore, transcript).forkBootstrap as {
+        searchOffset: number;
+      }).searchOffset);
+      expect(firstOffset).toBeGreaterThan(0);
+      expect(firstOffset).toBeLessThanOrEqual(16 * 1024 * 1024);
+      expect(entries).toHaveLength(0);
 
-      expect(responsesForTurn(entries, 'big-child-turn')).toHaveLength(1);
-      expect(responsesForTurn(entries, 'big-ancestor-turn')).toHaveLength(0);
-      const checkpoint = transcriptCheckpoint(stateStore, transcript);
+      await stateStore.save();
+      const restarted = await createDormantInput(root);
+
+      await processTranscriptOnce(restarted.input, transcript);
+      const secondOffset = ((transcriptCheckpoint(restarted.stateStore, transcript).forkBootstrap as {
+        searchOffset: number;
+      }).searchOffset);
+      expect(secondOffset).toBeGreaterThan(firstOffset);
+      expect(secondOffset).toBeLessThanOrEqual(32 * 1024 * 1024);
+      expect(restarted.entries).toHaveLength(0);
+
+      await processTranscriptOnce(restarted.input, transcript);
+
+      expect(responsesForTurn(restarted.entries, 'big-child-turn')).toHaveLength(1);
+      expect(responsesForTurn(restarted.entries, 'big-ancestor-turn')).toHaveLength(0);
+      const checkpoint = transcriptCheckpoint(restarted.stateStore, transcript);
       expect(checkpoint.scanOffset as number).toBeGreaterThan(16 * 1024 * 1024);
       expect(checkpoint.forkBootstrap).toBeUndefined();
     }, 30_000);

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -398,13 +398,6 @@ function transcriptCheckpoint(
   return stateStore.get(`codex-transcript:${transcript}`).extra?.codexTranscript as Record<string, unknown>;
 }
 
-function globalProcessedTurnIds(stateStore: StateStore): string[] {
-  const global = stateStore.get('codex-transcript').extra?.codexTranscriptGlobal as {
-    emittedTerminalTurnIds?: string[];
-  } | undefined;
-  return global?.emittedTerminalTurnIds ?? [];
-}
-
 describe('CodexTranscriptInput', () => {
   it('extracts the single-level subagent relationship from owning session metadata', async () => {
     const fixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, CHILD_FIXTURE_NAME), 'utf8');
@@ -473,7 +466,6 @@ describe('CodexTranscriptInput', () => {
     }
     await waitFor(() => [...childTranscripts.values()].every(transcript =>
       Boolean(transcriptCheckpoint(stateStore, transcript)?.pendingSubagent)));
-    expect(globalProcessedTurnIds(stateStore)).not.toContain('parent-turn-1');
     expect(CHILD_FIXTURES.every(fixture => responsesForTurn(entries, fixture.turnId).length === 0)).toBe(true);
 
     await fs.appendFile(parentTranscript, parentTerminal + '\n', 'utf8');
@@ -510,10 +502,6 @@ describe('CodexTranscriptInput', () => {
         }),
       );
     }
-    expect(globalProcessedTurnIds(stateStore)).toEqual(expect.arrayContaining([
-      'parent-turn-1',
-      ...CHILD_FIXTURES.map(fixture => fixture.turnId),
-    ]));
     expect(transcriptCheckpoint(stateStore, parentTranscript)).toMatchObject({
       pendingFusion: null,
       activeTurn: null,
@@ -708,8 +696,8 @@ describe('CodexTranscriptInput', () => {
     expect(transcriptCheckpoint(stateStore, childTranscript)).toMatchObject({
       activeTurn: null,
       pendingSubagent: null,
-      emittedTerminalTurnIds: ['child-turn-1'],
     });
+    expect(transcriptCheckpoint(stateStore, childTranscript).forkBootstrap).toBeUndefined();
     expect(transcriptCheckpoint(stateStore, parentTranscript)).toMatchObject({
       activeTurn: null,
       pendingFusion: null,
@@ -1115,7 +1103,7 @@ describe('CodexTranscriptInput', () => {
     });
   });
 
-  it('uses exact parent turn ownership when child metadata has no creation timestamp', async () => {
+  it('skips the copied prefix when child metadata has no creation timestamp', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-turn-owner-'));
     tempDirs.push(root);
     const { input, entries, sessionDir, stateStore } = await createInput(root);
@@ -1885,12 +1873,11 @@ describe('CodexTranscriptInput', () => {
     const checkpoint = transcriptCheckpoint(stateStore, transcript) as {
       activeTurn?: unknown;
       pendingTerminal?: unknown;
-      emittedTerminalTurnIds?: string[];
+      forkBootstrap?: unknown;
     };
     expect(checkpoint.activeTurn).toBeNull();
     expect(checkpoint.pendingTerminal).toBeNull();
-    expect(checkpoint.emittedTerminalTurnIds).toEqual(expect.arrayContaining([controlTurnId, normalTurnId]));
-    expect(globalProcessedTurnIds(stateStore)).toEqual(expect.arrayContaining([controlTurnId, normalTurnId]));
+    expect(checkpoint.forkBootstrap).toBeUndefined();
     expect(debug).toHaveBeenCalledWith(
       'processed terminal Codex turn without observable entries',
       expect.objectContaining({ turnId: controlTurnId, terminalStatus: 'interrupted' }),
@@ -1946,17 +1933,12 @@ describe('CodexTranscriptInput', () => {
       scanOffset?: number;
       activeTurn?: unknown;
       pendingTerminal?: unknown;
-      emittedTerminalTurnIds?: string[];
+      forkBootstrap?: unknown;
     };
     expect(checkpoint.scanOffset).toBe((await fs.stat(transcript)).size);
     expect(checkpoint.activeTurn).toBeNull();
     expect(checkpoint.pendingTerminal).toBeNull();
-    expect(checkpoint.emittedTerminalTurnIds).toEqual(
-      expect.arrayContaining([...normalTurnIds, controlTurnId]),
-    );
-    expect(globalProcessedTurnIds(stateStore)).toEqual(
-      expect.arrayContaining([...normalTurnIds, controlTurnId]),
-    );
+    expect(checkpoint.forkBootstrap).toBeUndefined();
     expect(debug).toHaveBeenCalledWith(
       'processed terminal Codex turn without observable entries',
       expect.objectContaining({ turnId: controlTurnId, terminalStatus: 'interrupted' }),
@@ -2026,12 +2008,11 @@ describe('CodexTranscriptInput', () => {
     const checkpoint = transcriptCheckpoint(stateStore, fork) as {
       activeTurn?: unknown;
       pendingTerminal?: unknown;
-      emittedTerminalTurnIds?: string[];
+      forkBootstrap?: unknown;
     };
     expect(checkpoint.activeTurn).toBeNull();
     expect(checkpoint.pendingTerminal).toBeNull();
-    expect(checkpoint.emittedTerminalTurnIds).toEqual([forkTurnId]);
-    expect(globalProcessedTurnIds(stateStore)).not.toContain(controlTurnId);
+    expect(checkpoint.forkBootstrap).toBeUndefined();
 
     await stateStore.save();
     const restarted = await createDormantInput(root);
@@ -2055,9 +2036,11 @@ describe('CodexTranscriptInput', () => {
     await processTranscriptOnce(restarted.input, secondFork);
 
     expect(responsesForTurn(restarted.entries, restartedTurnId)).toHaveLength(1);
-    expect((transcriptCheckpoint(restarted.stateStore, secondFork) as {
-      emittedTerminalTurnIds?: string[];
-    }).emittedTerminalTurnIds).toEqual([restartedTurnId]);
+    expect(transcriptCheckpoint(restarted.stateStore, secondFork)).toMatchObject({
+      activeTurn: null,
+      pendingTerminal: null,
+    });
+    expect(transcriptCheckpoint(restarted.stateStore, secondFork).forkBootstrap).toBeUndefined();
     expect(debug).not.toHaveBeenCalledWith(
       'processed terminal Codex turn without observable entries',
       expect.objectContaining({ turnId: controlTurnId }),
@@ -2113,14 +2096,11 @@ describe('CodexTranscriptInput', () => {
     const checkpoint = transcriptCheckpoint(recovered.stateStore, transcript) as {
       activeTurn?: unknown;
       pendingTerminal?: unknown;
-      emittedTerminalTurnIds?: string[];
+      forkBootstrap?: unknown;
     };
     expect(checkpoint.activeTurn).toBeNull();
     expect(checkpoint.pendingTerminal).toBeNull();
-    expect(checkpoint.emittedTerminalTurnIds).toEqual(expect.arrayContaining([controlTurnId, normalTurnId]));
-    expect(globalProcessedTurnIds(recovered.stateStore)).toEqual(
-      expect.arrayContaining([controlTurnId, normalTurnId]),
-    );
+    expect(checkpoint.forkBootstrap).toBeUndefined();
   });
 
   it('retains a truly unparseable pending range and does not scan later work', async () => {
@@ -2201,7 +2181,7 @@ describe('CodexTranscriptInput', () => {
     );
   });
 
-  it('does not re-emit completed turns copied into a forked Codex transcript file', async () => {
+  it('does not suppress matching turn IDs across independent transcript files', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-fork-'));
     tempDirs.push(root);
     const { input, entries, sessionDir } = await createInput(root);
@@ -2247,13 +2227,13 @@ describe('CodexTranscriptInput', () => {
     await new Promise(resolve => setTimeout(resolve, 50));
     await input.stop();
 
-    expect(responsesForTurn(entries, 'turn-1')).toHaveLength(1);
+    expect(responsesForTurn(entries, 'turn-1')).toHaveLength(2);
     expect(responsesForTurn(entries, 'turn-2')).toHaveLength(1);
     expect(responsesForTurn(entries, 'turn-1')[0]?.['gen_ai.usage.total_tokens']).toBe(110);
     expect(responsesForTurn(entries, 'turn-2')[0]?.['gen_ai.usage.total_tokens']).toBe(132);
   });
 
-  it('keeps fork dedupe after restarting the Codex transcript input', async () => {
+  it('does not restore cross-transcript turn-ID suppression after restart', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-fork-restart-'));
     tempDirs.push(root);
     const first = await createInput(root);
@@ -2273,6 +2253,8 @@ describe('CodexTranscriptInput', () => {
     await first.input.stop();
 
     const restarted = await createInput(root);
+    const debug = vi.fn();
+    (restarted.input as unknown as { logger: { debug: typeof debug } }).logger.debug = debug;
     const forkedHistory = simpleCompletedTurn(
       'session-1',
       'turn-1',
@@ -2301,12 +2283,16 @@ describe('CodexTranscriptInput', () => {
     await new Promise(resolve => setTimeout(resolve, 50));
     await restarted.input.stop();
 
-    expect(responsesForTurn(restarted.entries, 'turn-1')).toHaveLength(0);
+    expect(responsesForTurn(restarted.entries, 'turn-1')).toHaveLength(1);
     expect(responsesForTurn(restarted.entries, 'turn-2')).toHaveLength(1);
     expect(responsesForTurn(restarted.entries, 'turn-2')[0]?.['gen_ai.usage.total_tokens']).toBe(132);
+    expect(debug).not.toHaveBeenCalledWith(
+      'skipped terminal Codex turn already present in global registry',
+      expect.anything(),
+    );
   });
 
-  it('persists global fork dedupe after baselining an inode-changed transcript file', async () => {
+  it('does not let an inode baseline suppress matching IDs in another transcript', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-fork-inode-'));
     tempDirs.push(root);
     const first = await createInput(root);
@@ -2378,7 +2364,7 @@ describe('CodexTranscriptInput', () => {
     await new Promise(resolve => setTimeout(resolve, 50));
     await restarted.input.stop();
 
-    expect(responsesForTurn(restarted.entries, 'turn-2')).toHaveLength(0);
+    expect(responsesForTurn(restarted.entries, 'turn-2')).toHaveLength(1);
     expect(responsesForTurn(restarted.entries, 'turn-3')).toHaveLength(1);
     expect(responsesForTurn(restarted.entries, 'turn-3')[0]?.['gen_ai.usage.total_tokens']).toBe(330);
   });
@@ -2807,6 +2793,340 @@ describe('CodexTranscriptInput', () => {
       ];
     };
 
+    const expectStartupCopiedBaselineNotToPoisonParent = async (
+      ownerPayload: (parentThreadId: string) => Record<string, unknown>,
+    ): Promise<void> => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-startup-baseline-'));
+      tempDirs.push(root);
+      const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
+      const parent = uuidV7At('2026-08-05T09:00:00.000Z', '000000000041');
+      const owner = uuidV7At('2026-08-05T10:00:00.000Z', '000000000042');
+      const parentTurn = uuidV7At('2026-08-05T09:30:00.000Z', '000000000043');
+      const childTurn = uuidV7At('2026-08-05T10:00:00.010Z', '000000000044');
+      const parentMeta = record('2026-08-05T09:00:00.000Z', 'session_meta', {
+        id: parent, thread_source: 'user', model_provider: 'openai',
+      });
+      const parentTranscript = await writeTranscriptNamed(
+        sessionDir,
+        `rollout-2026-08-05T09-00-00-${parent}.jsonl`,
+        [parentMeta, ...turnBlock(parentTurn, '2026-08-05T09:30:00.000Z')].join('\n') + '\n',
+        { bootstrapFork: false },
+      );
+      const parentStat = await fs.stat(parentTranscript);
+      const parentScanOffset = Buffer.byteLength(parentMeta + '\n');
+      stateStore.update(`codex-transcript:${parentTranscript}`, {
+        lastOffset: parentScanOffset,
+        extra: {
+          codexTranscript: {
+            inode: parentStat.ino,
+            scanOffset: parentScanOffset,
+            activeTurn: null,
+            pendingTerminal: null,
+            pendingFusion: null,
+            pendingSubagent: null,
+            ownerSessionMetaOffset: 0,
+            emittedTerminalTurnIds: [],
+          },
+        },
+      });
+
+      await writeTranscriptNamed(
+        sessionDir,
+        `rollout-2026-08-05T10-00-00-${owner}.jsonl`,
+        [
+          record('2026-08-05T10:00:00.000Z', 'session_meta', {
+            id: owner,
+            model_provider: 'openai',
+            ...ownerPayload(parent),
+          }),
+          ...turnBlock(parentTurn, '2026-08-05T09:30:00.000Z'),
+          ...turnBlock(childTurn, '2026-08-05T10:00:00.010Z'),
+        ].join('\n') + '\n',
+        { bootstrapFork: false },
+      );
+
+      await input.start();
+      await input.stop();
+
+      expect(responsesForTurn(entries, parentTurn)).toHaveLength(1);
+      expect(responsesForTurn(entries, childTurn)).toHaveLength(0);
+    };
+
+    it('does not let a startup-baselined user fork suppress an uncollected parent turn', async () => {
+      await expectStartupCopiedBaselineNotToPoisonParent(parentThreadId => ({
+        forked_from_id: parentThreadId,
+        thread_source: 'user',
+      }));
+    });
+
+    it('does not let a startup-baselined subagent suppress an uncollected parent turn', async () => {
+      await expectStartupCopiedBaselineNotToPoisonParent(parentThreadId => ({
+        forked_from_id: parentThreadId,
+        thread_source: 'subagent',
+        source: {
+          subagent: {
+            thread_spawn: {
+              parent_thread_id: parentThreadId,
+              depth: 1,
+            },
+          },
+        },
+      }));
+    });
+
+    it('keeps probing after a startup baseline while copied history is still materializing', async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-startup-materialize-'));
+      tempDirs.push(root);
+      const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
+      const parent = uuidV7At('2026-08-05T09:00:00.000Z', '000000000061');
+      const owner = uuidV7At('2026-08-05T10:00:00.000Z', '000000000062');
+      const firstCopiedTurn = uuidV7At('2026-08-05T09:20:00.000Z', '000000000063');
+      const laterCopiedTurn = uuidV7At('2026-08-05T09:30:00.000Z', '000000000064');
+      const childTurn = uuidV7At('2026-08-05T10:00:00.010Z', '000000000065');
+      const transcript = await writeTranscriptNamed(
+        sessionDir,
+        `rollout-2026-08-05T10-00-00-${owner}.jsonl`,
+        [
+          record('2026-08-05T10:00:00.000Z', 'session_meta', {
+            id: owner, forked_from_id: parent, thread_source: 'user', model_provider: 'openai',
+          }),
+          ...turnBlock(firstCopiedTurn, '2026-08-05T09:20:00.000Z'),
+        ].join('\n') + '\n',
+        { bootstrapFork: false },
+      );
+      const baselineSize = (await fs.stat(transcript)).size;
+
+      await input.start();
+      expect(entries).toHaveLength(0);
+      expect(transcriptCheckpoint(stateStore, transcript)).toMatchObject({
+        scanOffset: baselineSize,
+        forkBootstrap: {
+          searchOffset: expect.any(Number),
+        },
+      });
+      // Subsequent calls intentionally drive processFile directly. Stop the
+      // public lifecycle first so its serialized collection cycle cannot race
+      // the test-only direct invocation and manufacture duplicate emissions.
+      await input.stop();
+
+      await fs.appendFile(transcript, [
+        ...turnBlock(laterCopiedTurn, '2026-08-05T09:30:00.000Z'),
+        ...turnBlock(childTurn, '2026-08-05T10:00:00.010Z'),
+      ].join('\n') + '\n', 'utf8');
+      await processTranscriptOnce(input, transcript);
+
+      expect(responsesForTurn(entries, firstCopiedTurn)).toHaveLength(0);
+      expect(responsesForTurn(entries, laterCopiedTurn)).toHaveLength(0);
+      expect(responsesForTurn(entries, childTurn)).toHaveLength(1);
+      expect(transcriptCheckpoint(stateStore, transcript)).toMatchObject({
+        activeTurn: null,
+        pendingTerminal: null,
+      });
+      expect(transcriptCheckpoint(stateStore, transcript).forkBootstrap).toBeUndefined();
+    });
+
+    it('rebuilds an owned turn that was already active at the startup fork baseline', async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-startup-active-tail-'));
+      tempDirs.push(root);
+      const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
+      const parent = uuidV7At('2026-08-05T09:00:00.000Z', '000000000071');
+      const owner = uuidV7At('2026-08-05T10:00:00.000Z', '000000000072');
+      const copiedTurn = uuidV7At('2026-08-05T09:30:00.000Z', '000000000073');
+      const ownedTurn = uuidV7At('2026-08-05T10:00:00.010Z', '000000000074');
+      const transcript = await writeTranscriptNamed(
+        sessionDir,
+        `rollout-2026-08-05T10-00-00-${owner}.jsonl`,
+        [
+          record('2026-08-05T10:00:00.000Z', 'session_meta', {
+            id: owner, forked_from_id: parent, thread_source: 'user', model_provider: 'openai',
+          }),
+          ...turnBlock(copiedTurn, '2026-08-05T09:30:00.000Z'),
+          record('2026-08-05T10:00:00.010Z', 'turn_context', {
+            turn_id: ownedTurn, model: 'gpt-5.5', cwd: '/tmp/owned',
+          }),
+          record('2026-08-05T10:00:01.010Z', 'event_msg', {
+            type: 'task_started', turn_id: ownedTurn,
+          }),
+          record('2026-08-05T10:00:02.010Z', 'response_item', {
+            type: 'message', role: 'user', content: [{ type: 'input_text', text: 'continue owned turn' }],
+          }),
+        ].join('\n') + '\n',
+        { bootstrapFork: false },
+      );
+      const baselineSize = (await fs.stat(transcript)).size;
+
+      await input.start();
+
+      expect(entries).toHaveLength(0);
+      expect(transcriptCheckpoint(stateStore, transcript)).toMatchObject({
+        scanOffset: baselineSize,
+        activeTurn: {
+          turnId: ownedTurn,
+          startOffset: baselineSize,
+          model: 'gpt-5.5',
+          cwd: '/tmp/owned',
+        },
+      });
+      expect(transcriptCheckpoint(stateStore, transcript).forkBootstrap).toBeUndefined();
+      await input.stop();
+
+      await fs.appendFile(transcript, [
+        record('2026-08-05T10:00:03.010Z', 'event_msg', {
+          type: 'agent_message', message: 'owned result', phase: 'final',
+        }),
+        record('2026-08-05T10:00:04.010Z', 'event_msg', tokenUsage(100, 10)),
+        record('2026-08-05T10:00:05.010Z', 'event_msg', {
+          type: 'task_complete', turn_id: ownedTurn, last_agent_message: 'owned result',
+        }),
+      ].join('\n') + '\n', 'utf8');
+      await processTranscriptOnce(input, transcript);
+
+      expect(responsesForTurn(entries, copiedTurn)).toHaveLength(0);
+      expect(responsesForTurn(entries, ownedTurn)).toHaveLength(1);
+      expect(transcriptCheckpoint(stateStore, transcript)).toMatchObject({
+        activeTurn: null,
+        pendingTerminal: null,
+      });
+      expect(transcriptCheckpoint(stateStore, transcript).forkBootstrap).toBeUndefined();
+    });
+
+    it('resumes a bounded owned-tail rebuild after restart', async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-startup-large-tail-'));
+      tempDirs.push(root);
+      const first = await createDormantInput(root);
+      const parent = uuidV7At('2026-08-05T09:00:00.000Z', '000000000081');
+      const owner = uuidV7At('2026-08-05T10:00:00.000Z', '000000000082');
+      const copiedTurn = uuidV7At('2026-08-05T09:30:00.000Z', '000000000083');
+      const ownedTurn = uuidV7At('2026-08-05T10:00:00.010Z', '000000000084');
+      const filler = 'x'.repeat(64 * 1024);
+      const ownedTailPadding: string[] = [];
+      for (let index = 0; index < 270; index++) {
+        ownedTailPadding.push(record('2026-08-05T10:00:03.010Z', 'event_msg', {
+          type: 'owned_tail_padding', filler,
+        }));
+      }
+      const transcript = await writeTranscriptNamed(
+        first.sessionDir,
+        `rollout-2026-08-05T10-00-00-${owner}.jsonl`,
+        [
+          record('2026-08-05T10:00:00.000Z', 'session_meta', {
+            id: owner, forked_from_id: parent, thread_source: 'user', model_provider: 'openai',
+          }),
+          ...turnBlock(copiedTurn, '2026-08-05T09:30:00.000Z'),
+          record('2026-08-05T10:00:00.010Z', 'turn_context', {
+            turn_id: ownedTurn, model: 'gpt-5.5', cwd: '/tmp/large-owned',
+          }),
+          record('2026-08-05T10:00:01.010Z', 'event_msg', {
+            type: 'task_started', turn_id: ownedTurn,
+          }),
+          record('2026-08-05T10:00:02.010Z', 'response_item', {
+            type: 'message', role: 'user', content: [{ type: 'input_text', text: 'continue large owned turn' }],
+          }),
+          ...ownedTailPadding,
+        ].join('\n') + '\n',
+        { bootstrapFork: false },
+      );
+      const baselineSize = (await fs.stat(transcript)).size;
+      expect(baselineSize).toBeGreaterThan(16 * 1024 * 1024);
+
+      await first.input.start();
+      const firstCheckpoint = transcriptCheckpoint(first.stateStore, transcript);
+      expect(firstCheckpoint).toMatchObject({
+        scanOffset: baselineSize,
+        activeTurn: null,
+        forkBootstrap: {
+          state: 'baseline-tail',
+          tailCandidate: { turnId: ownedTurn },
+        },
+      });
+      expect((firstCheckpoint.forkBootstrap as { searchOffset: number }).searchOffset)
+        .toBeLessThan(baselineSize);
+      expect(first.entries).toHaveLength(0);
+      await first.stateStore.save();
+      await first.input.stop();
+
+      const restarted = await createDormantInput(root);
+      await restarted.input.start();
+      expect(restarted.entries).toHaveLength(0);
+      expect(transcriptCheckpoint(restarted.stateStore, transcript)).toMatchObject({
+        scanOffset: baselineSize,
+        activeTurn: {
+          turnId: ownedTurn,
+          startOffset: baselineSize,
+          model: 'gpt-5.5',
+          cwd: '/tmp/large-owned',
+        },
+      });
+      expect(transcriptCheckpoint(restarted.stateStore, transcript).forkBootstrap).toBeUndefined();
+      await restarted.input.stop();
+
+      await fs.appendFile(transcript, [
+        record('2026-08-05T10:00:04.010Z', 'event_msg', {
+          type: 'agent_message', message: 'large owned result', phase: 'final',
+        }),
+        record('2026-08-05T10:00:05.010Z', 'event_msg', tokenUsage(100, 10)),
+        record('2026-08-05T10:00:06.010Z', 'event_msg', {
+          type: 'task_complete', turn_id: ownedTurn, last_agent_message: 'large owned result',
+        }),
+      ].join('\n') + '\n', 'utf8');
+      await processTranscriptOnce(restarted.input, transcript);
+
+      expect(responsesForTurn(restarted.entries, copiedTurn)).toHaveLength(0);
+      expect(responsesForTurn(restarted.entries, ownedTurn)).toHaveLength(1);
+    }, 30_000);
+
+    it('uses a Hook that arrives before a startup baseline to anchor a later non-UUID turn', async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-startup-hook-'));
+      tempDirs.push(root);
+      const { input, entries, sessionDir, wakeupDir, stateStore } = await createDormantInput(root);
+      const parent = 'aaaaaaaa-0061-4061-8061-000000000061';
+      const owner = 'cccccccc-0062-4062-8062-000000000062';
+      const copiedTurn = 'parent-turn-startup-hook';
+      const childTurn = 'child-turn-startup-hook';
+      const transcript = await writeTranscriptNamed(
+        sessionDir,
+        `rollout-2026-08-05T10-00-00-${owner}.jsonl`,
+        [
+          record('2026-08-05T10:00:00.000Z', 'session_meta', {
+            id: owner, forked_from_id: parent, thread_source: 'user', model_provider: 'openai',
+          }),
+          ...turnBlock(copiedTurn, '2026-08-05T09:20:00.000Z'),
+        ].join('\n') + '\n',
+        { bootstrapFork: false },
+      );
+      const baselineSize = (await fs.stat(transcript)).size;
+      await writeWakeupMarker(wakeupDir, owner, {
+        session_id: owner,
+        initial_turn_id: childTurn,
+        transcript_path: transcript,
+        hook_event: 'user-prompt-submit',
+      });
+
+      await input.start();
+      expect(entries).toHaveLength(0);
+      expect(transcriptCheckpoint(stateStore, transcript)).toMatchObject({
+        scanOffset: baselineSize,
+        forkBootstrap: { initialTurnId: childTurn },
+      });
+      await input.stop();
+
+      await fs.appendFile(
+        transcript,
+        turnBlock(childTurn, '2026-08-05T10:00:00.010Z').join('\n') + '\n',
+        'utf8',
+      );
+      await processTranscriptOnce(input, transcript);
+      await processTranscriptOnce(input, transcript);
+
+      expect(responsesForTurn(entries, copiedTurn)).toHaveLength(0);
+      expect(responsesForTurn(entries, childTurn)).toHaveLength(1);
+      expect(transcriptCheckpoint(stateStore, transcript)).toMatchObject({
+        activeTurn: null,
+        pendingTerminal: null,
+      });
+      expect(transcriptCheckpoint(stateStore, transcript).forkBootstrap).toBeUndefined();
+    });
+
     it('keeps a fork rollout pending until an initial-turn Hook arrives', async () => {
       const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-await-hook-'));
       tempDirs.push(root);
@@ -2950,8 +3270,6 @@ describe('CodexTranscriptInput', () => {
 
       expect(responsesForTurn(entries, parentTurn)).toHaveLength(0);
       expect(responsesForTurn(entries, childTurn)).toHaveLength(1);
-      expect(globalProcessedTurnIds(stateStore)).not.toContain(parentTurn);
-      expect(globalProcessedTurnIds(stateStore)).toContain(childTurn);
 
       const parentTranscript = await writeTranscriptNamed(
         sessionDir,
@@ -3021,6 +3339,69 @@ describe('CodexTranscriptInput', () => {
       expect(responsesForTurn(entries, parentTurn)).toHaveLength(0);
       expect(responsesForTurn(entries, childTurn)).toHaveLength(1);
       expect(transcriptCheckpoint(stateStore, transcript).forkBootstrap).toBeUndefined();
+    });
+
+    it('baselines a consumed fork replacement without poisoning parent dedupe', async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-inode-consumed-'));
+      tempDirs.push(root);
+      const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
+      const parent = uuidV7At('2026-08-05T09:00:00.000Z', '000000000051');
+      const owner = uuidV7At('2026-08-05T10:00:00.000Z', '000000000052');
+      const parentTurn = uuidV7At('2026-08-05T09:30:00.000Z', '000000000053');
+      const childTurn = uuidV7At('2026-08-05T10:00:00.010Z', '000000000054');
+      const text = [
+        record('2026-08-05T10:00:00.000Z', 'session_meta', {
+          id: owner, forked_from_id: parent, thread_source: 'user', model_provider: 'openai',
+        }),
+        ...turnBlock(parentTurn, '2026-08-05T09:30:00.000Z'),
+        ...turnBlock(childTurn, '2026-08-05T10:00:00.010Z'),
+      ].join('\n') + '\n';
+      const transcript = await writeTranscriptNamed(
+        sessionDir,
+        `rollout-2026-08-05T10-00-00-${owner}.jsonl`,
+        text,
+        { bootstrapFork: false },
+      );
+
+      await processTranscriptOnce(input, transcript);
+      expect(responsesForTurn(entries, parentTurn)).toHaveLength(0);
+      expect(responsesForTurn(entries, childTurn)).toHaveLength(1);
+      expect(transcriptCheckpoint(stateStore, transcript)).toMatchObject({
+        activeTurn: null,
+        pendingTerminal: null,
+      });
+      expect(transcriptCheckpoint(stateStore, transcript).forkBootstrap).toBeUndefined();
+
+      const originalStat = await fs.stat(transcript);
+      const replacement = `${transcript}.replacement`;
+      await fs.writeFile(replacement, text, 'utf8');
+      await fs.rename(replacement, transcript);
+      expect((await fs.stat(transcript)).ino).not.toBe(originalStat.ino);
+
+      await processTranscriptOnce(input, transcript);
+
+      expect(responsesForTurn(entries, parentTurn)).toHaveLength(0);
+      expect(responsesForTurn(entries, childTurn)).toHaveLength(1);
+      expect(transcriptCheckpoint(stateStore, transcript)).toMatchObject({
+        activeTurn: null,
+        pendingTerminal: null,
+        forkBootstrap: expect.any(Object),
+      });
+
+      const parentTranscript = await writeTranscriptNamed(
+        sessionDir,
+        `rollout-2026-08-05T09-00-00-${parent}.jsonl`,
+        [
+          record('2026-08-05T09:00:00.000Z', 'session_meta', {
+            id: parent, thread_source: 'user', model_provider: 'openai',
+          }),
+          ...turnBlock(parentTurn, '2026-08-05T09:30:00.000Z'),
+        ].join('\n') + '\n',
+        { bootstrapFork: false },
+      );
+      await processTranscriptOnce(input, parentTranscript);
+
+      expect(responsesForTurn(entries, parentTurn)).toHaveLength(1);
     });
 
     it('accepts a session-matched initial anchor when transcript paths differ', async () => {

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -2908,6 +2908,121 @@ describe('CodexTranscriptInput', () => {
       expect(responsesForTurn(entries, latestOwnedTurn)).toHaveLength(1);
     });
 
+    it('restarts a pending fork bootstrap after inode replacement without poisoning parent dedupe', async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-inode-pending-'));
+      tempDirs.push(root);
+      const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
+      const parent = uuidV7At('2026-08-05T09:00:00.000Z', '000000000021');
+      const owner = uuidV7At('2026-08-05T10:00:00.000Z', '000000000022');
+      const parentTurn = uuidV7At('2026-08-05T09:30:00.000Z', '000000000023');
+      const childTurn = uuidV7At('2026-08-05T10:00:00.010Z', '000000000024');
+      const transcript = await writeTranscriptNamed(
+        sessionDir,
+        `rollout-2026-08-05T10-00-00-${owner}.jsonl`,
+        [
+          record('2026-08-05T10:00:00.000Z', 'session_meta', {
+            id: owner, forked_from_id: parent, thread_source: 'user', model_provider: 'openai',
+          }),
+          ...turnBlock(parentTurn, '2026-08-05T09:30:00.000Z'),
+        ].join('\n') + '\n',
+        { bootstrapFork: false },
+      );
+
+      await processTranscriptOnce(input, transcript);
+      const originalStat = await fs.stat(transcript);
+      expect(transcriptCheckpoint(stateStore, transcript)).toMatchObject({
+        scanOffset: 0,
+        forkBootstrap: { searchOffset: expect.any(Number) },
+      });
+
+      const replacement = `${transcript}.replacement`;
+      await fs.writeFile(replacement, [
+        record('2026-08-05T10:00:00.000Z', 'session_meta', {
+          id: owner, forked_from_id: parent, thread_source: 'user', model_provider: 'openai',
+        }),
+        ...turnBlock(parentTurn, '2026-08-05T09:30:00.000Z'),
+        ...turnBlock(childTurn, '2026-08-05T10:00:00.010Z'),
+      ].join('\n') + '\n', 'utf8');
+      await fs.rename(replacement, transcript);
+      expect((await fs.stat(transcript)).ino).not.toBe(originalStat.ino);
+
+      await processTranscriptOnce(input, transcript);
+
+      expect(responsesForTurn(entries, parentTurn)).toHaveLength(0);
+      expect(responsesForTurn(entries, childTurn)).toHaveLength(1);
+      expect(globalProcessedTurnIds(stateStore)).not.toContain(parentTurn);
+      expect(globalProcessedTurnIds(stateStore)).toContain(childTurn);
+
+      const parentTranscript = await writeTranscriptNamed(
+        sessionDir,
+        `rollout-2026-08-05T09-00-00-${parent}.jsonl`,
+        [
+          record('2026-08-05T09:00:00.000Z', 'session_meta', {
+            id: parent, thread_source: 'user', model_provider: 'openai',
+          }),
+          ...turnBlock(parentTurn, '2026-08-05T09:30:00.000Z'),
+        ].join('\n') + '\n',
+        { bootstrapFork: false },
+      );
+      await processTranscriptOnce(input, parentTranscript);
+
+      expect(responsesForTurn(entries, parentTurn)).toHaveLength(1);
+    });
+
+    it('retains fork recovery state across the anchored-before-collection inode window', async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-inode-anchored-'));
+      tempDirs.push(root);
+      const { input, entries, sessionDir, wakeupDir, stateStore } = await createDormantInput(root);
+      const parent = uuidV7At('2026-08-05T09:00:00.000Z', '000000000031');
+      const owner = uuidV7At('2026-08-05T10:00:00.000Z', '000000000032');
+      const parentTurn = uuidV7At('2026-08-05T09:30:00.000Z', '000000000033');
+      const childTurn = uuidV7At('2026-08-05T10:00:00.010Z', '000000000034');
+      const text = [
+        record('2026-08-05T10:00:00.000Z', 'session_meta', {
+          id: owner, forked_from_id: parent, thread_source: 'user', model_provider: 'openai',
+        }),
+        ...turnBlock(parentTurn, '2026-08-05T09:30:00.000Z'),
+        ...turnBlock(childTurn, '2026-08-05T10:00:00.010Z'),
+      ].join('\n') + '\n';
+      const transcript = await writeTranscriptNamed(
+        sessionDir,
+        `rollout-2026-08-05T10-00-00-${owner}.jsonl`,
+        text,
+        { bootstrapFork: false },
+      );
+      await writeWakeupMarker(wakeupDir, owner, {
+        session_id: owner,
+        initial_turn_id: childTurn,
+        transcript_path: transcript,
+        hook_event: 'user-prompt-submit',
+      });
+
+      await processTranscriptOnce(input, transcript);
+      const anchored = transcriptCheckpoint(stateStore, transcript);
+      expect(anchored.scanOffset as number).toBeGreaterThan(0);
+      expect(anchored.forkBootstrap).toMatchObject({ initialTurnId: childTurn });
+      expect(entries).toHaveLength(0);
+
+      const originalStat = await fs.stat(transcript);
+      const replacement = `${transcript}.replacement`;
+      await fs.writeFile(replacement, text, 'utf8');
+      await fs.rename(replacement, transcript);
+      expect((await fs.stat(transcript)).ino).not.toBe(originalStat.ino);
+      await writeWakeupMarker(wakeupDir, owner, {
+        session_id: owner,
+        initial_turn_id: childTurn,
+        recovery_turn_id: childTurn,
+        transcript_path: transcript,
+        hook_event: 'stop',
+      });
+
+      await processTranscriptOnce(input, transcript);
+
+      expect(responsesForTurn(entries, parentTurn)).toHaveLength(0);
+      expect(responsesForTurn(entries, childTurn)).toHaveLength(1);
+      expect(transcriptCheckpoint(stateStore, transcript).forkBootstrap).toBeUndefined();
+    });
+
     it('accepts a session-matched initial anchor when transcript paths differ', async () => {
       const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-path-soft-check-'));
       tempDirs.push(root);

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -322,10 +322,51 @@ async function writeSpanContext(
   return marker;
 }
 
-async function writeTranscriptNamed(sessionDir: string, name: string, text: string): Promise<string> {
+async function writeTranscriptNamed(
+  sessionDir: string,
+  name: string,
+  text: string,
+  options: { bootstrapFork?: boolean } = {},
+): Promise<string> {
   const transcript = path.join(sessionDir, '2026', '06', '24', name);
   await fs.mkdir(path.dirname(transcript), { recursive: true });
   await fs.writeFile(transcript, text, 'utf8');
+  // Most fixture rollouts are already terminal when written. Mirror the
+  // corresponding Stop/SubagentStop marker so unrelated parser/linker tests
+  // exercise normal collection after the production fork bootstrap.
+  if (options.bootstrapFork !== false) {
+    const records = text.trimEnd().split('\n').flatMap(line => {
+      try {
+        return [JSON.parse(line) as { type?: string; payload?: Record<string, unknown> }];
+      } catch {
+        return [];
+      }
+    });
+    const owner = records[0];
+    const ownerId = owner?.type === 'session_meta' && typeof owner.payload?.id === 'string'
+      ? owner.payload.id
+      : undefined;
+    const isFork = typeof owner?.payload?.forked_from_id === 'string'
+      || owner?.payload?.thread_source === 'subagent'
+      || owner?.payload?.source !== undefined;
+    const ownedTurnId = records.flatMap(item => (
+      item.type === 'event_msg'
+      && item.payload?.type === 'task_started'
+      && typeof item.payload.turn_id === 'string'
+        ? [item.payload.turn_id]
+        : []
+    )).at(-1);
+    if (ownerId && isFork && ownedTurnId) {
+      await writeWakeupMarker(path.join(path.dirname(sessionDir), 'wakeups'), ownerId, {
+        session_id: ownerId,
+        turn_id: ownedTurnId,
+        initial_turn_id: ownedTurnId,
+        transcript_path: transcript,
+        hook_event: owner?.payload?.thread_source === 'subagent' ? 'subagent-stop' : 'stop',
+        received_at: new Date().toISOString(),
+      });
+    }
+  }
   return transcript;
 }
 
@@ -614,7 +655,7 @@ describe('CodexTranscriptInput', () => {
   it('forces a reliably linked active child to finalize when the parent reaches task_complete', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-parent-barrier-'));
     tempDirs.push(root);
-    const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
+    const { input, entries, sessionDir, wakeupDir, stateStore } = await createDormantInput(root);
     const parentFixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, PARENT_FIXTURE_NAME), 'utf8');
     const parentLines = parentFixture.trimEnd().split('\n');
     const parentTerminal = parentLines.pop()!;
@@ -673,7 +714,7 @@ describe('CodexTranscriptInput', () => {
   it('releases the parent when a reliable child cannot be rebuilt and emits that child independently later', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-subagent-missing-child-'));
     tempDirs.push(root);
-    const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
+    const { input, entries, sessionDir, wakeupDir, stateStore } = await createDormantInput(root);
     const parentFixture = await fs.readFile(path.join(SUBAGENT_FIXTURE_DIR, PARENT_FIXTURE_NAME), 'utf8');
     const parentLines = parentFixture.trimEnd().split('\n');
     const parentTerminal = parentLines.pop()!;
@@ -706,6 +747,13 @@ describe('CodexTranscriptInput', () => {
     });
 
     await fs.appendFile(childTranscript, childLines.slice(1).join('\n') + '\n', 'utf8');
+    await writeWakeupMarker(wakeupDir, CHILD_FIXTURES[0].threadId, {
+      session_id: CHILD_FIXTURES[0].threadId,
+      turn_id: CHILD_FIXTURES[0].turnId,
+      initial_turn_id: CHILD_FIXTURES[0].turnId,
+      transcript_path: childTranscript,
+      hook_event: 'subagent-stop',
+    });
     await processTranscriptOnce(input, childTranscript);
 
     expect(responsesForTurn(entries, 'child-turn-1')).toHaveLength(1);
@@ -1936,7 +1984,7 @@ describe('CodexTranscriptInput', () => {
       .toBe(transcriptSize);
   });
 
-  it('skips copied history, consumes a control abort, and emits new fork work in one cycle', async () => {
+  it('skips copied history and emits new fork work in one cycle', async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-transcript-fork-control-abort-'));
     tempDirs.push(root);
     const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
@@ -1977,10 +2025,8 @@ describe('CodexTranscriptInput', () => {
     };
     expect(checkpoint.activeTurn).toBeNull();
     expect(checkpoint.pendingTerminal).toBeNull();
-    expect(checkpoint.emittedTerminalTurnIds).toEqual(
-      expect.arrayContaining([historyTurnId, controlTurnId, forkTurnId]),
-    );
-    expect(globalProcessedTurnIds(stateStore)).toContain(controlTurnId);
+    expect(checkpoint.emittedTerminalTurnIds).toEqual([forkTurnId]);
+    expect(globalProcessedTurnIds(stateStore)).not.toContain(controlTurnId);
 
     await stateStore.save();
     const restarted = await createDormantInput(root);
@@ -2006,7 +2052,7 @@ describe('CodexTranscriptInput', () => {
     expect(responsesForTurn(restarted.entries, restartedTurnId)).toHaveLength(1);
     expect((transcriptCheckpoint(restarted.stateStore, secondFork) as {
       emittedTerminalTurnIds?: string[];
-    }).emittedTerminalTurnIds).toContain(controlTurnId);
+    }).emittedTerminalTurnIds).toEqual([restartedTurnId]);
     expect(debug).not.toHaveBeenCalledWith(
       'processed terminal Codex turn without observable entries',
       expect.objectContaining({ turnId: controlTurnId }),
@@ -2756,6 +2802,137 @@ describe('CodexTranscriptInput', () => {
       ];
     };
 
+    it('keeps a fork rollout pending until an initial-turn Hook arrives', async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-await-hook-'));
+      tempDirs.push(root);
+      const { input, entries, sessionDir, stateStore } = await createDormantInput(root);
+      const child = 'cccccccc-0001-4001-8001-000000000001';
+      const parent = 'aaaaaaaa-0001-4001-8001-000000000001';
+      const transcript = await writeTranscriptNamed(
+        sessionDir,
+        `rollout-2026-08-05T10-00-00-${child}.jsonl`,
+        [
+          record('2026-08-05T10:00:00.000Z', 'session_meta', {
+            id: child, forked_from_id: parent, thread_source: 'user', model_provider: 'openai',
+          }),
+          record('2026-06-01T00:00:00.000Z', 'session_meta', { id: parent, model_provider: 'openai' }),
+          ...turnBlock('parent-turn-awaiting', '2026-06-01T00:00:10.000Z'),
+          ...turnBlock('child-turn-awaiting', '2026-08-05T10:00:10.000Z'),
+        ].join('\n') + '\n',
+        { bootstrapFork: false },
+      );
+
+      await processTranscriptOnce(input, transcript);
+
+      expect(entries).toHaveLength(0);
+      expect(transcriptCheckpoint(stateStore, transcript)).toMatchObject({
+        scanOffset: 0,
+        forkBootstrap: { searchOffset: 0 },
+      });
+    });
+
+    it('resumes an exact-turn search when the Hook fires before task_started is appended', async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-hook-before-turn-'));
+      tempDirs.push(root);
+      const { input, entries, sessionDir, wakeupDir, stateStore } = await createDormantInput(root);
+      const child = 'cccccccc-0002-4002-8002-000000000002';
+      const parent = 'aaaaaaaa-0002-4002-8002-000000000002';
+      const turnId = 'child-turn-late-write';
+      const transcript = await writeTranscriptNamed(
+        sessionDir,
+        `rollout-2026-08-05T10-00-00-${child}.jsonl`,
+        [
+          record('2026-08-05T10:00:00.000Z', 'session_meta', {
+            id: child, forked_from_id: parent, thread_source: 'user', model_provider: 'openai',
+          }),
+          record('2026-06-01T00:00:00.000Z', 'session_meta', { id: parent, model_provider: 'openai' }),
+          ...turnBlock('parent-turn-before-hook', '2026-06-01T00:00:10.000Z'),
+        ].join('\n') + '\n',
+        { bootstrapFork: false },
+      );
+      await writeWakeupMarker(wakeupDir, child, {
+        session_id: child,
+        turn_id: turnId,
+        initial_turn_id: turnId,
+        transcript_path: transcript,
+        hook_event: 'user-prompt-submit',
+      });
+
+      await processTranscriptOnce(input, transcript);
+      const pending = transcriptCheckpoint(stateStore, transcript) as {
+        scanOffset: number;
+        forkBootstrap: { turnId: string; searchOffset: number };
+      };
+      expect(pending.scanOffset).toBe(0);
+      expect(pending.forkBootstrap.turnId).toBe(turnId);
+      expect(pending.forkBootstrap.searchOffset).toBeGreaterThan(0);
+
+      await fs.appendFile(transcript, [
+        record('2026-08-05T10:00:05.000Z', 'event_msg', { type: 'thread_settings_applied' }),
+        record('2026-08-05T10:00:10.000Z', 'event_msg', { type: 'task_started', turn_id: turnId }),
+        record('2026-08-05T10:00:11.000Z', 'turn_context', { turn_id: turnId, model: 'gpt-5.5' }),
+        record('2026-08-05T10:00:12.000Z', 'response_item', {
+          type: 'message', role: 'user', content: [{ type: 'input_text', text: 'new child work' }],
+        }),
+        record('2026-08-05T10:00:13.000Z', 'event_msg', { type: 'agent_message', message: 'done', phase: 'final' }),
+        record('2026-08-05T10:00:14.000Z', 'event_msg', tokenUsage(10, 2)),
+        record('2026-08-05T10:00:15.000Z', 'event_msg', { type: 'task_complete', turn_id: turnId }),
+      ].join('\n') + '\n', 'utf8');
+
+      await processTranscriptOnce(input, transcript); // establish checkpoint only
+      expect(responsesForTurn(entries, turnId)).toHaveLength(0);
+      await processTranscriptOnce(input, transcript); // normal poll/Stop path
+
+      expect(responsesForTurn(entries, turnId)).toHaveLength(1);
+      expect(responsesForTurn(entries, 'parent-turn-before-hook')).toHaveLength(0);
+      expect(transcriptCheckpoint(stateStore, transcript).forkBootstrap).toBeUndefined();
+    });
+
+    it('uses the Hook turn rather than historical settings markers in a recursive fork', async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-recursive-fork-'));
+      tempDirs.push(root);
+      const { input, entries, sessionDir, wakeupDir } = await createDormantInput(root);
+      const child = 'cccccccc-0003-4003-8003-000000000003';
+      const parent = 'bbbbbbbb-0003-4003-8003-000000000003';
+      const grandparent = 'aaaaaaaa-0003-4003-8003-000000000003';
+      const currentTurn = 'current-fork-turn';
+      const transcript = await writeTranscriptNamed(
+        sessionDir,
+        `rollout-2026-08-05T10-00-00-${child}.jsonl`,
+        [
+          record('2026-08-05T10:00:00.000Z', 'session_meta', {
+            id: child, forked_from_id: parent, thread_source: 'user', model_provider: 'openai',
+          }),
+          record('2026-08-04T10:00:00.000Z', 'session_meta', {
+            id: parent, forked_from_id: grandparent, model_provider: 'openai',
+          }),
+          record('2026-08-03T10:00:00.000Z', 'session_meta', { id: grandparent, model_provider: 'openai' }),
+          ...turnBlock('grandparent-turn', '2026-08-03T10:00:10.000Z'),
+          record('2026-08-03T10:01:00.000Z', 'event_msg', { type: 'thread_settings_applied' }),
+          ...turnBlock('parent-turn-a', '2026-08-04T10:00:10.000Z'),
+          record('2026-08-04T10:01:00.000Z', 'event_msg', { type: 'thread_settings_applied' }),
+          ...turnBlock('parent-turn-b', '2026-08-04T10:02:10.000Z'),
+          record('2026-08-05T10:00:05.000Z', 'event_msg', { type: 'thread_settings_applied' }),
+          ...turnBlock(currentTurn, '2026-08-05T10:00:10.000Z'),
+        ].join('\n') + '\n',
+        { bootstrapFork: false },
+      );
+      await writeWakeupMarker(wakeupDir, child, {
+        session_id: child,
+        turn_id: currentTurn,
+        initial_turn_id: currentTurn,
+        transcript_path: transcript,
+        hook_event: 'stop',
+      });
+
+      await processTranscriptOnce(input, transcript);
+
+      expect(responsesForTurn(entries, currentTurn)).toHaveLength(1);
+      expect(responsesForTurn(entries, 'grandparent-turn')).toHaveLength(0);
+      expect(responsesForTurn(entries, 'parent-turn-a')).toHaveLength(0);
+      expect(responsesForTurn(entries, 'parent-turn-b')).toHaveLength(0);
+    });
+
     it('drops the copied ancestor prefix of a resume/fork rollout, keeps the child turn', async () => {
       const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-fork-'));
       tempDirs.push(root);
@@ -2806,7 +2983,7 @@ describe('CodexTranscriptInput', () => {
       expect(responsesForTurn(entries, 'parent-turn')).toHaveLength(0);
     });
 
-    it('probes across cycles for a copied prefix larger than one scan window', async () => {
+    it('locates a Hook-anchored turn beyond one normal scan window', async () => {
       const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-big-'));
       tempDirs.push(root);
       const { input, entries, sessionDir, stateStore } = await createInput(root);
@@ -2838,11 +3015,9 @@ describe('CodexTranscriptInput', () => {
 
       expect(responsesForTurn(entries, 'big-child-turn')).toHaveLength(1);
       expect(responsesForTurn(entries, 'big-ancestor-turn')).toHaveLength(0);
-      // The boundary sits beyond the first window, so collection can only have
-      // started there by carrying probe state across cycles.
       const checkpoint = transcriptCheckpoint(stateStore, transcript);
       expect(checkpoint.scanOffset as number).toBeGreaterThan(16 * 1024 * 1024);
-      expect(checkpoint.copiedPrefixProbe).toMatchObject({ settled: true, sawForeignMeta: true });
+      expect(checkpoint.forkBootstrap).toBeUndefined();
     }, 30_000);
 
     it('does not skip a normal user session that has no copied prefix', async () => {

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -2739,4 +2739,88 @@ describe('CodexTranscriptInput', () => {
       'tool.result.status': 'cancelled',
     });
   });
+
+  // ── Copied fork/subagent history prefix must be dropped ──────────────────
+  describe('copied history prefix', () => {
+    // Build one emittable turn (produces an llm.response) at the given base time.
+    const turnBlock = (turnId: string, baseIso: string): string[] => {
+      const base = Date.parse(baseIso);
+      const at = (s: number) => new Date(base + s * 1000).toISOString();
+      return [
+        record(at(0), 'turn_context', { turn_id: turnId, model: 'gpt-5.5', cwd: '/tmp/p' }),
+        record(at(1), 'event_msg', { type: 'task_started', turn_id: turnId }),
+        record(at(2), 'response_item', { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hi' }] }),
+        record(at(3), 'event_msg', { type: 'agent_message', message: `done-${turnId}`, phase: 'final' }),
+        record(at(4), 'event_msg', tokenUsage(100, 10)),
+        record(at(5), 'event_msg', { type: 'task_complete', turn_id: turnId, last_agent_message: `done-${turnId}` }),
+      ];
+    };
+
+    it('drops the copied ancestor prefix of a resume/fork rollout, keeps the child turn', async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-fork-'));
+      tempDirs.push(root);
+      const { input, entries, sessionDir } = await createInput(root);
+      const child = 'cccccccc-1111-4111-8111-111111111111';
+      const ancestor = 'aaaaaaaa-9999-4999-8999-999999999999';
+      const text = [
+        record('2026-08-05T10:00:00.000Z', 'session_meta', {
+          id: child, forked_from_id: ancestor, thread_source: 'user', model_provider: 'openai',
+        }),
+        record('2026-06-01T00:00:00.000Z', 'session_meta', { id: ancestor, thread_source: 'user', model_provider: 'openai' }),
+        ...turnBlock('ancestor-turn', '2026-06-01T00:00:10.000Z'),
+        record('2026-08-05T10:00:05.000Z', 'event_msg', { type: 'thread_settings_applied', thread_settings: { model: 'gpt-5.5' } }),
+        ...turnBlock('child-turn', '2026-08-05T10:00:10.000Z'),
+      ].join('\n') + '\n';
+      await writeTranscriptNamed(sessionDir, `rollout-2026-08-05T10-00-00-${child}.jsonl`, text);
+
+      await waitFor(() => responsesForTurn(entries, 'child-turn').length === 1);
+      await input.stop();
+
+      expect(responsesForTurn(entries, 'child-turn')).toHaveLength(1);
+      expect(responsesForTurn(entries, 'ancestor-turn')).toHaveLength(0);
+      expect(entries.some(e => e['agent.codex.transcript_turn_id'] === 'ancestor-turn')).toBe(false);
+    });
+
+    it('drops the copied parent prefix of a subagent rollout, keeps the child turn', async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-sub-'));
+      tempDirs.push(root);
+      const { input, entries, sessionDir } = await createInput(root);
+      const child = 'cccccccc-2222-4222-8222-222222222222';
+      const parent = 'aaaaaaaa-8888-4888-8888-888888888888';
+      const text = [
+        record('2026-08-05T10:00:00.000Z', 'session_meta', {
+          id: child, forked_from_id: parent, thread_source: 'subagent', model_provider: 'openai',
+          source: { subagent: { thread_spawn: { parent_thread_id: parent, depth: 1, agent_path: '/root/child' } } },
+        }),
+        record('2026-06-01T00:00:00.000Z', 'session_meta', { id: parent, thread_source: 'user', model_provider: 'openai' }),
+        ...turnBlock('parent-turn', '2026-06-01T00:00:10.000Z'),
+        record('2026-08-05T10:00:05.000Z', 'event_msg', { type: 'thread_settings_applied', thread_settings: { model: 'gpt-5.5' } }),
+        ...turnBlock('subchild-turn', '2026-08-05T10:00:10.000Z'),
+      ].join('\n') + '\n';
+      await writeTranscriptNamed(sessionDir, `rollout-2026-08-05T10-00-00-${child}.jsonl`, text);
+
+      await waitFor(() => responsesForTurn(entries, 'subchild-turn').length === 1);
+      await input.stop();
+
+      expect(responsesForTurn(entries, 'subchild-turn')).toHaveLength(1);
+      expect(responsesForTurn(entries, 'parent-turn')).toHaveLength(0);
+    });
+
+    it('does not skip a normal user session that has no copied prefix', async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-normal-'));
+      tempDirs.push(root);
+      const { input, entries, sessionDir } = await createInput(root);
+      const own = 'dddddddd-3333-4333-8333-333333333333';
+      const text = [
+        record('2026-08-05T10:00:00.000Z', 'session_meta', { id: own, thread_source: 'user', model_provider: 'openai' }),
+        ...turnBlock('normal-turn', '2026-08-05T10:00:10.000Z'),
+      ].join('\n') + '\n';
+      await writeTranscriptNamed(sessionDir, `rollout-2026-08-05T10-00-00-${own}.jsonl`, text);
+
+      await waitFor(() => responsesForTurn(entries, 'normal-turn').length === 1);
+      await input.stop();
+
+      expect(responsesForTurn(entries, 'normal-turn')).toHaveLength(1);
+    });
+  });
 });

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -2806,6 +2806,45 @@ describe('CodexTranscriptInput', () => {
       expect(responsesForTurn(entries, 'parent-turn')).toHaveLength(0);
     });
 
+    it('probes across cycles for a copied prefix larger than one scan window', async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-copied-big-'));
+      tempDirs.push(root);
+      const { input, entries, sessionDir, stateStore } = await createInput(root);
+      const child = 'cccccccc-4444-4444-8444-444444444444';
+      const ancestor = 'aaaaaaaa-7777-4777-8777-777777777777';
+      // Pad the copied region past one scan window (16 MiB) so the boundary can
+      // only be reached by resuming the probe on a later cycle. Padding uses an
+      // unrecognised event type so it never yields entries by itself.
+      const filler = 'x'.repeat(64 * 1024);
+      const padding: string[] = [];
+      for (let i = 0; i < 280; i++) {
+        padding.push(record('2026-06-01T00:00:20.000Z', 'event_msg', { type: 'copied_padding', filler }));
+      }
+      const text = [
+        record('2026-08-05T10:00:00.000Z', 'session_meta', {
+          id: child, forked_from_id: ancestor, thread_source: 'user', model_provider: 'openai',
+        }),
+        record('2026-06-01T00:00:00.000Z', 'session_meta', { id: ancestor, thread_source: 'user', model_provider: 'openai' }),
+        ...turnBlock('big-ancestor-turn', '2026-06-01T00:00:10.000Z'),
+        ...padding,
+        record('2026-08-05T10:00:05.000Z', 'event_msg', { type: 'thread_settings_applied', thread_settings: { model: 'gpt-5.5' } }),
+        ...turnBlock('big-child-turn', '2026-08-05T10:00:10.000Z'),
+      ].join('\n') + '\n';
+      expect(Buffer.byteLength(text)).toBeGreaterThan(16 * 1024 * 1024);
+      const transcript = await writeTranscriptNamed(sessionDir, `rollout-2026-08-05T10-00-00-${child}.jsonl`, text);
+
+      await waitFor(() => responsesForTurn(entries, 'big-child-turn').length === 1, 15_000);
+      await input.stop();
+
+      expect(responsesForTurn(entries, 'big-child-turn')).toHaveLength(1);
+      expect(responsesForTurn(entries, 'big-ancestor-turn')).toHaveLength(0);
+      // The boundary sits beyond the first window, so collection can only have
+      // started there by carrying probe state across cycles.
+      const checkpoint = transcriptCheckpoint(stateStore, transcript);
+      expect(checkpoint.scanOffset as number).toBeGreaterThan(16 * 1024 * 1024);
+      expect(checkpoint.copiedPrefixProbe).toMatchObject({ settled: true, sawForeignMeta: true });
+    }, 30_000);
+
     it('does not skip a normal user session that has no copied prefix', async () => {
       const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-normal-'));
       tempDirs.push(root);


### PR DESCRIPTION
## Problem

Codex spawns a subagent (or resumes/forks a thread) by creating a **new rollout that begins with a verbatim copy of the ancestor's history**, then appends the child's own `thread_settings_applied` marker before any real new turn (`ForkPersistence::Copied` with `ThreadHistoryMode::Legacy`).

Emitting that copied region re-reports the ancestor's events. The existing guards don't cover it reliably:

- per-file and cross-transcript terminal-turn registries are bounded (`MAX_GLOBAL_EMITTED_TERMINAL_TURNS = 10000`);
- a long-lived session that keeps spawning subagents throughout the day evicts the ancestor turn id from that registry, after which **every later spawn re-emits the same history**.

Because `event.id` is derived from `(session, turn, kind, step)`, the re-emitted events collide with the ancestor's originals and inflate both event counts and token totals downstream.

## Fix

Skip the copied region on a file's **first** scan by advancing the scan offset to codex's own boundary marker.

- **Trigger** — the owning `session_meta` carries a first-party fork/child indicator: `forked_from_id`, `parent_thread_id`, or `thread_source=subagent`.
- **Boundary** — the first `event_msg/thread_settings_applied`, and only when a foreign `session_meta` (id ≠ owner) was seen before it. A mid-stream settings change in real content therefore cannot match.
- **Fails open** — no boundary found ⇒ nothing is skipped, so the change cannot drop real data.
- Ordinary user sessions have none of the trigger fields and are never touched.

Deliberately *not* keyed on whether the copied turn is terminal: the copied region can carry `task_complete`, be truncated by the 16 MB scan window, or belong to a still-running turn. A structural boundary is immune to all three.

Also parses top-level `session_meta.forked_from_id` into `CodexTranscriptMeta.forkedFromId`, which previously was not read.

## Verification

- New unit tests: copied prefix dropped for a resume/fork rollout, dropped for a subagent rollout, and **not** skipped for a normal user session.
- Existing codex suites unchanged: 88 tests pass.
- Full unit suite: 2412 pass.
- **Real customer data** — a rollout directory of 54 files (46 subagent spawns of one long-lived session, all `history_mode=legacy`): the skipped byte range equals the independently computed copied-region boundary in every case (1331582 / 2113334 / 149260), the child's own turns are still collected, and no copied turn is emitted.

## Notes

Complements #229, which fixed session attribution (`ownerSessionMetaOffset`) but left the copied region being emitted — after that fix the copied turns no longer collide by `event.id`, so dropping the region is what actually stops the duplicate reporting.
