### PR TITLE
docs: cross-reference the standalone dsh-plugin for DSH-only users

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ DeepSeek Harness (`dsh`) loads Pilot's observability plugin from its user-level
 and time-to-first-token events. See [Agent Configuration](docs/agents.md#deepseek-harness-collection-and-lifecycle)
 for activation, source-log, disable, and uninstall behavior.
 
+Only need DeepSeek Harness, and want it to emit standard OTLP straight to your
+own backend without running a local collector? Use the standalone
+[@loongsuite/dsh-plugin](https://github.com/loongsuite/dsh-plugin) instead.
+Pilot is the multi-agent path: discovery, normalization into a shared schema,
+and fan-out to files, SLS, HTTP, or trace backends.
+
 ### Documented Windows Agent Support
 
 The table above describes Pilot's general integration capabilities; it does not imply that every agent is supported on every operating system. The following agents are currently explicitly documented as supported on Windows:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -67,6 +67,10 @@ DeepSeek Harness（`dsh`）通过用户级 `cordis.patch.yml` 加载 Pilot
 延迟数据。启用、原始日志、禁用和卸载行为见
 [《Agent 配置》](docs/zh-CN/agents.md#deepseek-harness-采集与生命周期)。
 
+如果只用 DeepSeek Harness，且不想在本地跑 collector、只想让它以标准 OTLP 直接发到自己的后端，
+请改用独立插件 [@loongsuite/dsh-plugin](https://github.com/loongsuite/dsh-plugin)。
+Pilot 是多 Agent 路径：自动发现、归一化到统一 schema，并分发到文件、SLS、HTTP 或链路后端。
+
 ### Windows Agent 明确支持情况
 
 上表描述 Pilot 的总体接入能力，不代表每个 Agent 在所有操作系统上均受支持。目前文档明确说明支持 Windows 的 Agent 如下：


### PR DESCRIPTION
Both READMEs now mention [@loongsuite/dsh-plugin](https://github.com/loongsuite/dsh-plugin) right below the DeepSeek Harness integration paragraph, and spell out how the two paths differ:

- **dsh-plugin**: DSH-only, runs inside the harness process, exports standard OTLP/HTTP straight to the user's own backend — nothing else to install.
- **Pilot** (this repo): multi-agent discovery, normalization into the shared GenAI schema, and fan-out to JSONL / SLS / HTTP / OTLP backends, plus the local dashboard.

Readers who only use DSH and already run an OTLP backend currently land here and install a collector they do not need; the cross-reference sends them to the lighter option. Wording kept symmetric with the comparison table in the dsh-plugin README.