### PR TITLE
fix(windows): expose token usage CLI

### DIFF
--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -7,6 +7,7 @@
 #   loongsuite-pilot restart
 #   loongsuite-pilot status
 #   loongsuite-pilot info
+#   loongsuite-pilot token-usage
 #   loongsuite-pilot rollback
 #   loongsuite-pilot worker connect|list|status|disconnect|delete
 #   loongsuite-pilot help
@@ -1174,6 +1175,35 @@ function Cmd-Log {
 }
 
 # ============================================================
+# CMD: token-usage (foreground token usage CLI)
+# ============================================================
+function Cmd-TokenUsage {
+    $versionDir = Resolve-CurrentVersion
+    if (-not $versionDir) {
+        Write-Error "Current loongsuite-pilot version not found"
+        exit 1
+    }
+
+    $entry = Join-Path $versionDir "dist\index.js"
+    if (-not (Test-Path $entry -PathType Leaf)) {
+        Write-Error "Token usage CLI entrypoint missing"
+        exit 1
+    }
+
+    $nodeBin = Resolve-Node
+    if (-not $nodeBin) {
+        Write-Error "node runtime not found"
+        exit 1
+    }
+
+    $env:LOONGSUITE_PILOT_DATA_DIR = $DATA_DIR
+    $env:LOONGSUITE_PILOT_CACHE_DIR = $CACHE_DIR
+    $env:AGENT_DATA_COLLECTION_CONFIG = $CONFIG_FILE
+    & $nodeBin $entry "token-usage" @SubArgs
+    exit $LASTEXITCODE
+}
+
+# ============================================================
 # CMD: worker (foreground local Worker management CLI)
 # ============================================================
 function Cmd-Worker {
@@ -1302,6 +1332,8 @@ function Cmd-Help {
     Write-Host "  status          Show service status (default)"
     Write-Host "  info            Show version and config info"
     Write-Host "  log             Tail the service log"
+    Write-Host "  token-usage     Show token usage TUI"
+    Write-Host "  tokens          Alias for token-usage"
     Write-Host "  span-attr ...   Manage custom trace span attributes (set/unset/list/clear)"
     Write-Host "  agent ...       Register/list/diagnose PI SDK Agents"
     Write-Host "  rollback        Roll back to the previous version"
@@ -1320,6 +1352,8 @@ switch ($Command.ToLower()) {
     "status"             { Cmd-Status }
     "info"               { Cmd-Info }
     "log"                { Cmd-Log }
+    "token-usage"        { Cmd-TokenUsage }
+    "tokens"             { Cmd-TokenUsage }
     "rollback"           { Cmd-Rollback }
     "worker"             { Cmd-Worker }
     "agent"              { Cmd-Agent }

--- a/tests/unit/scripts/windows-token-usage-cli.test.mjs
+++ b/tests/unit/scripts/windows-token-usage-cli.test.mjs
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const sourceCli = path.join(projectRoot, 'scripts', 'loongsuite-pilot.ps1');
+
+describe('Windows token-usage CLI contract', () => {
+  test('advertises and dispatches token-usage and its alias', () => {
+    const script = fs.readFileSync(sourceCli, 'utf8');
+
+    expect(script).toMatch(/function Cmd-TokenUsage\s*\{/);
+    expect(script).toContain('"token-usage"        { Cmd-TokenUsage }');
+    expect(script).toContain('"tokens"             { Cmd-TokenUsage }');
+    expect(script).toContain('"token-usage" @SubArgs');
+    expect(script).toContain('$env:AGENT_DATA_COLLECTION_CONFIG = $CONFIG_FILE');
+  });
+});
+
+const describeOnWindows = process.platform === 'win32' ? describe : describe.skip;
+
+describeOnWindows('Windows token-usage CLI runtime', () => {
+  let root;
+  let profile;
+  let cli;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'pilot-token-usage-用户 With Space-'));
+    profile = path.join(root, 'profile');
+    cli = path.join(profile, '.local', 'bin', 'loongsuite-pilot.ps1');
+    const cacheDir = path.join(profile, '.loongsuite-pilot');
+    const versionDir = path.join(cacheDir, 'versions', 'test-version');
+
+    fs.mkdirSync(path.dirname(cli), { recursive: true });
+    fs.mkdirSync(path.join(versionDir, 'dist'), { recursive: true });
+    fs.copyFileSync(sourceCli, cli);
+    fs.writeFileSync(path.join(cacheDir, 'current'), 'test-version\n');
+    fs.writeFileSync(path.join(cacheDir, 'node-bin'), process.execPath);
+    fs.writeFileSync(
+      path.join(versionDir, 'dist', 'index.js'),
+      'console.log(JSON.stringify({ args: process.argv.slice(2), config: process.env.AGENT_DATA_COLLECTION_CONFIG, dataDir: process.env.LOONGSUITE_PILOT_DATA_DIR, cacheDir: process.env.LOONGSUITE_PILOT_CACHE_DIR }));\n',
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  function run(...args) {
+    return spawnSync(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', cli, ...args],
+      {
+        env: {
+          ...process.env,
+          USERPROFILE: profile,
+          LOONGSUITE_PILOT_DATA_DIR: '',
+          LOONGSUITE_PILOT_CACHE_DIR: '',
+        },
+        encoding: 'utf8',
+        timeout: 15_000,
+      },
+    );
+  }
+
+  test.each([
+    ['token-usage', 'token-usage'],
+    ['tokens', 'token-usage'],
+  ])('forwards %s and its options to the runtime CLI', (command, expectedCommand) => {
+    const result = run(command, '--range', '7d', '--no-color');
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout.trim())).toEqual({
+      args: [expectedCommand, '--range', '7d', '--no-color'],
+      config: path.join(profile, '.loongsuite-pilot', 'config.json'),
+      dataDir: path.join(profile, '.loongsuite-pilot'),
+      cacheDir: path.join(profile, '.loongsuite-pilot'),
+    });
+  });
+});


### PR DESCRIPTION
## What changed

- add `token-usage` and `tokens` dispatch entries to the Windows PowerShell wrapper
- forward range and output options to the existing runtime CLI
- pass the configured data, cache, and config paths to the runtime
- add a cross-platform contract test plus Windows-only PowerShell forwarding coverage

## Why

The runtime already implements `token-usage`, and the Unix wrapper already exposes it, but the Windows PowerShell wrapper did not dispatch the command. Windows users therefore received `Unknown command: token-usage` even though the underlying feature was available.

## User impact

Windows users can run commands such as:

```powershell
loongsuite-pilot token-usage
loongsuite-pilot token-usage --7d
loongsuite-pilot tokens --30d
```

## Validation

- `npm test -- tests/unit/scripts/windows-token-usage-cli.test.mjs tests/unit/cli/token-usage.test.ts`
- `npm run typecheck`
- `npm run build`
- `node dist/index.js token-usage --help`
- `git diff --check`

The Windows-only PowerShell runtime cases are skipped on macOS and remain to be exercised by a Windows runner or machine.
