### PR TITLE
fix(genai): align input messages and preserve Claude tool history

### DIFF
--- a/assets/hooks/claude-code/transcript-parser.mjs
+++ b/assets/hooks/claude-code/transcript-parser.mjs
@@ -440,11 +440,14 @@ export function parseClaudeTranscript(transcriptPath, byteOffset = 0) {
         promptId: group.promptId,
       });
 
+      // Only advance past messages that were part of this request. The
+      // assistant response becomes new history for the next LLM request and
+      // must be emitted together with any following tool_result message.
+      history.emittedCount = history.messages.length;
       history.messages.push({
         role: 'assistant',
         content: group.mergedContent,
       });
-      history.emittedCount = history.messages.length;
 
       for (const toolId of declaredToolIds) {
         const ts = toolResultTimestamps.get(toolId);

--- a/assets/plugins/mimo-code/plugin.mjs
+++ b/assets/plugins/mimo-code/plugin.mjs
@@ -586,7 +586,13 @@ function handleMessagePartUpdated(props, userId) {
         session.systemPrompt,
         turn.userPromptText
       );
-      if (inputMsgs) record["gen_ai.input.messages"] = inputMsgs;
+      if (inputMsgs) {
+        record["gen_ai.input.messages"] = inputMsgs;
+        record["gen_ai.input.messages_delta"] = inputMsgs.map((message) => ({
+          ...message,
+          parts: message.parts.map((part) => ({ ...part })),
+        }));
+      }
       if (session.systemInstructionsParts && session.systemInstructionsParts.length > 0) {
         record["gen_ai.system_instructions"] = session.systemInstructionsParts;
       } else if (session.systemPrompt) {

--- a/assets/plugins/opencode/plugin.mjs
+++ b/assets/plugins/opencode/plugin.mjs
@@ -579,7 +579,13 @@ function handleMessagePartUpdated(props, userId) {
         session.systemPrompt,
         turn.userPromptText
       );
-      if (inputMsgs) record["gen_ai.input.messages"] = inputMsgs;
+      if (inputMsgs) {
+        record["gen_ai.input.messages"] = inputMsgs;
+        record["gen_ai.input.messages_delta"] = inputMsgs.map((message) => ({
+          ...message,
+          parts: message.parts.map((part) => ({ ...part })),
+        }));
+      }
       if (session.systemInstructionsParts && session.systemInstructionsParts.length > 0) {
         record["gen_ai.system_instructions"] = session.systemInstructionsParts;
       } else if (session.systemPrompt) {

--- a/scripts/validate-trace.mjs
+++ b/scripts/validate-trace.mjs
@@ -562,9 +562,10 @@ function validateSchema(trace, rules) {
   return checks;
 }
 
-function validateMessageField(attrs, key, ruleId, span, checks) {
+export function validateMessageField(attrs, key, ruleId, span, checks) {
   const raw = attrs[key];
   if (raw === undefined || raw === null) return;
+  const isInput = key === 'gen_ai.input.messages';
   try {
     const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
     if (!Array.isArray(parsed)) {
@@ -573,44 +574,161 @@ function validateMessageField(attrs, key, ruleId, span, checks) {
     }
     for (let i = 0; i < parsed.length; i++) {
       const msg = parsed[i];
-      if (!msg.role) {
-        checks.push(error(ruleId, `${key}[${i}] missing role`, span.spanId, span.name));
+      const messagePath = `${key}[${i}]`;
+      if (isInput && !isObject(msg)) {
+        checks.push(error(ruleId, `${messagePath} is not an object`, span.spanId, span.name));
+        continue;
+      }
+      if (isInput && typeof msg.role !== 'string') {
+        checks.push(error(ruleId, `${messagePath} missing required string "role"`, span.spanId, span.name));
+      } else if (!isInput && !msg.role) {
+        checks.push(error(ruleId, `${messagePath} missing role`, span.spanId, span.name));
+      }
+      if (isInput &&
+          Object.hasOwn(msg, 'name') &&
+          msg.name !== null &&
+          typeof msg.name !== 'string') {
+        checks.push(error(ruleId, `${messagePath}.name must be a string or null`, span.spanId, span.name));
       }
       if (ruleId === 'schema.output_messages') {
         if (msg.finish_reason === undefined) {
-          checks.push(warn(ruleId, `${key}[${i}] missing finish_reason`, span.spanId, span.name));
+          checks.push(warn(ruleId, `${messagePath} missing finish_reason`, span.spanId, span.name));
         } else if (!VALID_FINISH_REASONS.has(msg.finish_reason)) {
           checks.push(error(ruleId,
-            `${key}[${i}] finish_reason="${msg.finish_reason}" is not a valid FinishReason (expected: ${[...VALID_FINISH_REASONS].join(', ')})`,
+            `${messagePath} finish_reason="${msg.finish_reason}" is not a valid FinishReason (expected: ${[...VALID_FINISH_REASONS].join(', ')})`,
             span.spanId, span.name));
         }
       }
-      if (msg.parts && Array.isArray(msg.parts)) {
-        for (let j = 0; j < msg.parts.length; j++) {
-          const part = msg.parts[j];
-          if (!part.type) {
-            checks.push(error(ruleId, `${key}[${i}].parts[${j}] missing type`, span.spanId, span.name));
-            continue;
+      if (isInput && !Array.isArray(msg.parts)) {
+        checks.push(error(ruleId, `${messagePath} missing required array "parts"`, span.spanId, span.name));
+        continue;
+      }
+      if (!Array.isArray(msg.parts)) continue;
+      for (let j = 0; j < msg.parts.length; j++) {
+        const part = msg.parts[j];
+        const partPath = `${messagePath}.parts[${j}]`;
+        if (isInput && !isObject(part)) {
+          checks.push(error(ruleId, `${partPath} is not an object`, span.spanId, span.name));
+          continue;
+        }
+        if (isInput && typeof part.type !== 'string') {
+          checks.push(error(ruleId, `${partPath} missing required string "type"`, span.spanId, span.name));
+          continue;
+        } else if (!isInput && !part.type) {
+          checks.push(error(ruleId, `${partPath} missing type`, span.spanId, span.name));
+          continue;
+        }
+        if (isInput) {
+          validateInputMessagePart(part, partPath, ruleId, span, checks);
+        } else if (VALID_PART_TYPES.has(part.type)) {
+          if (part.type === 'text' && part.content === undefined) {
+            checks.push(error(ruleId, `${partPath} TextPart missing required "content"`, span.spanId, span.name));
           }
-          if (VALID_PART_TYPES.has(part.type)) {
-            if (part.type === 'text' && part.content === undefined) {
-              checks.push(error(ruleId, `${key}[${i}].parts[${j}] TextPart missing required "content"`, span.spanId, span.name));
-            }
-            if (part.type === 'tool_call' && !part.id) {
-              checks.push(warn(ruleId, `${key}[${i}].parts[${j}] ToolCallPart missing "id"`, span.spanId, span.name));
-            }
-            if (part.type === 'tool_call_response' && !part.id) {
-              checks.push(warn(ruleId, `${key}[${i}].parts[${j}] ToolCallResponsePart missing "id"`, span.spanId, span.name));
-            }
-          } else {
-            checks.push(warn(ruleId, `${key}[${i}].parts[${j}] unknown part type="${part.type}"`, span.spanId, span.name));
+          if (part.type === 'tool_call' && !part.id) {
+            checks.push(warn(ruleId, `${partPath} ToolCallPart missing "id"`, span.spanId, span.name));
           }
+          if (part.type === 'tool_call_response' && !part.id) {
+            checks.push(warn(ruleId, `${partPath} ToolCallResponsePart missing "id"`, span.spanId, span.name));
+          }
+        } else {
+          checks.push(warn(ruleId, `${partPath} unknown part type="${part.type}"`, span.spanId, span.name));
         }
       }
     }
   } catch {
     checks.push(error(ruleId, `${key} is not valid JSON`, span.spanId, span.name));
   }
+}
+
+function validateInputMessagePart(part, partPath, ruleId, span, checks) {
+  const report = (detail) => checks.push(error(ruleId, `${partPath} ${detail}`, span.spanId, span.name));
+
+  switch (part.type) {
+    case 'text':
+      requireString(part, 'content', 'TextPart', report);
+      break;
+    case 'tool_call':
+      requireString(part, 'name', 'ToolCallRequestPart', report);
+      optionalNullableString(part, 'id', 'ToolCallRequestPart', report);
+      break;
+    case 'tool_call_response':
+      requireProperty(part, 'response', 'ToolCallResponsePart', report);
+      optionalNullableString(part, 'id', 'ToolCallResponsePart', report);
+      break;
+    case 'server_tool_call':
+      requireString(part, 'name', 'ServerToolCallPart', report);
+      requireGenericServerTool(part, 'server_tool_call', 'ServerToolCallPart', report);
+      optionalNullableString(part, 'id', 'ServerToolCallPart', report);
+      break;
+    case 'server_tool_call_response':
+      requireGenericServerTool(part, 'server_tool_call_response', 'ServerToolCallResponsePart', report);
+      optionalNullableString(part, 'id', 'ServerToolCallResponsePart', report);
+      break;
+    case 'blob':
+      requireString(part, 'modality', 'BlobPart', report);
+      requireString(part, 'content', 'BlobPart', report);
+      optionalNullableString(part, 'mime_type', 'BlobPart', report);
+      break;
+    case 'file':
+      requireString(part, 'modality', 'FilePart', report);
+      requireString(part, 'file_id', 'FilePart', report);
+      optionalNullableString(part, 'mime_type', 'FilePart', report);
+      break;
+    case 'uri':
+      requireString(part, 'modality', 'UriPart', report);
+      requireString(part, 'uri', 'UriPart', report);
+      optionalNullableString(part, 'mime_type', 'UriPart', report);
+      break;
+    case 'reasoning':
+      requireString(part, 'content', 'ReasoningPart', report);
+      break;
+    default:
+      checks.push(warn(
+        ruleId,
+        `${partPath} uses GenericPart extension type="${part.type}"`,
+        span.spanId,
+        span.name,
+      ));
+  }
+}
+
+function requireProperty(value, property, title, report) {
+  if (!Object.hasOwn(value, property)) {
+    report(`${title} missing required "${property}"`);
+  }
+}
+
+function requireString(value, property, title, report) {
+  if (!Object.hasOwn(value, property)) {
+    report(`${title} missing required "${property}"`);
+  } else if (typeof value[property] !== 'string') {
+    report(`${title}.${property} must be a string`);
+  }
+}
+
+function optionalNullableString(value, property, title, report) {
+  if (Object.hasOwn(value, property) &&
+      value[property] !== null &&
+      typeof value[property] !== 'string') {
+    report(`${title}.${property} must be a string or null`);
+  }
+}
+
+function requireGenericServerTool(value, property, title, report) {
+  if (!Object.hasOwn(value, property)) {
+    report(`${title} missing required "${property}"`);
+    return;
+  }
+  const nested = value[property];
+  if (!isObject(nested)) {
+    report(`${title}.${property} must be an object`);
+  } else if (typeof nested.type !== 'string') {
+    report(`${title}.${property} missing required string "type"`);
+  }
+}
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 // ─── 5e. Semantic Validation ────────────────────────────────────────────────

--- a/src/inputs/workbuddy/workbuddy-event-builder.ts
+++ b/src/inputs/workbuddy/workbuddy-event-builder.ts
@@ -316,8 +316,8 @@ export async function buildWorkBuddyEvents(
       const resultPart: Record<string, JsonValue> = {
         type: 'tool_call_response',
         id: callId,
+        response: output ?? null,
       };
-      if (output !== undefined) resultPart.result = output;
       pendingDelta.push({
         role: 'tool',
         parts: [resultPart],

--- a/tests/integration/claude-code-tool-context-flow.test.mjs
+++ b/tests/integration/claude-code-tool-context-flow.test.mjs
@@ -246,6 +246,39 @@ describe('Claude Code PreToolUse(Bash) downstream propagation flow', () => {
     expect(toolSpan).toBeDefined();
     expect(toolSpan.spanContext().traceId).toBe(upstreamTraceId);
     expect(toolSpan.spanContext().spanId).toBe(received.parentSpanId);
+
+    const llmSpans = exportedSpans
+      .filter((span) => span.attributes['gen_ai.span.kind'] === 'LLM')
+      .sort((a, b) => {
+        const seconds = a.startTime[0] - b.startTime[0];
+        return seconds || a.startTime[1] - b.startTime[1];
+      });
+    expect(llmSpans).toHaveLength(2);
+
+    const secondInput = JSON.parse(String(
+      llmSpans[1].attributes['gen_ai.input.messages'],
+    ));
+    const assistantIndex = secondInput.findIndex((message) =>
+      message.role === 'assistant'
+      && message.parts.some((part) =>
+        part.type === 'tool_call' && part.id === toolUseId));
+    const toolIndex = secondInput.findIndex((message) =>
+      message.role === 'tool'
+      && message.parts.some((part) =>
+        part.type === 'tool_call_response' && part.id === toolUseId));
+
+    expect(assistantIndex).toBeGreaterThanOrEqual(0);
+    expect(toolIndex).toBeGreaterThan(assistantIndex);
+    expect(secondInput[assistantIndex].parts).toContainEqual({
+      type: 'tool_call',
+      id: toolUseId,
+      name: 'Bash',
+      arguments: payload.tool_input,
+    });
+    expect(secondInput[toolIndex].parts).toContainEqual(expect.objectContaining({
+      type: 'tool_call_response',
+      id: toolUseId,
+    }));
   });
 
   test('disabled propagation leaves the downstream process without hidden inherited context', () => {

--- a/tests/schemas/gen-ai-input-messages.json
+++ b/tests/schemas/gen-ai-input-messages.json
@@ -1,5 +1,54 @@
 {
     "$defs": {
+        "BlobPart": {
+            "description": "Represents blob binary data sent inline to the model",
+            "properties": {
+                "type": {
+                    "const": "blob",
+                    "description": "The type of the content captured in this part.",
+                    "title": "Type",
+                    "type": "string"
+                },
+                "mime_type": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "The IANA MIME type of the attached data.",
+                    "title": "Mime Type"
+                },
+                "modality": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Modality"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "The general modality of the data if it is known. Instrumentations SHOULD also set the mimeType field if the specific type is known.",
+                    "title": "Modality"
+                },
+                "content": {
+                    "description": "Raw bytes of the attached data. This field SHOULD be encoded as a base64 string when serialized to JSON.",
+                    "format": "binary",
+                    "title": "Content",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type",
+                "modality",
+                "content"
+            ],
+            "title": "BlobPart",
+            "type": "object"
+        },
         "ChatMessage": {
             "additionalProperties": true,
             "properties": {
@@ -29,12 +78,43 @@
                                 "$ref": "#/$defs/ToolCallResponsePart"
                             },
                             {
+                                "$ref": "#/$defs/ServerToolCallPart"
+                            },
+                            {
+                                "$ref": "#/$defs/ServerToolCallResponsePart"
+                            },
+                            {
+                                "$ref": "#/$defs/BlobPart"
+                            },
+                            {
+                                "$ref": "#/$defs/FilePart"
+                            },
+                            {
+                                "$ref": "#/$defs/UriPart"
+                            },
+                            {
+                                "$ref": "#/$defs/ReasoningPart"
+                            },
+                            {
                                 "$ref": "#/$defs/GenericPart"
                             }
                         ]
                     },
                     "title": "Parts",
                     "type": "array"
+                },
+                "name": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "The name of the participant.",
+                    "title": "Name"
                 }
             },
             "required": [
@@ -42,6 +122,55 @@
                 "parts"
             ],
             "title": "ChatMessage",
+            "type": "object"
+        },
+        "FilePart": {
+            "additionalProperties": true,
+            "description": "Represents an external referenced file sent to the model by file id",
+            "properties": {
+                "type": {
+                    "const": "file",
+                    "description": "The type of the content captured in this part.",
+                    "title": "Type",
+                    "type": "string"
+                },
+                "mime_type": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "The IANA MIME type of the attached data.",
+                    "title": "Mime Type"
+                },
+                "modality": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Modality"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "The general modality of the data if it is known. Instrumentations SHOULD also set the mimeType field if the specific type is known.",
+                    "title": "Modality"
+                },
+                "file_id": {
+                    "description": "An identifier referencing a file that was pre-uploaded to the provider.",
+                    "title": "File Id",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type",
+                "modality",
+                "file_id"
+            ],
+            "title": "FilePart",
             "type": "object"
         },
         "GenericPart": {
@@ -60,106 +189,68 @@
             "title": "GenericPart",
             "type": "object"
         },
-        "UriPart": {
+        "GenericServerToolCall": {
             "additionalProperties": true,
-            "description": "Represents an external referenced file sent to the model by URI",
+            "description": "Represents an arbitrary server tool call with any type and properties.\nThis allows for extensibility with custom server tool types.",
             "properties": {
                 "type": {
-                    "description": "The type of the content captured in this part.",
+                    "description": "Type identifier for the server tool call.",
                     "title": "Type",
-                    "type": "string"
-                },
-                "mime_type": {
-                    "description": "The IANA MIME type of the attached data.",
-                    "title": "MimeType",
-                    "type": "string"
-                },
-                "modality": {
-                    "description": "The general modality of the data if it is known.",
-                    "title": "Modality",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "A URI referencing attached data. It should not be a base64 data URL, which should use the `blob` part instead. The URI may use a scheme known to the provider api (e.g. `gs://bucket/object.png`), or be a publicly accessible location.",
-                    "title": "Uri",
                     "type": "string"
                 }
             },
             "required": [
-                "type",
-                "mime_type",
-                "modality",
-                "uri"
+                "type"
             ],
-            "title": "UriPart",
+            "title": "GenericServerToolCall",
             "type": "object"
         },
-        "FilePart": {
+        "GenericServerToolCallResponse": {
             "additionalProperties": true,
-            "description": "Represents an external referenced file sent to the model by file id",
+            "description": "Represents an arbitrary server tool call response with any type and properties.\nThis allows for extensibility with custom server tool response types.",
             "properties": {
                 "type": {
-                    "description": "The type of the content captured in this part.",
+                    "description": "Type identifier for the server tool call response.",
                     "title": "Type",
-                    "type": "string"
-                },
-                "mime_type": {
-                    "description": "The IANA MIME type of the attached data.",
-                    "title": "MimeType",
-                    "type": "string"
-                },
-                "modality": {
-                    "description": "The general modality of the data if it is known.",
-                    "title": "Modality",
-                    "type": "string"
-                },
-                "file_id": {
-                    "description": "An identifier referencing a file that was pre-uploaded to the provider.",
-                    "title": "FileId",
                     "type": "string"
                 }
             },
             "required": [
-                "type",
-                "mime_type",
-                "modality",
-                "file_id"
+                "type"
             ],
-            "title": "FilePart",
+            "title": "GenericServerToolCallResponse",
             "type": "object"
         },
-        "BlobPart": {
+        "Modality": {
+            "enum": [
+                "image",
+                "video",
+                "audio"
+            ],
+            "title": "Modality",
+            "type": "string"
+        },
+        "ReasoningPart": {
             "additionalProperties": true,
-            "description": "Represents blob binary data sent inline to the model",
+            "description": "Represents reasoning/thinking content received from the model.",
             "properties": {
                 "type": {
+                    "const": "reasoning",
                     "description": "The type of the content captured in this part.",
                     "title": "Type",
-                    "type": "string"
-                },
-                "mime_type": {
-                    "description": "The IANA MIME type of the attached data.",
-                    "title": "MimeType",
-                    "type": "string"
-                },
-                "modality": {
-                    "description": "The general modality of the data if it is known.",
-                    "title": "Modality",
                     "type": "string"
                 },
                 "content": {
-                    "description": "Raw bytes of the attached data. This field SHOULD be encoded as a base64 string when serialized to JSON.",
+                    "description": "Reasoning/thinking content received from the model.",
                     "title": "Content",
                     "type": "string"
                 }
             },
             "required": [
                 "type",
-                "mime_type",
-                "modality",
                 "content"
             ],
-            "title": "BlobPart",
+            "title": "ReasoningPart",
             "type": "object"
         },
         "Role": {
@@ -269,6 +360,141 @@
                 "response"
             ],
             "title": "ToolCallResponsePart",
+            "type": "object"
+        },
+        "ServerToolCallPart": {
+            "additionalProperties": true,
+            "description": "Represents a server-side tool call invocation. Server tool calls are executed by the model provider on the server side rather than by the client application. Provider-specific tools (e.g., code_interpreter, web_search) can have well-defined schemas defined by the respective providers.",
+            "properties": {
+                "type": {
+                    "const": "server_tool_call",
+                    "description": "The type of the content captured in this part.",
+                    "title": "Type",
+                    "type": "string"
+                },
+                "id": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "Unique identifier for the server tool call.",
+                    "title": "Id"
+                },
+                "name": {
+                    "description": "Name of the server tool.",
+                    "title": "Name",
+                    "type": "string"
+                },
+                "server_tool_call": {
+                    "description": "Polymorphic server tool call details with type discriminator. The structure varies based on the tool type.",
+                    "oneOf": [
+                        {
+                            "$ref": "#/$defs/GenericServerToolCall"
+                        }
+                    ],
+                    "title": "Server Tool Call"
+                }
+            },
+            "required": [
+                "type",
+                "name",
+                "server_tool_call"
+            ],
+            "title": "ServerToolCallPart",
+            "type": "object"
+        },
+        "ServerToolCallResponsePart": {
+            "additionalProperties": true,
+            "description": "Represents a server-side tool call response. Contains the outcome and details of a server tool execution. Provider-specific tools (e.g., code_interpreter, web_search) can have well-defined response schemas defined by the respective providers.",
+            "properties": {
+                "type": {
+                    "const": "server_tool_call_response",
+                    "description": "The type of the content captured in this part.",
+                    "title": "Type",
+                    "type": "string"
+                },
+                "id": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "Unique server tool call identifier matching the original call.",
+                    "title": "Id"
+                },
+                "server_tool_call_response": {
+                    "description": "Polymorphic server tool call response with type discriminator. The structure varies based on the tool type.",
+                    "oneOf": [
+                        {
+                            "$ref": "#/$defs/GenericServerToolCallResponse"
+                        }
+                    ],
+                    "title": "Server Tool Call Response"
+                }
+            },
+            "required": [
+                "type",
+                "server_tool_call_response"
+            ],
+            "title": "ServerToolCallResponsePart",
+            "type": "object"
+        },
+        "UriPart": {
+            "additionalProperties": true,
+            "description": "Represents an external referenced file sent to the model by URI",
+            "properties": {
+                "type": {
+                    "const": "uri",
+                    "description": "The type of the content captured in this part.",
+                    "title": "Type",
+                    "type": "string"
+                },
+                "mime_type": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "The IANA MIME type of the attached data.",
+                    "title": "Mime Type"
+                },
+                "modality": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Modality"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "The general modality of the data if it is known. Instrumentations SHOULD also set the mimeType field if the specific type is known.",
+                    "title": "Modality"
+                },
+                "uri": {
+                    "description": "A URI referencing attached data. It should not be a base64 data URL, which should use the `blob` part instead. The URI may use a scheme known to the provider api (e.g. `gs://bucket/object.png`), or be a publicly accessible location.",
+                    "title": "Uri",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type",
+                "modality",
+                "uri"
+            ],
+            "title": "UriPart",
             "type": "object"
         }
     },

--- a/tests/unit/hooks/claude-code/hook-processor.test.mjs
+++ b/tests/unit/hooks/claude-code/hook-processor.test.mjs
@@ -422,6 +422,37 @@ describe('claude-code-hook-processor v2 端到端', () => {
     // 2 tool calls
     expect(toolCalls.length).toBe(2);
 
+    expect(llmRequests[1]['gen_ai.input.messages_delta']).toEqual([
+      {
+        role: 'assistant',
+        parts: [{
+          type: 'tool_call',
+          id: 'tu_1',
+          name: 'Read',
+          arguments: { file_path: '/a' },
+        }],
+      },
+      {
+        role: 'tool',
+        parts: [{ type: 'tool_call_response', id: 'tu_1', response: 'aaa' }],
+      },
+    ]);
+    expect(llmRequests[2]['gen_ai.input.messages_delta']).toEqual([
+      {
+        role: 'assistant',
+        parts: [{
+          type: 'tool_call',
+          id: 'tu_2',
+          name: 'Bash',
+          arguments: { command: 'echo hi' },
+        }],
+      },
+      {
+        role: 'tool',
+        parts: [{ type: 'tool_call_response', id: 'tu_2', response: 'hi' }],
+      },
+    ]);
+
     // Tool tu_1 in step s1, tu_2 in step s2
     const t1 = toolCalls.find((r) => r['gen_ai.tool.call.id'] === 'tu_1');
     const t2 = toolCalls.find((r) => r['gen_ai.tool.call.id'] === 'tu_2');

--- a/tests/unit/hooks/claude-code/transcript-parser.test.mjs
+++ b/tests/unit/hooks/claude-code/transcript-parser.test.mjs
@@ -144,6 +144,20 @@ describe('parseClaudeTranscript', () => {
     const result = parseClaudeTranscript(file, 0);
     expect(result.turns.length).toBe(1);
     expect(result.turns[0].llmCalls.length).toBe(2);
+    expect(result.turns[0].llmCalls[0].input_messages).toEqual([{
+      role: 'user',
+      content: [{ type: 'text', text: 'do it' }],
+    }]);
+    expect(result.turns[0].llmCalls[1].input_messages).toEqual([
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: {} }],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }],
+      },
+    ]);
   });
 
   test('tool_result request_start_time 不跨 promptId 污染下一轮', () => {
@@ -237,6 +251,29 @@ describe('parseClaudeTranscript', () => {
     const llm2 = result.turns[0].llmCalls[1];
     expect(llm2.declaredToolIds).toEqual([]);
     expect(llm2.request_start_time).toBe('2026-06-04T02:57:53.000Z');
+    expect(llm2.input_messages).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'reading...' },
+          { type: 'tool_use', id: 'read_1', name: 'Read', input: { file_path: '/a.txt' } },
+          { type: 'tool_use', id: 'read_2', name: 'Read', input: { file_path: '/b.txt' } },
+          { type: 'tool_use', id: 'read_3', name: 'Read', input: { file_path: '/c.txt' } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'read_1', content: 'aaa' }],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'read_2', content: 'bbb' }],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'read_3', content: 'ccc' }],
+      },
+    ]);
   });
 
   test('msg.id 缺失的 end_turn assistant 被正确解析', () => {

--- a/tests/unit/hooks/mimo-code/plugin-replay.test.mjs
+++ b/tests/unit/hooks/mimo-code/plugin-replay.test.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
+import { convertEventLogToReadableSpans } from '@loongsuite/otel-util-genai';
 
 const __dirname_test = path.dirname(fileURLToPath(import.meta.url));
 
@@ -209,9 +210,46 @@ describe('MiMo Code plugin — end-to-end fixture replay', () => {
     // The fixture user prompt starts with "List py files..."
     const inputMsgs = firstReq['gen_ai.input.messages'];
     expect(inputMsgs).toBeTruthy();
+    expect(firstReq['gen_ai.input.messages_delta']).toEqual(inputMsgs);
     const userMsg = inputMsgs.find((m) => m.role === 'user');
     expect(userMsg).toBeTruthy();
     expect(userMsg.parts[0].content).toContain('List py files');
+  });
+
+  it('preserves the first user message in later converted LLM spans', async () => {
+    for (const e of events) {
+      await hooks.event({ event: e });
+    }
+    const previousStability = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+    const previousCapture = process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+    process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'gen_ai_latest_experimental';
+    process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = 'SPAN_ONLY';
+    try {
+      const records = capture.map((c) => parseRecord(c.data));
+      const conversion = await convertEventLogToReadableSpans(records);
+      expect(conversion.warnings).toEqual([]);
+      const llmSpans = conversion.spans
+        .filter((span) => span.attributes['gen_ai.span.kind'] === 'LLM')
+        .sort((a, b) => {
+          const seconds = a.startTime[0] - b.startTime[0];
+          return seconds || a.startTime[1] - b.startTime[1];
+        });
+      expect(llmSpans).toHaveLength(5);
+      const secondInput = JSON.parse(String(llmSpans[1].attributes['gen_ai.input.messages']));
+      const userMessage = secondInput.find((message) => message.role === 'user');
+      expect(userMessage.parts[0].content).toContain('List py files');
+    } finally {
+      if (previousStability === undefined) {
+        delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+      } else {
+        process.env.OTEL_SEMCONV_STABILITY_OPT_IN = previousStability;
+      }
+      if (previousCapture === undefined) {
+        delete process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+      } else {
+        process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = previousCapture;
+      }
+    }
   });
 
   it('captures gen_ai.response.id from info.id', async () => {

--- a/tests/unit/hooks/opencode-plugin-session.test.mjs
+++ b/tests/unit/hooks/opencode-plugin-session.test.mjs
@@ -1,12 +1,52 @@
-import { describe, expect, it, beforeEach } from 'vitest';
-import { createRequire } from 'node:module';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
 
 const PLUGIN_PATH = path.resolve(
   fileURLToPath(import.meta.url),
   '../../../../assets/plugins/opencode/plugin.mjs',
 );
+
+const FIXTURE_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  './mimo-code/fixtures/plugin_events.jsonl',
+);
+
+async function replayPluginFixture() {
+  const capture = [];
+  vi.resetModules();
+  vi.spyOn(fs, 'appendFileSync').mockImplementation((_target, data) => {
+    capture.push(JSON.parse(String(data)));
+  });
+  vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined);
+  const plugin = (await import(PLUGIN_PATH)).default;
+  const hooks = await plugin.server({ directory: os.tmpdir() }, {});
+  const events = fs.readFileSync(FIXTURE_PATH, 'utf8')
+    .split('\n')
+    .filter(line => line.trim())
+    .map(line => JSON.parse(line));
+  const userInfo = events.find(event =>
+    event.type === 'message.updated'
+    && event.properties?.info?.role === 'user')?.properties.info;
+  const userText = events.find(event =>
+    event.type === 'message.part.updated'
+    && event.properties?.part?.type === 'text'
+    && event.properties.part.messageID === userInfo?.id)?.properties.part.text;
+  await hooks['chat.message'](
+    { sessionID: userInfo.sessionID, agent: userInfo.agent },
+    {
+      message: {
+        agent: userInfo.agent,
+        model: userInfo.model,
+      },
+      parts: [{ type: 'text', text: userText }],
+    },
+  );
+  for (const event of events) await hooks.event({ event });
+  return capture;
+}
 
 /**
  * Extract session management functions from plugin.mjs for unit testing.
@@ -66,6 +106,10 @@ describe('opencode plugin session turnSeq persistence', () => {
 
   beforeEach(() => {
     mgr = createSessionManager();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('restores turnSeq after session.idle clears the session', () => {
@@ -138,5 +182,17 @@ describe('opencode plugin session turnSeq persistence', () => {
     mgr.clearSession('ses_X');
     expect(mgr.simulateTurn('ses_X')).toBe('ses_X:t3');
     expect(mgr.simulateTurn('ses_Y')).toBe('ses_Y:t2');
+  });
+
+  it('emits the first full input as a delta baseline for later LLM steps', async () => {
+    const records = await replayPluginFixture();
+    const requests = records.filter(record => record['event.name'] === 'llm.request');
+
+    expect(requests).toHaveLength(5);
+    expect(requests[0]['gen_ai.input.messages']).toBeTruthy();
+    expect(requests[0]['gen_ai.input.messages_delta'])
+      .toEqual(requests[0]['gen_ai.input.messages']);
+    expect(requests[1]['gen_ai.input.messages']).toBeUndefined();
+    expect(requests[1]['gen_ai.input.messages_delta']).toBeTruthy();
   });
 });

--- a/tests/unit/inputs/workbuddy-input.test.ts
+++ b/tests/unit/inputs/workbuddy-input.test.ts
@@ -122,6 +122,13 @@ describe('WorkBuddy audit-event builder', () => {
     expect((requests[1]['gen_ai.input.messages_delta'] as any[])
       .map(message => message.parts[0].id))
       .toEqual(['call-synthetic-a', 'call-synthetic-b']);
+    const toolResponseParts = (requests[1]['gen_ai.input.messages_delta'] as any[])
+      .map(message => message.parts[0]);
+    expect(toolResponseParts.map(part => part.response)).toEqual([
+      { ok: true, value: 'SYNTHETIC_RESULT_A' },
+      { ok: true, value: 'SYNTHETIC_RESULT_B' },
+    ]);
+    expect(toolResponseParts.every(part => !('result' in part))).toBe(true);
 
     const toolCalls = entries.filter(entry => entry['event.name'] === 'tool.call');
     const toolResults = entries.filter(entry => entry['event.name'] === 'tool.result');
@@ -279,6 +286,27 @@ describe('WorkBuddy audit-event builder', () => {
       && entry['gen_ai.step.id'] === 'request-synthetic-1:s2');
     expect((nextRequest?.['gen_ai.input.messages_delta'] as any[]))
       .toHaveLength(1);
+  });
+
+  it('emits a standard null tool response when WorkBuddy has no usable output', async () => {
+    const records = fixtureRecords().map(record =>
+      record.type === 'function_call_result' && record.callId === 'call-synthetic-a'
+        ? { ...record, output: undefined }
+        : record);
+    const entries = await buildWorkBuddyEvents(records, { sessionId: 'session-1' });
+    const nextRequest = entries.find(entry =>
+      entry['event.name'] === 'llm.request'
+      && entry['gen_ai.step.id'] === 'request-synthetic-1:s2');
+    const responsePart = (nextRequest?.['gen_ai.input.messages_delta'] as any[])
+      .find(message => message.parts[0].id === 'call-synthetic-a')
+      ?.parts[0];
+
+    expect(responsePart).toEqual({
+      type: 'tool_call_response',
+      id: 'call-synthetic-a',
+      response: null,
+    });
+    expect(responsePart).not.toHaveProperty('result');
   });
 
   it('uses structural Hook data to repair missing transcript tool identity and timestamps', async () => {
@@ -456,17 +484,44 @@ describe('WorkBuddy audit-event builder', () => {
     const entries = await buildWorkBuddyEvents(records, {
       sessionId: 'workbuddy-duration-test',
     });
-    const conversion = await convertEventLogToReadableSpans(entries);
-    expect(conversion.warnings).toEqual([]);
+    const previousStability = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+    const previousCapture = process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+    process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'gen_ai_latest_experimental';
+    process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = 'SPAN_ONLY';
+    try {
+      const conversion = await convertEventLogToReadableSpans(entries);
+      expect(conversion.warnings).toEqual([]);
 
-    const llmDurations = conversion.spans
-      .filter(span => span.attributes['gen_ai.span.kind'] === 'LLM')
-      .map(span => spanDurationNanos(span));
-    const toolDurations = conversion.spans
-      .filter(span => span.attributes['gen_ai.span.kind'] === 'TOOL')
-      .map(span => spanDurationNanos(span));
-    expect(llmDurations).toEqual([100_000_000n, 100_000_000n]);
-    expect(toolDurations).toEqual([100_000_000n, 0n]);
+      const llmSpans = conversion.spans
+        .filter(span => span.attributes['gen_ai.span.kind'] === 'LLM');
+      const llmDurations = llmSpans.map(span => spanDurationNanos(span));
+      const toolDurations = conversion.spans
+        .filter(span => span.attributes['gen_ai.span.kind'] === 'TOOL')
+        .map(span => spanDurationNanos(span));
+      expect(llmDurations).toEqual([100_000_000n, 100_000_000n]);
+      expect(toolDurations).toEqual([100_000_000n, 0n]);
+
+      const secondInput = JSON.parse(String(llmSpans[1].attributes['gen_ai.input.messages']));
+      const responseParts = secondInput
+        .filter((message: any) => message.role === 'tool')
+        .flatMap((message: any) => message.parts);
+      expect(responseParts.map((part: any) => part.response)).toEqual([
+        { ok: true, value: 'SYNTHETIC_RESULT_A' },
+        { ok: true, value: 'SYNTHETIC_RESULT_B' },
+      ]);
+      expect(responseParts.every((part: any) => !('result' in part))).toBe(true);
+    } finally {
+      if (previousStability === undefined) {
+        delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+      } else {
+        process.env.OTEL_SEMCONV_STABILITY_OPT_IN = previousStability;
+      }
+      if (previousCapture === undefined) {
+        delete process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+      } else {
+        process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = previousCapture;
+      }
+    }
   });
 
   it('does not infer model finish semantics from assistant status', async () => {

--- a/tests/unit/validate-trace.test.mjs
+++ b/tests/unit/validate-trace.test.mjs
@@ -1,12 +1,32 @@
 import { describe, expect, test } from 'vitest';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
 import {
   hasModelToolSpanForOutput,
   isRuntimeSkillLoadSpan,
   unmatchedToolsForLlmOutput,
+  validateMessageField,
 } from '../../scripts/validate-trace.mjs';
+
+const LOONGSUITE_INPUT_MESSAGES_SCHEMA_SOURCE =
+  'https://github.com/alibaba/loongsuite-semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-input-messages.json';
+const LOONGSUITE_INPUT_MESSAGES_SCHEMA_SHA256 =
+  'c1fddd81ea2b3cd547f74407f1267658f400f5c608772ab2fc4d9a5b3d16297f';
 
 function tool(attributes) {
   return { spanId: attributes['gen_ai.tool.call.id'], attributes };
+}
+
+function validateInputMessages(messages) {
+  const checks = [];
+  validateMessageField(
+    { 'gen_ai.input.messages': messages },
+    'gen_ai.input.messages',
+    'schema.input_messages',
+    { spanId: 'llm-span', name: 'chat test-model' },
+    checks,
+  );
+  return checks;
 }
 
 describe('semantic.tool_matches_llm_output runtime Skill handling', () => {
@@ -66,5 +86,106 @@ describe('semantic.tool_matches_llm_output runtime Skill handling', () => {
 
     expect(isRuntimeSkillLoadSpan(extensionTool)).toBe(false);
     expect(unmatchedToolsForLlmOutput([extensionTool], [])).toEqual([extensionTool]);
+  });
+});
+
+describe('gen_ai.input.messages schema validation', () => {
+  test('vendored schema matches the pinned LoongSuite source', () => {
+    const schema = readFileSync(new URL('../schemas/gen-ai-input-messages.json', import.meta.url));
+    const actualSha256 = createHash('sha256').update(schema).digest('hex');
+
+    expect({
+      source: LOONGSUITE_INPUT_MESSAGES_SCHEMA_SOURCE,
+      sha256: actualSha256,
+    }).toEqual({
+      source: LOONGSUITE_INPUT_MESSAGES_SCHEMA_SOURCE,
+      sha256: LOONGSUITE_INPUT_MESSAGES_SCHEMA_SHA256,
+    });
+  });
+
+  test('accepts all standard part types and optional nullable fields', () => {
+    const checks = validateInputMessages([{
+      role: 'user',
+      name: null,
+      parts: [
+        { type: 'text', content: '' },
+        { type: 'tool_call', name: 'Read' },
+        { type: 'tool_call_response', response: null },
+        {
+          type: 'server_tool_call',
+          name: 'web_search',
+          server_tool_call: { type: 'web_search' },
+        },
+        {
+          type: 'server_tool_call_response',
+          server_tool_call_response: { type: 'web_search_result' },
+        },
+        { type: 'blob', modality: 'image', content: '' },
+        { type: 'file', modality: 'document', file_id: 'file-1' },
+        { type: 'uri', modality: 'image', uri: 'https://example.test/image.png' },
+        { type: 'reasoning', content: '' },
+      ],
+    }]);
+
+    expect(checks).toEqual([]);
+  });
+
+  test('rejects WorkBuddy tool result field in place of response', () => {
+    const checks = validateInputMessages([{
+      role: 'tool',
+      parts: [{
+        type: 'tool_call_response',
+        id: 'call-1',
+        result: { ok: true },
+      }],
+    }]);
+
+    expect(checks).toEqual([
+      expect.objectContaining({
+        status: 'error',
+        detail: expect.stringContaining('ToolCallResponsePart missing required "response"'),
+      }),
+    ]);
+  });
+
+  test.each(['image', 'compaction'])(
+    'allows GenericPart extension %s with a compatibility warning',
+    (partType) => {
+      const checks = validateInputMessages([{
+        role: 'user',
+        parts: [{ type: partType }],
+      }]);
+
+      expect(checks).toEqual([
+        expect.objectContaining({
+          status: 'warn',
+          detail: expect.stringContaining(`GenericPart extension type="${partType}"`),
+        }),
+      ]);
+    },
+  );
+
+  test.each([
+    ['message role', [{ role: 123, parts: [] }], 'missing required string "role"'],
+    ['message parts', [{ role: 'user' }], 'missing required array "parts"'],
+    ['part type', [{ role: 'user', parts: [{}] }], 'missing required string "type"'],
+    ['text content', [{ role: 'user', parts: [{ type: 'text' }] }], 'TextPart missing required "content"'],
+    ['tool call name', [{ role: 'assistant', parts: [{ type: 'tool_call' }] }], 'ToolCallRequestPart missing required "name"'],
+    ['server tool call', [{ role: 'assistant', parts: [{ type: 'server_tool_call', name: 'web_search' }] }], 'ServerToolCallPart missing required "server_tool_call"'],
+    ['server tool response', [{ role: 'assistant', parts: [{ type: 'server_tool_call_response' }] }], 'ServerToolCallResponsePart missing required "server_tool_call_response"'],
+    ['blob modality', [{ role: 'user', parts: [{ type: 'blob', content: '' }] }], 'BlobPart missing required "modality"'],
+    ['blob content', [{ role: 'user', parts: [{ type: 'blob', modality: 'image' }] }], 'BlobPart missing required "content"'],
+    ['file id', [{ role: 'user', parts: [{ type: 'file', modality: 'document' }] }], 'FilePart missing required "file_id"'],
+    ['URI', [{ role: 'user', parts: [{ type: 'uri', modality: 'image' }] }], 'UriPart missing required "uri"'],
+    ['reasoning content', [{ role: 'assistant', parts: [{ type: 'reasoning' }] }], 'ReasoningPart missing required "content"'],
+  ])('rejects missing required %s', (_label, messages, expectedDetail) => {
+    const checks = validateInputMessages(messages);
+
+    expect(checks).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        status: 'error',
+        detail: expect.stringContaining(expectedDetail),
+      }),
+    ]));
   });
 });


### PR DESCRIPTION
## Summary

- vendor the LoongSuite `gen-ai-input-messages` schema and pin its source SHA in validation tests
- strengthen input-message validation and align OpenCode, MiMo Code, and WorkBuddy payloads with the schema
- preserve Claude Code assistant reasoning/text/tool calls and matching tool responses in subsequent LLM input history
- cover single-tool, parallel-tool, multi-step, and final OTLP span reconstruction paths

## Testing

- `npm test -- --run tests/unit/validate-trace.test.mjs tests/unit/hooks/claude-code/transcript-parser.test.mjs tests/unit/hooks/claude-code/hook-processor.test.mjs tests/integration/claude-code-tool-context-flow.test.mjs tests/unit/hooks/mimo-code/plugin-replay.test.mjs tests/unit/hooks/opencode-plugin-session.test.mjs tests/unit/inputs/workbuddy-input.test.ts` (123 tests)
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## Related issue

Closes #251
