### PR TITLE
feat(otlp): support trace endpoint routing

### DIFF
--- a/docs/trace-output.md
+++ b/docs/trace-output.md
@@ -13,7 +13,7 @@ Trace output is separate from log output. SLS, JSONL, and HTTP receive event rec
   "collectTrace": true,
   "serviceName": "my-agent-service",
   "otlpTrace": {
-    "endpoint": "https://otel-collector.example.com",
+    "traceEndpoint": "https://traces.example.com/v1/traces",
     "headers": {
       "Authorization": "Bearer token"
     },
@@ -31,7 +31,8 @@ Trace output is separate from log output. SLS, JSONL, and HTTP receive event rec
 |---------|-------------|
 | `collectTrace` | Master switch for trace export. |
 | `serviceName` | Exact `service.name` shared by every agent, OTLP backend, and SLS backend. |
-| `otlpTrace.endpoint` | OTLP HTTP base URL. Pilot auto-appends `/v1/traces` if the path does not already end with it. |
+| `otlpTrace.traceEndpoint` | Full OTLP HTTP trace URL, used as-is. Takes precedence over `endpoint`. |
+| `otlpTrace.endpoint` | Legacy trace base URL. Pilot appends `/v1/traces` when needed. |
 | `otlpTrace.headers` | Headers sent to the OTLP endpoint. |
 | `otlpTrace.serviceName` | Legacy trace-only service-name base. Pilot appends `-<agentType>`; top-level `serviceName` takes precedence and disables the suffix. |
 | `otlpTrace.resourceAttributes` | Extra OpenTelemetry resource attributes. |
@@ -45,7 +46,8 @@ Environment variables:
 |----------|-------------|
 | `LOONGSUITE_PILOT_COLLECT_TRACE` | Set `false` or `0` to disable trace export. |
 | `LOONGSUITE_PILOT_SERVICE_NAME` | Exact service name shared by all agents and reporting backends. |
-| `LOONGSUITE_PILOT_OTLP_ENDPOINT` | OTLP trace endpoint. |
+| `LOONGSUITE_PILOT_OTLP_TRACES_ENDPOINT` | Signal-specific OTLP trace endpoint. |
+| `LOONGSUITE_PILOT_OTLP_ENDPOINT` | Legacy OTLP trace endpoint. |
 | `LOONGSUITE_PILOT_OTLP_HEADERS` | JSON string for OTLP headers. |
 
 ## ARMS/CMS-Compatible Trace Output
@@ -102,7 +104,7 @@ Managed/hosted deployments can push extra trace backends via `~/.loongsuite-pilo
   "otlp": [
     {
       "name": "team-collector",
-      "endpoint": "https://collector.internal:4318",
+      "traceEndpoint": "https://traces.internal:4318/v1/traces",
       "headers": { "x-token": "..." },
       "compression": "gzip"
     }
@@ -123,7 +125,8 @@ Managed/hosted deployments can push extra trace backends via `~/.loongsuite-pilo
 |-------|-----------|-------------|
 | `serviceNamePrefix` | top-level | Service-name prefix for **all** managed backends — trace (`otlp[]`/`cms[]`, as `service.name`) and log (`sls[]`, as the `__service_name__` tag) — keeping them distinct from user backends. Optional; falls back to the user `serviceNamePrefix` when omitted (no differentiation). A user-configured top-level `serviceName` overrides this prefix. |
 | `otlp[].name` / `cms[].name` | both | Label used in logs and in the per-backend failed-log filename. Optional (defaults to `inner-otlp-<i>` / `inner-cms-<i>`). |
-| `otlp[].endpoint` | otlp | OTLP HTTP base URL (`/v1/traces` auto-appended). |
+| `otlp[].traceEndpoint` | otlp | Full OTLP HTTP trace URL, used as-is. Takes precedence over `endpoint`. |
+| `otlp[].endpoint` | otlp | Legacy trace base URL (`/v1/traces` auto-appended). |
 | `otlp[].headers` | otlp | Request headers (e.g. auth token). |
 | `otlp[].compression` | otlp | `gzip` (default) or `none`. |
 | `cms[].endpoint` | cms | ARMS/CMS trace endpoint. |

--- a/docs/zh-CN/trace-output.md
+++ b/docs/zh-CN/trace-output.md
@@ -13,7 +13,7 @@ Trace 输出和日志输出是分开的。SLS、JSONL、HTTP 接收事件记录�
   "collectTrace": true,
   "serviceName": "my-agent-service",
   "otlpTrace": {
-    "endpoint": "https://otel-collector.example.com",
+    "traceEndpoint": "https://traces.example.com/v1/traces",
     "headers": {
       "Authorization": "Bearer token"
     },
@@ -31,7 +31,8 @@ Trace 输出和日志输出是分开的。SLS、JSONL、HTTP 接收事件记录�
 |--------|------|
 | `collectTrace` | Trace 上报总开关。 |
 | `serviceName` | 所有 Agent、OTLP 后端和 SLS 后端共用的唯一 `service.name`。 |
-| `otlpTrace.endpoint` | OTLP HTTP base URL。如果路径未以 `/v1/traces` 结尾，Pilot 会自动追加。 |
+| `otlpTrace.traceEndpoint` | 完整的 OTLP HTTP Trace 地址，按原值使用；优先于 `endpoint`。 |
+| `otlpTrace.endpoint` | 兼容旧配置的 Trace 基础地址，Pilot 会按需追加 `/v1/traces`。 |
 | `otlpTrace.headers` | 发送到 OTLP endpoint 的请求头。 |
 | `otlpTrace.serviceName` | 兼容原有行为的 Trace 服务名基础值，Pilot 会追加 `-<agentType>`；顶层 `serviceName` 优先并关闭该后缀。 |
 | `otlpTrace.resourceAttributes` | 额外 OpenTelemetry resource attributes。 |
@@ -45,7 +46,8 @@ Trace 输出和日志输出是分开的。SLS、JSONL、HTTP 接收事件记录�
 |----------|------|
 | `LOONGSUITE_PILOT_COLLECT_TRACE` | 设置为 `false` 或 `0` 可关闭 Trace 上报。 |
 | `LOONGSUITE_PILOT_SERVICE_NAME` | 所有 Agent 和上报后端共用的唯一服务名。 |
-| `LOONGSUITE_PILOT_OTLP_ENDPOINT` | OTLP Trace endpoint。 |
+| `LOONGSUITE_PILOT_OTLP_TRACES_ENDPOINT` | 按信号配置的 OTLP Trace endpoint。 |
+| `LOONGSUITE_PILOT_OTLP_ENDPOINT` | 兼容旧配置的 OTLP Trace endpoint。 |
 | `LOONGSUITE_PILOT_OTLP_HEADERS` | OTLP 请求头 JSON 字符串。 |
 
 ## ARMS/CMS 兼容 Trace 输出
@@ -102,7 +104,7 @@ Trace 导出会把**同一批**转换后的 span **同时**发往**所有**已�
   "otlp": [
     {
       "name": "team-collector",
-      "endpoint": "https://collector.internal:4318",
+      "traceEndpoint": "https://traces.internal:4318/v1/traces",
       "headers": { "x-token": "..." },
       "compression": "gzip"
     }
@@ -123,7 +125,8 @@ Trace 导出会把**同一批**转换后的 span **同时**发往**所有**已�
 |------|------|------|
 | `serviceNamePrefix` | 顶层 | **所有**托管后端的 service name 前缀——trace(`otlp[]`/`cms[]`,作为 `service.name`)与 log(`sls[]`,作为 `__service_name__` tag)——用于与用户后端区分。可选;省略时回退到用户的 `serviceNamePrefix`(即不做区分)。用户配置的顶层 `serviceName` 会覆盖此前缀。 |
 | `otlp[].name` / `cms[].name` | 两者 | 用于日志与失败日志文件名的标签。可选(默认 `inner-otlp-<i>` / `inner-cms-<i>`)。 |
-| `otlp[].endpoint` | otlp | OTLP HTTP 基础 URL(自动补 `/v1/traces`)。 |
+| `otlp[].traceEndpoint` | otlp | 完整的 OTLP HTTP Trace 地址，按原值使用；优先于 `endpoint`。 |
+| `otlp[].endpoint` | otlp | 兼容旧配置的 Trace 基础地址（自动补 `/v1/traces`）。 |
 | `otlp[].headers` | otlp | 请求 header(如鉴权 token)。 |
 | `otlp[].compression` | otlp | `gzip`(默认)或 `none`。 |
 | `cms[].endpoint` | cms | ARMS/CMS trace endpoint。 |

--- a/src/core/config-loader.ts
+++ b/src/core/config-loader.ts
@@ -170,6 +170,7 @@ export interface ConfigFile {
 
   otlpTrace?: {
     endpoint?: string;
+    traceEndpoint?: string;
     headers?: Record<string, string>;
     resourceAttributes?: Record<string, string>;
     serviceName?: string;
@@ -672,9 +673,10 @@ function buildFlushersConfig(
  *   - inner config.innerTrace.otlp[]  (managed generic OTLP backends)
  *   - inner config.innerTrace.cms[]   (managed ARMS shorthand backends)
  *
- * Endpoints are deduped by normalized URL + license-key + project. Conversion
- * happens once; serviceName / resourceAttributes / captureMessageContent are
- * therefore shared across all backends. Requires collectTrace=true.
+ * Routes are deduped by normalized URL + full headers + serviceName.
+ * Conversion happens once; serviceName / resourceAttributes /
+ * captureMessageContent are therefore shared across all backends. Requires
+ * collectTrace=true.
  */
 export function buildOtlpTraceConfig(config: AnalyticsConfig): OtlpTraceFlusherConfig | undefined {
   if (!config.collectTrace) return undefined;
@@ -692,9 +694,22 @@ export function buildOtlpTraceConfig(config: AnalyticsConfig): OtlpTraceFlusherC
   const innerPrefix = config.serviceName ? undefined : config.innerTrace?.serviceNamePrefix;
   const innerServiceName = innerPrefix && innerPrefix !== userServiceName ? innerPrefix : undefined;
 
-  // 1. User generic OTLP (endpoint via env or config).
-  const userOtlpEndpoint = env('LOONGSUITE_PILOT_OTLP_ENDPOINT') ?? config.otlpTrace?.endpoint;
-  if (userOtlpEndpoint) {
+  // 1. User generic OTLP. The signal-specific route wins over the legacy
+  // endpoint while preserving the legacy environment-variable precedence.
+  const envTraceEndpoint = env('LOONGSUITE_PILOT_OTLP_TRACES_ENDPOINT');
+  const envLegacyEndpoint = env('LOONGSUITE_PILOT_OTLP_ENDPOINT');
+  let userTraceEndpoint: string | undefined;
+  let userLegacyEndpoint: string | undefined;
+  if (envTraceEndpoint !== undefined) {
+    userTraceEndpoint = envTraceEndpoint;
+  } else if (envLegacyEndpoint !== undefined) {
+    userLegacyEndpoint = envLegacyEndpoint;
+  } else if (config.otlpTrace?.traceEndpoint !== undefined) {
+    userTraceEndpoint = config.otlpTrace.traceEndpoint;
+  } else {
+    userLegacyEndpoint = config.otlpTrace?.endpoint;
+  }
+  if (userTraceEndpoint || userLegacyEndpoint) {
     let headers: Record<string, string> | undefined;
     const envHeaders = env('LOONGSUITE_PILOT_OTLP_HEADERS');
     if (envHeaders) {
@@ -705,7 +720,8 @@ export function buildOtlpTraceConfig(config: AnalyticsConfig): OtlpTraceFlusherC
     }
     endpoints.push({
       name: 'user-otlp',
-      endpoint: userOtlpEndpoint,
+      endpoint: userLegacyEndpoint,
+      traceEndpoint: userTraceEndpoint,
       headers,
       compression: config.otlpTrace?.compression,
     });
@@ -726,10 +742,11 @@ export function buildOtlpTraceConfig(config: AnalyticsConfig): OtlpTraceFlusherC
   // buildSlsConfig's guard and keeps a bad push from bricking all flushers.
   const innerOtlp = Array.isArray(config.innerTrace?.otlp) ? config.innerTrace!.otlp : [];
   innerOtlp.forEach((ep, i) => {
-    if (!ep.endpoint) return;
+    if (!ep.endpoint && !ep.traceEndpoint) return;
     endpoints.push({
       name: ep.name ?? `inner-otlp-${i}`,
       endpoint: ep.endpoint,
+      traceEndpoint: ep.traceEndpoint,
       headers: ep.headers,
       compression: ep.compression,
       serviceName: innerServiceName,
@@ -795,23 +812,30 @@ function stableHeaderKey(headers?: Record<string, string>): string {
 }
 
 /**
- * Dedup by normalized URL + full headers + serviceName. Because the CMS shorthand
- * encodes license-key / project / workspace as headers, this subsumes those fields
- * and also distinguishes generic OTLP backends that share a URL but differ in auth
- * headers — so a managed backend is never silently folded into a user endpoint.
- * serviceName is included so the same URL under two service names is kept as two
- * distinct backends. First occurrence wins.
+ * Dedup by normalized trace URL + full headers + serviceName. Because the CMS
+ * shorthand encodes license-key, project, and workspace as headers, those
+ * fields remain tenant boundaries. First occurrence wins.
  */
 function dedupOtlpEndpoints(endpoints: OtlpEndpoint[]): OtlpEndpoint[] {
   const seen = new Set<string>();
   const result: OtlpEndpoint[] = [];
   for (const ep of endpoints) {
-    const key = `${normalizeEndpointUrl(ep.endpoint)}|${stableHeaderKey(ep.headers)}|${ep.serviceName ?? ''}`;
+    const commonKey = `${stableHeaderKey(ep.headers)}|${ep.serviceName ?? ''}`;
+    const traceRoute = normalizeOtlpTraceRoute(ep);
+    if (!traceRoute) continue;
+    const key = `${traceRoute}|${commonKey}`;
     if (seen.has(key)) continue;
     seen.add(key);
     result.push(ep);
   }
   return result;
+}
+
+function normalizeOtlpTraceRoute(endpoint: OtlpEndpoint): string {
+  if (endpoint.traceEndpoint) return normalizeEndpointUrl(endpoint.traceEndpoint);
+  if (!endpoint.endpoint) return '';
+  const base = normalizeEndpointUrl(endpoint.endpoint);
+  return base.endsWith('/v1/traces') ? base : `${base}/v1/traces`;
 }
 
 function resolveResourceAttributeKeys(

--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -88,7 +88,7 @@ export type OtlpExporterFactory = (opts: {
 
 interface ResolvedOtlpEndpoint {
   name: string;
-  url: string;
+  traceUrl: string;
   headers: Record<string, string>;
   compression: CompressionAlgorithm;
   serviceName: string;
@@ -119,12 +119,16 @@ interface AgentResourceIdentity {
 
 const SENSITIVE_RESOURCE_KEY_RE = /(^|[_.-])(TOKEN|SECRET|PASSWORD|CREDENTIAL|COOKIE)([_.-]|$)|^(API_KEY|API_HEADER)$/i;
 
-function resolveEndpointUrl(raw: string): string {
+function resolveLegacyTraceEndpointUrl(raw: string): string {
   let url = raw.replace(/\/+$/, '');
   if (!url.endsWith('/v1/traces')) {
     url += '/v1/traces';
   }
   return url;
+}
+
+function normalizeExactTraceEndpointUrl(raw: string): string {
+  return raw.replace(/\/+$/, '');
 }
 
 const defaultExporterFactory: OtlpExporterFactory = ({ url, headers, compression }) =>
@@ -199,14 +203,25 @@ export class OtlpTraceFlusher extends BaseFlusher {
     this.cfg = cfg;
     this.globalAttributesProvider = globalAttributesProvider;
     this.exporterFactory = exporterFactory ?? defaultExporterFactory;
-    this.endpoints = cfg.endpoints.map((ep, i) => ({
-      name: ep.name || `otlp-${i}`,
-      url: resolveEndpointUrl(ep.endpoint),
-      headers: ep.headers ?? {},
-      compression: ep.compression === 'none' ? CompressionAlgorithm.NONE : CompressionAlgorithm.GZIP,
-      serviceName: ep.serviceName || cfg.serviceName,
-      appendAgentTypeToServiceName: cfg.appendAgentTypeToServiceName !== false,
-    }));
+    this.endpoints = cfg.endpoints
+      .map((ep, i) => {
+        return {
+          name: ep.name || `otlp-${i}`,
+          traceUrl: ep.traceEndpoint
+            ? normalizeExactTraceEndpointUrl(ep.traceEndpoint)
+            : ep.endpoint
+              ? resolveLegacyTraceEndpointUrl(ep.endpoint)
+              : undefined,
+          headers: ep.headers ?? {},
+          compression: ep.compression === 'none' ? CompressionAlgorithm.NONE : CompressionAlgorithm.GZIP,
+          serviceName: ep.serviceName || cfg.serviceName,
+          appendAgentTypeToServiceName: cfg.appendAgentTypeToServiceName !== false,
+        };
+      })
+      .filter((ep): ep is ResolvedOtlpEndpoint => !!ep.traceUrl);
+    if (this.endpoints.length === 0) {
+      throw new Error('[otlp-trace-flusher] every endpoint is missing a trace route');
+    }
     const dataDir = cfg.dataDir ?? os.homedir() + '/.loongsuite-pilot';
     this.pilotVersion = readInstalledVersion(dataDir);
     this.debugDir = path.join(dataDir, 'logs', 'otlp-debug');
@@ -229,7 +244,7 @@ export class OtlpTraceFlusher extends BaseFlusher {
     }
 
     logger.info(
-      `OTLP trace flusher initialized → ${this.endpoints.map(e => `${e.name}(${e.url})`).join(', ')}`,
+      `OTLP trace flusher initialized → ${this.endpoints.map((endpoint) => `${endpoint.name}(${endpoint.traceUrl})`).join(', ')}`,
     );
   }
 
@@ -990,7 +1005,7 @@ export class OtlpTraceFlusher extends BaseFlusher {
       .map((ep) => ({
         name: ep.name,
         exporter: this.exporterFactory({
-          url: ep.url,
+          url: ep.traceUrl,
           headers: ep.headers,
           compression: ep.compression,
           name: ep.name,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,7 +59,10 @@ export interface MaskConfig {
 }
 
 export interface OtlpTraceRawConfig {
+  /** Legacy trace endpoint. Prefer traceEndpoint for signal-specific routing. */
   endpoint?: string;
+  /** Full OTLP trace endpoint, used as-is. Takes precedence over endpoint. */
+  traceEndpoint?: string;
   headers?: Record<string, string>;
   resourceAttributes?: Record<string, string>;
   serviceName?: string;
@@ -76,7 +79,10 @@ export interface OtlpTraceRawConfig {
 /** A single OTLP trace backend (managed inner or user), export-time only. */
 export interface OtlpEndpointEntry {
   name?: string;
-  endpoint: string;
+  /** Legacy trace endpoint. Prefer traceEndpoint for new configurations. */
+  endpoint?: string;
+  /** Full OTLP trace endpoint, used as-is. */
+  traceEndpoint?: string;
   headers?: Record<string, string>;
   compression?: 'none' | 'gzip';
 }
@@ -220,7 +226,10 @@ export interface FlusherConfig {
 /** A resolved OTLP backend the flusher exports to (name required for logging). */
 export interface OtlpEndpoint {
   name: string;
-  endpoint: string;
+  /** Legacy trace route retained for compatibility. */
+  endpoint?: string;
+  /** Full signal-specific trace route, used as-is. */
+  traceEndpoint?: string;
   headers?: Record<string, string>;
   compression?: 'none' | 'gzip';
   /** Overrides the shared config.serviceName for this backend's spans. */

--- a/tests/unit/core/config-loader.test.ts
+++ b/tests/unit/core/config-loader.test.ts
@@ -1047,6 +1047,19 @@ describe('ConfigLoader', () => {
       });
     });
 
+    it('loadConfig preserves traceEndpoint', async () => {
+      mockReadJsonFile.mockResolvedValueOnce({
+        otlpTrace: {
+          traceEndpoint: 'http://trace-collector:4318',
+        },
+      });
+
+      const config = await loadConfig();
+      expect(config.otlpTrace).toMatchObject({
+        traceEndpoint: 'http://trace-collector:4318',
+      });
+    });
+
     it('otlpTrace is undefined when not in config file', async () => {
       mockReadJsonFile.mockResolvedValueOnce(null);
 
@@ -1083,6 +1096,24 @@ describe('ConfigLoader', () => {
       expect(result!.debug).toBe(true);
       expect(result!.turnIdleTimeoutMs).toBe(5000);
       expect(result!.resourceAttributeKeys).toEqual([]);
+    });
+
+    it('buildOtlpTraceConfig prefers traceEndpoint over legacy endpoint', async () => {
+      mockReadJsonFile.mockResolvedValueOnce({
+        collectTrace: true,
+        otlpTrace: {
+          endpoint: 'http://legacy-trace:4318',
+          traceEndpoint: 'http://trace-collector:4318',
+        },
+      });
+
+      const result = buildOtlpTraceConfig(await loadConfig());
+
+      expect(result!.endpoints).toEqual([expect.objectContaining({
+        name: 'user-otlp',
+        endpoint: undefined,
+        traceEndpoint: 'http://trace-collector:4318',
+      })]);
     });
 
     it('buildOtlpTraceConfig allows custom resource attribute keys', async () => {
@@ -1294,6 +1325,30 @@ describe('ConfigLoader', () => {
       expect(result!.endpoints.map(e => e.name)).toEqual(['user-cms', 'other-tenant']);
     });
 
+    it('dedups equivalent legacy and exact trace routes', async () => {
+      mockReadJsonFile.mockResolvedValueOnce({
+        collectTrace: true,
+        otlpTrace: {
+          traceEndpoint: 'http://collector:4318/v1/traces',
+          headers: { Authorization: 'token' },
+        },
+      });
+      mockReadJsonFile.mockResolvedValueOnce({
+        otlp: [{
+          name: 'managed',
+          endpoint: 'http://collector:4318',
+          headers: { Authorization: 'token' },
+        }],
+      });
+
+      const result = buildOtlpTraceConfig(await loadConfig());
+
+      expect(result!.endpoints).toHaveLength(1);
+      expect(result!.endpoints[0]).toMatchObject({
+        traceEndpoint: 'http://collector:4318/v1/traces',
+      });
+    });
+
     it('buildOtlpTraceConfig keeps same-url/license/project backends that differ only by workspace', async () => {
       mockReadJsonFile.mockResolvedValueOnce({
         collectTrace: true,
@@ -1354,6 +1409,22 @@ describe('ConfigLoader', () => {
 
       expect(result).toBeDefined();
       expect(result!.endpoints[0]!.endpoint).toBe('http://from-env:4318');
+    });
+
+    it('signal-specific trace env var overrides the file route', async () => {
+      mockReadJsonFile.mockResolvedValueOnce({
+        collectTrace: true,
+        otlpTrace: {
+          traceEndpoint: 'http://trace-from-file:4318',
+        },
+      });
+      vi.stubEnv('LOONGSUITE_PILOT_OTLP_TRACES_ENDPOINT', 'http://trace-from-env:4318');
+
+      const result = buildOtlpTraceConfig(await loadConfig());
+
+      expect(result!.endpoints[0]).toMatchObject({
+        traceEndpoint: 'http://trace-from-env:4318',
+      });
     });
 
     it('env var LOONGSUITE_PILOT_OTLP_HEADERS overrides file headers', async () => {

--- a/tests/unit/flushers/otlp-trace-flusher/endpoint.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/endpoint.test.ts
@@ -78,4 +78,25 @@ describe('OtlpTraceFlusher - endpoint normalization', () => {
       }),
     );
   });
+
+  it('uses traceEndpoint as an exact URL', async () => {
+    const flusher = new OtlpTraceFlusher({
+      enabled: true,
+      endpoints: [{
+        name: 'primary',
+        traceEndpoint: 'https://traces.example.com/custom/traces',
+      }],
+      protocol: 'http/protobuf',
+      serviceName: 'test',
+    });
+
+    await flusher.exportSpansForAgent('codex', []);
+    await flusher.shutdown();
+
+    expect(OTLPTraceExporter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://traces.example.com/custom/traces',
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- add a full-URL `traceEndpoint` route for user and managed OTLP trace backends
- preserve legacy `endpoint` behavior, including automatic `/v1/traces` suffixing
- add `LOONGSUITE_PILOT_OTLP_TRACES_ENDPOINT` with environment-over-file precedence
- deduplicate equivalent legacy and exact trace routes
- document the configuration in English and Chinese

## Compatibility

- `traceEndpoint` is used as the exact trace URL and takes precedence over `endpoint`
- legacy `endpoint` remains supported without behavior changes
- metrics export is not included

## Testing

- `npm run typecheck`
- `npm run build`
- focused OTLP/config tests: 121 passed
- full suite: 3119 passed; one unrelated dashboard PID lifecycle test failed in this environment
- `git diff --check`