### PR TITLE
fix(ps1): make hooks and CLI wrapper CLM-safe and pin JSON interchange to UTF-8

### DIFF
--- a/assets/hooks/claude-code-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/claude-code-loongsuite-pilot-hook.ps1
@@ -32,7 +32,12 @@ function Log-Error {
         $time = (Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ")
         $escapedMsg = $Message -replace '\\', '\\\\' -replace '"', '\"'
         $line = "{`"time`":`"$time`",`"gen_ai.agent.type`":`"claude-code`",`"stage`":`"$Stage`",`"error.type`":`"ps1_$Stage`",`"error.message`":`"$escapedMsg`"}"
-        Add-Content -Path $file -Value $line
+        # Explicit UTF8 and -LiteralPath: Add-Content defaults to the ANSI codepage, so a
+        # Chinese username in a path or message lands as mojibake -- and node's
+        # shared/error-logger.mjs appends UTF-8 to this very file, making it mixed-encoding.
+        # A BOM on the first line is harmless here: nothing machine-parses this log (the
+        # retention service only deletes it by age). Matches codex-loongsuite-pilot-hook.ps1.
+        Add-Content -LiteralPath $file -Value $line -Encoding UTF8
     } catch {}
 }
 

--- a/assets/hooks/codex-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/codex-loongsuite-pilot-hook.ps1
@@ -36,14 +36,22 @@ function Log-Error {
             New-Item -ItemType Directory -Path $dir -Force | Out-Null
         }
         $file = Join-Path $dir "codex-error-$day.jsonl"
-        $record = [ordered]@{
+        # Plain @{}, never [ordered]@{}: on a WDAC machine this hook runs in
+        # ConstrainedLanguage mode, where the accelerator-converts-an-@{}-literal shape
+        # can throw (see the CLM header in deploy/installer.ps1 -- [pscustomobject] does
+        # exactly that on 5.1 despite being documented as allowed). The catch below would
+        # swallow it, so the symptom is an error log that is never written on precisely
+        # the machines where it is needed. Key order is cosmetic in a JSONL log line.
+        $record = @{
             time = (Get-Date).ToUniversalTime().ToString("o")
             "gen_ai.agent.type" = "codex"
             stage = $Stage
             "error.type" = "ps1_$Stage"
             "error.message" = $Message
         }
-        Add-Content -LiteralPath $file -Value ($record | ConvertTo-Json -Compress)
+        # Explicit UTF8: Add-Content defaults to the ANSI codepage, which garbles
+        # non-ASCII paths and messages in the record.
+        Add-Content -LiteralPath $file -Value ($record | ConvertTo-Json -Compress) -Encoding UTF8
     } catch {}
 }
 
@@ -59,7 +67,13 @@ function Convert-NodePath {
     if ($candidate -match '^/([A-Za-z])/(.*)$') {
         $candidate = "$($Matches[1]):\$($Matches[2] -replace '/', '\')"
     }
-    if (-not [System.IO.Path]::HasExtension($candidate) -and (Test-Path -LiteralPath "$candidate.exe")) {
+    # -match, not [System.IO.Path]::HasExtension(): a static method call on a
+    # non-core type throws under ConstrainedLanguage mode (WDAC), and the catch at
+    # the bottom of this file would swallow it into a silent empty result. The regex
+    # is HasExtension's contract: a dot after the last separator that is not the
+    # final character. Trailing dot ("node.") and a dotted parent directory
+    # ("v18.20.4/node") both correctly yield no match.
+    if (-not ($candidate -match '\.[^\\/.]+$') -and (Test-Path -LiteralPath "$candidate.exe")) {
         $candidate = "$candidate.exe"
     }
     return $candidate

--- a/assets/hooks/cursor-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/cursor-loongsuite-pilot-hook.ps1
@@ -20,7 +20,12 @@ function Log-Error {
         $time = (Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ")
         $escapedMsg = $Message -replace '\\', '\\\\' -replace '"', '\"'
         $line = "{`"time`":`"$time`",`"clientType`":`"CursorHook`",`"stage`":`"$Stage`",`"error.type`":`"ps1_$Stage`",`"error.message`":`"$escapedMsg`"}"
-        Add-Content -Path $file -Value $line
+        # Explicit UTF8 and -LiteralPath: Add-Content defaults to the ANSI codepage, so a
+        # Chinese username in a path or message lands as mojibake -- and node's
+        # shared/error-logger.mjs appends UTF-8 to this very file, making it mixed-encoding.
+        # A BOM on the first line is harmless here: nothing machine-parses this log (the
+        # retention service only deletes it by age). Matches codex-loongsuite-pilot-hook.ps1.
+        Add-Content -LiteralPath $file -Value $line -Encoding UTF8
     } catch {}
 }
 

--- a/assets/hooks/qwen-code-cli-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/qwen-code-cli-loongsuite-pilot-hook.ps1
@@ -32,7 +32,12 @@ function Log-Error {
         $time = (Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ")
         $escapedMsg = $Message -replace '\\', '\\\\' -replace '"', '\"'
         $line = "{`"time`":`"$time`",`"gen_ai.agent.type`":`"qwen-code-cli`",`"stage`":`"$Stage`",`"error.type`":`"ps1_$Stage`",`"error.message`":`"$escapedMsg`"}"
-        Add-Content -Path $file -Value $line
+        # Explicit UTF8 and -LiteralPath: Add-Content defaults to the ANSI codepage, so a
+        # Chinese username in a path or message lands as mojibake -- and node's
+        # shared/error-logger.mjs appends UTF-8 to this very file, making it mixed-encoding.
+        # A BOM on the first line is harmless here: nothing machine-parses this log (the
+        # retention service only deletes it by age). Matches codex-loongsuite-pilot-hook.ps1.
+        Add-Content -LiteralPath $file -Value $line -Encoding UTF8
     } catch {}
 }
 

--- a/assets/hooks/shared/common.ps1
+++ b/assets/hooks/shared/common.ps1
@@ -120,6 +120,11 @@ function Log-HookError {
         $time = (Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ")
         $escapedMsg = $Message -replace '\\', '\\\\' -replace '"', '\"'
         $line = "{`"time`":`"$time`",`"gen_ai.agent.type`":`"$AgentType`",`"stage`":`"$Stage`",`"error.type`":`"ps1_$Stage`",`"error.message`":`"$escapedMsg`"}"
-        Add-Content -Path $file -Value $line
+        # Explicit UTF8 and -LiteralPath: Add-Content defaults to the ANSI codepage, so a
+        # Chinese username in a path or message lands as mojibake -- and node's
+        # shared/error-logger.mjs appends UTF-8 to this very file, making it mixed-encoding.
+        # A BOM on the first line is harmless here: nothing machine-parses this log (the
+        # retention service only deletes it by age). Matches codex-loongsuite-pilot-hook.ps1.
+        Add-Content -LiteralPath $file -Value $line -Encoding UTF8
     } catch {}
 }

--- a/assets/hooks/workbuddy-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/workbuddy-loongsuite-pilot-hook.ps1
@@ -35,7 +35,13 @@ function Convert-NodePath {
     if ($candidate -match '^/([A-Za-z])/(.*)$') {
         $candidate = "$($Matches[1]):\$($Matches[2] -replace '/', '\')"
     }
-    if (-not [System.IO.Path]::HasExtension($candidate) -and (Test-Path -LiteralPath "$candidate.exe")) {
+    # -match, not [System.IO.Path]::HasExtension(): a static method call on a
+    # non-core type throws under ConstrainedLanguage mode (WDAC), and the catch at
+    # the bottom of this file would swallow it into a silent empty result. The regex
+    # is HasExtension's contract: a dot after the last separator that is not the
+    # final character. Trailing dot ("node.") and a dotted parent directory
+    # ("v18.20.4/node") both correctly yield no match.
+    if (-not ($candidate -match '\.[^\\/.]+$') -and (Test-Path -LiteralPath "$candidate.exe")) {
         $candidate = "$candidate.exe"
     }
     return $candidate

--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -1,4 +1,4 @@
-# loongsuite-pilot.ps1 — Service management for loongsuite-pilot (Windows)
+# loongsuite-pilot.ps1 -- Service management for loongsuite-pilot (Windows)
 # Uses Windows Task Scheduler for autostart (analogous to macOS launchd)
 #
 # Usage:
@@ -504,7 +504,7 @@ function Install-CollectorTask {
     # Kill any collector daemon left running under the OLD task registration BEFORE we
     # delete/re-create the task. Deleting a task does not stop its running child, and the
     # freshly registered task's MultipleInstances=IgnoreNew only counts instances under the
-    # new registration — so without this reap the orphan keeps running alongside the new
+    # new registration -- so without this reap the orphan keeps running alongside the new
     # instance and both write the same output (duplicate-collection incident root cause).
     Stop-OrphanProcesses -Match "collector-daemon"
 
@@ -602,7 +602,7 @@ function Cmd-Run {
 
     # Windows has no exec(2): node runs as our child, so it publishes its own pid file
     # (see src/index.ts) instead of us recording the wrapper pid here. Export the data
-    # dir so node's env-first resolution writes $DATA_DIR\loongsuite-pilot.pid — the exact
+    # dir so node's env-first resolution writes $DATA_DIR\loongsuite-pilot.pid -- the exact
     # path stop/status read.
     $env:LOONGSUITE_PILOT_DATA_DIR = $DATA_DIR
     $env:AGENT_DATA_COLLECTION_CONFIG = $CONFIG_FILE
@@ -702,7 +702,7 @@ function Cmd-Start {
         }
     }
 
-    # No background fallback — Task Scheduler registration is required.
+    # No background fallback -- Task Scheduler registration is required.
     $staleTask = Get-ScheduledTask `
         -TaskName $TASK_NAME_COLLECTOR `
         -TaskPath "$TASK_FOLDER\" `
@@ -827,7 +827,7 @@ function Cmd-RestartCollector {
                 }
                 $errLog = Join-Path $LOG_DIR "loongsuite-pilot-service-err.log"
                 # node publishes its own pid file on Windows (see src/index.ts); export the
-                # data dir so it lands at $DATA_DIR\loongsuite-pilot.pid. No Set-Content here —
+                # data dir so it lands at $DATA_DIR\loongsuite-pilot.pid. No Set-Content here --
                 # $proc.Id would be the wrapper pid, not node's.
                 Start-Process -FilePath "powershell.exe" `
                     -ArgumentList "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:LOONGSUITE_PILOT_DATA_DIR='$DATA_DIR'; `$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$entry' >> '$LOG_FILE' 2>> '$errLog'`"" `
@@ -926,7 +926,7 @@ function Cmd-RestartUpdater {
                 $updaterErrLog = Join-Path $LOG_DIR "loongsuite-pilot-updater-err.log"
                 # node publishes its own pid file on Windows (see src/updater/index.ts); export
                 # the data dir so it lands at $DATA_DIR\loongsuite-pilot-updater.pid. No
-                # Set-Content — $proc.Id would be the wrapper pid, not node's.
+                # Set-Content -- $proc.Id would be the wrapper pid, not node's.
                 Start-Process -FilePath "powershell.exe" `
                     -ArgumentList "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:LOONGSUITE_PILOT_DATA_DIR='$DATA_DIR'; `$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$entry' >> '$UPDATER_LOG_FILE' 2>> '$updaterErrLog'`"" `
                     -WorkingDirectory $CACHE_DIR `
@@ -1045,7 +1045,9 @@ function Cmd-Info {
 
     Write-Host ""
     if (Test-Path $CONFIG_FILE) {
-        Get-Content $CONFIG_FILE
+        # -Encoding UTF8: node writes config.json as UTF-8 with no BOM, and 5.1's
+        # BOM sniffing then falls back to ANSI, printing a Chinese prefix as mojibake.
+        Get-Content $CONFIG_FILE -Encoding UTF8
     }
 }
 
@@ -1063,9 +1065,20 @@ function Remove-HermesPluginForRollback {
     $state = $null
     if (Test-Path $stateFile) {
         try {
-            $state = Get-Content $stateFile -Raw | ConvertFrom-Json
+            # -Encoding UTF8 on the read too: node writes this file as UTF-8 without a
+            # BOM, and 5.1's Get-Content falls back to the ANSI codepage when there is no
+            # BOM to sniff. Without it a non-ASCII targetDir comes back mangled and the
+            # plugin at that path goes uncleaned.
+            $state = Get-Content $stateFile -Raw -Encoding UTF8 | ConvertFrom-Json
             $recorded = $state.'hermes-agent'.targetDir
-            if ($recorded -and [System.IO.Path]::IsPathRooted([string]$recorded)) {
+            # Regex instead of [System.IO.Path]::IsPathRooted: System.IO.Path is not a
+            # Constrained-Language core type, so the call throws under CLM (WDAC). The
+            # catch below would swallow it and reset $state, silently leaving a plugin
+            # installed at a custom targetDir uncleaned. Matches a drive-absolute path
+            # (C:\ or C:/) or a UNC share (\\server\share); deliberately rejects the
+            # drive-relative "C:dir" and root-relative "\dir" forms that IsPathRooted
+            # accepts, since neither is safe to use as an absolute delete target.
+            if ($recorded -and ([string]$recorded) -match '^([A-Za-z]:[\\/]|\\\\[^\\/]+[\\/])') {
                 $pluginDir = [string]$recorded
             }
         } catch {
@@ -1076,13 +1089,27 @@ function Remove-HermesPluginForRollback {
     $marker = Join-Path $pluginDir ".loongsuite-pilot-managed.json"
     if (-not (Test-Path $marker)) { return }
     try {
-        $meta = Get-Content $marker -Raw | ConvertFrom-Json
+        # Same as above: the marker is written by node (directory-plugin-strategy) as
+        # BOM-less UTF-8.
+        $meta = Get-Content $marker -Raw -Encoding UTF8 | ConvertFrom-Json
         if ($meta.owner -ne "loongsuite-pilot" -or $meta.agentId -ne "hermes-agent") { return }
         Remove-Item $pluginDir -Recurse -Force
         if ($state -and $state.'hermes-agent') {
-            $state.PSObject.Properties.Remove('hermes-agent')
+            # Select-Object -ExcludeProperty (a cmdlet) instead of
+            # $state.PSObject.Properties.Remove(): PSMemberInfoCollection is not a
+            # Constrained-Language core type, so the method call throws under CLM (WDAC)
+            # and the state file would keep a stale hermes-agent entry. -Property * is
+            # required alongside -ExcludeProperty on PowerShell 5.1.
+            $pruned = $state | Select-Object -Property * -ExcludeProperty 'hermes-agent'
             $tmp = "$stateFile.tmp"
-            $state | ConvertTo-Json -Depth 20 | Set-Content $tmp
+            # -Encoding UTF8 is required: Set-Content on PowerShell 5.1 defaults to the
+            # ANSI codepage, while the node side reads and writes deployed-agents.json as
+            # UTF-8 (readJsonFile / writeJsonFile). A targetDir under a non-ASCII user
+            # profile would round-trip as mojibake. 5.1 has no utf8NoBOM, so this writes a
+            # BOM -- readJsonFile strips a leading BOM for exactly this reason. Without
+            # that strip JSON.parse throws, readJsonFile swallows it and returns null, and
+            # the whole deployment state silently resets to empty.
+            $pruned | ConvertTo-Json -Depth 20 | Set-Content $tmp -Encoding UTF8
             Move-Item -Force $tmp $stateFile
         }
         Write-Host "   Removed Hermes plugin not supported by rollback target: $pluginDir"
@@ -1177,7 +1204,7 @@ function Cmd-Worker {
 # ============================================================
 # CMD: help
 # ============================================================
-# Manage span-attributes.json — user-defined attributes injected into trace
+# Manage span-attributes.json -- user-defined attributes injected into trace
 # spans (not the event log). The collector re-reads the file per turn, so
 # changes take effect without a restart.
 function Cmd-SpanAttr {
@@ -1197,7 +1224,7 @@ const fs = require("fs");
 const file = process.argv[1], op = process.argv[2], key = process.argv[3], value = process.argv[4];
 const RESERVED = ["gen_ai.","git.","workspace.","event.","trace_","user.","cost_","agent.","time_unix_nano","observed_time_unix_nano"];
 const isReserved = k => RESERVED.some(p => k === p || k.indexOf(p) === 0);
-function read() { try { const o = JSON.parse(fs.readFileSync(file, "utf-8")); return (o && typeof o === "object" && !Array.isArray(o)) ? o : {}; } catch { return {}; } }
+function read() { try { const o = JSON.parse(fs.readFileSync(file, "utf-8").replace(/^\uFEFF/, "")); return (o && typeof o === "object" && !Array.isArray(o)) ? o : {}; } catch { return {}; } }
 function write(o) { const tmp = file + ".tmp"; fs.writeFileSync(tmp, JSON.stringify(o, null, 2) + "\n"); fs.renameSync(tmp, file); }
 if (op === "set") {
   if (!key || value === undefined) { console.error("usage: span-attr set <key> <value>"); process.exit(1); }

--- a/src/utils/fs-utils.ts
+++ b/src/utils/fs-utils.ts
@@ -29,11 +29,19 @@ export async function directoryExists(path: string): Promise<boolean> {
 
 /**
  * Reads and parses JSON from a file. Returns `null` on missing file or parse errors.
+ *
+ * A leading UTF-8 BOM is stripped before parsing. `JSON.parse` rejects it, and
+ * because this function swallows parse errors a BOM would silently degrade to
+ * "file absent" — i.e. deployment state or config reverting to defaults rather
+ * than failing loudly. Windows produces BOMs routinely: PowerShell 5.1's
+ * `Set-Content -Encoding UTF8` always writes one (there is no utf8NoBOM before
+ * PowerShell 6), and so does Notepad. Both touch files we read here
+ * (`deployed-agents.json`, `config.json`).
  */
 export async function readJsonFile<T>(path: string): Promise<T | null> {
   try {
     const text = await fsp.readFile(path, 'utf8');
-    return JSON.parse(text) as T;
+    return JSON.parse(text.replace(/^\uFEFF/, '')) as T;
   } catch {
     return null;
   }

--- a/src/utils/json-document.ts
+++ b/src/utils/json-document.ts
@@ -30,9 +30,24 @@ export function parseJsonDocument<T>(
   raw: string,
   syntax: JsonSyntax = 'json',
 ): JsonTextParseResult<T> {
+  // A leading UTF-8 BOM defeats *both* parsers: JSON.parse throws, and
+  // jsonc-parser recovers the data but reports a parse error, which the
+  // errors.length check below turns into a failure. Agent settings files arrive
+  // with a BOM routinely on Windows — PowerShell 5.1's `Set-Content -Encoding
+  // UTF8` always writes one (no utf8NoBOM before PS 6), and so does Notepad —
+  // so a BOM'd ~/.claude/settings.json would fail hook deploy and remove, not
+  // just a read.
+  //
+  // The strip belongs here rather than in readJsonDocument: callers use the
+  // returned `raw` as the expected content of a compare-and-swap write and as
+  // the base text for editJsonc, so it must stay byte-identical to the file.
+  // modify()/applyEdits() handle BOM-prefixed text and preserve the BOM, which
+  // keeps the user's encoding marker intact on write-back.
+  const text = raw.replace(/^\uFEFF/, '');
+
   if (syntax === 'json') {
     try {
-      return { ok: true, data: JSON.parse(raw) as T };
+      return { ok: true, data: JSON.parse(text) as T };
     } catch (err) {
       return {
         ok: false,
@@ -42,7 +57,7 @@ export function parseJsonDocument<T>(
   }
 
   const errors: ParseError[] = [];
-  const data = parseJsonc(raw, errors, {
+  const data = parseJsonc(text, errors, {
     allowTrailingComma: true,
     disallowComments: false,
   }) as T;

--- a/tests/unit/scripts/ps1-clm-safe.test.mjs
+++ b/tests/unit/scripts/ps1-clm-safe.test.mjs
@@ -1,0 +1,149 @@
+// Static CLM (Constrained Language Mode) guard for every tracked .ps1.
+//
+// Some machines that run these scripts have a WDAC / AppLocker application-control
+// policy, so any .ps1 the policy does not allow executes in ConstrainedLanguage
+// Mode. Under CLM only "core types" may be cast or have their *methods* invoked;
+// a method call on any other .NET type throws. Static *property gets* are exempt —
+// CLM permits those on any type.
+//
+// Combined with `$ErrorActionPreference = "Stop"` (installers) or the fail-open
+// `catch` every hook wraps its body in, an unguarded CLM violation is either a
+// terminating error that aborts the install or silence that drops telemetry on
+// precisely the locked-down machines where the error log matters. A real install
+// died this way on `[pscustomobject]@{...}`: the accelerator's true conversion
+// target is the internal type `LanguagePrimitives+InternalPSCustomObject`, which is
+// not in Windows PowerShell 5.1's CoreTypes list even though `about_Language_Modes`
+// documents `[pscustomobject]` as allowed. The documented allow-list is NOT
+// authoritative for 5.1 — only a run on a WDAC box is.
+//
+// So: structured data in a .ps1 uses a plain `[hashtable]`, paths are inspected with
+// language operators and cmdlets (`Split-Path`, `-match`, `Test-Path`) rather than
+// `[System.IO.Path]::`, and anything with no CLM-safe substitute is wrapped in
+// `try { } catch { }` with a working fallback in the catch.
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+// .ps1 files that still violate the rules below. Shrink this list, never grow it —
+// a new .ps1 must be CLM-safe from the start. Each entry is reverse-asserted, so
+// cleaning a file forces its removal from here. Entries for files this repo does
+// not track are simply never visited, which keeps the list valid downstream where
+// the same file set is larger.
+//   * installer-opensource.ps1 — [pscustomobject]/[ordered]/.PSObject plus
+//     [System.IO.Directory|File]:: method calls; tracked as its own change.
+//   * create-new-feature.ps1 / git-common.ps1 — dev tooling, never shipped to a
+//     user machine ([PSCustomObject], [Math]::, [Console]::Error.WriteLine()).
+const KNOWN_CLM_UNSAFE = new Set([
+  'deploy/installer-opensource.ps1',
+  '.specify/extensions/git/scripts/powershell/create-new-feature.ps1',
+  '.specify/extensions/git/scripts/powershell/git-common.ps1',
+]);
+
+// Every .NET static member access that is allowed to remain across all tracked
+// .ps1. Adding an entry means you confirmed one of:
+//   (a) it is a property *get* — CLM permits those on any type; or
+//   (b) it is a core type ([datetime], [TimeSpan], ...); or
+//   (c) the call sits inside a try block whose catch is a working fallback.
+// Nothing qualifies just because about_Language_Modes lists it (see header).
+const ALLOWED_STATIC_ACCESS = new Set([
+  '[Console]::IsInputRedirected',                 // (a) property get; every hook
+  '[Console]::IsOutputRedirected',                // (a) property get; Test-Interactive
+  '[Environment]::UserInteractive',               // (c) Test-Interactive, in try/catch
+  '[Net.ServicePointManager]::SecurityProtocol',  // (c) TLS1.2 bump before a download
+  '[Net.SecurityProtocolType]::Tls12',            // (c) TLS1.2 bump before a download
+  '[Environment]::SetEnvironmentVariable',        // (c) PATH broadcast on install
+  '[datetime]::MinValue',                         // (b) core type; scripts/loongsuite-pilot.ps1
+  '[TimeSpan]::Zero',                             // (b) core type; scripts/loongsuite-pilot.ps1
+]);
+
+// Shapes that are never acceptable, whatever the file. `.PSObject` is included
+// because its member-removal form is a method call on a non-core type; the CLM-safe
+// substitute is `Select-Object -Property * -ExcludeProperty k`.
+const BANNED_SHAPES = [
+  [/\[pscustomobject\]/i, '[pscustomobject] (throws ConversionSupportedOnlyToCoreTypes on 5.1)'],
+  [/\[ordered\]/, '[ordered]'],
+  [/\bNew-Object\b/, 'New-Object'],
+  [/\bAdd-Type\b/, 'Add-Type'],
+  [/\bInvoke-Expression\b/, 'Invoke-Expression'],
+  [/\.PSObject\b/, '.PSObject member access'],
+  [/\bContainsKey\b/, '.ContainsKey() (use `.Keys -contains`)'],
+  [/^\s*(class|enum)\s+\w+/m, 'class/enum declaration'],
+];
+
+// Drop whole-line comments so the assertions below only see executable code. The
+// comments explaining each rewrite necessarily name the API they replaced.
+const codeOf = (text) => text
+  .split('\n')
+  .filter(line => !/^\s*#/.test(line))
+  .join('\n');
+
+const staticsIn = (code) => [...new Set(
+  code.match(/\[[A-Za-z_][A-Za-z0-9_.]*\]::[A-Za-z_][A-Za-z0-9_]*/g) || []
+)];
+
+const violationsIn = (code) => [
+  ...BANNED_SHAPES.filter(([re]) => re.test(code)).map(([, label]) => label),
+  ...staticsIn(code).filter(m => !ALLOWED_STATIC_ACCESS.has(m)),
+];
+
+const tracked = execFileSync('git', ['ls-files', '*.ps1'], { encoding: 'utf-8' })
+  .split('\n')
+  .filter(Boolean);
+
+describe('every tracked .ps1 stays CLM-safe', () => {
+  it('finds .ps1 files to check', () => {
+    // Guards against a silently empty sweep (wrong cwd, glob change).
+    expect(tracked.length).toBeGreaterThan(10);
+    expect(tracked).toContain('scripts/loongsuite-pilot.ps1');
+    expect(tracked.filter(f => f.startsWith('assets/hooks/')).length).toBeGreaterThan(5);
+  });
+
+  for (const file of tracked) {
+    const expectClean = !KNOWN_CLM_UNSAFE.has(file);
+    it(`${file} ${expectClean ? 'is CLM-safe' : '(known CLM-unsafe)'}`, () => {
+      const found = violationsIn(codeOf(readFileSync(file, 'utf-8')));
+      if (expectClean) {
+        // A failure naming a static is not automatically a bug: it means a new
+        // .NET static access appeared and someone must confirm (a)/(b)/(c) above
+        // before adding it to ALLOWED_STATIC_ACCESS.
+        expect(found).toEqual([]);
+      } else {
+        // Ratchet: once a file is cleaned, drop it from KNOWN_CLM_UNSAFE so the
+        // assertion above starts protecting it.
+        expect(found.length).toBeGreaterThan(0);
+      }
+    });
+  }
+});
+
+describe('the CLM-safe rewrites stay in place', () => {
+  // The two shapes that actually broke on a WDAC box, pinned at their call sites so
+  // a refactor cannot quietly reintroduce them while the sweep above still passes
+  // (both substitutes are invisible to a shape/static match).
+  it('hooks probe for a file extension with -match, not [System.IO.Path]', () => {
+    for (const file of tracked.filter(f => f.startsWith('assets/hooks/'))) {
+      const code = codeOf(readFileSync(file, 'utf-8'));
+      if (!/function Convert-NodePath/.test(code)) continue;
+      expect(code).not.toContain('HasExtension');
+      expect(code).toMatch(/-match '\\\.\[\^\\\\\/\.\]\+\$'/);
+    }
+  });
+
+  it('the CLI wrapper prunes state with Select-Object, not $state.PSObject', () => {
+    // PSMemberInfoCollection is not a core type, so .Properties.Remove() throws under
+    // CLM and the rollback would leave a stale hermes-agent entry behind.
+    const cli = codeOf(readFileSync('scripts/loongsuite-pilot.ps1', 'utf-8'));
+    expect(cli).toMatch(/Select-Object -Property \* -ExcludeProperty 'hermes-agent'/);
+    // -Property * is required alongside -ExcludeProperty on PowerShell 5.1.
+    expect(cli).not.toMatch(/Select-Object -ExcludeProperty/);
+  });
+
+  it('the CLI wrapper validates an absolute path with a regex, not IsPathRooted', () => {
+    const cli = codeOf(readFileSync('scripts/loongsuite-pilot.ps1', 'utf-8'));
+    expect(cli).not.toContain('IsPathRooted');
+    // Drive-absolute (C:\ or C:/) or UNC (\\server\share). Deliberately narrower
+    // than IsPathRooted, which also accepts the drive-relative "C:dir" and
+    // root-relative "\dir" forms — neither is safe as an absolute delete target.
+    expect(cli).toMatch(/\^\(\[A-Za-z\]:\[\\\\\/\]\|\\\\\\\\\[\^\\\\\/\]\+\[\\\\\/\]\)/);
+  });
+});

--- a/tests/unit/scripts/ps1-comments-ascii.test.mjs
+++ b/tests/unit/scripts/ps1-comments-ascii.test.mjs
@@ -1,0 +1,85 @@
+// Every comment in every tracked .ps1 must be ASCII-only.
+//
+// A .ps1 with a UTF-8 BOM decodes correctly from disk, but two paths bypass the BOM:
+//   * lose the BOM (copy/paste, a tool rewrite, CRLF conversion) and Windows
+//     PowerShell 5.1 falls back to the ANSI codepage;
+//   * the documented `irm <url>/installer.ps1 | iex` decodes per the HTTP charset and
+//     never looks at a BOM at all.
+// Either way non-ASCII comment text garbles, and a mangled byte sequence can carry a
+// quote or backtick that takes the parser down with it. On a WDAC-locked box (see
+// ps1-clm-safe.test.mjs) that turns into a failed install, so comments are held to
+// ASCII.
+//
+// Bilingual *output* strings (Msg / Write-Host / Write-Log) are intentionally exempt:
+// they are user-facing text, not parser fodder.
+//
+// Entries in KNOWN_UNCONVERTED for files this repo does not track are simply never
+// visited, so the list stays valid downstream where the same file set is larger.
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+// Files not yet converted. Shrink this list, never grow it — a new .ps1 must be clean.
+const KNOWN_UNCONVERTED = new Set([
+  'deploy/installer-opensource.ps1',
+  '.specify/extensions/git/scripts/powershell/auto-commit.ps1',
+  '.specify/extensions/git/scripts/powershell/git-common.ps1',
+  '.specify/extensions/git/scripts/powershell/initialize-repo.ps1',
+]);
+
+const NON_ASCII = /[^\x00-\x7F]/;
+
+// A `#` only starts a comment outside a string literal. Approximating "outside a
+// string" by an even quote count ahead of it is enough here and, importantly, keeps
+// `Write-Host "   loongsuite-pilot   # status"` out of the results.
+const commentOffenders = (text) => text
+  .replace(/^﻿/, '')
+  .split('\n')
+  .map((line, i) => [i + 1, line])
+  .filter(([, line]) => {
+    if (!NON_ASCII.test(line)) return false;
+    if (line.trimStart().startsWith('#')) return true;
+    const hash = line.indexOf('#');
+    if (hash < 0) return false;
+    const before = line.slice(0, hash);
+    const balanced = (before.split('"').length - 1) % 2 === 0
+      && (before.split("'").length - 1) % 2 === 0;
+    return balanced && NON_ASCII.test(line.slice(hash));
+  });
+
+const tracked = execFileSync('git', ['ls-files', '*.ps1'], { encoding: 'utf-8' })
+  .split('\n')
+  .filter(Boolean);
+
+describe('tracked .ps1 comments are ASCII-only', () => {
+  it('finds .ps1 files to check', () => {
+    expect(tracked.length).toBeGreaterThan(10);
+  });
+
+  for (const file of tracked) {
+    const expectClean = !KNOWN_UNCONVERTED.has(file);
+    it(`${file} ${expectClean ? 'has ASCII-only comments' : '(known unconverted)'}`, () => {
+      const offenders = commentOffenders(readFileSync(file, 'utf-8'));
+      if (expectClean) {
+        expect(offenders).toEqual([]);
+      } else {
+        // Ratchet: once a file is cleaned, drop it from KNOWN_UNCONVERTED so the
+        // assertion above starts protecting it.
+        expect(offenders.length).toBeGreaterThan(0);
+      }
+    });
+  }
+
+  it('flags a BOM-less file only if it still holds non-ASCII bytes anywhere', () => {
+    // scripts/loongsuite-pilot.ps1 has no BOM. That is harmless precisely because it is
+    // now pure ASCII (ASCII decodes identically under every codepage). If non-ASCII
+    // bytes reappear in a BOM-less file, the ANSI-fallback hazard is live again.
+    const risky = tracked.filter((f) => {
+      if (KNOWN_UNCONVERTED.has(f)) return false;
+      const buf = readFileSync(f);
+      const hasBom = buf[0] === 0xef && buf[1] === 0xbb && buf[2] === 0xbf;
+      return !hasBom && NON_ASCII.test(buf.toString('utf-8'));
+    });
+    expect(risky).toEqual([]);
+  });
+});

--- a/tests/unit/scripts/ps1-json-encoding.test.mjs
+++ b/tests/unit/scripts/ps1-json-encoding.test.mjs
@@ -1,0 +1,158 @@
+// Every JSON file exchanged between a .ps1 and the node side must be read and
+// written with an explicit -Encoding UTF8.
+//
+// On Windows PowerShell 5.1, Set-Content / Add-Content / Get-Content default to the
+// *ANSI codepage* (GBK/936 on Chinese Windows), while node reads and writes these
+// files as UTF-8 (src/utils/fs-utils.ts). Without -Encoding UTF8 a non-ASCII value
+// — a targetDir under `C:\Users\张三\` is the realistic case — round-trips as
+// mojibake, and the plugin at that path silently goes uncleaned on rollback.
+//
+// The paired half of this rule lives on the node side: 5.1 has no `utf8NoBOM`, so
+// `-Encoding UTF8` always emits a BOM, and `JSON.parse` rejects a leading BOM.
+// readJsonFile() swallows parse errors and returns null, which callers read as
+// "file absent" — so a BOM alone would reset deployment state to empty instead of
+// failing loudly. readJsonFile() therefore strips it; see
+// tests/unit/utils/fs-utils.test.ts. Fixing only one side is worse than fixing
+// neither.
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+
+// Files not converted yet. Shrink, never grow; each entry is reverse-asserted. An
+// entry for a file this repo does not track is simply never visited, which keeps the
+// list valid downstream where the same file set is larger.
+const KNOWN_UNENCODED = new Set([
+  'deploy/installer-opensource.ps1', // rollback state/marker reads, tracked separately
+]);
+
+// The internal installer variant. Two assertions below are specific to it, so they
+// stand down where it is not part of the tree.
+const INNER = 'deploy/installer-inner.ps1';
+
+const tracked = execFileSync('git', ['ls-files', '*.ps1'], { encoding: 'utf-8' })
+  .split('\n')
+  .filter(Boolean);
+
+const codeLines = (text) => text
+  .split('\n')
+  .map((line, i) => [i + 1, line])
+  .filter(([, line]) => !/^\s*#/.test(line));
+
+// Variables holding a path that ends in .json/.jsonl. Needed because matching only
+// on ConvertTo-Json/ConvertFrom-Json misses the hand-rolled case: the four hook
+// Log-Error helpers build their JSONL line by string interpolation and contain no
+// ConvertTo-Json anywhere, so a converter-keyed rule stayed silent while all four
+// appended to a .jsonl with the ANSI codepage. Keying off the *target path* catches
+// them regardless of how the JSON text was produced.
+const jsonPathVars = (lines) => {
+  const vars = new Set();
+  for (const [, line] of lines) {
+    const m = line.match(/\$(?:script:)?([A-Za-z_]\w*)\s*=\s*[^=].*\.jsonl?["']/);
+    if (m) vars.add(m[1]);
+  }
+  return vars;
+};
+
+// A line is a JSON interchange site when it converts to or from JSON while touching
+// a file, or when a file cmdlet touches a known .json/.jsonl path. Pipelines in this
+// repo are written on one line, so per-line matching is sufficient and keeps the rule
+// easy to read at the call site.
+const interchangeSites = (text) => {
+  const lines = codeLines(text);
+  const vars = [...jsonPathVars(lines)];
+  const touchesJsonPath = (line) =>
+    /\b(Get-Content|Set-Content|Add-Content|Out-File)\b/.test(line)
+    && vars.some(v => new RegExp(`\\$(?:script:)?${v}\\b`).test(line));
+
+  return lines.filter(([, line]) => (
+    (/\bGet-Content\b/.test(line) && /\bConvertFrom-Json\b/.test(line))
+    || (/\bConvertTo-Json\b/.test(line) && /\b(Set-Content|Add-Content|Out-File)\b/.test(line))
+    || touchesJsonPath(line)
+  ));
+};
+
+// The node half of the same boundary. Every `readFileSync` whose result is handed to
+// JSON.parse must strip a leading BOM, because `-Encoding UTF8` on 5.1 always writes
+// one and JSON.parse rejects it. Scoped to JSON.parse deliberately: a bare
+// readFileSync is *not* required to strip — installer-inner.ps1 filters the user's
+// ~/.codex/config.toml line by line and writes it straight back, so stripping there
+// would silently rewrite someone else's file. A plain count comparison
+// (`readFileSync count == replace count`) would demand exactly that.
+const jsonParseReads = (text) => codeLines(text)
+  .filter(([, line]) => /\bJSON\.parse\b/.test(line) && /\breadFileSync\b/.test(line));
+
+describe('ps1 <-> node JSON interchange is explicitly UTF-8', () => {
+  it('finds interchange sites to check', () => {
+    // Guards against the regex silently matching nothing (renamed cmdlet, reflow).
+    const total = tracked.reduce(
+      (n, f) => n + interchangeSites(readFileSync(f, 'utf-8')).length, 0);
+    expect(total).toBeGreaterThanOrEqual(6);
+  });
+
+  for (const file of tracked) {
+    const sites = interchangeSites(readFileSync(file, 'utf-8'));
+    if (sites.length === 0) continue;
+    const expectClean = !KNOWN_UNENCODED.has(file);
+    it(`${file} ${expectClean ? 'passes -Encoding UTF8 at every site' : '(known unencoded)'}`, () => {
+      const bare = sites
+        .filter(([, line]) => !/-Encoding\s+UTF8\b/.test(line))
+        .map(([n, line]) => `${n}: ${line.trim()}`);
+      if (expectClean) {
+        expect(bare).toEqual([]);
+      } else {
+        expect(bare.length).toBeGreaterThan(0);
+      }
+    });
+  }
+
+  it('catches a hand-rolled JSONL write that never calls ConvertTo-Json', () => {
+    // Pins the blind spot itself, not just its symptom: the hook Log-Error helpers
+    // are the shape that escaped the converter-keyed rule. If someone reverts the
+    // matcher to converters only, this fails even when the hooks stay correct.
+    const hook = readFileSync('assets/hooks/shared/common.ps1', 'utf-8');
+    expect(hook).not.toMatch(/\bConvertTo-Json\b/);
+    const sites = interchangeSites(hook).map(([, l]) => l.trim());
+    expect(sites.some(l => /\bAdd-Content\b/.test(l))).toBe(true);
+  });
+
+  it('every embedded-node readFileSync feeding JSON.parse strips the BOM', () => {
+    const bare = [];
+    let total = 0;
+    for (const file of tracked) {
+      if (KNOWN_UNENCODED.has(file)) continue;
+      for (const [n, line] of jsonParseReads(readFileSync(file, 'utf-8'))) {
+        total += 1;
+        if (!/\.replace\(\/\^\\uFEFF\//.test(line)) bare.push(`${file}:${n}: ${line.trim()}`);
+      }
+    }
+    // Guards against the matcher silently matching nothing. The floor here is the
+    // span-attr payload in scripts/loongsuite-pilot.ps1; the internal installer
+    // variants carry ~15 more sites wherever they are part of the tree.
+    expect(total).toBeGreaterThanOrEqual(existsSync(INNER) ? 15 : 1);
+    expect(bare).toEqual([]);
+  });
+
+  it.skipIf(!existsSync(INNER))('leaves the codex config.toml read unstripped', () => {
+    // The exclusion above is load-bearing, so assert it directly: this read filters
+    // the user's TOML and writes it back, and a BOM strip would silently alter a file
+    // we do not own. If it ever becomes a JSON.parse, the previous test takes over.
+    const inner = readFileSync(INNER, 'utf-8');
+    const toml = codeLines(inner).filter(([, l]) =>
+      /\breadFileSync\b/.test(l) && !/\bJSON\.parse\b/.test(l));
+    expect(toml.length).toBe(1);
+    expect(toml[0][1]).toContain("split('\\n')");
+    expect(toml[0][1]).not.toContain('uFEFF');
+  });
+
+  it('the hermes rollback path reads and writes deployed-agents.json as UTF-8', () => {
+    // Named explicitly because this is the site the CR flagged: the write alone was
+    // reported, but Get-Content without -Encoding also falls back to ANSI when there
+    // is no BOM to sniff, so the read direction needed the same fix.
+    const cli = readFileSync('scripts/loongsuite-pilot.ps1', 'utf-8');
+    const fn = cli.slice(cli.indexOf('function Remove-HermesPluginForRollback'));
+    const body = fn.slice(0, fn.indexOf('\n}\n'));
+    expect(body).toMatch(/\$state = Get-Content \$stateFile -Raw -Encoding UTF8/);
+    expect(body).toMatch(/\$meta = Get-Content \$marker -Raw -Encoding UTF8/);
+    expect(body).toMatch(/ConvertTo-Json -Depth 20 \| Set-Content \$tmp -Encoding UTF8/);
+  });
+});

--- a/tests/unit/utils/fs-utils.test.ts
+++ b/tests/unit/utils/fs-utils.test.ts
@@ -4,6 +4,8 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import {
   cleanStaleTmpFiles,
+  readJsonFile,
+  writeJsonFile,
   writeTextFileAtomic,
 } from '../../../src/utils/fs-utils.js';
 
@@ -67,5 +69,57 @@ describe('cleanStaleTmpFiles', () => {
     )).rejects.toThrow('file changed before write');
 
     await expect(fs.readFile(target, 'utf8')).resolves.toBe('{"model":"new"}\n');
+  });
+});
+
+// readJsonFile swallows parse errors and returns null, which every caller reads as
+// "file absent" -> fall back to defaults. That makes a leading UTF-8 BOM far worse
+// than a parse failure: deployment state or user config silently resets to empty
+// instead of erroring. And BOMs arrive routinely on Windows — PowerShell 5.1's
+// `Set-Content -Encoding UTF8` always writes one (no utf8NoBOM before PS 6), and so
+// does Notepad. scripts/loongsuite-pilot.ps1's rollback path writes
+// deployed-agents.json exactly that way; see tests/unit/scripts/ps1-json-encoding.test.mjs.
+describe('readJsonFile', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'read-json-test-'));
+  });
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('parses a file written with a UTF-8 BOM (PowerShell 5.1 -Encoding UTF8)', async () => {
+    const target = path.join(dir, 'deployed-agents.json');
+    // Byte-for-byte what `Set-Content -Encoding UTF8` produces: EF BB BF + UTF-8.
+    await fs.writeFile(target, Buffer.concat([
+      Buffer.from([0xef, 0xbb, 0xbf]),
+      Buffer.from(JSON.stringify({ 'hermes-agent': { targetDir: 'C:\\Users\\张三\\p' } }), 'utf8'),
+    ]));
+
+    const state = await readJsonFile<Record<string, { targetDir: string }>>(target);
+    // Not just non-null: a BOM must not degrade to "{}" either, or a rollback would
+    // wipe the very entries it is meant to prune.
+    expect(state).not.toBeNull();
+    expect(state!['hermes-agent'].targetDir).toBe('C:\\Users\\张三\\p');
+  });
+
+  it('parses the same content without a BOM', async () => {
+    const target = path.join(dir, 'config.json');
+    await fs.writeFile(target, JSON.stringify({ a: 1 }), 'utf8');
+    expect(await readJsonFile<{ a: number }>(target)).toEqual({ a: 1 });
+  });
+
+  it('strips only a leading BOM, leaving one inside a string untouched', async () => {
+    const target = path.join(dir, 'inner-bom.json');
+    await writeJsonFile(target, { note: 'a\uFEFFb' });
+    expect(await readJsonFile<{ note: string }>(target)).toEqual({ note: 'a\uFEFFb' });
+  });
+
+  it('still returns null for a missing file and for malformed JSON', async () => {
+    expect(await readJsonFile(path.join(dir, 'nope.json'))).toBeNull();
+    const broken = path.join(dir, 'broken.json');
+    await fs.writeFile(broken, '\uFEFF{"a":', 'utf8');
+    expect(await readJsonFile(broken)).toBeNull();
   });
 });

--- a/tests/unit/utils/json-document.test.ts
+++ b/tests/unit/utils/json-document.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  editJsonc,
+  parseJsonDocument,
+  readJsonDocument,
+} from '../../../src/utils/json-document.js';
+
+// A leading UTF-8 BOM must not make an agent settings file look invalid.
+//
+// These files belong to the user's editor and toolchain, not to us: PowerShell 5.1's
+// `Set-Content -Encoding UTF8` always emits a BOM (no utf8NoBOM before PS 6) and so
+// does Notepad, so a BOM'd ~/.claude/settings.json or ~/.cursor/hooks.json is a
+// routine state on Windows. Both parser branches used to reject it — JSON.parse
+// throws, and jsonc-parser reports a parse error that parseJsonDocument treats as
+// fatal — which failed hook *deploy and remove*, not merely a read.
+//
+// The strip lives in parseJsonDocument rather than readJsonDocument on purpose:
+// callers pass the returned `raw` back as the expected content of a compare-and-swap
+// write and as the base text for editJsonc, so it must stay byte-identical to disk.
+// The last two tests pin that invariant; without them, "fix" the read instead and the
+// guarded write starts failing with "file changed before write".
+
+const withBom = (s: string) => `\uFEFF${s}`;
+
+describe('parseJsonDocument with a leading BOM', () => {
+  it('parses BOM-prefixed strict JSON', () => {
+    const r = parseJsonDocument<{ model: string }>(withBom('{"model":"pilot"}'), 'json');
+    expect(r.ok).toBe(true);
+    expect(r.ok && r.data.model).toBe('pilot');
+  });
+
+  it('parses BOM-prefixed JSONC, comments and trailing commas included', () => {
+    // The jsonc branch backs hook deploy/remove (hook-manager's settings edits), so
+    // its BOM handling is the one that breaks writes, not just reads.
+    const raw = withBom('{\n  // pilot\n  "hooks": {"a": 1},\n}');
+    const r = parseJsonDocument<{ hooks: Record<string, number> }>(raw, 'jsonc');
+    expect(r.ok).toBe(true);
+    expect(r.ok && r.data.hooks.a).toBe(1);
+  });
+
+  it('still reports malformed content as an error, BOM or not', () => {
+    expect(parseJsonDocument(withBom('{"a":'), 'json').ok).toBe(false);
+    expect(parseJsonDocument('{"a":', 'json').ok).toBe(false);
+    expect(parseJsonDocument(withBom('{"a": }'), 'jsonc').ok).toBe(false);
+  });
+
+  it('strips only a leading BOM, leaving one inside a string intact', () => {
+    const r = parseJsonDocument<{ note: string }>('{"note":"a\uFEFFb"}', 'json');
+    expect(r.ok && r.data.note).toBe('a\uFEFFb');
+  });
+});
+
+describe('readJsonDocument keeps raw byte-exact', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'json-doc-test-'));
+  });
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('returns the BOM in raw while still parsing the data', async () => {
+    const target = path.join(dir, 'settings.json');
+    // Byte-for-byte what `Set-Content -Encoding UTF8` produces.
+    await fs.writeFile(target, Buffer.concat([
+      Buffer.from([0xef, 0xbb, 0xbf]),
+      Buffer.from('{"model":"pilot"}\n', 'utf8'),
+    ]));
+
+    const doc = await readJsonDocument<{ model: string }>(target, 'json');
+    expect(doc.status).toBe('ok');
+    if (doc.status !== 'ok') return;
+    expect(doc.data.model).toBe('pilot');
+    // Load-bearing: raw is the compare-and-swap baseline, so it must equal the file
+    // on disk, BOM included.
+    expect(doc.raw).toBe('\uFEFF{"model":"pilot"}\n');
+    expect(doc.raw).toBe(await fs.readFile(target, 'utf8'));
+  });
+
+  it('editJsonc round-trips BOM-prefixed text and preserves the BOM', () => {
+    const raw = '\uFEFF{\n  "model": "old"\n}\n';
+    const next = editJsonc(raw, ['model'], 'pilot');
+    expect(next.startsWith('\uFEFF')).toBe(true);
+    const r = parseJsonDocument<{ model: string }>(next, 'jsonc');
+    expect(r.ok && r.data.model).toBe('pilot');
+  });
+});


### PR DESCRIPTION
## Why

Windows validation machines run a WDAC application-control policy, so any `.ps1` not covered by the policy executes in **ConstrainedLanguage Mode** (CLM). Under CLM only CoreTypes may be cast or have *methods* invoked. The hooks wrap their work in a fail-open `catch`, so a CLM violation there doesn't fail loudly — it silently drops telemetry.

Worth recording: `about_Language_Modes`' allowed-types list is **not** authoritative for Windows PowerShell 5.1. `[pscustomobject]@{}` really does throw `ConversionSupportedOnlyToCoreTypes`, because the accelerator targets the internal type `LanguagePrimitives+InternalPSCustomObject`.

## What changed

**1. CLM violations removed**

| Site | Before | After |
|---|---|---|
| `codex-…-hook.ps1` | `[ordered]@{ … }` | `@{ … }` |
| `codex`/`workbuddy` hooks | `[System.IO.Path]::HasExtension($candidate)` | `$candidate -match '\.[^\\/.]+$'` |
| `scripts/loongsuite-pilot.ps1` | `[System.IO.Path]::IsPathRooted($p)` | `-match '^([A-Za-z]:[\\/]\|\\\\[^\\/]+[\\/])'` |
| `scripts/loongsuite-pilot.ps1` | `$state.PSObject.Properties.Remove('hermes-agent')` | `$state \| Select-Object -Property * -ExcludeProperty 'hermes-agent'` |

**2. JSON interchange pinned to UTF-8**

`Set-Content` / `Add-Content` / `Get-Content` default to the **ANSI codepage** on 5.1 (GBK/936 on Chinese Windows) while node reads and writes the same files as UTF-8. A `targetDir` under `C:\Users\<non-ASCII>\` round-tripped as mojibake, and the plugin at that path went uncleaned on rollback. Every JSON/JSONL interchange site now passes `-Encoding UTF8`.

The paired half is on the node side: 5.1 has no `utf8NoBOM`, so `-Encoding UTF8` **always** emits a BOM, and `JSON.parse` rejects a leading BOM. `readJsonFile()` swallows parse errors and returns `null`, which callers read as *"file absent"* — so a BOM alone would silently reset deployment state instead of failing. `readJsonFile()` and `parseJsonDocument()` now strip it.

`readJsonDocument()` deliberately does **not** strip: its callers reuse `raw` as a compare-and-swap baseline and as `editJsonc`'s base text, so stripping there would corrupt the round-trip. `tests/unit/utils/json-document.test.ts` pins both halves of that asymmetry.

Fixing only one side of this boundary would be worse than fixing neither.

## Guardrails

Three static ratchets, each sweeping every tracked `.ps1` via `git ls-files` with a reverse-asserted whitelist that may shrink but never grow:

- `tests/unit/scripts/ps1-clm-safe.test.mjs` — banned shapes (`[pscustomobject]`, `[ordered]`, `New-Object`, `Add-Type`, `Invoke-Expression`, `.PSObject`, `.ContainsKey()`, `class`/`enum`) plus an explicit allow-list for the .NET static accesses that are legitimate (property *gets*, core types, or calls inside a try with a working fallback).
- `tests/unit/scripts/ps1-comments-ascii.test.mjs` — comments stay ASCII. A BOM-less `.ps1` decodes with the ANSI codepage, and the documented `irm <url> | iex` decodes per the HTTP charset and never looks at a BOM; either way a mangled byte can carry a quote and take the parser down. Bilingual *output* strings stay exempt.
- `tests/unit/scripts/ps1-json-encoding.test.mjs` — `-Encoding UTF8` at every interchange site, plus the node-side BOM strip.

The encoding ratchet keys off the **target path**, not the converter. The four hook `Log-Error` helpers build their JSONL line by string interpolation and contain no `ConvertTo-Json` anywhere, so a converter-keyed rule stayed silent while all four appended with the ANSI codepage. That blind spot is pinned by its own test.

## Testing

- `tests/unit/scripts/*` + `tests/unit/utils/{fs-utils,json-document}.test.ts` — all pass.
- Full suite compared against clean `main`: identical pre-existing failures (`hermes-agent-plugin`, `hermes-agent-event-log-flow`, `plugin-inject-strategy`, `cursor/resource-context`, `qoder-hook-processor-cold-start`). The few hook-processor files that flake under parallel load pass in isolation. No regression from this change.