### PR TITLE
fix(genai): preserve assistant tool-call history across agents

### DIFF
--- a/assets/hooks/cursor/react-assembler.mjs
+++ b/assets/hooks/cursor/react-assembler.mjs
@@ -265,6 +265,7 @@ function buildParentSteps(events, ctx) {
   let currentStepId = null;
   let currentStepHasTools = false;
   let currentLlmResponse = null;
+  let previousAssistantToolMessage = null;
   let previousToolResults = [];
   // Track last event timestamp for computing next step's LLM start time
   let lastStepEndTs = ctx.promptEventTs; // first step starts at prompt time
@@ -390,6 +391,7 @@ function buildParentSteps(events, ctx) {
     if (!currentLlmResponse) return;
     const toolCalls = stepToolCalls.get(currentStepId);
     appendToolCallParts(currentLlmResponse, toolCalls);
+    previousAssistantToolMessage = toolCallsToMessage(toolCalls);
     applyToolCallResponseTiming(currentLlmResponse, toolCalls);
 
     // Guard: if LLM request start >= response end (buffered-tool scenario),
@@ -457,7 +459,13 @@ function buildParentSteps(events, ctx) {
     //   s1: user prompt (if any) — already pre-seeded in cumulative.
     //   s2+: tool results from previous step — append to cumulative.
     const latestResultEndTs = latestToolResultEndTs(previousToolResults);
-    const deltaMessages = buildDeltaMessages(isFirst, userPrompt, previousToolResults, cumulativeInputMessages);
+    const deltaMessages = buildDeltaMessages(
+      isFirst,
+      userPrompt,
+      previousAssistantToolMessage,
+      previousToolResults,
+      cumulativeInputMessages,
+    );
 
     const requestStart = llmRequestStartTime(ev, lastStepEndTs);
     const { timestamp: reqTs, source: reqTsSource } = clampRequestStartToToolResults(
@@ -470,6 +478,7 @@ function buildParentSteps(events, ctx) {
       cumulativeInputMessages,
       reqTsSource,
     ));
+    previousAssistantToolMessage = null;
     previousToolResults = [];
   }
 
@@ -483,7 +492,14 @@ function buildParentSteps(events, ctx) {
     currentStepId = `${ctx.stepPrefix || ctx.turnId}:s${stepRound}`;
     stepToolCalls.set(currentStepId, []);
 
-    const deltaMessages = buildDeltaMessages(isFirstStep, ctx.userPrompt, previousToolResults, cumulativeInputMessages);
+    const deltaMessages = buildDeltaMessages(
+      isFirstStep,
+      ctx.userPrompt,
+      previousAssistantToolMessage,
+      previousToolResults,
+      cumulativeInputMessages,
+    );
+    previousAssistantToolMessage = null;
     previousToolResults = [];
 
     records.push(buildLlmRequestWithTs(
@@ -683,12 +699,19 @@ function toolResultsToMessage(toolResults) {
  * Build per-step delta messages and update cumulative input.
  *
  * - isFirst step: delta includes the user prompt (already pre-seeded in cumulative).
- * - s2+ steps: delta includes a tool-role message from the previous step's results,
- *   which is also appended to cumulativeInputMessages.
+ * - s2+ steps: delta includes the previous assistant tool-call message followed
+ *   by the tool-role message containing its results. Both are appended to the
+ *   cumulative input in source order.
  *
  * Callers are responsible for resetting previousToolResults after this call.
  */
-function buildDeltaMessages(isFirst, userPrompt, previousToolResults, cumulativeInputMessages) {
+function buildDeltaMessages(
+  isFirst,
+  userPrompt,
+  previousAssistantToolMessage,
+  previousToolResults,
+  cumulativeInputMessages,
+) {
   const deltaMessages = [];
   if (isFirst && userPrompt) {
     deltaMessages.push({
@@ -697,6 +720,11 @@ function buildDeltaMessages(isFirst, userPrompt, previousToolResults, cumulative
     });
   }
   if (previousToolResults.length > 0) {
+    if (previousAssistantToolMessage) {
+      const assistantMessage = cloneMessages([previousAssistantToolMessage])[0];
+      deltaMessages.push(assistantMessage);
+      cumulativeInputMessages.push(cloneMessages([assistantMessage])[0]);
+    }
     const toolMessage = toolResultsToMessage(previousToolResults);
     deltaMessages.push(toolMessage);
     cumulativeInputMessages.push({ ...toolMessage, parts: [...toolMessage.parts] });
@@ -839,6 +867,19 @@ function appendToolCallParts(llmResponse, toolCalls) {
       arguments: parseMaybeJson(tc.toolInput),
     });
   }
+}
+
+function toolCallsToMessage(toolCalls) {
+  if (!toolCalls || toolCalls.length === 0) return null;
+  return {
+    role: 'assistant',
+    parts: toolCalls.map(tc => ({
+      type: 'tool_call',
+      id: tc.toolUseId || null,
+      name: tc.toolName,
+      arguments: parseMaybeJson(tc.toolInput),
+    })),
+  };
 }
 
 function applyToolCallResponseTiming(llmResponse, toolCalls) {

--- a/assets/hooks/cursor/transcript-assembler.mjs
+++ b/assets/hooks/cursor/transcript-assembler.mjs
@@ -104,6 +104,10 @@ export function buildCursorRecordsFromTranscript(transcriptPath, journalEvents, 
   // Build per-step records
   const steps = alignSteps(turn.assistantEntries, parentEvents, turnId);
   const stopEvent = parentEvents.find(e => e.hook_event === 'stop');
+  const cumulativeInputMessages = userText
+    ? [{ role: 'user', parts: [{ type: 'text', content: userText }] }]
+    : [];
+  let previousAssistantToolMessage = null;
   let prevToolResults = [];
 
   for (let i = 0; i < steps.length; i++) {
@@ -136,13 +140,13 @@ export function buildCursorRecordsFromTranscript(transcriptPath, journalEvents, 
     // llm.request.model from step events
     const stepModel = step.thoughtEvent?.model || step.responseEvent?.model || model;
 
-    const inputMessages = [];
-    if (i === 0 && userText) {
-      inputMessages.push({ role: 'user', parts: [{ type: 'text', content: userText }] });
-    } else if (prevToolResults.length > 0) {
+    if (i > 0 && prevToolResults.length > 0) {
+      if (previousAssistantToolMessage) {
+        cumulativeInputMessages.push(cloneMessage(previousAssistantToolMessage));
+      }
       // NOTE: tool_output from journal postToolUse may contain GB18030-garbled text.
       // Omit response content to avoid garbled data in output; structure is preserved.
-      inputMessages.push({
+      cumulativeInputMessages.push({
         role: 'tool',
         parts: prevToolResults.map(tr => ({
           type: 'tool_call_response',
@@ -151,6 +155,7 @@ export function buildCursorRecordsFromTranscript(transcriptPath, journalEvents, 
         })),
       });
     }
+    const inputMessages = cumulativeInputMessages.map(cloneMessage);
 
     // ── llm.request ──
     const reqSource = step.thoughtEvent || step.responseEvent || promptEvent;
@@ -273,10 +278,18 @@ export function buildCursorRecordsFromTranscript(transcriptPath, journalEvents, 
     }
 
     records.push(respRecord);
+    const assistantToolParts = outputParts.filter(part => part.type === 'tool_call');
+    previousAssistantToolMessage = assistantToolParts.length > 0
+      ? { role: 'assistant', parts: assistantToolParts.map(part => ({ ...part })) }
+      : null;
     prevToolResults = step.toolResults;
   }
 
   return records.length > 0 ? records : null;
+}
+
+function cloneMessage(message) {
+  return JSON.parse(JSON.stringify(message));
 }
 
 // ─── Transcript Parser ───

--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -1015,6 +1015,7 @@ export function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, 
   const assignedContent = assignContentToBoundaries(boundaries, contentEvents);
 
   // For each LLM call boundary, produce events
+  let toolCallsForNextStep = [];
   let toolResultsForNextStep = [];
   for (let i = 0; i < boundaries.length; i++) {
     const boundary = boundaries[i];
@@ -1022,6 +1023,15 @@ export function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, 
     const content = assignedContent[i] || [];
     const startNanos = isoToUnixNanos(boundary.startTs);
     const endNanos = boundary.endTs ? isoToUnixNanos(boundary.endTs) : startNanos;
+    const previousToolCallIds = new Set(toolCallsForNextStep.map(tc => tc.id).filter(Boolean));
+    const currentContentToolResults = extractToolResults(content);
+    const inputToolResultsById = new Map();
+    for (const result of [...toolResultsForNextStep, ...currentContentToolResults]) {
+      if (result.toolId && previousToolCallIds.has(result.toolId)) {
+        inputToolResultsById.set(result.toolId, result);
+      }
+    }
+    const inputToolResults = [...inputToolResultsById.values()];
 
     // Pre-scan: extract model name from this step's assistant rows (CLI has message.model)
     const stepModel = content.find(r => r.type === 'assistant' && r.message?.model)?.message?.model || 'auto';
@@ -1032,11 +1042,23 @@ export function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, 
     if (i === 0 && userRow) {
       inputDelta = [{ role: 'user', parts: [{ type: 'text', content: extractUserText(userRow) }] }];
       emitRequest = true;
-    } else if (toolResultsForNextStep.length > 0) {
-      inputDelta = toolResultsForNextStep.map(tr => ({
+    } else if (inputToolResults.length > 0) {
+      inputDelta = [];
+      if (toolCallsForNextStep.length > 0) {
+        inputDelta.push({
+          role: 'assistant',
+          parts: toolCallsForNextStep.map(tc => ({
+            type: 'tool_call',
+            id: tc.id,
+            name: tc.name,
+            arguments: tc.input,
+          })),
+        });
+      }
+      inputDelta.push(...inputToolResults.map(tr => ({
         role: 'tool',
         parts: [{ type: 'tool_call_response', id: tr.toolId, response: tr.result }],
-      }));
+      })));
     }
 
     if (emitRequest) {
@@ -1060,7 +1082,6 @@ export function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, 
     // Build merged llm.response (multi-parts)
     const outputParts = [];
     const toolCalls = [];
-    toolResultsForNextStep = [];
     let responseId = undefined;
     let lastAssistantTs = null;
     let firstAssistantTs = null;
@@ -1089,21 +1110,16 @@ export function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, 
             });
           }
         }
-      } else if (row.type === 'user' && isToolResult(row)) {
-        const blocks = Array.isArray(row.message?.content) ? row.message.content : [];
-        for (const block of blocks) {
-          if (block.type === 'tool_result') {
-            const resultText = typeof block.content === 'string' ? block.content : JSON.stringify(block.content);
-            toolResultsForNextStep.push({
-              toolId: block.tool_use_id,
-              result: resultText,
-              isError: block.is_error === true,
-              resultTs: row.timestamp,
-            });
-          }
-        }
       }
     }
+    const currentToolCallIds = new Set(toolCalls.map(tc => tc.id).filter(Boolean));
+    toolResultsForNextStep = currentContentToolResults
+      .filter(result => result.toolId && currentToolCallIds.has(result.toolId));
+    toolCallsForNextStep = toolCalls.map(tc => ({
+      id: tc.id,
+      name: tc.name,
+      input: tc.input,
+    }));
 
     // When startTs == endTs (no distinguishable progress boundary), use assistant timestamp as end
     let responseEndNanos = endNanos;
@@ -1336,6 +1352,23 @@ function ensureEndAfterStart(startNanos, candidateEndNanos) {
 function isToolResult(row) {
   const content = row.message?.content;
   return Array.isArray(content) && content.length > 0 && content[0].type === 'tool_result';
+}
+
+function extractToolResults(rows) {
+  const results = [];
+  for (const row of rows) {
+    if (row.type !== 'user' || !isToolResult(row)) continue;
+    for (const block of row.message?.content || []) {
+      if (block.type !== 'tool_result') continue;
+      results.push({
+        toolId: block.tool_use_id,
+        result: typeof block.content === 'string' ? block.content : JSON.stringify(block.content),
+        isError: block.is_error === true,
+        resultTs: row.timestamp,
+      });
+    }
+  }
+  return results;
 }
 
 function extractUserText(row) {

--- a/assets/hooks/qoderwork-hook-processor.mjs
+++ b/assets/hooks/qoderwork-hook-processor.mjs
@@ -233,7 +233,7 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
 
   const userText = userRow ? extractText(userRow) : '';
   const userTs = userRow ? timestampToUnixNanos(userRow.timestamp) : undefined;
-  let prevToolCalls = []; // tool_call ids from previous step, for building tool_result delta
+  let prevToolCalls = []; // tool calls from previous step, for building assistant + tool_result delta
   let prevStepLastToolResultTs = undefined; // 上一个 step 最后一个 tool_result 的 nano ts，用于本 step llm.request 时间
 
   let stepCounter = 0;
@@ -243,7 +243,7 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
 
     // Build input.messages_delta for this step's llm.request:
     // - Step 1: user prompt
-    // - Step N>1: previous step's tool results
+    // - Step N>1: previous assistant tool calls + their tool results
     let inputDelta;
     if (stepCounter === 1 && userText) {
       inputDelta = [{ role: 'user', parts: [{ type: 'text', content: userText }] }];
@@ -258,7 +258,18 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
         }
       }
       if (toolParts.length > 0) {
-        inputDelta = [{ role: 'tool', parts: toolParts }];
+        inputDelta = [
+          {
+            role: 'assistant',
+            parts: prevToolCalls.map(tc => ({
+              type: 'tool_call',
+              id: tc.id,
+              name: tc.name,
+              arguments: tc.input,
+            })),
+          },
+          { role: 'tool', parts: toolParts },
+        ];
       }
     }
 
@@ -279,7 +290,7 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
       const content = Array.isArray(msg.content) ? msg.content : [];
       for (const b of content) {
         if (b.type === 'tool_use') {
-          prevToolCalls.push({ id: b.id, name: b.name });
+          prevToolCalls.push({ id: b.id, name: b.name, input: b.input });
           // 找到本 step 该 tool_use 对应的 tool_result 行，记录 ts；多 tool 场景保留最后一个
           const matchingResult = toolResultsByUseId.get(b.id);
           if (matchingResult?.row.timestamp) {
@@ -405,7 +416,7 @@ function buildStepEvents(group, toolResultsByUseId, stepId, turnId, sessionId, u
   //
   // Each step's delta contains only the NEW content since the previous step:
   //   - Step 1: user prompt
-  //   - Step N>1: previous step's tool_results
+  //   - Step N>1: previous assistant tool_calls followed by tool_results
   // The converter (@loongsuite/otel-util-genai) accumulates deltas across
   // steps to reconstruct the full context window for each LLM span, which
   // is the correct behaviour.

--- a/assets/hooks/qwen-code-cli/message-converter.mjs
+++ b/assets/hooks/qwen-code-cli/message-converter.mjs
@@ -127,15 +127,16 @@ export function inferAssistantFinishReason(assistantRecord) {
  * LLM call (or turn start) and this LLM call — i.e. one of:
  *
  *   - the original user prompt (for the first step of a turn)
- *   - tool_result records produced since the last assistant call
+ *   - the previous assistant message and tool_result records produced from it
  *   - mid-turn user messages
  *
  * Each input is a qwen-code transcript record. We extract its message.parts
  * and convert to ARMS format, mapping role appropriately:
  *   - type=user → role: 'user'
+ *   - type=assistant → role: 'assistant' (including tool_call parts)
  *   - type=tool_result → role: 'tool' (with tool_call_response parts)
  *
- * @param {Array} sourceRecords  qwen-code transcript records (user or tool_result)
+ * @param {Array} sourceRecords  qwen-code transcript records (user, assistant, or tool_result)
  * @param {Map<string,string>} [toolCallIdByResponseUuid]
  *   Optional map: tool_result record uuid → original tool call id. Used because
  *   qwen's functionResponse doesn't carry the call id; we recover it from the
@@ -147,6 +148,13 @@ export function buildInputMessagesDelta(sourceRecords, toolCallIdByResponseUuid 
   for (const rec of sourceRecords) {
     if (!rec || typeof rec !== 'object') continue;
     const msg = rec.message || {};
+    if (rec.type === 'assistant') {
+      const parts = convertQwenParts(msg.parts);
+      if (parts.length > 0) {
+        messages.push({ role: 'assistant', parts });
+      }
+      continue;
+    }
     if (rec.type === 'tool_result') {
       const callId = toolCallIdByResponseUuid.get(rec.uuid) || rec?.toolCallResult?.callId || null;
       const parts = convertQwenParts(msg.parts, callId);

--- a/assets/hooks/qwen-code-cli/transcript-parser.mjs
+++ b/assets/hooks/qwen-code-cli/transcript-parser.mjs
@@ -244,8 +244,9 @@ function enrichTurn(turn, mainSessionId) {
       };
       llmCalls.push(llmCall);
 
-      // Reset delta buffer; next step's delta starts accumulating from here.
-      inputDeltaBuffer = [];
+      // The next request includes this assistant message before any tool
+      // results produced from its function calls.
+      inputDeltaBuffer = [r];
       prevStepEndTimestamp = r.timestamp;
     }
     // skip other system subtypes (slash_command, notification, etc.) in v1

--- a/assets/hooks/qwen-work-cn-hook-processor.mjs
+++ b/assets/hooks/qwen-work-cn-hook-processor.mjs
@@ -195,7 +195,20 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, observedTs, runtim
         if (!match) return [];
         return [{ type: 'tool_call_response', id: call.id, response: resultValue(match) }];
       });
-      if (parts.length > 0) inputDelta = [{ role: 'tool', parts }];
+      if (parts.length > 0) {
+        inputDelta = [
+          {
+            role: 'assistant',
+            parts: previousToolCalls.map(call => ({
+              type: 'tool_call',
+              id: call.id,
+              name: call.name,
+              arguments: toJsonValue(call.input),
+            })),
+          },
+          { role: 'tool', parts },
+        ];
+      }
     }
 
     const result = buildStepEvents({

--- a/src/inputs/qoder-work-log/qoder-work-trace-input.ts
+++ b/src/inputs/qoder-work-log/qoder-work-trace-input.ts
@@ -669,22 +669,34 @@ export class QoderWorkTraceInput extends BaseSessionInput {
       const stepFields = { ...baseFields, 'gen_ai.step.id': stepId, 'gen_ai.request.model': turnModel };
       const stepEntries: AgentActivityEntry[] = [];
 
-      // Build input.messages_delta (step1=user prompt, stepN=prev tool results)
+      // Build input.messages_delta (step1=user prompt, stepN=prev assistant tool calls + results)
       let inputDelta: JsonValue | undefined;
       if (round === 0 && matchedPrompt?.text) {
         inputDelta = [{ role: 'user', parts: [{ type: 'text', content: matchedPrompt.text }] }];
       } else if (round > 0) {
         const prevTurn = session.turns[round - 1];
         if (prevTurn && prevTurn.toolCalls.length > 0) {
+          const assistantParts: JsonValue[] = [];
           const toolParts: JsonValue[] = [];
           for (const tc of prevTurn.toolCalls) {
+            const toolCallPart: Record<string, JsonValue> = {
+              type: 'tool_call',
+              id: tc.id,
+              name: tc.name,
+            };
+            const args = safeParseJson(tc.argumentsJson);
+            if (args !== undefined) toolCallPart.arguments = args;
+            assistantParts.push(toolCallPart);
             const result = toolResultMap.get(tc.id);
             if (result) {
               toolParts.push({ type: 'tool_call_response', id: tc.id, response: result });
             }
           }
           if (toolParts.length > 0) {
-            inputDelta = [{ role: 'tool', parts: toolParts }];
+            inputDelta = [
+              { role: 'assistant', parts: assistantParts },
+              { role: 'tool', parts: toolParts },
+            ];
           }
         }
       }

--- a/src/inputs/workbuddy/workbuddy-event-builder.ts
+++ b/src/inputs/workbuddy/workbuddy-event-builder.ts
@@ -177,10 +177,13 @@ export async function buildWorkBuddyEvents(
     );
     if (responseTimestamp === undefined) return;
     const requestTimestamp = requestStartMs ?? responseTimestamp;
+    const assistantToolParts = normalizedCalls.map(call => (
+      toToolCallPart(call.record, call.callId, call.toolName)
+    ));
     const outputParts = [
       ...reasoningParts,
       ...assistantParts,
-      ...normalizedCalls.map(call => toToolCallPart(call.record, call.callId, call.toolName)),
+      ...assistantToolParts,
     ];
     const request = baseEntry(
       'llm.request',
@@ -237,7 +240,9 @@ export async function buildWorkBuddyEvents(
       await push(toolCall, call.record);
     }
 
-    pendingDelta = [];
+    pendingDelta = assistantToolParts.length > 0
+      ? [{ role: 'assistant', parts: assistantToolParts.map(part => ({ ...part })) }]
+      : [];
     reasoningParts = [];
     reasoningStartMs = undefined;
     requestStartMs = responseTimestamp;

--- a/tests/unit/hooks/cursor-react-assembler.test.ts
+++ b/tests/unit/hooks/cursor-react-assembler.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { convertEventLogToReadableSpans } from '@loongsuite/otel-util-genai';
 import { describe, expect, it } from 'vitest';
 import { assembleTurn } from '../../../assets/hooks/cursor/react-assembler.mjs';
 
@@ -383,7 +384,8 @@ describe('Cursor react assembler', () => {
       'This callback arrived before the read result.',
     ]);
     expect(BigInt(secondRequest!.time_unix_nano)).toBeGreaterThanOrEqual(BigInt(ns(500)));
-    expect(secondRequest?.['gen_ai.input.messages_delta']?.[0]?.parts).toHaveLength(1);
+    expect(secondRequest?.['gen_ai.input.messages_delta']?.map((message: Record<string, unknown>) => message.role))
+      .toEqual(['assistant', 'tool']);
   });
 
   it('recovers the next step when a synchronous tool completion hook is missing', () => {
@@ -479,7 +481,15 @@ describe('Cursor react assembler', () => {
     expect(requests).toHaveLength(3);
     expect(responses).toHaveLength(3);
     expect(secondRequest?.['gen_ai.input.messages_delta']).toBeUndefined();
-    expect(thirdRequest?.['gen_ai.input.messages_delta']?.[0]?.parts).toEqual([
+    const thirdDelta = thirdRequest?.['gen_ai.input.messages_delta'] ?? [];
+    expect(thirdDelta.map((message: Record<string, unknown>) => message.role))
+      .toEqual(['assistant', 'tool']);
+    expect(thirdDelta[0]?.parts?.[0]).toMatchObject({
+      type: 'tool_call',
+      id: 'call-normal-shell',
+      name: 'Shell',
+    });
+    expect(thirdDelta[1]?.parts).toEqual([
       {
         type: 'tool_call_response',
         id: 'call-normal-shell',
@@ -553,7 +563,14 @@ describe('Cursor react assembler', () => {
 
     const requests = records.filter(record => record['event.name'] === 'llm.request');
     expect(requests).toHaveLength(2);
-    expect(requests[1]?.['gen_ai.input.messages_delta']?.[0]?.parts).toEqual([
+    const secondDelta = requests[1]?.['gen_ai.input.messages_delta'] ?? [];
+    expect(secondDelta.map((message: Record<string, unknown>) => message.role))
+      .toEqual(['assistant', 'tool']);
+    expect(secondDelta[0]?.parts?.[0]).toMatchObject({
+      type: 'tool_call',
+      id: 'call-failing-read',
+    });
+    expect(secondDelta[1]?.parts).toEqual([
       {
         type: 'tool_call_response',
         id: 'call-failing-read',
@@ -843,22 +860,28 @@ describe('Cursor react assembler', () => {
         'agent.cursor.hook_event_name': 'subagent_result_synthesized',
         'gen_ai.tool.call.result': { summary: 'child final result' },
       });
-      // Delta on s2 = the tool result that arrived since s1
-      expect(secondStepDelta).toHaveLength(1);
-      expect(secondStepDelta[0]).toMatchObject({ role: 'tool' });
-      expect(secondStepDelta[0]?.parts).toHaveLength(1);
+      // Delta on s2 preserves the assistant call immediately before its result.
+      expect(secondStepDelta).toHaveLength(2);
+      expect(secondStepDelta.map(message => message.role)).toEqual(['assistant', 'tool']);
       expect(secondStepDelta[0]?.parts?.[0]).toMatchObject({
+        type: 'tool_call',
+        id: 'call-subagent',
+        name: 'Subagent',
+      });
+      expect(secondStepDelta[1]?.parts).toHaveLength(1);
+      expect(secondStepDelta[1]?.parts?.[0]).toMatchObject({
         type: 'tool_call_response',
         id: 'call-subagent',
         response: 'child final result',
       });
-      // Full = cumulative user prompt + tool result
-      expect(secondStepFull).toHaveLength(2);
+      // Full = cumulative user prompt + assistant call + tool result.
+      expect(secondStepFull).toHaveLength(3);
       expect(secondStepFull[0]).toMatchObject({
         role: 'user',
         parts: [{ type: 'text', content: 'delegate this' }],
       });
-      expect(secondStepFull[1]).toMatchObject({ role: 'tool' });
+      expect(secondStepFull[1]).toMatchObject({ role: 'assistant' });
+      expect(secondStepFull[2]).toMatchObject({ role: 'tool' });
     } finally {
       fs.rmSync(transcriptDir, { recursive: true, force: true });
     }
@@ -982,7 +1005,10 @@ describe('Cursor react assembler', () => {
         observed_time_unix_nano: ns(800),
         'agent.cursor.llm_request_time_source': 'previous_tool_result_end',
       });
-      expect(secondRequest?.['gen_ai.input.messages_delta']?.[0]?.parts?.[0]).toMatchObject({
+      const secondDelta = secondRequest?.['gen_ai.input.messages_delta'] ?? [];
+      expect(secondDelta.map((message: Record<string, unknown>) => message.role))
+        .toEqual(['assistant', 'tool']);
+      expect(secondDelta[1]?.parts?.[0]).toMatchObject({
         type: 'tool_call_response',
         id: 'call-subagent-causality',
         response: 'child final result',
@@ -1165,11 +1191,14 @@ describe('Cursor react assembler', () => {
         record['event.name'] === 'llm.request' &&
         record['gen_ai.step.id'] === 'turn-parallel:s2'
       );
-      const secondStepInputParts = secondRequest?.['gen_ai.input.messages_delta']?.[0]?.parts ?? [];
+      const secondStepDelta = secondRequest?.['gen_ai.input.messages_delta'] ?? [];
 
       expect(parentRequests).toHaveLength(3);
       expect(firstStepTaskCalls).toHaveLength(2);
-      expect(secondStepInputParts).toHaveLength(2);
+      expect(secondStepDelta.map((message: Record<string, unknown>) => message.role))
+        .toEqual(['assistant', 'tool']);
+      expect(secondStepDelta[0]?.parts).toHaveLength(2);
+      expect(secondStepDelta[1]?.parts).toHaveLength(2);
       expect(BigInt(secondRequest!.time_unix_nano)).toBeGreaterThanOrEqual(BigInt(ns(600)));
     } finally {
       fs.rmSync(transcriptDir, { recursive: true, force: true });
@@ -1248,22 +1277,28 @@ describe('Cursor react assembler', () => {
       'agent.cursor.hook_event_name': 'postToolUse',
       'gen_ai.tool.call.result': 'cursor fallback result',
     });
-    // Delta on s2 = only the new tool result added since s1's llm.request.
-    expect(secondStepDelta).toHaveLength(1);
-    expect(secondStepDelta[0]).toMatchObject({ role: 'tool' });
-    expect(secondStepDelta[0]?.parts).toHaveLength(1);
+    // Delta on s2 preserves the assistant call immediately before its result.
+    expect(secondStepDelta).toHaveLength(2);
+    expect(secondStepDelta.map(message => message.role)).toEqual(['assistant', 'tool']);
     expect(secondStepDelta[0]?.parts?.[0]).toMatchObject({
+      type: 'tool_call',
+      id: 'call-subagent-fallback',
+      name: 'Subagent',
+    });
+    expect(secondStepDelta[1]?.parts).toHaveLength(1);
+    expect(secondStepDelta[1]?.parts?.[0]).toMatchObject({
       type: 'tool_call_response',
       id: 'call-subagent-fallback',
       response: 'cursor fallback result',
     });
-    // Full = cumulative user prompt + tool result.
-    expect(secondStepFull).toHaveLength(2);
+    // Full = cumulative user prompt + assistant call + tool result.
+    expect(secondStepFull).toHaveLength(3);
     expect(secondStepFull[0]).toMatchObject({
       role: 'user',
       parts: [{ type: 'text', content: 'delegate without child transcript' }],
     });
-    expect(secondStepFull[1]).toMatchObject({ role: 'tool' });
+    expect(secondStepFull[1]).toMatchObject({ role: 'assistant' });
+    expect(secondStepFull[2]).toMatchObject({ role: 'tool' });
   });
 
   // Skip: requires stopGenerationId generation-level isolation (not in this branch)
@@ -1477,7 +1512,7 @@ describe('Cursor react assembler', () => {
     expect(s2Response?.time_unix_nano).toBe(ns(800));
   });
 
-  it('emits delta + full messages on llm.request: s1 has user prompt, s2 has tool result + cumulative', () => {
+  it('emits assistant tool-call history before the matching result in raw events and the final LLM span', async () => {
     const { records } = assembleTurn([
       {
         _journal_ts: iso(0),
@@ -1544,28 +1579,63 @@ describe('Cursor react assembler', () => {
       { role: 'user', parts: [{ type: 'text', content: 'list files' }] },
     ]);
 
-    // s2: delta = [tool result], full = [user prompt, tool result]
+    // s2: delta = [assistant tool call, tool result].
     const s2Delta = llmRequests[1]!['gen_ai.input.messages_delta'] as Array<{ role: string; parts: Array<Record<string, unknown>> }>;
-    expect(s2Delta).toHaveLength(1);
-    expect(s2Delta[0]).toMatchObject({ role: 'tool' });
+    expect(s2Delta.map(message => message.role)).toEqual(['assistant', 'tool']);
     expect(s2Delta[0]?.parts?.[0]).toMatchObject({
+      type: 'tool_call',
+      id: 'call-1',
+      name: 'ls',
+      arguments: { path: '.' },
+    });
+    expect(s2Delta[1]?.parts?.[0]).toMatchObject({
       type: 'tool_call_response',
       id: 'call-1',
       response: 'a.txt b.txt',
     });
 
     const s2Full = llmRequests[1]!['gen_ai.input.messages'] as Array<{ role: string; parts: Array<Record<string, unknown>> }>;
-    expect(s2Full).toHaveLength(2);
+    expect(s2Full.map(message => message.role)).toEqual(['user', 'assistant', 'tool']);
     expect(s2Full[0]).toMatchObject({
       role: 'user',
       parts: [{ type: 'text', content: 'list files' }],
     });
-    expect(s2Full[1]).toMatchObject({ role: 'tool' });
-    expect(s2Full[1]?.parts?.[0]).toMatchObject({
+    expect(s2Full[1]).toMatchObject({ role: 'assistant' });
+    expect(s2Full[2]).toMatchObject({ role: 'tool' });
+    expect(s2Full[2]?.parts?.[0]).toMatchObject({
       type: 'tool_call_response',
       id: 'call-1',
       response: 'a.txt b.txt',
     });
+
+    const previousStability = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+    const previousCapture = process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+    process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'gen_ai_latest_experimental';
+    process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = 'SPAN_ONLY';
+    try {
+      const conversion = await convertEventLogToReadableSpans(records);
+      expect(conversion.warnings).toEqual([]);
+      const llmSpans = conversion.spans
+        .filter(span => span.attributes['gen_ai.span.kind'] === 'LLM');
+      const convertedInput = JSON.parse(String(
+        llmSpans[1]?.attributes['gen_ai.input.messages'],
+      ));
+      expect(convertedInput.map((message: Record<string, unknown>) => message.role))
+        .toEqual(['user', 'assistant', 'tool']);
+      expect(convertedInput[1].parts[0]).toMatchObject({
+        type: 'tool_call',
+        id: 'call-1',
+      });
+      expect(convertedInput[2].parts[0]).toMatchObject({
+        type: 'tool_call_response',
+        id: 'call-1',
+      });
+    } finally {
+      if (previousStability === undefined) delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+      else process.env.OTEL_SEMCONV_STABILITY_OPT_IN = previousStability;
+      if (previousCapture === undefined) delete process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+      else process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = previousCapture;
+    }
 
     // Deep-clone isolation: mutating s2's full messages should not affect s1's full.
     s2Full[0]!.role = 'mutated';
@@ -1693,16 +1763,14 @@ describe('Cursor react assembler', () => {
     expect(s1ToolCalls).toHaveLength(2);
     expect(s1ToolResults).toHaveLength(2);
 
-    // s2 input: delta = [tool results for Read+Write], full = [user prompt, tool results].
+    // s2 input preserves both parallel assistant calls before their tool results.
     const s2Delta = s2Request!['gen_ai.input.messages_delta'] as Array<{ role: string; parts: Array<Record<string, unknown>> }>;
-    expect(s2Delta).toHaveLength(1);
-    expect(s2Delta[0]).toMatchObject({ role: 'tool' });
+    expect(s2Delta.map(message => message.role)).toEqual(['assistant', 'tool']);
     expect(s2Delta[0]!.parts).toHaveLength(2);
+    expect(s2Delta[1]!.parts).toHaveLength(2);
 
     const s2Full = s2Request!['gen_ai.input.messages'] as Array<{ role: string; parts: Array<Record<string, unknown>> }>;
-    expect(s2Full).toHaveLength(2);
-    expect(s2Full[0]).toMatchObject({ role: 'user' });
-    expect(s2Full[1]).toMatchObject({ role: 'tool' });
+    expect(s2Full.map(message => message.role)).toEqual(['user', 'assistant', 'tool']);
 
     // s2 llm.response should carry the final text but NO tool_call parts.
     const s2Output = s2Response!['gen_ai.output.messages'] as Array<{ parts: Array<Record<string, unknown>> }>;

--- a/tests/unit/hooks/cursor-transcript-assembler.test.mjs
+++ b/tests/unit/hooks/cursor-transcript-assembler.test.mjs
@@ -317,6 +317,22 @@ describe('buildCursorRecordsFromTranscript', () => {
       expect(s1Resp['gen_ai.usage.output_tokens']).toBe(0);
     });
 
+    it('step 2 input preserves the assistant tool call before its matching result', () => {
+      const messages = records[5]['gen_ai.input.messages'];
+      expect(messages.map(message => message.role)).toEqual(['user', 'assistant', 'tool']);
+      expect(messages[1].parts[0]).toMatchObject({
+        type: 'tool_call',
+        id: 'tool-ws-001',
+        name: 'WebSearch',
+        arguments: { query: '上海天气' },
+      });
+      expect(messages[2].parts[0]).toMatchObject({
+        type: 'tool_call_response',
+        id: 'tool-ws-001',
+        response: '',
+      });
+    });
+
     it('step 2 llm.response has correct final text', () => {
       const s2Resp = records[6];
       expect(s2Resp['gen_ai.step.id']).toMatch(/:s2$/);

--- a/tests/unit/hooks/qoder-turn-boundary.test.mjs
+++ b/tests/unit/hooks/qoder-turn-boundary.test.mjs
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { convertEventLogToReadableSpans } from '@loongsuite/otel-util-genai';
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -111,7 +112,7 @@ function readHistory(agentId = 'qoder') {
 }
 
 describe('qoder-hook-processor turn boundary markers', () => {
-  it('marks the user input as turn start and the final llm.response as turn end', () => {
+  it('marks turn boundaries and preserves tool-call history in the final LLM span', async () => {
     writeTranscript(ideTurnRows());
 
     expect(runProcessor().status).toBe(0);
@@ -131,6 +132,44 @@ describe('qoder-hook-processor turn boundary markers', () => {
     expect(ends[0]['event.name']).toBe('llm.response');
     expect(ends[0]['gen_ai.response.finish_reasons']).toEqual(['end_turn']);
     expect(records[records.length - 1]).toBe(ends[0]);
+
+    const requests = records.filter(r => r['event.name'] === 'llm.request');
+    expect(requests[1]['gen_ai.input.messages_delta']).toEqual([
+      {
+        role: 'assistant',
+        parts: [{
+          type: 'tool_call',
+          id: 'call-1',
+          name: 'Bash',
+          arguments: { command: 'ls' },
+        }],
+      },
+      {
+        role: 'tool',
+        parts: [{ type: 'tool_call_response', id: 'call-1', response: 'a.txt' }],
+      },
+    ]);
+
+    const previousStability = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+    const previousCapture = process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+    process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'gen_ai_latest_experimental';
+    process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = 'SPAN_ONLY';
+    try {
+      const conversion = await convertEventLogToReadableSpans(records);
+      const llmSpans = conversion.spans
+        .filter(span => span.attributes['gen_ai.span.kind'] === 'LLM');
+      const secondInput = JSON.parse(String(
+        llmSpans[1]?.attributes['gen_ai.input.messages'],
+      ));
+      expect(secondInput.map(message => message.role)).toEqual(['user', 'assistant', 'tool']);
+      expect(secondInput[1].parts[0]).toMatchObject({ type: 'tool_call', id: 'call-1' });
+      expect(secondInput[2].parts[0]).toMatchObject({ type: 'tool_call_response', id: 'call-1' });
+    } finally {
+      if (previousStability === undefined) delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+      else process.env.OTEL_SEMCONV_STABILITY_OPT_IN = previousStability;
+      if (previousCapture === undefined) delete process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+      else process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = previousCapture;
+    }
 
     // Both markers share one turn, and the events in between carry neither.
     expect(starts[0]['gen_ai.turn.id']).toBe(ends[0]['gen_ai.turn.id']);

--- a/tests/unit/hooks/qoderwork/hook-processor.test.mjs
+++ b/tests/unit/hooks/qoderwork/hook-processor.test.mjs
@@ -237,16 +237,27 @@ describe('qoderwork-hook-processor user prompt extraction', () => {
     const records = readJsonlRecords();
     const requests = records.filter((record) => record['event.name'] === 'llm.request');
     const promptDelta = [{ role: 'user', parts: [{ type: 'text', content: 'solve it' }] }];
-    const toolDelta = [{
-      role: 'tool',
-      parts: [{ type: 'tool_call_response', id: 'tool-1', response: '/tmp/project' }],
-    }];
+    const toolHistoryDelta = [
+      {
+        role: 'assistant',
+        parts: [{
+          type: 'tool_call',
+          id: 'tool-1',
+          name: 'shell',
+          arguments: { command: 'pwd' },
+        }],
+      },
+      {
+        role: 'tool',
+        parts: [{ type: 'tool_call_response', id: 'tool-1', response: '/tmp/project' }],
+      },
+    ];
 
     expect(requests).toHaveLength(2);
     expect(requests.map((request) => request['gen_ai.input.messages'])).toEqual([undefined, undefined]);
     expect(requests.map((request) => request['gen_ai.input.messages_delta'])).toEqual([
       promptDelta,
-      toolDelta,
+      toolHistoryDelta,
     ]);
 
     const previousStability = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
@@ -261,7 +272,7 @@ describe('qoderwork-hook-processor user prompt extraction', () => {
 
       expect(convertedInputs).toEqual([
         promptDelta,
-        [...promptDelta, ...toolDelta],
+        [...promptDelta, ...toolHistoryDelta],
       ]);
     } finally {
       if (previousStability === undefined) delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;

--- a/tests/unit/hooks/qwen-code-cli/e2e-self-check.test.mjs
+++ b/tests/unit/hooks/qwen-code-cli/e2e-self-check.test.mjs
@@ -164,8 +164,14 @@ describe('EVENT_LOG_TO_TRACE_SPEC §11 self-check (real fixture)', () => {
     expect(secondInput.map(message => message.role)).toEqual([
       'user', 'assistant', 'tool', 'tool', 'tool',
     ]);
-    const assistantCallIds = secondInput
-      .find(message => message.role === 'assistant').parts
+    const assistantMessages = secondInput.filter(message => message.role === 'assistant');
+    expect(assistantMessages).toHaveLength(1);
+    const assistantParts = assistantMessages[0].parts;
+    expect(assistantParts.filter(part => part.type === 'reasoning')).toHaveLength(1);
+    expect(assistantParts.filter(part => part.type === 'text')).toHaveLength(1);
+    const firstOutput = JSON.parse(llmSpans[0].attributes['gen_ai.output.messages']);
+    expect(assistantParts).toEqual(firstOutput[0].parts);
+    const assistantCallIds = assistantParts
       .filter(part => part.type === 'tool_call')
       .map(part => part.id);
     const toolResponseIds = secondInput

--- a/tests/unit/hooks/qwen-code-cli/e2e-self-check.test.mjs
+++ b/tests/unit/hooks/qwen-code-cli/e2e-self-check.test.mjs
@@ -79,8 +79,20 @@ describe('EVENT_LOG_TO_TRACE_SPEC §11 self-check (real fixture)', () => {
     const events = readAllEventRecords();
     expect(events.length).toBeGreaterThan(0);
 
-    // Convert through util-genai
-    const result = await convertEventLogToReadableSpans(events);
+    // Convert through util-genai with message attributes enabled.
+    const previousStability = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+    const previousCapture = process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+    process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'gen_ai_latest_experimental';
+    process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = 'SPAN_ONLY';
+    let result;
+    try {
+      result = await convertEventLogToReadableSpans(events);
+    } finally {
+      if (previousStability === undefined) delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+      else process.env.OTEL_SEMCONV_STABILITY_OPT_IN = previousStability;
+      if (previousCapture === undefined) delete process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+      else process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = previousCapture;
+    }
     const spans = result.spans || [];
     const warnings = result.warnings || [];
 
@@ -148,6 +160,19 @@ describe('EVENT_LOG_TO_TRACE_SPEC §11 self-check (real fixture)', () => {
       expect(llm.attributes['gen_ai.request.model']).toBe('qwen3.6-plus');
       expect(llm.attributes['gen_ai.provider.name']).toBe('qwen');
     }
+    const secondInput = JSON.parse(llmSpans[1].attributes['gen_ai.input.messages']);
+    expect(secondInput.map(message => message.role)).toEqual([
+      'user', 'assistant', 'tool', 'tool', 'tool',
+    ]);
+    const assistantCallIds = secondInput
+      .find(message => message.role === 'assistant').parts
+      .filter(part => part.type === 'tool_call')
+      .map(part => part.id);
+    const toolResponseIds = secondInput
+      .filter(message => message.role === 'tool')
+      .flatMap(message => message.parts)
+      .map(part => part.id);
+    expect(toolResponseIds).toEqual(assistantCallIds);
 
     // AGENT span aggregates tokens across all LLM calls (sum of step tokens)
     const agentSpan = spans.find((s) => s.attributes['gen_ai.span.kind'] === 'AGENT');

--- a/tests/unit/hooks/qwen-code-cli/message-converter.test.mjs
+++ b/tests/unit/hooks/qwen-code-cli/message-converter.test.mjs
@@ -176,6 +176,24 @@ describe('buildInputMessagesDelta', () => {
     ]);
   });
 
+  test('assistant record → role=assistant with tool_call parts', () => {
+    const records = [
+      {
+        uuid: 'a1', type: 'assistant',
+        message: {
+          role: 'model',
+          parts: [{ functionCall: { id: 'call_abc', name: 'Bash', args: { cmd: 'ls' } } }],
+        },
+      },
+    ];
+    expect(buildInputMessagesDelta(records)).toEqual([
+      {
+        role: 'assistant',
+        parts: [{ type: 'tool_call', id: 'call_abc', name: 'Bash', arguments: { cmd: 'ls' } }],
+      },
+    ]);
+  });
+
   test('tool_result record → role=tool with tool_call_response part (id from toolCallResult.callId)', () => {
     const records = [
       {

--- a/tests/unit/hooks/qwen-code-cli/transcript-parser.test.mjs
+++ b/tests/unit/hooks/qwen-code-cli/transcript-parser.test.mjs
@@ -331,7 +331,7 @@ describe('parseQwenTranscript', () => {
     expect(result.turns[0].llmCalls[0].assistantUuid).toBe('a-main');
   });
 
-  test('inputMessagesDeltaRecords contains user/tool_result between steps', () => {
+  test('inputMessagesDeltaRecords contains user then assistant/tool_result history between steps', () => {
     const file = path.join(TMP, 't.jsonl');
     writeJsonl(file, [
       userRec('u1', 'q'),                                                       // step 1 input
@@ -344,8 +344,8 @@ describe('parseQwenTranscript', () => {
     const step2Delta = result.turns[0].llmCalls[1].inputMessagesDeltaRecords;
     expect(step1Delta).toHaveLength(1);
     expect(step1Delta[0].type).toBe('user');
-    expect(step2Delta).toHaveLength(1);
-    expect(step2Delta[0].type).toBe('tool_result');
+    expect(step2Delta).toHaveLength(2);
+    expect(step2Delta.map(record => record.type)).toEqual(['assistant', 'tool_result']);
   });
 
   test('requestStartTime: step 1 uses user.timestamp, step 2 uses tool_result.timestamp', () => {

--- a/tests/unit/hooks/qwen-work-cn-hook-processor.test.mjs
+++ b/tests/unit/hooks/qwen-work-cn-hook-processor.test.mjs
@@ -171,6 +171,12 @@ describe('QwenWorkCN hook processor', () => {
       ['reasoning', 'tool_call'],
       ['reasoning', 'text'],
     ]);
+    expect(events.filter(event => event['event.name'] === 'llm.request').map(event =>
+      (event['gen_ai.input.messages_delta'] || []).map(message => message.role))).toEqual([
+      ['user'],
+      ['assistant', 'tool'],
+      ['assistant', 'tool'],
+    ]);
 
     const previousStability = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
     const previousCapture = process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
@@ -186,6 +192,23 @@ describe('QwenWorkCN hook processor', () => {
       expect(conversion.spans
         .filter(span => span.attributes['gen_ai.span.kind'] === 'LLM')
         .every(span => span.duration[0] > 0 || span.duration[1] > 0)).toBe(true);
+      const convertedInputs = conversion.spans
+        .filter(span => span.attributes['gen_ai.span.kind'] === 'LLM')
+        .map(span => JSON.parse(span.attributes['gen_ai.input.messages']));
+      expect(convertedInputs.map(messages => messages.map(message => message.role))).toEqual([
+        ['user'],
+        ['user', 'assistant', 'tool'],
+        ['user', 'assistant', 'tool', 'assistant', 'tool'],
+      ]);
+      expect(convertedInputs[1][1].parts[0]).toMatchObject({
+        type: 'tool_call',
+        id: 'call-1',
+        name: 'Glob',
+      });
+      expect(convertedInputs[1][2].parts[0]).toMatchObject({
+        type: 'tool_call_response',
+        id: 'call-1',
+      });
     } finally {
       if (previousStability === undefined) delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
       else process.env.OTEL_SEMCONV_STABILITY_OPT_IN = previousStability;

--- a/tests/unit/inputs/qoder-work-cn-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-work-cn-trace-input.test.ts
@@ -135,7 +135,7 @@ describe('QoderWorkTraceInput (CN variant)', () => {
     expect(toolResultNano).toBeLessThan(step2StartNano);
   });
 
-  it('includes tool results in input.messages_delta for subsequent steps', async () => {
+  it('includes assistant tool calls before tool results in subsequent input deltas', async () => {
     const lines = buildTwoTurnSession({
       sessionId: 'sess-toolmsg',
       turn1: {
@@ -162,7 +162,18 @@ describe('QoderWorkTraceInput (CN variant)', () => {
 
     const inputMessages = step2Request!['gen_ai.input.messages_delta'] as Array<Record<string, unknown>>;
     expect(inputMessages).toBeDefined();
-    expect(inputMessages.length).toBeGreaterThan(0);
+    expect(inputMessages.map(message => message.role)).toEqual(['assistant', 'tool']);
+
+    const assistantMsg = inputMessages[0];
+    expect(assistantMsg).toMatchObject({
+      role: 'assistant',
+      parts: [{
+        type: 'tool_call',
+        id: 'tc-1',
+        name: 'Read',
+        arguments: { path: '/tmp/x.txt' },
+      }],
+    });
 
     const toolMsg = inputMessages.find(m => m.role === 'tool');
     expect(toolMsg).toBeDefined();

--- a/tests/unit/inputs/workbuddy-input.test.ts
+++ b/tests/unit/inputs/workbuddy-input.test.ts
@@ -116,13 +116,15 @@ describe('WorkBuddy audit-event builder', () => {
     expect(responses[0]['agent.workbuddy.usage.credit']).toBe(0.5);
     expect((responses[0]['gen_ai.output.messages'] as any)[0].parts.map((part: any) => part.type))
       .toEqual(['reasoning', 'text', 'tool_call', 'tool_call']);
-    expect(requests[1]['gen_ai.input.messages_delta']).toHaveLength(2);
+    expect(requests[1]['gen_ai.input.messages_delta']).toHaveLength(3);
     expect((requests[1]['gen_ai.input.messages_delta'] as any[]).map(message => message.role))
-      .toEqual(['tool', 'tool']);
-    expect((requests[1]['gen_ai.input.messages_delta'] as any[])
-      .map(message => message.parts[0].id))
+      .toEqual(['assistant', 'tool', 'tool']);
+    const assistantCallParts = (requests[1]['gen_ai.input.messages_delta'] as any[])
+      .find(message => message.role === 'assistant').parts;
+    expect(assistantCallParts.map((part: any) => part.id))
       .toEqual(['call-synthetic-a', 'call-synthetic-b']);
     const toolResponseParts = (requests[1]['gen_ai.input.messages_delta'] as any[])
+      .filter(message => message.role === 'tool')
       .map(message => message.parts[0]);
     expect(toolResponseParts.map(part => part.response)).toEqual([
       { ok: true, value: 'SYNTHETIC_RESULT_A' },
@@ -284,8 +286,9 @@ describe('WorkBuddy audit-event builder', () => {
     const nextRequest = entries.find(entry =>
       entry['event.name'] === 'llm.request'
       && entry['gen_ai.step.id'] === 'request-synthetic-1:s2');
-    expect((nextRequest?.['gen_ai.input.messages_delta'] as any[]))
-      .toHaveLength(1);
+    const nextDelta = nextRequest?.['gen_ai.input.messages_delta'] as any[];
+    expect(nextDelta.map(message => message.role)).toEqual(['assistant', 'tool']);
+    expect(nextDelta[0].parts.map((part: any) => part.id)).toEqual(['call-synthetic-b']);
   });
 
   it('emits a standard null tool response when WorkBuddy has no usable output', async () => {
@@ -298,7 +301,7 @@ describe('WorkBuddy audit-event builder', () => {
       entry['event.name'] === 'llm.request'
       && entry['gen_ai.step.id'] === 'request-synthetic-1:s2');
     const responsePart = (nextRequest?.['gen_ai.input.messages_delta'] as any[])
-      .find(message => message.parts[0].id === 'call-synthetic-a')
+      .find(message => message.role === 'tool' && message.parts[0].id === 'call-synthetic-a')
       ?.parts[0];
 
     expect(responsePart).toEqual({
@@ -502,9 +505,16 @@ describe('WorkBuddy audit-event builder', () => {
       expect(toolDurations).toEqual([100_000_000n, 0n]);
 
       const secondInput = JSON.parse(String(llmSpans[1].attributes['gen_ai.input.messages']));
+      expect(secondInput.map((message: any) => message.role)).toEqual([
+        'user', 'assistant', 'tool', 'tool',
+      ]);
+      const assistantCallIds = secondInput
+        .find((message: any) => message.role === 'assistant').parts
+        .map((part: any) => part.id);
       const responseParts = secondInput
         .filter((message: any) => message.role === 'tool')
         .flatMap((message: any) => message.parts);
+      expect(responseParts.map((part: any) => part.id)).toEqual(assistantCallIds);
       expect(responseParts.map((part: any) => part.response)).toEqual([
         { ok: true, value: 'SYNTHETIC_RESULT_A' },
         { ok: true, value: 'SYNTHETIC_RESULT_B' },


### PR DESCRIPTION
## Summary

- preserve the previous assistant `tool_call` message before matching `tool_call_response` messages in subsequent LLM inputs
- cover Qoder/QoderWork, Cursor, Qwen Code/QwenWorkCN, and WorkBuddy source-specific collection paths
- keep correlation source-faithful by matching native call IDs and avoiding fabricated tool responses
- leave the shared converter, semantic schema, flushers, and unrelated agents unchanged

## Agent coverage

- Qoder family: Hook transcript paths plus QoderWork CN direct trace input
- Cursor: React assembler and transcript fallback assembler
- Qwen: Qwen Code CLI transcript conversion and QwenWorkCN Hook processing
- WorkBuddy: transcript tool-wave event construction

## Validation

- related-agent regression: 541 passed, 3 skipped across 44 test files
- schema and content-policy validation: 30 passed
- `npm run typecheck`: passed
- `npm run build`: passed
- `git diff --check`: passed
- full test run: 2991 passed, 48 skipped, 3 failed; the Qoder cold-start and FileWatcher timing failures passed on isolated rerun, while the remaining environment-dependent QwenWork real-transcript test selected a local incomplete transcript containing user records but no assistant response

Live real-Agent traffic and SLS/ARMS readback are not included in this PR validation yet.

Fixes #258