### PR TITLE
fix(dsh): correct token usage mapping

### DIFF
--- a/src/inputs/dsh/dsh-event-transform.ts
+++ b/src/inputs/dsh/dsh-event-transform.ts
@@ -395,10 +395,16 @@ export function transformDshRecord(
       const responseId = asString(message.id);
       const content = message.content;
       const usage = asObject(data.usage) ?? {};
-      const inputTokens = asNumber(usage.inputTokens);
+      const uncachedInputTokens = asNumber(usage.inputTokens);
       const outputTokens = asNumber(usage.outputTokens);
       const cacheRead = asNumber(usage.cacheReadTokens);
-      const reasoningTokens = asNumber(usage.reasoningTokens);
+      const cacheWrite = asNumber(usage.cacheWriteTokens);
+
+      // DSH reports disjoint input buckets, while Pilot's public schema defines
+      // cache-read and cache-creation tokens as subsets of input_tokens.
+      const inputTokens = uncachedInputTokens === undefined
+        ? undefined
+        : uncachedInputTokens + (cacheRead ?? 0) + (cacheWrite ?? 0);
 
       let finishReasons: string[] | undefined;
       let timeToFirstToken: number | undefined;
@@ -419,10 +425,6 @@ export function transformDshRecord(
         }
       }
 
-      const outputTokensTotal = outputTokens !== undefined && reasoningTokens !== undefined
-        ? outputTokens + reasoningTokens
-        : outputTokens;
-
       const assistantParts = normalizeAssistantParts(content);
       rememberToolNames(content, state);
 
@@ -440,8 +442,11 @@ export function transformDshRecord(
         'gen_ai.response.finish_reasons': finishReasons,
         'gen_ai.response.time_to_first_token': timeToFirstToken,
         'gen_ai.usage.input_tokens': inputTokens,
-        'gen_ai.usage.output_tokens': outputTokensTotal,
+        // DSH outputTokens already includes its optional reasoningTokens
+        // breakdown, so forwarding the total avoids counting reasoning twice.
+        'gen_ai.usage.output_tokens': outputTokens,
         'gen_ai.usage.cache_read.input_tokens': cacheRead,
+        'gen_ai.usage.cache_creation.input_tokens': cacheWrite,
         'gen_ai.output.messages': toJsonValue([{
           role: 'assistant',
           parts: assistantParts,

--- a/tests/unit/inputs/dsh-log/dsh-event-transform.test.ts
+++ b/tests/unit/inputs/dsh-log/dsh-event-transform.test.ts
@@ -114,6 +114,52 @@ describe('dsh-event-transform (real fixture)', () => {
     }
   });
 
+  it('maps real DSH disjoint usage into cumulative Pilot token fields', async () => {
+    const { entries } = await loadAll();
+    const responses = entries
+      .filter(e => e['event.name'] === 'llm.response')
+      .sort((a, b) => (a['gen_ai.step.id'] as string).localeCompare(b['gen_ai.step.id'] as string));
+
+    expect(responses.map(r => ({
+      input: r['gen_ai.usage.input_tokens'],
+      output: r['gen_ai.usage.output_tokens'],
+      cacheRead: r['gen_ai.usage.cache_read.input_tokens'],
+    }))).toEqual([
+      { input: 7_493, output: 105, cacheRead: 0 },
+      { input: 7_632, output: 46, cacheRead: 7_552 },
+      { input: 7_723, output: 36, cacheRead: 7_552 },
+    ]);
+  });
+
+  it('includes cache writes in input without double-counting reasoning', () => {
+    const r = transformDshRecord({
+      type: 'assistant/message',
+      sid: 's',
+      time: 1000,
+      data: {
+        turn: 1,
+        step: 1,
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'done' }],
+          source: { provider: 'test', model: 'test-model' },
+        },
+        usage: {
+          inputTokens: 10,
+          outputTokens: 5,
+          cacheReadTokens: 20,
+          cacheWriteTokens: 30,
+          reasoningTokens: 4,
+        },
+      },
+    }, ClientType.Dsh, newState());
+
+    expect(r!['gen_ai.usage.input_tokens']).toBe(60);
+    expect(r!['gen_ai.usage.output_tokens']).toBe(5);
+    expect(r!['gen_ai.usage.cache_read.input_tokens']).toBe(20);
+    expect(r!['gen_ai.usage.cache_creation.input_tokens']).toBe(30);
+  });
+
   it('emits paired tool.call + tool.result with matching call.id', async () => {
     const { entries } = await loadAll();
     const calls = entries.filter(e => e['event.name'] === 'tool.call');

--- a/tests/unit/inputs/dsh-log/dsh-otlp-grouping.test.ts
+++ b/tests/unit/inputs/dsh-log/dsh-otlp-grouping.test.ts
@@ -40,7 +40,13 @@ function transformTurn(sid: string, baseTime: number): AgentActivityEntry[] {
           content: [{ type: 'text', text: 'done' }],
           source: { provider: 'deepseek', model: 'deepseek-test' },
         },
-        usage: { inputTokens: 1, outputTokens: 1 },
+        usage: {
+          inputTokens: 3,
+          outputTokens: 5,
+          cacheReadTokens: 7,
+          cacheWriteTokens: 11,
+          reasoningTokens: 2,
+        },
       },
     },
   ];
@@ -94,6 +100,13 @@ describe('DSH session-scoped turn ids in OTLP buffering', () => {
     expect(llmSpans).toHaveLength(2);
     expect(llmSpans.map(span => span.attributes['gen_ai.response.time_to_first_token']))
       .toEqual([1_000_000, 1_000_000]);
+    for (const span of [...llmSpans, ...agentSpans]) {
+      expect(span.attributes['gen_ai.usage.input_tokens']).toBe(21);
+      expect(span.attributes['gen_ai.usage.output_tokens']).toBe(5);
+      expect(span.attributes['gen_ai.usage.cache_read.input_tokens']).toBe(7);
+      expect(span.attributes['gen_ai.usage.cache_creation.input_tokens']).toBe(11);
+      expect(span.attributes['gen_ai.usage.total_tokens']).toBe(26);
+    }
     for (const span of captured) {
       expect(span.resource.attributes['gen_ai.agent.type']).toBe('dsh');
       expect(span.resource.attributes['gen_ai.agent.system']).toBe('dsh');


### PR DESCRIPTION
## Summary

- convert DSH's disjoint uncached, cache-read, and cache-write input buckets into cumulative `gen_ai.usage.input_tokens`
- forward DSH `outputTokens` unchanged because its optional reasoning count is already included
- map `cacheWriteTokens` to `gen_ai.usage.cache_creation.input_tokens`
- add exact real-fixture and OTLP LLM/AGENT aggregation regression coverage

The change is scoped to the DSH transform and DSH-specific tests; shared normalization and flusher behavior are unchanged.

## Validation

- `npm test -- --run tests/unit/inputs/dsh-log/dsh-event-transform.test.ts tests/unit/inputs/dsh-log/dsh-otlp-grouping.test.ts` — 2 files, 33 tests passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `npm test -- --run` — 258 files / 3122 tests passed; one local-data-dependent `qwen-work-cn-real-transcript` test failed and reproduces unchanged on `origin/main@253eefcfeeac705d498dfb9652a07dc029effd64`

Fixes #267