### PR TITLE
fix(service): re-register missing daemon services

### DIFF
--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -798,25 +798,23 @@ function Cmd-RestartCollector {
     }
 
     if (-not $restarted) {
-        # Self-healing: try to register Task Scheduler for degraded (background/unknown) installs
+        # init-type is shared by collector/updater. Re-register this daemon's task
+        # even when it already says "taskscheduler" because the task may be absent.
         $initType = ""
         if (Test-Path $INIT_TYPE_FILE) { $initType = (Get-Content $INIT_TYPE_FILE -ErrorAction SilentlyContinue).Trim() }
-        # "background" is a legacy init-type value from pre-Task-Scheduler installs (aligned with Linux nohup/unknown)
-        if ($initType -in @("background", "unknown", "")) {
-            try {
-                $ok = Install-CollectorTask $nodeBin
-                if ($ok) {
-                    Start-ScheduledTask -TaskName $TASK_NAME_COLLECTOR -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
-                    Start-Sleep -Seconds 1
-                    if (Get-TaskRunning $TASK_NAME_COLLECTOR) {
-                        Set-Content -Path $INIT_TYPE_FILE -Value "taskscheduler"
-                        Write-Host "collector self-healed: registered with Task Scheduler"
-                        $restarted = $true
-                    }
+        try {
+            $ok = Install-CollectorTask $nodeBin
+            if ($ok) {
+                Start-ScheduledTask -TaskName $TASK_NAME_COLLECTOR -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
+                Start-Sleep -Seconds 1
+                if (Get-TaskRunning $TASK_NAME_COLLECTOR) {
+                    Set-Content -Path $INIT_TYPE_FILE -Value "taskscheduler"
+                    Write-Host "collector self-healed: registered with Task Scheduler"
+                    $restarted = $true
                 }
-            } catch {
-                Write-Host "Self-heal failed: $($_.Exception.Message)" -ForegroundColor Yellow
             }
+        } catch {
+            Write-Host "Self-heal failed: $($_.Exception.Message)" -ForegroundColor Yellow
         }
         if (-not $restarted) {
             if ($initType -in @("background", "unknown", "")) {
@@ -896,25 +894,23 @@ function Cmd-RestartUpdater {
     }
 
     if (-not $restarted) {
-        # Self-healing: try to register Task Scheduler for degraded (background/unknown) installs
+        # init-type is shared by collector/updater. Re-register this daemon's task
+        # even when it already says "taskscheduler" because the task may be absent.
         $initType = ""
         if (Test-Path $INIT_TYPE_FILE) { $initType = (Get-Content $INIT_TYPE_FILE -ErrorAction SilentlyContinue).Trim() }
-        # "background" is a legacy init-type value from pre-Task-Scheduler installs (aligned with Linux nohup/unknown)
-        if ($initType -in @("background", "unknown", "")) {
-            try {
-                $ok = Install-UpdaterTask $nodeBin
-                if ($ok) {
-                    Start-ScheduledTask -TaskName $TASK_NAME_UPDATER -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
-                    Start-Sleep -Seconds 1
-                    if (Get-TaskRunning $TASK_NAME_UPDATER) {
-                        Set-Content -Path $INIT_TYPE_FILE -Value "taskscheduler"
-                        Write-Host "updater self-healed: registered with Task Scheduler"
-                        $restarted = $true
-                    }
+        try {
+            $ok = Install-UpdaterTask $nodeBin
+            if ($ok) {
+                Start-ScheduledTask -TaskName $TASK_NAME_UPDATER -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
+                Start-Sleep -Seconds 1
+                if (Get-TaskRunning $TASK_NAME_UPDATER) {
+                    Set-Content -Path $INIT_TYPE_FILE -Value "taskscheduler"
+                    Write-Host "updater self-healed: registered with Task Scheduler"
+                    $restarted = $true
                 }
-            } catch {
-                Write-Host "Self-heal failed: $($_.Exception.Message)" -ForegroundColor Yellow
             }
+        } catch {
+            Write-Host "Self-heal failed: $($_.Exception.Message)" -ForegroundColor Yellow
         }
         if (-not $restarted) {
             if ($initType -in @("background", "unknown", "")) {

--- a/scripts/loongsuite-pilot.sh
+++ b/scripts/loongsuite-pilot.sh
@@ -711,6 +711,12 @@ cmd_restart_collector() {
                 fi
             fi
         fi
+        # A concrete manager now owns this daemon. Even if its first liveness
+        # check is slow, starting a nohup copy could create duplicate collectors.
+        if [ "$_restarted" = false ] && [ "$_new_init" != "none" ]; then
+            echo "❌ Service manager failed to restart collector (init_type=$_new_init)" >&2
+            exit 1
+        fi
         if [ "$_restarted" = false ]; then
             case "$init_type" in
                 nohup|unknown|"")
@@ -852,6 +858,12 @@ cmd_restart_updater() {
                     echo "⚠️  updater self-heal registered ($_new_init) but process not found" >&2
                 fi
             fi
+        fi
+        # A concrete manager now owns this daemon. Never race it with an
+        # unmanaged updater just because the first liveness check is slow.
+        if [ "$_restarted" = false ] && [ "$_new_init" != "none" ]; then
+            echo "❌ Service manager failed to restart updater (init_type=$_new_init)" >&2
+            return 1
         fi
         if [ "$_restarted" = false ]; then
             case "$init_type" in
@@ -1639,6 +1651,12 @@ autostart_install_collector_only() {
 
 autostart_install_updater_only() {
     local interactive="${1:-true}"
+
+    # Open-source packages may intentionally omit the updater daemon. Do not
+    # create a service definition whose executable payload does not exist.
+    if [ ! -f "$BOOTSTRAP_DIR/updater-daemon.js" ]; then
+        return 1
+    fi
 
     local init_system
     init_system=$(detect_init_system "$interactive") || return 1

--- a/scripts/loongsuite-pilot.sh
+++ b/scripts/loongsuite-pilot.sh
@@ -52,10 +52,13 @@ has_sudo_noninteractive() {
 
 # Run a privileged command, escalating only when needed.
 # As root: exec directly — sudo may be absent (e.g. container images) and is
-#   redundant anyway. As non-root: prefix with sudo (interactive escalation OK).
+#   redundant anyway. As non-root: default to interactive sudo; restart self-heal
+#   opts into sudo -n through a dynamically scoped internal flag.
 maybe_sudo() {
     if [ "$(id -u)" -eq 0 ]; then
         "$@"
+    elif [ "${_PILOT_SUDO_NONINTERACTIVE:-false}" = "true" ]; then
+        sudo -n "$@"
     else
         sudo "$@"
     fi
@@ -270,6 +273,10 @@ detect_init_system() {
         local saved
         saved=$(cat "$INIT_TYPE_FILE" 2>/dev/null | tr -d '[:space:]')
         case "$saved" in
+            systemd)
+                echo "systemd-system"
+                return
+                ;;
             launchd|systemd-user|systemd-system|initd)
                 echo "$saved"
                 return
@@ -646,32 +653,36 @@ cmd_restart_collector() {
     case "$(uname -s)" in
         Darwin)
             if launchctl list "$SERVICE_LABEL" &>/dev/null; then
-                launchctl start "$SERVICE_LABEL" 2>/dev/null || true
-                echo "✅ collector restarted (launchd)"
-                _restarted=true
+                if launchctl start "$SERVICE_LABEL" 2>/dev/null; then
+                    echo "✅ collector restarted (launchd)"
+                    _restarted=true
+                fi
             fi
             ;;
         Linux)
             case "$init_type" in
                 systemd-user)
                     if systemctl --user is-enabled loongsuite-pilot.service &>/dev/null; then
-                        systemctl --user start loongsuite-pilot.service &>/dev/null
-                        echo "✅ collector restarted (systemd user-level)"
-                        _restarted=true
+                        if systemctl --user start loongsuite-pilot.service &>/dev/null; then
+                            echo "✅ collector restarted (systemd user-level)"
+                            _restarted=true
+                        fi
                     fi
                     ;;
                 systemd-system|systemd)
                     if [ -f "$SYSTEMD_SYSTEM_UNIT_DIR/$sys_unit" ] && maybe_sudo_n systemctl is-enabled "$sys_unit" &>/dev/null; then
-                        maybe_sudo systemctl start "$sys_unit" &>/dev/null
-                        echo "✅ collector restarted (systemd system-level)"
-                        _restarted=true
+                        if maybe_sudo systemctl start "$sys_unit" &>/dev/null; then
+                            echo "✅ collector restarted (systemd system-level)"
+                            _restarted=true
+                        fi
                     fi
                     ;;
                 initd)
                     if [ -f "$initd_script" ]; then
-                        maybe_sudo "$initd_script" start &>/dev/null
-                        echo "✅ collector restarted (init.d)"
-                        _restarted=true
+                        if maybe_sudo "$initd_script" start &>/dev/null; then
+                            echo "✅ collector restarted (init.d)"
+                            _restarted=true
+                        fi
                     fi
                     ;;
             esac
@@ -685,23 +696,24 @@ cmd_restart_collector() {
         fi
     fi
     if [ "$_restarted" = false ]; then
-        # Self-healing: try to register a proper service for degraded (nohup/unknown) installs
-        case "$init_type" in
-            nohup|unknown|"")
-                local _new_init
-                _new_init=$(detect_init_system "false")
-                if [ "$_new_init" != "none" ]; then
-                    if autostart_install_collector_only "false" 2>>"$LOG_FILE"; then
-                        sleep 1
-                        if is_running; then
-                            echo "✅ collector self-healed: registered as $_new_init"
-                            _restarted=true
-                        else
-                            echo "⚠️  collector self-heal registered ($_new_init) but process not found" >&2
-                        fi
-                    fi
+        # init-type selects a service manager; it does not prove this daemon's
+        # service definition exists. Re-register the collector independently.
+        local _new_init
+        _new_init=$(detect_init_system "false")
+        if [ "$_new_init" != "none" ]; then
+            if _PILOT_SUDO_NONINTERACTIVE=true autostart_install_collector_only "false" 2>>"$LOG_FILE"; then
+                sleep 1
+                if is_running; then
+                    echo "✅ collector self-healed: registered as $_new_init"
+                    _restarted=true
+                else
+                    echo "⚠️  collector self-heal registered ($_new_init) but process not found" >&2
                 fi
-                if [ "$_restarted" = false ]; then
+            fi
+        fi
+        if [ "$_restarted" = false ]; then
+            case "$init_type" in
+                nohup|unknown|"")
                     local entry="$BOOTSTRAP_DIR/collector-daemon.js"
                     if [ ! -f "$entry" ]; then
                         echo "❌ Bootstrap script missing"
@@ -716,13 +728,13 @@ cmd_restart_collector() {
                     nohup "$node_bin" "$entry" >> "$LOG_FILE" 2>&1 &
                     echo "$!" > "$PID_FILE"
                     echo "⚠️  collector restarted (nohup fallback, self-heal failed)"
-                fi
-                ;;
-            *)
-                echo "❌ Service manager failed to restart collector (init_type=$init_type)" >&2
-                exit 1
-                ;;
-        esac
+                    ;;
+                *)
+                    echo "❌ Service manager failed to restart collector (init_type=$init_type)" >&2
+                    exit 1
+                    ;;
+            esac
+        fi
     fi
 
     if ! is_running; then
@@ -783,31 +795,35 @@ cmd_restart_updater() {
     case "$(uname -s)" in
         Darwin)
             if launchctl list "$UPDATER_LABEL" &>/dev/null; then
-                launchctl start "$UPDATER_LABEL" 2>/dev/null || true
-                _restarted=true
+                if launchctl start "$UPDATER_LABEL" 2>/dev/null; then
+                    _restarted=true
+                fi
             fi
             ;;
         Linux)
             case "$init_type" in
                 systemd-user)
                     if systemctl --user is-enabled loongsuite-pilot-updater.service &>/dev/null; then
-                        systemctl --user start loongsuite-pilot-updater.service &>/dev/null
-                        echo "✅ updater restarted (systemd user-level)"
-                        _restarted=true
+                        if systemctl --user start loongsuite-pilot-updater.service &>/dev/null; then
+                            echo "✅ updater restarted (systemd user-level)"
+                            _restarted=true
+                        fi
                     fi
                     ;;
                 systemd-system|systemd)
                     if [ -f "$SYSTEMD_SYSTEM_UNIT_DIR/$sys_unit" ] && maybe_sudo_n systemctl is-enabled "$sys_unit" &>/dev/null; then
-                        maybe_sudo systemctl start "$sys_unit" &>/dev/null
-                        echo "✅ updater restarted (systemd system-level)"
-                        _restarted=true
+                        if maybe_sudo systemctl start "$sys_unit" &>/dev/null; then
+                            echo "✅ updater restarted (systemd system-level)"
+                            _restarted=true
+                        fi
                     fi
                     ;;
                 initd)
                     if [ -f "$initd_script" ]; then
-                        maybe_sudo "$initd_script" start &>/dev/null
-                        echo "✅ updater restarted (init.d)"
-                        _restarted=true
+                        if maybe_sudo "$initd_script" start &>/dev/null; then
+                            echo "✅ updater restarted (init.d)"
+                            _restarted=true
+                        fi
                     fi
                     ;;
             esac
@@ -822,23 +838,24 @@ cmd_restart_updater() {
         fi
     fi
     if [ "$_restarted" = false ]; then
-        # Self-healing: try to register a proper service for degraded installs
-        case "$init_type" in
-            nohup|unknown|"")
-                local _new_init
-                _new_init=$(detect_init_system "false")
-                if [ "$_new_init" != "none" ]; then
-                    if autostart_install_updater_only "false" 2>>"$UPDATER_LOG_FILE"; then
-                        sleep 1
-                        if updater_process_exists; then
-                            echo "✅ updater self-healed: registered as $_new_init"
-                            _restarted=true
-                        else
-                            echo "⚠️  updater self-heal registered ($_new_init) but process not found" >&2
-                        fi
-                    fi
+        # init-type is shared by collector/updater, so a concrete value does not
+        # prove the updater service itself was registered. Repair it independently.
+        local _new_init
+        _new_init=$(detect_init_system "false")
+        if [ "$_new_init" != "none" ]; then
+            if _PILOT_SUDO_NONINTERACTIVE=true autostart_install_updater_only "false" 2>>"$UPDATER_LOG_FILE"; then
+                sleep 1
+                if updater_process_exists; then
+                    echo "✅ updater self-healed: registered as $_new_init"
+                    _restarted=true
+                else
+                    echo "⚠️  updater self-heal registered ($_new_init) but process not found" >&2
                 fi
-                if [ "$_restarted" = false ]; then
+            fi
+        fi
+        if [ "$_restarted" = false ]; then
+            case "$init_type" in
+                nohup|unknown|"")
                     local entry="$BOOTSTRAP_DIR/updater-daemon.js"
                     if [ ! -f "$entry" ]; then
                         echo "❌ Updater bootstrap script missing"
@@ -853,13 +870,13 @@ cmd_restart_updater() {
                     nohup "$node_bin" "$entry" >> "$UPDATER_LOG_FILE" 2>&1 &
                     echo "$!" > "$UPDATER_PID_FILE"
                     echo "⚠️  updater restarted (nohup fallback, self-heal failed)"
-                fi
-                ;;
-            *)
-                echo "❌ Service manager failed to restart updater (init_type=$init_type)" >&2
-                return 1
-                ;;
-        esac
+                    ;;
+                *)
+                    echo "❌ Service manager failed to restart updater (init_type=$init_type)" >&2
+                    return 1
+                    ;;
+            esac
+        fi
     fi
 
     if ! updater_process_exists; then
@@ -1412,8 +1429,14 @@ INITEOF
         "$tmp_script"
     rm -f "${tmp_script}.bak"
 
-    maybe_sudo install -m 755 "$tmp_script" "$script_path"
-    rm -f "$tmp_script"
+    local install_status=0
+    maybe_sudo install -m 755 "$tmp_script" "$script_path" || install_status=$?
+    local cleanup_status=0
+    rm -f "$tmp_script" || cleanup_status=$?
+    if [ "$install_status" -ne 0 ]; then
+        return "$install_status"
+    fi
+    return "$cleanup_status"
 }
 
 _write_initd_updater_script() {
@@ -1544,8 +1567,14 @@ INITEOF
         "$tmp_script"
     rm -f "${tmp_script}.bak"
 
-    maybe_sudo install -m 755 "$tmp_script" "$script_path"
-    rm -f "$tmp_script"
+    local install_status=0
+    maybe_sudo install -m 755 "$tmp_script" "$script_path" || install_status=$?
+    local cleanup_status=0
+    rm -f "$tmp_script" || cleanup_status=$?
+    if [ "$install_status" -ne 0 ]; then
+        return "$install_status"
+    fi
+    return "$cleanup_status"
 }
 
 _register_initd_boot() {
@@ -1572,35 +1601,35 @@ autostart_install_collector_only() {
     local interactive="${1:-true}"
 
     local init_system
-    init_system=$(detect_init_system "$interactive")
+    init_system=$(detect_init_system "$interactive") || return 1
     local target_user
-    target_user=$(whoami)
+    target_user=$(whoami) || return 1
 
     case "$init_system" in
         launchd)
             launchctl unload -w "$LAUNCHD_PLIST" 2>/dev/null || true
-            _write_launchd_plist
-            launchctl load -w "$LAUNCHD_PLIST"
-            echo "launchd" > "$INIT_TYPE_FILE"
+            _write_launchd_plist || return 1
+            launchctl load -w "$LAUNCHD_PLIST" || return 1
+            echo "launchd" > "$INIT_TYPE_FILE" || return 1
             ;;
         systemd-user)
-            _write_systemd_user_unit
-            systemctl --user daemon-reload &>/dev/null
-            systemctl --user enable --now loongsuite-pilot.service &>/dev/null
+            _write_systemd_user_unit || return 1
+            systemctl --user daemon-reload &>/dev/null || return 1
+            systemctl --user enable --now loongsuite-pilot.service &>/dev/null || return 1
             enable_linger || true
-            echo "systemd-user" > "$INIT_TYPE_FILE"
+            echo "systemd-user" > "$INIT_TYPE_FILE" || return 1
             ;;
         systemd-system)
-            _write_systemd_system_unit "$target_user"
-            maybe_sudo systemctl daemon-reload &>/dev/null
-            maybe_sudo systemctl enable --now "loongsuite-pilot-${target_user}.service" &>/dev/null
-            echo "systemd-system" > "$INIT_TYPE_FILE"
+            _write_systemd_system_unit "$target_user" || return 1
+            maybe_sudo systemctl daemon-reload &>/dev/null || return 1
+            maybe_sudo systemctl enable --now "loongsuite-pilot-${target_user}.service" &>/dev/null || return 1
+            echo "systemd-system" > "$INIT_TYPE_FILE" || return 1
             ;;
         initd)
-            _write_initd_script "$target_user"
+            _write_initd_script "$target_user" || return 1
             _register_initd_boot "loongsuite-pilot-${target_user}"
             maybe_sudo "/etc/init.d/loongsuite-pilot-${target_user}" start &>/dev/null || true
-            echo "initd" > "$INIT_TYPE_FILE"
+            echo "initd" > "$INIT_TYPE_FILE" || return 1
             ;;
         *)
             return 1
@@ -1612,35 +1641,35 @@ autostart_install_updater_only() {
     local interactive="${1:-true}"
 
     local init_system
-    init_system=$(detect_init_system "$interactive")
+    init_system=$(detect_init_system "$interactive") || return 1
     local target_user
-    target_user=$(whoami)
+    target_user=$(whoami) || return 1
 
     case "$init_system" in
         launchd)
             launchctl unload -w "$UPDATER_PLIST" 2>/dev/null || true
-            _write_launchd_updater_plist
-            launchctl load -w "$UPDATER_PLIST"
-            echo "launchd" > "$INIT_TYPE_FILE"
+            _write_launchd_updater_plist || return 1
+            launchctl load -w "$UPDATER_PLIST" || return 1
+            echo "launchd" > "$INIT_TYPE_FILE" || return 1
             ;;
         systemd-user)
-            _write_systemd_user_updater_unit
-            systemctl --user daemon-reload &>/dev/null
-            systemctl --user enable --now loongsuite-pilot-updater.service &>/dev/null
+            _write_systemd_user_updater_unit || return 1
+            systemctl --user daemon-reload &>/dev/null || return 1
+            systemctl --user enable --now loongsuite-pilot-updater.service &>/dev/null || return 1
             enable_linger || true
-            echo "systemd-user" > "$INIT_TYPE_FILE"
+            echo "systemd-user" > "$INIT_TYPE_FILE" || return 1
             ;;
         systemd-system)
-            _write_systemd_system_updater_unit "$target_user"
-            maybe_sudo systemctl daemon-reload &>/dev/null
-            maybe_sudo systemctl enable --now "loongsuite-pilot-updater-${target_user}.service" &>/dev/null
-            echo "systemd-system" > "$INIT_TYPE_FILE"
+            _write_systemd_system_updater_unit "$target_user" || return 1
+            maybe_sudo systemctl daemon-reload &>/dev/null || return 1
+            maybe_sudo systemctl enable --now "loongsuite-pilot-updater-${target_user}.service" &>/dev/null || return 1
+            echo "systemd-system" > "$INIT_TYPE_FILE" || return 1
             ;;
         initd)
-            _write_initd_updater_script "$target_user"
+            _write_initd_updater_script "$target_user" || return 1
             _register_initd_boot "loongsuite-pilot-updater-${target_user}"
             maybe_sudo "/etc/init.d/loongsuite-pilot-updater-${target_user}" start &>/dev/null || true
-            echo "initd" > "$INIT_TYPE_FILE"
+            echo "initd" > "$INIT_TYPE_FILE" || return 1
             ;;
         *)
             return 1

--- a/tests/unit/scripts/service-reregistration.test.mjs
+++ b/tests/unit/scripts/service-reregistration.test.mjs
@@ -1,0 +1,314 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const SCRIPT_PATH = path.resolve('scripts/loongsuite-pilot.sh');
+const POWERSHELL_SCRIPT_PATH = path.resolve('scripts/loongsuite-pilot.ps1');
+let tempDir;
+let sourcePath;
+
+beforeAll(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pilot-service-reregistration-'));
+  sourcePath = path.join(tempDir, 'loongsuite-pilot-functions.sh');
+  const script = fs.readFileSync(SCRIPT_PATH, 'utf8');
+  const dispatchOffset = script.indexOf('# ---- Dispatch ----');
+  expect(dispatchOffset).toBeGreaterThan(0);
+  fs.writeFileSync(sourcePath, script.slice(0, dispatchOffset), 'utf8');
+});
+
+afterAll(() => {
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+function runShell(body) {
+  const homeDir = path.join(tempDir, `home-${Math.random().toString(16).slice(2)}`);
+  const dataDir = path.join(homeDir, 'data');
+  const cacheDir = path.join(homeDir, 'cache');
+  fs.mkdirSync(dataDir, { recursive: true });
+  fs.mkdirSync(cacheDir, { recursive: true });
+
+  return spawnSync('bash', ['-c', `source "$1"\n${body}`, 'pilot-service-test', sourcePath], {
+    cwd: tempDir,
+    env: {
+      ...process.env,
+      HOME: homeDir,
+      LOONGSUITE_PILOT_DATA_DIR: dataDir,
+      LOONGSUITE_PILOT_CACHE_DIR: cacheDir,
+    },
+    encoding: 'utf8',
+    timeout: 10_000,
+  });
+}
+
+const commonMocks = String.raw`
+uname() { echo Linux; }
+whoami() { echo pilot_test_user; }
+pkill() { return 0; }
+sleep() { return 0; }
+stop_pid_file() { return 0; }
+sync_bootstrap_scripts() { return 0; }
+setsid() { return 0; }
+ensure_dirs() { mkdir -p "$LOG_DIR" "$BOOTSTRAP_DIR"; }
+`;
+
+describe.runIf(process.platform !== 'win32')('service-specific restart self-healing', () => {
+  it('uses non-interactive sudo only inside restart self-healing', () => {
+    const result = runShell(String.raw`
+${commonMocks}
+id() { echo 1000; }
+sudo() { printf '%s\n' "$*" >> "$DATA_DIR/sudo-calls"; }
+updater_running=false
+updater_process_exists() { [ "$updater_running" = true ]; }
+detect_init_system() { echo systemd-system; }
+autostart_install_updater_only() {
+  maybe_sudo nested-installer-command
+  updater_running=true
+}
+
+echo initd > "$INIT_TYPE_FILE"
+cmd_restart_updater
+maybe_sudo ordinary-command
+[ "$(cat "$DATA_DIR/sudo-calls")" = $'-n nested-installer-command\nordinary-command' ]
+`);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain('updater self-healed: registered as systemd-system');
+
+    const script = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    expect(script).toContain('_PILOT_SUDO_NONINTERACTIVE=true autostart_install_collector_only');
+    expect(script).toContain('_PILOT_SUDO_NONINTERACTIVE=true autostart_install_updater_only');
+  });
+
+  it('propagates critical service-specific installer failures inside an if condition', () => {
+    const result = runShell(String.raw`
+${commonMocks}
+detect_init_system() { echo systemd-system; }
+_write_systemd_system_updater_unit() { return 0; }
+maybe_sudo() {
+  if [ "$2" = enable ]; then
+    return 1
+  fi
+  return 0
+}
+
+if autostart_install_updater_only false; then
+  exit 1
+fi
+[ ! -e "$INIT_TYPE_FILE" ]
+`);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+  });
+
+  it('propagates real init.d writer install failures after cleaning temporary files', () => {
+    const result = runShell(String.raw`
+${commonMocks}
+detect_init_system() { echo initd; }
+resolve_user_home() { echo "$DATA_DIR/daemon-home"; }
+maybe_sudo() {
+  if [ "$1" = install ]; then
+    printf '%s\n' "$4" >> "$DATA_DIR/initd-temp-paths"
+    return 23
+  fi
+  return 0
+}
+
+if autostart_install_collector_only false; then
+  exit 1
+fi
+[ ! -e "$INIT_TYPE_FILE" ]
+if autostart_install_updater_only false; then
+  exit 1
+fi
+[ ! -e "$INIT_TYPE_FILE" ]
+[ "$(wc -l < "$DATA_DIR/initd-temp-paths" | tr -d '[:space:]')" = 2 ]
+while IFS= read -r tmp_path; do
+  [ ! -e "$tmp_path" ]
+done < "$DATA_DIR/initd-temp-paths"
+`);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+  });
+
+  it('normalizes legacy systemd state before updater self-healing', () => {
+    const result = runShell(String.raw`
+${commonMocks}
+id() {
+  if [ "\${1:-}" = -u ]; then
+    echo 1000
+  else
+    command id "$@"
+  fi
+}
+systemctl() { return 0; }
+maybe_sudo() { "$@"; }
+maybe_sudo_n() { "$@"; }
+updater_running=false
+updater_process_exists() { [ "$updater_running" = true ]; }
+autostart_install_updater_only() {
+  detect_init_system false > "$DATA_DIR/selected-init"
+  updater_running=true
+}
+
+echo systemd > "$INIT_TYPE_FILE"
+[ "$(detect_init_system false)" = systemd-system ]
+cmd_restart_updater
+[ "$(cat "$DATA_DIR/selected-init")" = systemd-system ]
+`);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain('updater self-healed: registered as systemd-system');
+  });
+
+  it('repairs updater registration after collector changes unknown init-type to initd', () => {
+    const result = runShell(String.raw`
+${commonMocks}
+collector_running=false
+updater_running=false
+is_running() { [ "$collector_running" = true ]; }
+updater_process_exists() { [ "$updater_running" = true ]; }
+detect_init_system() { echo initd; }
+autostart_install_collector_only() {
+  echo collector >> "$DATA_DIR/registrations"
+  collector_running=true
+  echo initd > "$INIT_TYPE_FILE"
+}
+autostart_install_updater_only() {
+  echo updater >> "$DATA_DIR/registrations"
+  updater_running=true
+  echo initd > "$INIT_TYPE_FILE"
+}
+
+echo unknown > "$INIT_TYPE_FILE"
+cmd_restart_collector
+[ "$(cat "$INIT_TYPE_FILE")" = initd ]
+cmd_restart_updater
+[ "$(cat "$DATA_DIR/registrations")" = $'collector\nupdater' ]
+`);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain('collector self-healed: registered as initd');
+    expect(result.stdout).toContain('updater self-healed: registered as initd');
+  });
+
+  it('re-registers updater when a concrete service starts but fails liveness', () => {
+    const result = runShell(String.raw`
+${commonMocks}
+updater_running=false
+updater_process_exists() { [ "$updater_running" = true ]; }
+systemctl() { return 0; }
+detect_init_system() { echo systemd-user; }
+autostart_install_updater_only() {
+  echo called > "$DATA_DIR/updater-reregistered"
+  updater_running=true
+}
+
+echo systemd-user > "$INIT_TYPE_FILE"
+cmd_restart_updater
+[ -f "$DATA_DIR/updater-reregistered" ]
+`);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain('service manager reported success but updater process not found');
+    expect(result.stdout).toContain('updater self-healed: registered as systemd-user');
+  });
+
+  it('re-registers updater when the service-manager start command fails', () => {
+    const result = runShell(String.raw`
+${commonMocks}
+updater_running=false
+updater_process_exists() { [ "$updater_running" = true ]; }
+systemctl() {
+  case " $* " in
+    *" start "*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+detect_init_system() { echo systemd-user; }
+autostart_install_updater_only() {
+  echo called > "$DATA_DIR/updater-reregistered"
+  updater_running=true
+}
+
+echo systemd-user > "$INIT_TYPE_FILE"
+cmd_restart_updater
+[ -f "$DATA_DIR/updater-reregistered" ]
+`);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain('updater self-healed: registered as systemd-user');
+  });
+
+  it('does not fall back to unmanaged processes for a concrete service manager', () => {
+    const result = runShell(String.raw`
+${commonMocks}
+collector_running=false
+updater_running=false
+is_running() { [ "$collector_running" = true ]; }
+updater_process_exists() { [ "$updater_running" = true ]; }
+detect_init_system() { echo none; }
+autostart_install_collector_only() { return 1; }
+autostart_install_updater_only() { return 1; }
+nohup() { echo called >> "$DATA_DIR/nohup-called"; }
+
+echo initd > "$INIT_TYPE_FILE"
+if (cmd_restart_collector); then exit 1; fi
+if cmd_restart_updater; then exit 1; fi
+[ ! -e "$DATA_DIR/nohup-called" ]
+`);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stderr).toContain('Service manager failed to restart collector (init_type=initd)');
+    expect(result.stderr).toContain('Service manager failed to restart updater (init_type=initd)');
+  });
+
+  it('preserves the legacy updater fallback when no service manager can be detected', () => {
+    const result = runShell(String.raw`
+${commonMocks}
+updater_process_exists() { return 0; }
+detect_init_system() { echo none; }
+autostart_install_updater_only() { return 1; }
+resolve_node() { echo /bin/true; }
+
+echo unknown > "$INIT_TYPE_FILE"
+mkdir -p "$BOOTSTRAP_DIR"
+touch "$BOOTSTRAP_DIR/updater-daemon.js"
+cmd_restart_updater
+`);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain('updater restarted (nohup fallback, self-heal failed)');
+  });
+});
+
+describe('Windows Task Scheduler restart self-healing', () => {
+  const script = fs.readFileSync(POWERSHELL_SCRIPT_PATH, 'utf8');
+
+  function commandBody(name, nextSection) {
+    const start = script.indexOf(`function ${name} {`);
+    const end = script.indexOf(`# CMD: ${nextSection}`, start);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    return script.slice(start, end);
+  }
+
+  it.each([
+    ['Cmd-RestartCollector', 'restart-updater', 'Install-CollectorTask'],
+    ['Cmd-RestartUpdater', 'status', 'Install-UpdaterTask'],
+  ])('%s re-registers a missing concrete task before considering legacy fallback', (name, nextSection, installCommand) => {
+    const body = commandBody(name, nextSection);
+    const selfHeal = body.indexOf('init-type is shared by collector/updater');
+    const registration = body.indexOf(installCommand, selfHeal);
+    const fallbackGuard = body.indexOf('$initType -in @("background", "unknown", "")', selfHeal);
+
+    expect(selfHeal).toBeGreaterThanOrEqual(0);
+    expect(registration).toBeGreaterThan(selfHeal);
+    expect(fallbackGuard).toBeGreaterThan(registration);
+    expect(body.match(/\$initType -in/g)).toHaveLength(1);
+    expect(body.slice(registration, fallbackGuard)).toContain('Get-TaskRunning');
+    expect(body.slice(fallbackGuard)).toContain('Start-Process');
+    expect(body.slice(fallbackGuard)).toContain('Service manager failed to restart');
+  });
+});

--- a/tests/unit/scripts/service-reregistration.test.mjs
+++ b/tests/unit/scripts/service-reregistration.test.mjs
@@ -84,6 +84,8 @@ maybe_sudo ordinary-command
   it('propagates critical service-specific installer failures inside an if condition', () => {
     const result = runShell(String.raw`
 ${commonMocks}
+mkdir -p "$BOOTSTRAP_DIR"
+touch "$BOOTSTRAP_DIR/updater-daemon.js"
 detect_init_system() { echo systemd-system; }
 _write_systemd_system_updater_unit() { return 0; }
 maybe_sudo() {
@@ -105,6 +107,8 @@ fi
   it('propagates real init.d writer install failures after cleaning temporary files', () => {
     const result = runShell(String.raw`
 ${commonMocks}
+mkdir -p "$BOOTSTRAP_DIR"
+touch "$BOOTSTRAP_DIR/updater-daemon.js"
 detect_init_system() { echo initd; }
 resolve_user_home() { echo "$DATA_DIR/daemon-home"; }
 maybe_sudo() {
@@ -130,6 +134,53 @@ done < "$DATA_DIR/initd-temp-paths"
 `);
 
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+  });
+
+  it('does not register any updater service when the updater bootstrap is absent', () => {
+    const result = runShell(String.raw`
+${commonMocks}
+rm -f "$BOOTSTRAP_DIR/updater-daemon.js" "$INIT_TYPE_FILE" "$DATA_DIR/manager-called"
+selected_init=""
+detect_init_system() { echo "$selected_init"; }
+record_manager_call() { printf '%s\n' "$selected_init:$*" >> "$DATA_DIR/manager-called"; }
+_write_launchd_updater_plist() { record_manager_call writer-launchd; }
+_write_systemd_user_updater_unit() { record_manager_call writer-systemd-user; }
+_write_systemd_system_updater_unit() { record_manager_call writer-systemd-system; }
+_write_initd_updater_script() { record_manager_call writer-initd; }
+launchctl() { record_manager_call launchctl "$@"; }
+systemctl() { record_manager_call systemctl "$@"; }
+maybe_sudo() { record_manager_call sudo "$@"; }
+_register_initd_boot() { record_manager_call initd-register "$@"; }
+
+for selected_init in launchd systemd-user systemd-system initd; do
+  if autostart_install_updater_only false; then
+    exit 1
+  fi
+  [ ! -e "$DATA_DIR/manager-called" ]
+  [ ! -e "$INIT_TYPE_FILE" ]
+done
+`);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+  });
+
+  it('hard-fails a concrete updater restart without an unmanaged fallback when its bootstrap is absent', () => {
+    const result = runShell(String.raw`
+${commonMocks}
+updater_process_exists() { return 1; }
+systemctl() { return 1; }
+nohup() { touch "$DATA_DIR/nohup-called"; }
+
+echo systemd-user > "$INIT_TYPE_FILE"
+rm -f "$BOOTSTRAP_DIR/updater-daemon.js"
+if cmd_restart_updater; then
+  exit 1
+fi
+[ ! -e "$DATA_DIR/nohup-called" ]
+`);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stderr).toContain('Service manager failed to restart updater (init_type=systemd-user)');
   });
 
   it('normalizes legacy systemd state before updater self-healing', () => {
@@ -264,6 +315,39 @@ if cmd_restart_updater; then exit 1; fi
     expect(result.stderr).toContain('Service manager failed to restart updater (init_type=initd)');
   });
 
+  it.each([
+    ['collector', 'unknown'],
+    ['updater', 'nohup'],
+  ])('does not start an unmanaged %s after a concrete manager registers but liveness is delayed', (daemon, oldInitType) => {
+    const result = runShell(String.raw`
+${commonMocks}
+is_running() { return 1; }
+updater_process_exists() { return 1; }
+detect_init_system() { echo systemd-user; }
+autostart_install_collector_only() { touch "$DATA_DIR/collector-registered"; }
+autostart_install_updater_only() {
+  [ -f "$BOOTSTRAP_DIR/updater-daemon.js" ]
+  touch "$DATA_DIR/updater-registered"
+}
+nohup() { touch "$DATA_DIR/nohup-called"; }
+mkdir -p "$BOOTSTRAP_DIR"
+touch "$BOOTSTRAP_DIR/updater-daemon.js"
+
+echo "$2" > "$INIT_TYPE_FILE"
+if [ "$1" = collector ]; then
+  if (cmd_restart_collector); then exit 1; fi
+  [ -e "$DATA_DIR/collector-registered" ]
+else
+  if cmd_restart_updater; then exit 1; fi
+  [ -e "$DATA_DIR/updater-registered" ]
+fi
+[ ! -e "$DATA_DIR/nohup-called" ]
+`.replace('$1', daemon).replace('$2', oldInitType));
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stderr).toContain(`Service manager failed to restart ${daemon} (init_type=systemd-user)`);
+  });
+
   it('preserves the legacy updater fallback when no service manager can be detected', () => {
     const result = runShell(String.raw`
 ${commonMocks}
@@ -293,6 +377,19 @@ describe('Windows Task Scheduler restart self-healing', () => {
     expect(end).toBeGreaterThan(start);
     return script.slice(start, end);
   }
+
+  it('refuses to install an updater task when its bootstrap is absent', () => {
+    const start = script.indexOf('function Install-UpdaterTask {');
+    const end = script.indexOf('function Remove-AllTasks {', start);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    const body = script.slice(start, end);
+    const bootstrapGuard = body.indexOf('if (-not (Test-Path $entry)) { return $false }');
+    const taskAction = body.indexOf('New-HiddenTaskAction');
+
+    expect(bootstrapGuard).toBeGreaterThanOrEqual(0);
+    expect(taskAction).toBeGreaterThan(bootstrapGuard);
+  });
 
   it.each([
     ['Cmd-RestartCollector', 'restart-updater', 'Install-CollectorTask'],


### PR DESCRIPTION
## What changed

- Re-register collector and updater services independently when their service definition is missing or cannot start.
- Cover launchd, systemd user/system scopes, init.d, and Windows Task Scheduler while preserving legacy unmanaged fallback when no service manager exists.
- Verify process liveness before reporting restart success and propagate service registration failures.
- Keep background self-heal elevation non-interactive without changing normal interactive install behavior.
- Prevent open-source packages without `updater-daemon.js` from creating an empty updater service.
- Prevent a delayed concrete service-manager start from racing with a second `nohup` process.

## Why

Collector and updater share one `init-type` state file but have separate service definitions. After collector self-heal persisted a concrete manager, updater restart could incorrectly assume its own service was registered, fail to start, and emit `pid file is missing; no matching process found`.

## Impact

Restart self-heal now repairs only the missing daemon service and reports success only after the process is observable. Open-source installs continue to omit the updater service when the updater payload is not shipped.

## Validation

- Shell syntax check
- Service re-registration tests: 16/16
- Updater watchdog tests: 14/14
- TypeScript typecheck
- Full build
- Diff whitespace check

## Validation boundaries

- Real Linux init-manager, launchd, and Windows Task Scheduler environments were not available locally.
- Install smoke did not start because `.env.e2e` is absent.
- Broad tests have unrelated existing Hermes/OpenClaw failures; targeted tests and build pass.
