### PR TITLE
fix: correct broken clone URL and complete npm package metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,10 +210,12 @@ To disable it, set `LOONGSUITE_PILOT_ENABLE_STATUS_BAR_APP=false` or add `"enabl
 
 [Output Schema](docs/output-event-schema.md) - Normalized event names, fields, provider values, and finish reasons
 
-[Developer Guide](docs/agent-onboarding.md) - Add support for a new AI coding agentBuild From Source
+[Developer Guide](docs/agent-onboarding.md) - Add support for a new AI coding agent
+
+## Build From Source
 
 ```bash
-git clone https://github.com/loongsuite/loongsuite-pilot.git
+git clone https://github.com/alibaba/loongsuite-pilot.git
 cd loongsuite-pilot
 npm install
 npm run build

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -197,7 +197,7 @@ macOS 菜单栏 App：
 ## 从源码构建
 
 ```bash
-git clone https://github.com/loongsuite/loongsuite-pilot.git
+git clone https://github.com/alibaba/loongsuite-pilot.git
 cd loongsuite-pilot
 npm install
 npm run build

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -173,7 +173,7 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer uninstall -Pu
 ## Build And Run From Source
 
 ```bash
-git clone https://github.com/loongsuite/loongsuite-pilot.git
+git clone https://github.com/alibaba/loongsuite-pilot.git
 cd loongsuite-pilot
 npm install
 npm run build

--- a/docs/zh-CN/installation.md
+++ b/docs/zh-CN/installation.md
@@ -215,7 +215,7 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer uninstall -Pu
 ## 从源码构建并运行
 
 ```bash
-git clone https://github.com/loongsuite/loongsuite-pilot.git
+git clone https://github.com/alibaba/loongsuite-pilot.git
 cd loongsuite-pilot
 npm install
 npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loongsuite-pilot",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loongsuite-pilot",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "dependencies": {
         "@alicloud/log": "^1.2.6",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,31 @@
 {
   "name": "loongsuite-pilot",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "type": "module",
   "description": "Multi-agent AI coding data collection platform",
+  "keywords": [
+    "ai-coding",
+    "coding-agent",
+    "claude-code",
+    "codex",
+    "cursor",
+    "opentelemetry",
+    "observability",
+    "telemetry",
+    "token-usage",
+    "cost-tracking",
+    "llm",
+    "cli"
+  ],
+  "homepage": "https://github.com/alibaba/loongsuite-pilot#readme",
+  "bugs": {
+    "url": "https://github.com/alibaba/loongsuite-pilot/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alibaba/loongsuite-pilot.git"
+  },
+  "license": "Apache-2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {


### PR DESCRIPTION
## Why

Four zero-cost hygiene issues found while auditing the repo for npm publishing readiness. All are docs / metadata; no functional change.

## What

| # | Issue | Before | After |
|---|---|---|---|
| 1 | `git clone` URL points at the wrong org in 4 files | `github.com/loongsuite/loongsuite-pilot` — **404**, git prompts for credentials and the clone fails | `github.com/alibaba/loongsuite-pilot` |
| 2 | `README.md` lost the `## Build From Source` heading | glued onto the Developer Guide line: `...a new AI coding agentBuild From Source` | heading restored (parity with `## 从源码构建` in `README.zh-CN.md`) |
| 3 | `package.json` version drift | `1.0.0`, latest tag is `v1.2.0` | `1.2.0` in `package.json` + `package-lock.json` root entry |
| 4 | `package.json` missing publish metadata | no `license` / `repository` / `bugs` / `homepage` / `keywords` | added |

Files touched by #1: `README.md`, `README.zh-CN.md`, `docs/installation.md`, `docs/zh-CN/installation.md`.

## Notes for the reviewer

- **On #3**: `deploy/release-opensource.sh` computes the next version from git tags (`get_latest_version_from_tags`), not from `package.json`, so this only removes the drift — the release flow is unaffected. The `1.0.0` occurrences under `tests/` are explicit fixtures passed into `MetricsCollector` / `AlarmManager`, not read from `package.json`, so nothing breaks.
- **On #4**: `license` matters most — npm renders a package with no `license` field as **UNLICENSED**, even though `LICENSE` in the repo is Apache-2.0. `homepage` is set to the README anchor for now; happy to repoint it at a docs site once one exists.
- `keywords` is the one judgement call in here — drop the list if you'd rather curate it separately.

## Not covered here (cannot be done in a PR)

These need repo settings / registry access:

- GitHub **description** is `null` — the repo shows no one-line summary anywhere in search results
- GitHub **topics** is empty — the repo appears on no topic page
- GitHub **homepage** is `null`
- The package name `loongsuite-pilot` and the `@loongsuite` scope are **both unclaimed on npm**, while `bin` is already wired up for a `npx`-style entry point

🤖 Generated with [Claude Code](https://claude.com/claude-code)
