### PR TITLE
feat: support OpenCode first install and shared service name

### DIFF
--- a/agents.d/opencode.json
+++ b/agents.d/opencode.json
@@ -7,6 +7,7 @@
     "commands": ["opencode"]
   },
   "pluginInject": {
+    "createIfMissing": true,
     "configPaths": [
       "~/.config/opencode/opencode.jsonc",
       "~/.config/opencode/opencode.json",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@ Set `AGENT_DATA_COLLECTION_CONFIG` to use a different config file path.
   "userId": "your-user-id",
   "collectLog": true,
   "collectTrace": true,
-  "serviceNamePrefix": "loongsuite-pilot"
+  "serviceName": "my-agent-service"
 }
 ```
 
@@ -34,7 +34,8 @@ Set `AGENT_DATA_COLLECTION_CONFIG` to use a different config file path.
 | `userId` | User identity written to emitted events. Defaults to the machine hostname. |
 | `collectLog` | Enables SLS log reporting. JSONL and HTTP remain controlled by their own `enabled` flags. |
 | `collectTrace` | Enables OTLP trace export when a trace destination is configured. |
-| `serviceNamePrefix` | Service name prefix used by reporting backends. |
+| `serviceName` | Exact service name shared by every agent and reporting backend. It takes precedence over all service-name prefixes. |
+| `serviceNamePrefix` | Legacy service-name base. When `serviceName` is unset, Pilot reports each agent as `<serviceNamePrefix>-<agentType>`. |
 
 Equivalent environment variables:
 
@@ -46,6 +47,7 @@ Equivalent environment variables:
 | `LOONGSUITE_PILOT_USER_ID` | Override `userId`. |
 | `LOONGSUITE_PILOT_COLLECT_LOG` | Set `false` or `0` to disable SLS log reporting. |
 | `LOONGSUITE_PILOT_COLLECT_TRACE` | Set `false` or `0` to disable trace reporting. |
+| `LOONGSUITE_PILOT_SERVICE_NAME` | Override `serviceName` with one exact name for all agents and backends. |
 | `LOONGSUITE_PILOT_SERVICE_NAME_PREFIX` | Override `serviceNamePrefix`. |
 | `LOG_LEVEL` | Runtime log level: `debug`, `info`, `warn`, `error`, or `silent`. |
 

--- a/docs/trace-output.md
+++ b/docs/trace-output.md
@@ -11,12 +11,12 @@ Trace output is separate from log output. SLS, JSONL, and HTTP receive event rec
 ```json
 {
   "collectTrace": true,
+  "serviceName": "my-agent-service",
   "otlpTrace": {
     "endpoint": "https://otel-collector.example.com",
     "headers": {
       "Authorization": "Bearer token"
     },
-    "serviceName": "loongsuite-pilot",
     "resourceAttributes": {
       "deployment.environment": "prod"
     },
@@ -30,9 +30,10 @@ Trace output is separate from log output. SLS, JSONL, and HTTP receive event rec
 | Setting | Description |
 |---------|-------------|
 | `collectTrace` | Master switch for trace export. |
+| `serviceName` | Exact `service.name` shared by every agent, OTLP backend, and SLS backend. |
 | `otlpTrace.endpoint` | OTLP HTTP base URL. Pilot auto-appends `/v1/traces` if the path does not already end with it. |
 | `otlpTrace.headers` | Headers sent to the OTLP endpoint. |
-| `otlpTrace.serviceName` | Service name attached to exported spans. |
+| `otlpTrace.serviceName` | Legacy trace-only service-name base. Pilot appends `-<agentType>`; top-level `serviceName` takes precedence and disables the suffix. |
 | `otlpTrace.resourceAttributes` | Extra OpenTelemetry resource attributes. |
 | `otlpTrace.captureMessageContent` | Whether trace export may include message content. |
 | `otlpTrace.debug` | Enables local debug output for trace conversion. |
@@ -43,6 +44,7 @@ Environment variables:
 | Variable | Description |
 |----------|-------------|
 | `LOONGSUITE_PILOT_COLLECT_TRACE` | Set `false` or `0` to disable trace export. |
+| `LOONGSUITE_PILOT_SERVICE_NAME` | Exact service name shared by all agents and reporting backends. |
 | `LOONGSUITE_PILOT_OTLP_ENDPOINT` | OTLP trace endpoint. |
 | `LOONGSUITE_PILOT_OTLP_HEADERS` | JSON string for OTLP headers. |
 
@@ -119,7 +121,7 @@ Managed/hosted deployments can push extra trace backends via `~/.loongsuite-pilo
 
 | Field | Applies to | Description |
 |-------|-----------|-------------|
-| `serviceNamePrefix` | top-level | Service-name prefix for **all** managed backends — trace (`otlp[]`/`cms[]`, as `service.name`) and log (`sls[]`, as the `__service_name__` tag) — keeping them distinct from user backends. Optional; falls back to the user `serviceNamePrefix` when omitted (no differentiation). |
+| `serviceNamePrefix` | top-level | Service-name prefix for **all** managed backends — trace (`otlp[]`/`cms[]`, as `service.name`) and log (`sls[]`, as the `__service_name__` tag) — keeping them distinct from user backends. Optional; falls back to the user `serviceNamePrefix` when omitted (no differentiation). A user-configured top-level `serviceName` overrides this prefix. |
 | `otlp[].name` / `cms[].name` | both | Label used in logs and in the per-backend failed-log filename. Optional (defaults to `inner-otlp-<i>` / `inner-cms-<i>`). |
 | `otlp[].endpoint` | otlp | OTLP HTTP base URL (`/v1/traces` auto-appended). |
 | `otlp[].headers` | otlp | Request headers (e.g. auth token). |
@@ -129,7 +131,7 @@ Managed/hosted deployments can push extra trace backends via `~/.loongsuite-pilo
 | `cms[].project` | cms | Sent as `x-arms-project`. Extracted from the endpoint hostname if omitted. |
 | `cms[].workspace` | cms | Sent as `x-cms-workspace`. |
 
-Each `cms[]` entry is expanded into an OTLP endpoint with the corresponding `x-arms-*` / `x-cms-*` headers, and any CMS backend adds the `acs.arms.service.feature=genai_app` resource attribute (shared, as noted above). When `serviceNamePrefix` is set here, managed backends report under `<serviceNamePrefix>-<agent>` while user backends keep the user prefix; spans are then converted once per distinct `service.name` (typically twice — user and managed). Malformed managed config (e.g. `otlp`/`cms` written as a non-array) is ignored rather than failing collection.
+Each `cms[]` entry is expanded into an OTLP endpoint with the corresponding `x-arms-*` / `x-cms-*` headers, and any CMS backend adds the `acs.arms.service.feature=genai_app` resource attribute (shared, as noted above). When `serviceNamePrefix` is set here, managed backends report under `<serviceNamePrefix>-<agent>` while user backends keep the user prefix; spans are then converted once per distinct `service.name` (typically twice — user and managed). If the user sets top-level `serviceName`, that exact value is used instead for every user and managed backend. Malformed managed config (e.g. `otlp`/`cms` written as a non-array) is ignored rather than failing collection.
 
 ## Backend Examples
 

--- a/docs/zh-CN/configuration.md
+++ b/docs/zh-CN/configuration.md
@@ -23,7 +23,7 @@ Pilot 按以下顺序解析配置：
   "userId": "your-user-id",
   "collectLog": true,
   "collectTrace": true,
-  "serviceNamePrefix": "loongsuite-pilot"
+  "serviceName": "my-agent-service"
 }
 ```
 
@@ -34,7 +34,8 @@ Pilot 按以下顺序解析配置：
 | `userId` | 写入输出事件的用户标识，默认使用机器 hostname。 |
 | `collectLog` | 控制 SLS 日志上报。JSONL 和 HTTP 由各自的 `enabled` 控制。 |
 | `collectTrace` | 当配置了 Trace 目标时，控制 OTLP Trace 上报。 |
-| `serviceNamePrefix` | 上报后端使用的服务名前缀。 |
+| `serviceName` | 所有 Agent 和上报后端共用的唯一服务名，优先级高于所有服务名前缀配置。 |
+| `serviceNamePrefix` | 兼容原有行为的服务名基础值。未设置 `serviceName` 时，各 Agent 以 `<serviceNamePrefix>-<agentType>` 上报。 |
 
 对应环境变量：
 
@@ -46,6 +47,7 @@ Pilot 按以下顺序解析配置：
 | `LOONGSUITE_PILOT_USER_ID` | 覆盖 `userId`。 |
 | `LOONGSUITE_PILOT_COLLECT_LOG` | 设置为 `false` 或 `0` 可关闭 SLS 日志上报。 |
 | `LOONGSUITE_PILOT_COLLECT_TRACE` | 设置为 `false` 或 `0` 可关闭 Trace 上报。 |
+| `LOONGSUITE_PILOT_SERVICE_NAME` | 用一个唯一服务名覆盖所有 Agent 和上报后端的 `serviceName`。 |
 | `LOONGSUITE_PILOT_SERVICE_NAME_PREFIX` | 覆盖 `serviceNamePrefix`。 |
 | `LOG_LEVEL` | 运行日志级别：`debug`、`info`、`warn`、`error` 或 `silent`。 |
 

--- a/docs/zh-CN/trace-output.md
+++ b/docs/zh-CN/trace-output.md
@@ -11,12 +11,12 @@ Trace 输出和日志输出是分开的。SLS、JSONL、HTTP 接收事件记录�
 ```json
 {
   "collectTrace": true,
+  "serviceName": "my-agent-service",
   "otlpTrace": {
     "endpoint": "https://otel-collector.example.com",
     "headers": {
       "Authorization": "Bearer token"
     },
-    "serviceName": "loongsuite-pilot",
     "resourceAttributes": {
       "deployment.environment": "prod"
     },
@@ -30,9 +30,10 @@ Trace 输出和日志输出是分开的。SLS、JSONL、HTTP 接收事件记录�
 | 配置项 | 说明 |
 |--------|------|
 | `collectTrace` | Trace 上报总开关。 |
+| `serviceName` | 所有 Agent、OTLP 后端和 SLS 后端共用的唯一 `service.name`。 |
 | `otlpTrace.endpoint` | OTLP HTTP base URL。如果路径未以 `/v1/traces` 结尾，Pilot 会自动追加。 |
 | `otlpTrace.headers` | 发送到 OTLP endpoint 的请求头。 |
-| `otlpTrace.serviceName` | 导出 span 使用的 service name。 |
+| `otlpTrace.serviceName` | 兼容原有行为的 Trace 服务名基础值，Pilot 会追加 `-<agentType>`；顶层 `serviceName` 优先并关闭该后缀。 |
 | `otlpTrace.resourceAttributes` | 额外 OpenTelemetry resource attributes。 |
 | `otlpTrace.captureMessageContent` | Trace 输出是否可以包含消息内容。 |
 | `otlpTrace.debug` | 开启 Trace 转换 debug 本地输出。 |
@@ -43,6 +44,7 @@ Trace 输出和日志输出是分开的。SLS、JSONL、HTTP 接收事件记录�
 | 环境变量 | 说明 |
 |----------|------|
 | `LOONGSUITE_PILOT_COLLECT_TRACE` | 设置为 `false` 或 `0` 可关闭 Trace 上报。 |
+| `LOONGSUITE_PILOT_SERVICE_NAME` | 所有 Agent 和上报后端共用的唯一服务名。 |
 | `LOONGSUITE_PILOT_OTLP_ENDPOINT` | OTLP Trace endpoint。 |
 | `LOONGSUITE_PILOT_OTLP_HEADERS` | OTLP 请求头 JSON 字符串。 |
 
@@ -119,7 +121,7 @@ Trace 导出会把**同一批**转换后的 span **同时**发往**所有**已�
 
 | 字段 | 适用 | 说明 |
 |------|------|------|
-| `serviceNamePrefix` | 顶层 | **所有**托管后端的 service name 前缀——trace(`otlp[]`/`cms[]`,作为 `service.name`)与 log(`sls[]`,作为 `__service_name__` tag)——用于与用户后端区分。可选;省略时回退到用户的 `serviceNamePrefix`(即不做区分)。 |
+| `serviceNamePrefix` | 顶层 | **所有**托管后端的 service name 前缀——trace(`otlp[]`/`cms[]`,作为 `service.name`)与 log(`sls[]`,作为 `__service_name__` tag)——用于与用户后端区分。可选;省略时回退到用户的 `serviceNamePrefix`(即不做区分)。用户配置的顶层 `serviceName` 会覆盖此前缀。 |
 | `otlp[].name` / `cms[].name` | 两者 | 用于日志与失败日志文件名的标签。可选(默认 `inner-otlp-<i>` / `inner-cms-<i>`)。 |
 | `otlp[].endpoint` | otlp | OTLP HTTP 基础 URL(自动补 `/v1/traces`)。 |
 | `otlp[].headers` | otlp | 请求 header(如鉴权 token)。 |
@@ -129,7 +131,7 @@ Trace 导出会把**同一批**转换后的 span **同时**发往**所有**已�
 | `cms[].project` | cms | 作为 `x-arms-project` 发送。省略时从 endpoint 域名提取。 |
 | `cms[].workspace` | cms | 作为 `x-cms-workspace` 发送。 |
 
-每个 `cms[]` 条目会展开为一个带 `x-arms-*` / `x-cms-*` header 的 OTLP 后端;只要存在 CMS 后端,就会附加 `acs.arms.service.feature=genai_app` 资源属性(如上所述为共享)。此处设置 `serviceNamePrefix` 后,托管后端会以 `<serviceNamePrefix>-<agent>` 上报,用户后端仍用用户前缀;此时 span 会按不同 `service.name` 各转换一次(通常两次——用户与托管)。托管配置格式错误(例如 `otlp`/`cms` 写成非数组)会被忽略,而不会导致采集失败。
+每个 `cms[]` 条目会展开为一个带 `x-arms-*` / `x-cms-*` header 的 OTLP 后端;只要存在 CMS 后端,就会附加 `acs.arms.service.feature=genai_app` 资源属性(如上所述为共享)。此处设置 `serviceNamePrefix` 后,托管后端会以 `<serviceNamePrefix>-<agent>` 上报,用户后端仍用用户前缀;此时 span 会按不同 `service.name` 各转换一次(通常两次——用户与托管)。如果用户设置了顶层 `serviceName`，所有用户与托管后端都会改用这个唯一值。托管配置格式错误(例如 `otlp`/`cms` 写成非数组)会被忽略,而不会导致采集失败。
 
 ## 后端接入示例
 

--- a/src/core/config-loader.ts
+++ b/src/core/config-loader.ts
@@ -114,6 +114,7 @@ export interface ConfigFile {
 
   collectLog?: boolean;
   collectTrace?: boolean;
+  serviceName?: string;
   serviceNamePrefix?: string;
 
   upstreamLink?: {
@@ -185,6 +186,11 @@ function env(key: string): string | undefined {
   return v !== undefined ? (process.platform === 'win32' ? v.trim() : v) : undefined;
 }
 
+function nonEmpty(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
 function envBool(key: string, fallback: boolean): boolean {
   const v = env(key);
   if (v === undefined || v.trim() === '') return fallback; // empty string == unset, not "true"
@@ -223,6 +229,7 @@ export async function loadConfig(): Promise<AnalyticsConfig> {
 
   const userId = env('LOONGSUITE_PILOT_USER_ID') ?? file?.userId ?? file?.['user.id'] ?? os.hostname();
 
+  const serviceName = nonEmpty(env('LOONGSUITE_PILOT_SERVICE_NAME')) ?? nonEmpty(file?.serviceName);
   const serviceNamePrefix = env('LOONGSUITE_PILOT_SERVICE_NAME_PREFIX') ?? file?.serviceNamePrefix ?? 'loongsuite-pilot';
 
   return {
@@ -232,6 +239,7 @@ export async function loadConfig(): Promise<AnalyticsConfig> {
     userId,
     collectLog: envBool('LOONGSUITE_PILOT_COLLECT_LOG', file?.collectLog ?? true),
     collectTrace: envBool('LOONGSUITE_PILOT_COLLECT_TRACE', file?.collectTrace ?? true),
+    serviceName,
     serviceNamePrefix,
     cms: buildCmsConfig(file),
     otlpTrace: buildOtlpTraceRawConfig(file),
@@ -245,7 +253,7 @@ export async function loadConfig(): Promise<AnalyticsConfig> {
     autoUpdate: buildAutoUpdateConfig(file),
 
     listeners: buildListenersConfig(file),
-    flushers: buildFlushersConfig(file, dataDir, serviceNamePrefix, innerDataConfig),
+    flushers: buildFlushersConfig(file, dataDir, serviceName, serviceNamePrefix, innerDataConfig),
     retention: buildRetentionConfig(file),
     agents: buildAgentsConfig(file),
     mask: buildMaskConfig(file),
@@ -490,11 +498,12 @@ function buildStatusBarConfig(file: ConfigFile | null): StatusBarConfig {
 function buildFlushersConfig(
   file: ConfigFile | null,
   dataDir: string,
+  serviceName: string | undefined,
   serviceNamePrefix: string,
   innerDataConfig: InnerDataConfig | null,
 ): FlusherConfig {
   return {
-    sls: buildSlsConfig(file, serviceNamePrefix, innerDataConfig),
+    sls: buildSlsConfig(file, serviceName, serviceNamePrefix, innerDataConfig),
     jsonl: buildJsonlConfig(file, dataDir),
     http: buildHttpConfig(file),
   };
@@ -518,12 +527,14 @@ export function buildOtlpTraceConfig(config: AnalyticsConfig): OtlpTraceFlusherC
   const endpoints: OtlpEndpoint[] = [];
   // Collected from any ARMS/CMS backend; merged into the shared resource.
   const armsResourceAttributes: Record<string, string> = {};
-  // User backends use the top-level (shared) serviceName. Managed backends may
-  // override it via inner serviceNamePrefix; only tag them when it actually
-  // differs, so the default case keeps user/inner backends dedup-identical and
-  // leaves the flusher on its single-conversion path.
-  const userServiceName = config.otlpTrace?.serviceName ?? (config.serviceNamePrefix || 'loongsuite-pilot');
-  const innerPrefix = config.innerTrace?.serviceNamePrefix;
+  // An exact top-level serviceName wins for every user/managed backend. Without
+  // it, user backends use the legacy base and managed backends may override that
+  // base via inner serviceNamePrefix. Only tag an override when it differs, so
+  // the default case stays on the flusher's single-conversion path.
+  const userServiceName = config.serviceName
+    ?? config.otlpTrace?.serviceName
+    ?? (config.serviceNamePrefix || 'loongsuite-pilot');
+  const innerPrefix = config.serviceName ? undefined : config.innerTrace?.serviceNamePrefix;
   const innerServiceName = innerPrefix && innerPrefix !== userServiceName ? innerPrefix : undefined;
 
   // 1. User generic OTLP (endpoint via env or config).
@@ -592,6 +603,7 @@ export function buildOtlpTraceConfig(config: AnalyticsConfig): OtlpTraceFlusherC
     endpoints: deduped,
     protocol: 'http/protobuf',
     serviceName,
+    appendAgentTypeToServiceName: config.serviceName ? false : undefined,
     resourceAttributes: Object.keys(resourceAttributes).length > 0 ? resourceAttributes : undefined,
     captureMessageContent,
     debug: otlp?.debug ?? config.cms.debug ?? false,
@@ -729,7 +741,12 @@ function parseSlsEndpointEntry(ep: SlsEndpointEntry, index: number): SlsEndpoint
   return result;
 }
 
-function buildSlsConfig(file: ConfigFile | null, serviceNamePrefix: string, innerDataConfig: InnerDataConfig | null) {
+function buildSlsConfig(
+  file: ConfigFile | null,
+  serviceName: string | undefined,
+  serviceNamePrefix: string,
+  innerDataConfig: InnerDataConfig | null,
+) {
   const rawSls = file?.sls;
   const isArray = Array.isArray(rawSls);
   const single = isArray ? null : (rawSls as SlsSingleConfig | undefined) ?? null;
@@ -772,9 +789,9 @@ function buildSlsConfig(file: ConfigFile | null, serviceNamePrefix: string, inne
   }
 
   if (innerDataConfig?.sls && Array.isArray(innerDataConfig.sls)) {
-    // Managed endpoints get their own __service_name__; only tag them when the
-    // inner prefix differs, so the default case stays byte-identical to before.
-    const innerPrefix = innerDataConfig.serviceNamePrefix;
+    // An exact user serviceName wins globally. Otherwise managed endpoints get
+    // their own __service_name__ base only when the inner prefix differs.
+    const innerPrefix = serviceName ? undefined : innerDataConfig.serviceNamePrefix;
     const innerServiceName = innerPrefix && innerPrefix !== serviceNamePrefix ? innerPrefix : undefined;
     const innerEndpoints = innerDataConfig.sls
       .filter(ep => ep.endpoint && ep.logstore)
@@ -814,6 +831,7 @@ function buildSlsConfig(file: ConfigFile | null, serviceNamePrefix: string, inne
     endpoints,
     batchMaxSize: single?.batchMaxSize ?? 20,
     flushIntervalMs: single?.flushIntervalMs ?? 2_000,
+    serviceName,
     serviceNamePrefix,
   };
 }

--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -92,6 +92,7 @@ interface ResolvedOtlpEndpoint {
   headers: Record<string, string>;
   compression: CompressionAlgorithm;
   serviceName: string;
+  appendAgentTypeToServiceName: boolean;
 }
 
 interface AgentExportState {
@@ -199,6 +200,7 @@ export class OtlpTraceFlusher extends BaseFlusher {
       headers: ep.headers ?? {},
       compression: ep.compression === 'none' ? CompressionAlgorithm.NONE : CompressionAlgorithm.GZIP,
       serviceName: ep.serviceName || cfg.serviceName,
+      appendAgentTypeToServiceName: cfg.appendAgentTypeToServiceName !== false,
     }));
     const dataDir = cfg.dataDir ?? os.homedir() + '/.loongsuite-pilot';
     this.pilotVersion = readInstalledVersion(dataDir);
@@ -375,7 +377,9 @@ export class OtlpTraceFlusher extends BaseFlusher {
     }
     // Fan out to every backend; each endpoint belongs to exactly one serviceName
     // group, so the spans reach each backend once.
-    const serviceNames = [...new Set(this.endpoints.map((e) => e.serviceName))];
+    const serviceNames = [...new Set(
+      this.endpoints.map((endpoint) => this.resolveEndpointServiceName(endpoint, agentType)),
+    )];
     await Promise.all(
       serviceNames.map((serviceName) =>
         this.exportInBatches(this.getOrCreateExportState(agentType, serviceName), agentType, spans),
@@ -479,7 +483,9 @@ export class OtlpTraceFlusher extends BaseFlusher {
     // Convert once per distinct service.name (backends may split into user/inner
     // service names). Each service name owns an independent convert state, so the
     // common single-name case still converts exactly once.
-    const serviceNames = [...new Set(this.endpoints.map((e) => e.serviceName))];
+    const serviceNames = [...new Set(
+      this.endpoints.map((endpoint) => this.resolveEndpointServiceName(endpoint, agentType)),
+    )];
     await Promise.all(
       serviceNames.map((serviceName) => {
         const convertKey = this.buildConvertStateKey(agentType, serviceName, projectedResourceAttributes);
@@ -931,7 +937,7 @@ export class OtlpTraceFlusher extends BaseFlusher {
     if (state) return state;
 
     const exporters = this.endpoints
-      .filter((ep) => ep.serviceName === serviceName)
+      .filter((endpoint) => this.resolveEndpointServiceName(endpoint, agentType) === serviceName)
       .map((ep) => ({
         name: ep.name,
         exporter: this.exporterFactory({
@@ -945,6 +951,12 @@ export class OtlpTraceFlusher extends BaseFlusher {
     state = { exporters };
     this.agentExportStates.set(key, state);
     return state;
+  }
+
+  private resolveEndpointServiceName(endpoint: ResolvedOtlpEndpoint, agentType: string): string {
+    return endpoint.appendAgentTypeToServiceName
+      ? `${endpoint.serviceName}-${agentType}`
+      : endpoint.serviceName;
   }
 
   private buildResource(
@@ -980,7 +992,7 @@ export class OtlpTraceFlusher extends BaseFlusher {
     }
 
     return new Resource({
-      'service.name': `${serviceName}-${agentType}`,
+      'service.name': serviceName,
       'service.version': this.pilotVersion,
       'service.instance.id': this.instanceId,
       'service.namespace': 'loongsuite-pilot',

--- a/src/flushers/sls-flusher.ts
+++ b/src/flushers/sls-flusher.ts
@@ -65,6 +65,7 @@ export class SlsFlusher extends BaseFlusher {
   private alarmManager: AlarmManager | null = null;
 
   private readonly serviceName: string;
+  private readonly serviceNamePrefix: string;
   private readonly userAgent: string;
 
   constructor(config: SlsFlusherConfig, dataDir: string) {
@@ -73,7 +74,8 @@ export class SlsFlusher extends BaseFlusher {
     this.failedLogWriter = new SlsFailureLogWriter(
       path.join(dataDir, 'logs', 'sls-failed-logs'),
     );
-    this.serviceName = config.serviceNamePrefix || '';
+    this.serviceName = config.serviceName || '';
+    this.serviceNamePrefix = config.serviceNamePrefix || '';
     this.userAgent = buildUserAgent(dataDir);
     for (const ep of config.endpoints) {
       this.endpointCounters.set(ep.name, {
@@ -170,14 +172,15 @@ export class SlsFlusher extends BaseFlusher {
     await Promise.all(tasks);
   }
 
-  /** Per-endpoint service name: managed endpoints may override the shared prefix. */
+  /** Exact global name wins; otherwise managed endpoints may override the shared prefix. */
   private effectiveServiceName(endpoint?: SlsEndpoint): string {
-    return endpoint?.serviceName || this.serviceName;
+    return this.serviceName || endpoint?.serviceName || this.serviceNamePrefix;
   }
 
   private resolveServiceName(endpoint?: SlsEndpoint, agentType?: string): string {
     const base = this.effectiveServiceName(endpoint);
     if (!base) return '';
+    if (this.serviceName) return this.serviceName;
     return agentType ? `${base}-${agentType}` : base;
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -105,6 +105,9 @@ export interface AnalyticsConfig {
   userId: string;
   collectLog: boolean;
   collectTrace: boolean;
+  /** Exact service.name shared by every agent and backend. */
+  serviceName?: string;
+  /** Legacy base name; agent type is appended when serviceName is unset. */
   serviceNamePrefix: string;
   cms: CmsConfig;
   otlpTrace?: OtlpTraceRawConfig;
@@ -168,6 +171,8 @@ export interface OtlpTraceFlusherConfig {
   protocol: 'http/protobuf';
   // Shared across backends unless an endpoint overrides it (see OtlpEndpoint.serviceName).
   serviceName: string;
+  /** Legacy mode appends the normalized agent type to serviceName. Defaults to true. */
+  appendAgentTypeToServiceName?: boolean;
   resourceAttributes?: Record<string, string>;
   captureMessageContent?: boolean;
   debug?: boolean;
@@ -193,6 +198,8 @@ export interface SlsFlusherConfig {
   endpoints: SlsEndpoint[];
   batchMaxSize: number;
   flushIntervalMs: number;
+  /** Exact __service_name__ shared by every agent and endpoint. */
+  serviceName?: string;
   serviceNamePrefix: string;
 }
 

--- a/tests/unit/core/config-loader.test.ts
+++ b/tests/unit/core/config-loader.test.ts
@@ -674,13 +674,14 @@ describe('ConfigLoader', () => {
     });
   });
 
-  describe('collectLog, collectTrace, serviceNamePrefix, cms', () => {
+  describe('collectLog, collectTrace, serviceName, serviceNamePrefix, cms', () => {
     it('defaults when config file is missing', async () => {
       mockReadJsonFile.mockResolvedValueOnce(null);
 
       const config = await loadConfig();
       expect(config.collectLog).toBe(true);
       expect(config.collectTrace).toBe(true);
+      expect(config.serviceName).toBeUndefined();
       expect(config.serviceNamePrefix).toBe('loongsuite-pilot');
       expect(config.cms).toEqual({ enabled: false, licenseKey: '', endpoint: '', workspace: '', debug: false });
     });
@@ -747,6 +748,27 @@ describe('ConfigLoader', () => {
 
       const config = await loadConfig();
       expect(config.serviceNamePrefix).toBe('from-env');
+    });
+
+    it('loads an exact serviceName from env over config and passes it to SLS', async () => {
+      mockReadJsonFile.mockResolvedValueOnce({
+        serviceName: 'from-file',
+        serviceNamePrefix: 'legacy-prefix',
+      });
+      vi.stubEnv('LOONGSUITE_PILOT_SERVICE_NAME', 'shared-service');
+
+      const config = await loadConfig();
+      expect(config.serviceName).toBe('shared-service');
+      expect(config.flushers.sls?.serviceName).toBe('shared-service');
+      expect(config.serviceNamePrefix).toBe('legacy-prefix');
+    });
+
+    it('treats an empty exact serviceName env as unset and falls back to config', async () => {
+      mockReadJsonFile.mockResolvedValueOnce({ serviceName: 'from-file' });
+      vi.stubEnv('LOONGSUITE_PILOT_SERVICE_NAME', '   ');
+
+      const config = await loadConfig();
+      expect(config.serviceName).toBe('from-file');
     });
   });
 
@@ -937,6 +959,25 @@ describe('ConfigLoader', () => {
       // both inner backends carry the managed serviceName
       expect(result!.endpoints.find(e => e.name === 'managed-otlp')!.serviceName).toBe('managed-svc');
       expect(result!.endpoints.find(e => e.name === 'managed-arms')!.serviceName).toBe('managed-svc');
+    });
+
+    it('buildOtlpTraceConfig uses one exact serviceName for user and managed backends', async () => {
+      mockReadJsonFile.mockResolvedValueOnce({
+        collectTrace: true,
+        serviceName: 'shared-service',
+        serviceNamePrefix: 'user-svc',
+        otlpTrace: { endpoint: 'http://tempo:4318', serviceName: 'legacy-otlp-svc' },
+      });
+      mockReadJsonFile.mockResolvedValueOnce({
+        serviceNamePrefix: 'managed-svc',
+        otlp: [{ name: 'managed-otlp', endpoint: 'http://collector.internal:4318' }],
+      });
+
+      const result = buildOtlpTraceConfig(await loadConfig());
+
+      expect(result!.serviceName).toBe('shared-service');
+      expect(result!.appendAgentTypeToServiceName).toBe(false);
+      expect(result!.endpoints.every(endpoint => endpoint.serviceName === undefined)).toBe(true);
     });
 
     it('buildOtlpTraceConfig leaves inner serviceName unset when it equals the user prefix', async () => {

--- a/tests/unit/deployment/plugin-inject-strategy.test.ts
+++ b/tests/unit/deployment/plugin-inject-strategy.test.ts
@@ -72,6 +72,24 @@ describe('PluginInjectStrategy', () => {
     }
   });
 
+  it('creates and injects the first OpenCode config from the shipped agent definition', async () => {
+    const definitionUrl = new URL('../../../agents.d/opencode.json', import.meta.url);
+    const definition = JSON.parse(await fs.readFile(definitionUrl, 'utf8')) as AgentDefinition;
+    definition.pluginInject!.configPaths = definition.pluginInject!.configPaths.map((configPath) =>
+      configPath.replace(/^~\//, `${tmpDir}/`),
+    );
+
+    const result = await strategy.deploy(definition);
+
+    expect(result.success).toBe(true);
+    const firstConfigPath = path.join(tmpDir, '.config', 'opencode', 'opencode.jsonc');
+    const config = JSON.parse(await fs.readFile(firstConfigPath, 'utf8'));
+    expect(config.plugin).toEqual([
+      `file://${path.join(dataDir, 'plugins', 'opencode', 'plugin.mjs')}`,
+    ]);
+    expect(await strategy.needsDeploy(definition)).toBe(false);
+  });
+
   it('does not create a missing config during a read-only health check', async () => {
     expect(await strategy.needsDeploy(piDefinition())).toBe(true);
     await expect(fs.access(settingsPath)).rejects.toThrow();

--- a/tests/unit/flushers/otlp-trace-flusher/export.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/export.test.ts
@@ -263,10 +263,25 @@ describe('OtlpTraceFlusher - multi-backend fan-out', () => {
     });
     const flusher = new OtlpTraceFlusher(cfg) as any;
     // default group uses cfg.serviceName; inner group uses its override
-    const userRes = flusher.buildResource('claude-code', 'test-pilot');
-    const innerRes = flusher.buildResource('claude-code', 'managed-svc');
+    const userRes = flusher.buildResource('claude-code', 'test-pilot-claude-code');
+    const innerRes = flusher.buildResource('claude-code', 'managed-svc-claude-code');
     expect(userRes.attributes['service.name']).toBe('test-pilot-claude-code');
     expect(innerRes.attributes['service.name']).toBe('managed-svc-claude-code');
+  });
+
+  it('uses one exact service.name for different agent types when suffixing is disabled', () => {
+    const flusher = new OtlpTraceFlusher(makeConfig({
+      serviceName: 'shared-service',
+      appendAgentTypeToServiceName: false,
+    })) as any;
+    const endpoint = flusher.endpoints[0];
+
+    for (const agentType of ['opencode', 'codex']) {
+      const serviceName = flusher.resolveEndpointServiceName(endpoint, agentType);
+      const resource = flusher.buildResource(agentType, serviceName);
+      expect(resource.attributes['service.name']).toBe('shared-service');
+      expect(resource.attributes['gen_ai.agent.type']).toBe(agentType);
+    }
   });
 
   it('isolates a failing backend and still exports to the healthy one', async () => {

--- a/tests/unit/flushers/sls-flusher.test.ts
+++ b/tests/unit/flushers/sls-flusher.test.ts
@@ -293,6 +293,27 @@ describe('SlsFlusher', () => {
       expect(logGroup.tags).toContainEqual({ __service_name__: 'loongsuite-pilot-claude-code' });
     });
 
+    it('uses one exact serviceName for different agent types and all endpoints', async () => {
+      const config = makeConfig({
+        serviceName: 'shared-service',
+        serviceNamePrefix: 'legacy-prefix',
+        endpoints: [
+          { name: 'user', endpoint: 'https://cn-hangzhou.log.aliyuncs.com', project: 'p1', logstore: 'l1', kind: 'agentActivity', mode: 'ak', accessKeyId: 'ak', accessKeySecret: 'sk' },
+          { name: 'inner', endpoint: 'https://cn-hangzhou.log.aliyuncs.com', project: 'p2', logstore: 'l2', kind: 'agentActivity', mode: 'ak', accessKeyId: 'ak', accessKeySecret: 'sk', serviceName: 'managed-svc' },
+        ],
+      });
+      flusher = new SlsFlusher(config, '/tmp/data');
+
+      await flusher.send(buildTestEntry({ agentType: ClientType.ClaudeCliHook }));
+      await flusher.send(buildTestEntry({ agentType: ClientType.OpenCode }));
+      await flusher.flush();
+
+      expect(mockPostLogStoreLogs).toHaveBeenCalledTimes(4);
+      for (const call of mockPostLogStoreLogs.mock.calls) {
+        expect(call[2].tags).toContainEqual({ __service_name__: 'shared-service' });
+      }
+    });
+
     it('uses per-endpoint serviceName override for its own __service_name__', async () => {
       const config = makeConfig({
         serviceNamePrefix: 'user-svc',


### PR DESCRIPTION
## Summary

- enable OpenCode plugin injection when no user config exists by creating the preferred `~/.config/opencode/opencode.jsonc` before the first conversation
- add top-level `serviceName` and `LOONGSUITE_PILOT_SERVICE_NAME` for one exact service name across all agents, user/managed OTLP backends, and SLS backends
- keep the existing `<serviceNamePrefix>-<agentType>` behavior when the new exact service name is unset
- add regression coverage and update the English/Chinese configuration and trace-output documentation

## Configuration

```json
{
  "serviceName": "my-agent-service"
}
```

Or set `LOONGSUITE_PILOT_SERVICE_NAME=my-agent-service`. The environment variable takes precedence over the config file.

## Validation

- `npm run typecheck`
- `npm run build`
- targeted regression suite: 148 tests passed
- full `npm test`: 2738 passed, 47 skipped, 1 unrelated existing failure in `tests/integration/qwen-work-cn-real-transcript.test.ts` because the local transcript produced no `llm.request` event; the test also fails when rerun in isolation

## Compatibility

When `serviceName` is not configured, Pilot continues to append the normalized agent type to `serviceNamePrefix` and preserves managed endpoint prefix overrides.

## Related issue

Resolves #252
