### PR TITLE
fix(cursor): preserve prior assistant output in LLM inputs

### DIFF
--- a/assets/hooks/cursor-hook-processor.mjs
+++ b/assets/hooks/cursor-hook-processor.mjs
@@ -168,7 +168,13 @@ function toolCallIdsFromMessages(messages) {
  * Merge synthetic Skill reads into the previous round's single assistant
  * output, then add one independent tool-role response message per Skill read.
  */
-function mergeSkillExchange(messages, sourceToolCallIds, callParts, responseParts) {
+function mergeSkillExchange(
+  messages,
+  sourceToolCallIds,
+  sourceHadToolCalls,
+  callParts,
+  responseParts,
+) {
   const merged = Array.isArray(messages) ? cloneJson(messages) : [];
   const existingPartIds = new Set(merged.flatMap(message =>
     Array.isArray(message?.parts) ? message.parts.map(part => part?.id).filter(Boolean) : []
@@ -182,10 +188,18 @@ function mergeSkillExchange(messages, sourceToolCallIds, callParts, responsePart
     return response ? [{ role: 'tool', parts: [cloneJson(response)] }] : [];
   });
 
-  const assistantIndex = merged.findIndex(message =>
+  let assistantIndex = merged.findIndex(message =>
     message?.role === 'assistant' &&
     message.parts?.some(part => part?.id && sourceToolCallIds.has(part.id))
   );
+  // Cursor can omit tool_use_id while still preserving the prior assistant in
+  // request history. In that case reuse the first assistant (the target is the
+  // first LLM response) instead of creating a second, Skill-only assistant.
+  // Keep the no-source-tool path unchanged: there is no prior tool assistant to
+  // reuse, so the synthetic exchange must remain its own assistant message.
+  if (assistantIndex < 0 && sourceHadToolCalls) {
+    assistantIndex = merged.findIndex(message => message?.role === 'assistant');
+  }
 
   if (assistantIndex < 0) {
     const firstHistoryIndex = merged.findIndex(message =>
@@ -228,6 +242,10 @@ function injectSkillRecords(records, skills, runtimeConfig = {}) {
     ? llmRecord['gen_ai.output.messages']
     : [];
   const sourceToolCallIds = toolCallIdsFromMessages(outputMsgs);
+  const sourceHadToolCalls = outputMsgs.some(message =>
+    message?.role === 'assistant' &&
+    message.parts?.some(part => part?.type === 'tool_call')
+  );
 
   let assistantMsg = outputMsgs.find(m => m.role === 'assistant');
   if (!assistantMsg) {
@@ -269,6 +287,7 @@ function injectSkillRecords(records, skills, runtimeConfig = {}) {
   for (let index = targetLlmIdx + 1; index < records.length; index++) {
     const record = records[index];
     if (record['event.name'] !== 'llm.request') continue;
+    if (record['gen_ai.agent.scope'] === 'subagent') continue;
     if (targetTraceId && record.trace_id !== targetTraceId) continue;
     if (targetTurnId && record['gen_ai.turn.id'] !== targetTurnId) continue;
     laterRequestIndexes.push(index);
@@ -280,6 +299,7 @@ function injectSkillRecords(records, skills, runtimeConfig = {}) {
       request['gen_ai.input.messages_delta'] = mergeSkillExchange(
         request['gen_ai.input.messages_delta'],
         sourceToolCallIds,
+        sourceHadToolCalls,
         skillCallParts,
         skillResponseParts,
       );
@@ -287,6 +307,7 @@ function injectSkillRecords(records, skills, runtimeConfig = {}) {
     request['gen_ai.input.messages'] = mergeSkillExchange(
       request['gen_ai.input.messages'],
       sourceToolCallIds,
+      sourceHadToolCalls,
       skillCallParts,
       skillResponseParts,
     );

--- a/assets/hooks/cursor-hook-processor.mjs
+++ b/assets/hooks/cursor-hook-processor.mjs
@@ -148,7 +148,67 @@ function applyPolicy(record, runtimeConfig) {
   return sanitizeObject(applyHookContentPolicy(record, runtimeConfig)) || {};
 }
 
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function toolCallIdsFromMessages(messages) {
+  const ids = new Set();
+  if (!Array.isArray(messages)) return ids;
+  for (const message of messages) {
+    if (message?.role !== 'assistant' || !Array.isArray(message.parts)) continue;
+    for (const part of message.parts) {
+      if (part?.type === 'tool_call' && part.id) ids.add(part.id);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Merge synthetic Skill reads into the previous round's single assistant
+ * output, then add one independent tool-role response message per Skill read.
+ */
+function mergeSkillExchange(messages, sourceToolCallIds, callParts, responseParts) {
+  const merged = Array.isArray(messages) ? cloneJson(messages) : [];
+  const existingPartIds = new Set(merged.flatMap(message =>
+    Array.isArray(message?.parts) ? message.parts.map(part => part?.id).filter(Boolean) : []
+  ));
+  const pendingCalls = callParts.filter(part => !existingPartIds.has(part.id));
+  if (pendingCalls.length === 0) return merged;
+
+  const responseById = new Map(responseParts.map(part => [part.id, part]));
+  const responseMessages = pendingCalls.flatMap(call => {
+    const response = responseById.get(call.id);
+    return response ? [{ role: 'tool', parts: [cloneJson(response)] }] : [];
+  });
+
+  const assistantIndex = merged.findIndex(message =>
+    message?.role === 'assistant' &&
+    message.parts?.some(part => part?.id && sourceToolCallIds.has(part.id))
+  );
+
+  if (assistantIndex < 0) {
+    const firstHistoryIndex = merged.findIndex(message =>
+      message?.role === 'assistant' || message?.role === 'tool'
+    );
+    const insertAt = firstHistoryIndex >= 0 ? firstHistoryIndex : merged.length;
+    merged.splice(
+      insertAt,
+      0,
+      { role: 'assistant', parts: cloneJson(pendingCalls) },
+      ...responseMessages,
+    );
+  } else {
+    merged[assistantIndex].parts.push(...cloneJson(pendingCalls));
+    let insertAt = assistantIndex + 1;
+    while (insertAt < merged.length && merged[insertAt]?.role === 'tool') insertAt++;
+    merged.splice(insertAt, 0, ...responseMessages);
+  }
+  return merged;
+}
+
 function injectSkillRecords(records, skills, runtimeConfig = {}) {
+  if (!Array.isArray(skills) || skills.length === 0) return;
   // Skill-to-step alignment is best-effort: attach detected reads to the first
   // assembled LLM response. Cursor's assemblers synthesize a response even for
   // thought-only and implicit tool steps, so never attach output to a request.
@@ -167,6 +227,7 @@ function injectSkillRecords(records, skills, runtimeConfig = {}) {
   const outputMsgs = Array.isArray(llmRecord['gen_ai.output.messages'])
     ? llmRecord['gen_ai.output.messages']
     : [];
+  const sourceToolCallIds = toolCallIdsFromMessages(outputMsgs);
 
   let assistantMsg = outputMsgs.find(m => m.role === 'assistant');
   if (!assistantMsg) {
@@ -185,6 +246,52 @@ function injectSkillRecords(records, skills, runtimeConfig = {}) {
   }
   llmRecord['gen_ai.output.messages'] = outputMsgs;
   records[targetLlmIdx] = applyPolicy(llmRecord, runtimeConfig);
+
+  const skillCallParts = skillEntries.map(({ skill, toolCallId }) => ({
+    type: 'tool_call',
+    id: toolCallId,
+    name: 'Read',
+    arguments: { path: skill.skillPath },
+  }));
+  // Preserve the call/response relationship without copying SKILL.md content.
+  const skillResponseParts = skillEntries.map(({ toolCallId }) => ({
+    type: 'tool_call_response',
+    id: toolCallId,
+    response: '',
+  }));
+
+  // The assemblers computed request history before this post-assembly injection.
+  // Backfill the immediate next request's delta/full messages, then keep the
+  // synthetic exchange in every later full context for this same turn.
+  const targetTraceId = llmRecord.trace_id;
+  const targetTurnId = llmRecord['gen_ai.turn.id'];
+  const laterRequestIndexes = [];
+  for (let index = targetLlmIdx + 1; index < records.length; index++) {
+    const record = records[index];
+    if (record['event.name'] !== 'llm.request') continue;
+    if (targetTraceId && record.trace_id !== targetTraceId) continue;
+    if (targetTurnId && record['gen_ai.turn.id'] !== targetTurnId) continue;
+    laterRequestIndexes.push(index);
+  }
+  for (let index = 0; index < laterRequestIndexes.length; index++) {
+    const requestIndex = laterRequestIndexes[index];
+    const request = records[requestIndex];
+    if (index === 0) {
+      request['gen_ai.input.messages_delta'] = mergeSkillExchange(
+        request['gen_ai.input.messages_delta'],
+        sourceToolCallIds,
+        skillCallParts,
+        skillResponseParts,
+      );
+    }
+    request['gen_ai.input.messages'] = mergeSkillExchange(
+      request['gen_ai.input.messages'],
+      sourceToolCallIds,
+      skillCallParts,
+      skillResponseParts,
+    );
+    records[requestIndex] = applyPolicy(request, runtimeConfig);
+  }
 
   // Create tool.call + tool.result record pairs for each skill read
   const insertRecords = [];

--- a/assets/hooks/cursor/react-assembler.mjs
+++ b/assets/hooks/cursor/react-assembler.mjs
@@ -391,7 +391,7 @@ function buildParentSteps(events, ctx) {
     if (!currentLlmResponse) return;
     const toolCalls = stepToolCalls.get(currentStepId);
     appendToolCallParts(currentLlmResponse, toolCalls);
-    previousAssistantToolMessage = toolCallsToMessage(toolCalls);
+    previousAssistantToolMessage = llmResponseToInputAssistantMessage(currentLlmResponse);
     applyToolCallResponseTiming(currentLlmResponse, toolCalls);
 
     // Guard: if LLM request start >= response end (buffered-tool scenario),
@@ -685,23 +685,53 @@ function cloneMessages(messages) {
   return JSON.parse(JSON.stringify(messages));
 }
 
-/** Build a tool-role message from collected tool results (used as delta input on s2+ steps). */
-function toolResultsToMessage(toolResults) {
-  const parts = toolResults.map(tr => ({
+/** Build one tool response part from a collected result. */
+function toolResultToPart(toolResult) {
+  return {
     type: 'tool_call_response',
-    id: tr.toolUseId || null,
-    response: tr.error || stringify(tr.result),
-  }));
-  return { role: 'tool', parts };
+    id: toolResult.toolUseId || null,
+    response: toolResult.error || stringify(toolResult.result),
+  };
+}
+
+/**
+ * Preserve the previous LLM output as one assistant message, then emit one
+ * tool-role message per completed response. This mirrors the causal sequence:
+ * assistant(reasoning/text + all calls), tool(result A), tool(result B).
+ */
+function toolExchangeMessages(assistantToolMessage, toolResults) {
+  const calls = Array.isArray(assistantToolMessage?.parts)
+    ? assistantToolMessage.parts.filter(part => part?.type === 'tool_call')
+    : [];
+  const usedResultIndexes = new Set();
+  const messages = assistantToolMessage
+    ? [cloneMessages([assistantToolMessage])[0]]
+    : [];
+
+  for (const call of calls) {
+    const resultIndex = toolResults.findIndex((result, index) =>
+      !usedResultIndexes.has(index) && (result.toolUseId || null) === (call.id || null)
+    );
+    if (resultIndex >= 0) {
+      usedResultIndexes.add(resultIndex);
+      messages.push({ role: 'tool', parts: [toolResultToPart(toolResults[resultIndex])] });
+    }
+  }
+
+  for (let index = 0; index < toolResults.length; index++) {
+    if (usedResultIndexes.has(index)) continue;
+    messages.push({ role: 'tool', parts: [toolResultToPart(toolResults[index])] });
+  }
+  return messages;
 }
 
 /**
  * Build per-step delta messages and update cumulative input.
  *
  * - isFirst step: delta includes the user prompt (already pre-seeded in cumulative).
- * - s2+ steps: delta includes the previous assistant tool-call message followed
- *   by the tool-role message containing its results. Both are appended to the
- *   cumulative input in source order.
+ * - s2+ steps: delta includes the complete previous assistant output followed
+ *   by one tool message per completed result. They are appended to cumulative
+ *   input in source order.
  *
  * Callers are responsible for resetting previousToolResults after this call.
  */
@@ -720,14 +750,12 @@ function buildDeltaMessages(
     });
   }
   if (previousToolResults.length > 0) {
-    if (previousAssistantToolMessage) {
-      const assistantMessage = cloneMessages([previousAssistantToolMessage])[0];
-      deltaMessages.push(assistantMessage);
-      cumulativeInputMessages.push(cloneMessages([assistantMessage])[0]);
-    }
-    const toolMessage = toolResultsToMessage(previousToolResults);
-    deltaMessages.push(toolMessage);
-    cumulativeInputMessages.push({ ...toolMessage, parts: [...toolMessage.parts] });
+    const exchangeMessages = toolExchangeMessages(
+      previousAssistantToolMessage,
+      previousToolResults,
+    );
+    deltaMessages.push(...cloneMessages(exchangeMessages));
+    cumulativeInputMessages.push(...cloneMessages(exchangeMessages));
   }
   return deltaMessages;
 }
@@ -869,17 +897,14 @@ function appendToolCallParts(llmResponse, toolCalls) {
   }
 }
 
-function toolCallsToMessage(toolCalls) {
-  if (!toolCalls || toolCalls.length === 0) return null;
-  return {
-    role: 'assistant',
-    parts: toolCalls.map(tc => ({
-      type: 'tool_call',
-      id: tc.toolUseId || null,
-      name: tc.toolName,
-      arguments: parseMaybeJson(tc.toolInput),
-    })),
-  };
+function llmResponseToInputAssistantMessage(llmResponse) {
+  const outputMessages = llmResponse?.['gen_ai.output.messages'];
+  const assistant = Array.isArray(outputMessages)
+    ? outputMessages.find(message => message?.role === 'assistant')
+    : null;
+  if (!assistant || !Array.isArray(assistant.parts)) return null;
+  if (!assistant.parts.some(part => part?.type === 'tool_call')) return null;
+  return { role: 'assistant', parts: cloneMessages(assistant.parts) };
 }
 
 function applyToolCallResponseTiming(llmResponse, toolCalls) {

--- a/assets/hooks/cursor/react-assembler.mjs
+++ b/assets/hooks/cursor/react-assembler.mjs
@@ -710,7 +710,10 @@ function toolExchangeMessages(assistantToolMessage, toolResults) {
 
   for (const call of calls) {
     const resultIndex = toolResults.findIndex((result, index) =>
-      !usedResultIndexes.has(index) && (result.toolUseId || null) === (call.id || null)
+      !usedResultIndexes.has(index) &&
+      typeof call.id === 'string' && call.id.length > 0 &&
+      typeof result.toolUseId === 'string' && result.toolUseId.length > 0 &&
+      result.toolUseId === call.id
     );
     if (resultIndex >= 0) {
       usedResultIndexes.add(resultIndex);

--- a/assets/hooks/cursor/transcript-assembler.mjs
+++ b/assets/hooks/cursor/transcript-assembler.mjs
@@ -141,19 +141,10 @@ export function buildCursorRecordsFromTranscript(transcriptPath, journalEvents, 
     const stepModel = step.thoughtEvent?.model || step.responseEvent?.model || model;
 
     if (i > 0 && prevToolResults.length > 0) {
-      if (previousAssistantToolMessage) {
-        cumulativeInputMessages.push(cloneMessage(previousAssistantToolMessage));
-      }
-      // NOTE: tool_output from journal postToolUse may contain GB18030-garbled text.
-      // Omit response content to avoid garbled data in output; structure is preserved.
-      cumulativeInputMessages.push({
-        role: 'tool',
-        parts: prevToolResults.map(tr => ({
-          type: 'tool_call_response',
-          id: tr.tool_use_id || null,
-          response: '',
-        })),
-      });
+      cumulativeInputMessages.push(...toolExchangeMessages(
+        previousAssistantToolMessage,
+        prevToolResults,
+      ));
     }
     const inputMessages = cumulativeInputMessages.map(cloneMessage);
 
@@ -280,7 +271,7 @@ export function buildCursorRecordsFromTranscript(transcriptPath, journalEvents, 
     records.push(respRecord);
     const assistantToolParts = outputParts.filter(part => part.type === 'tool_call');
     previousAssistantToolMessage = assistantToolParts.length > 0
-      ? { role: 'assistant', parts: assistantToolParts.map(part => ({ ...part })) }
+      ? { role: 'assistant', parts: outputParts.map(part => cloneMessage(part)) }
       : null;
     prevToolResults = step.toolResults;
   }
@@ -290,6 +281,49 @@ export function buildCursorRecordsFromTranscript(transcriptPath, journalEvents, 
 
 function cloneMessage(message) {
   return JSON.parse(JSON.stringify(message));
+}
+
+/** Preserve one complete assistant output, followed by one message per tool result. */
+function toolExchangeMessages(assistantToolMessage, toolResults) {
+  const calls = Array.isArray(assistantToolMessage?.parts)
+    ? assistantToolMessage.parts.filter(part => part?.type === 'tool_call')
+    : [];
+  const usedResultIndexes = new Set();
+  const messages = assistantToolMessage
+    ? [cloneMessage(assistantToolMessage)]
+    : [];
+
+  for (const call of calls) {
+    const resultIndex = toolResults.findIndex((result, index) =>
+      !usedResultIndexes.has(index) &&
+      (result.tool_use_id || null) === (call.id || null)
+    );
+    if (resultIndex >= 0) {
+      usedResultIndexes.add(resultIndex);
+      messages.push({
+        role: 'tool',
+        parts: [{
+          type: 'tool_call_response',
+          id: toolResults[resultIndex].tool_use_id || null,
+          // Journal output may contain GB18030-garbled text. Preserve structure only.
+          response: '',
+        }],
+      });
+    }
+  }
+
+  for (let index = 0; index < toolResults.length; index++) {
+    if (usedResultIndexes.has(index)) continue;
+    messages.push({
+      role: 'tool',
+      parts: [{
+        type: 'tool_call_response',
+        id: toolResults[index].tool_use_id || null,
+        response: '',
+      }],
+    });
+  }
+  return messages;
 }
 
 // ─── Transcript Parser ───

--- a/assets/hooks/cursor/transcript-assembler.mjs
+++ b/assets/hooks/cursor/transcript-assembler.mjs
@@ -296,7 +296,9 @@ function toolExchangeMessages(assistantToolMessage, toolResults) {
   for (const call of calls) {
     const resultIndex = toolResults.findIndex((result, index) =>
       !usedResultIndexes.has(index) &&
-      (result.tool_use_id || null) === (call.id || null)
+      typeof call.id === 'string' && call.id.length > 0 &&
+      typeof result.tool_use_id === 'string' && result.tool_use_id.length > 0 &&
+      result.tool_use_id === call.id
     );
     if (resultIndex >= 0) {
       usedResultIndexes.add(resultIndex);

--- a/tests/unit/hooks/cursor-react-assembler.test.ts
+++ b/tests/unit/hooks/cursor-react-assembler.test.ts
@@ -484,7 +484,7 @@ describe('Cursor react assembler', () => {
     const thirdDelta = thirdRequest?.['gen_ai.input.messages_delta'] ?? [];
     expect(thirdDelta.map((message: Record<string, unknown>) => message.role))
       .toEqual(['assistant', 'tool']);
-    expect(thirdDelta[0]?.parts?.[0]).toMatchObject({
+    expect(thirdDelta[0]?.parts?.find((part: Record<string, unknown>) => part.type === 'tool_call')).toMatchObject({
       type: 'tool_call',
       id: 'call-normal-shell',
       name: 'Shell',
@@ -566,7 +566,7 @@ describe('Cursor react assembler', () => {
     const secondDelta = requests[1]?.['gen_ai.input.messages_delta'] ?? [];
     expect(secondDelta.map((message: Record<string, unknown>) => message.role))
       .toEqual(['assistant', 'tool']);
-    expect(secondDelta[0]?.parts?.[0]).toMatchObject({
+    expect(secondDelta[0]?.parts?.find((part: Record<string, unknown>) => part.type === 'tool_call')).toMatchObject({
       type: 'tool_call',
       id: 'call-failing-read',
     });
@@ -863,7 +863,7 @@ describe('Cursor react assembler', () => {
       // Delta on s2 preserves the assistant call immediately before its result.
       expect(secondStepDelta).toHaveLength(2);
       expect(secondStepDelta.map(message => message.role)).toEqual(['assistant', 'tool']);
-      expect(secondStepDelta[0]?.parts?.[0]).toMatchObject({
+      expect(secondStepDelta[0]?.parts?.find(part => part.type === 'tool_call')).toMatchObject({
         type: 'tool_call',
         id: 'call-subagent',
         name: 'Subagent',
@@ -1196,9 +1196,12 @@ describe('Cursor react assembler', () => {
       expect(parentRequests).toHaveLength(3);
       expect(firstStepTaskCalls).toHaveLength(2);
       expect(secondStepDelta.map((message: Record<string, unknown>) => message.role))
-        .toEqual(['assistant', 'tool']);
-      expect(secondStepDelta[0]?.parts).toHaveLength(2);
-      expect(secondStepDelta[1]?.parts).toHaveLength(2);
+        .toEqual(['assistant', 'tool', 'tool']);
+      expect(secondStepDelta[0]?.parts
+        ?.filter((part: Record<string, unknown>) => part.type === 'tool_call')).toHaveLength(2);
+      expect(secondStepDelta.slice(1).every((message: Record<string, unknown>) =>
+        Array.isArray(message.parts) && message.parts.length === 1
+      )).toBe(true);
       expect(BigInt(secondRequest!.time_unix_nano)).toBeGreaterThanOrEqual(BigInt(ns(600)));
     } finally {
       fs.rmSync(transcriptDir, { recursive: true, force: true });
@@ -1280,7 +1283,7 @@ describe('Cursor react assembler', () => {
     // Delta on s2 preserves the assistant call immediately before its result.
     expect(secondStepDelta).toHaveLength(2);
     expect(secondStepDelta.map(message => message.role)).toEqual(['assistant', 'tool']);
-    expect(secondStepDelta[0]?.parts?.[0]).toMatchObject({
+    expect(secondStepDelta[0]?.parts?.find((part: Record<string, unknown>) => part.type === 'tool_call')).toMatchObject({
       type: 'tool_call',
       id: 'call-subagent-fallback',
       name: 'Subagent',
@@ -1582,7 +1585,7 @@ describe('Cursor react assembler', () => {
     // s2: delta = [assistant tool call, tool result].
     const s2Delta = llmRequests[1]!['gen_ai.input.messages_delta'] as Array<{ role: string; parts: Array<Record<string, unknown>> }>;
     expect(s2Delta.map(message => message.role)).toEqual(['assistant', 'tool']);
-    expect(s2Delta[0]?.parts?.[0]).toMatchObject({
+    expect(s2Delta[0]?.parts?.find((part: Record<string, unknown>) => part.type === 'tool_call')).toMatchObject({
       type: 'tool_call',
       id: 'call-1',
       name: 'ls',
@@ -1622,7 +1625,7 @@ describe('Cursor react assembler', () => {
       ));
       expect(convertedInput.map((message: Record<string, unknown>) => message.role))
         .toEqual(['user', 'assistant', 'tool']);
-      expect(convertedInput[1].parts[0]).toMatchObject({
+      expect(convertedInput[1].parts.find((part: Record<string, unknown>) => part.type === 'tool_call')).toMatchObject({
         type: 'tool_call',
         id: 'call-1',
       });
@@ -1763,14 +1766,18 @@ describe('Cursor react assembler', () => {
     expect(s1ToolCalls).toHaveLength(2);
     expect(s1ToolResults).toHaveLength(2);
 
-    // s2 input preserves both parallel assistant calls before their tool results.
+    // s2 input preserves the complete assistant output, then one response per tool.
     const s2Delta = s2Request!['gen_ai.input.messages_delta'] as Array<{ role: string; parts: Array<Record<string, unknown>> }>;
-    expect(s2Delta.map(message => message.role)).toEqual(['assistant', 'tool']);
-    expect(s2Delta[0]!.parts).toHaveLength(2);
-    expect(s2Delta[1]!.parts).toHaveLength(2);
+    expect(s2Delta.map(message => message.role))
+      .toEqual(['assistant', 'tool', 'tool']);
+    expect(s2Delta[0].parts.filter(part => part.type === 'tool_call').map(part => part.id))
+      .toEqual(['tool-aaa', 'tool-bbb']);
+    expect(s2Delta.slice(1).map(message => message.parts[0]?.id))
+      .toEqual(['tool-aaa', 'tool-bbb']);
 
     const s2Full = s2Request!['gen_ai.input.messages'] as Array<{ role: string; parts: Array<Record<string, unknown>> }>;
-    expect(s2Full.map(message => message.role)).toEqual(['user', 'assistant', 'tool']);
+    expect(s2Full.map(message => message.role))
+      .toEqual(['user', 'assistant', 'tool', 'tool']);
 
     // s2 llm.response should carry the final text but NO tool_call parts.
     const s2Output = s2Response!['gen_ai.output.messages'] as Array<{ parts: Array<Record<string, unknown>> }>;

--- a/tests/unit/hooks/cursor-react-assembler.test.ts
+++ b/tests/unit/hooks/cursor-react-assembler.test.ts
@@ -637,6 +637,38 @@ describe('Cursor react assembler', () => {
     expect(requests).toHaveLength(2);
   });
 
+  it('only pairs tool calls and results when both have non-empty ids', () => {
+    const base = {
+      conversation_id: 'conv-null-id-pairing',
+      generation_id: 'turn-null-id-pairing',
+    };
+    const { records } = assembleTurn([
+      { ...base, _journal_ts: iso(0), hook_event: 'beforeSubmitPrompt', prompt: 'inspect files' },
+      { ...base, _journal_ts: iso(100), hook_event: 'afterAgentThought', text: 'Inspecting.', duration_ms: 50 },
+      { ...base, _journal_ts: iso(200), hook_event: 'preToolUse', tool_name: 'Read', tool_use_id: 'call-read', tool_input: {} },
+      { ...base, _journal_ts: iso(210), hook_event: 'preToolUse', tool_name: 'Shell', tool_input: {} },
+      { ...base, _journal_ts: iso(220), hook_event: 'preToolUse', tool_name: 'Grep', tool_use_id: 'call-grep', tool_input: {} },
+      { ...base, _journal_ts: iso(300), hook_event: 'postToolUse', tool_name: 'Read', tool_output: 'read without id' },
+      { ...base, _journal_ts: iso(310), hook_event: 'postToolUse', tool_name: 'Grep', tool_use_id: 'call-grep', tool_output: 'grep with id' },
+      { ...base, _journal_ts: iso(320), hook_event: 'postToolUse', tool_name: 'Shell', tool_output: 'shell without id' },
+      { ...base, _journal_ts: iso(500), hook_event: 'afterAgentThought', text: 'Done inspecting.', duration_ms: 50 },
+      { ...base, _journal_ts: iso(600), hook_event: 'stop', status: 'completed' },
+    ], { stopConversationId: base.conversation_id });
+
+    const secondRequest = records.find(record =>
+      record['event.name'] === 'llm.request' &&
+      record['gen_ai.step.id'] === 'turn-null-id-pairing:s2'
+    );
+    const toolParts = (secondRequest?.['gen_ai.input.messages_delta'] ?? [])
+      .filter((message: Record<string, unknown>) => message.role === 'tool')
+      .map((message: { parts: Array<Record<string, unknown>> }) => message.parts[0]);
+
+    expect(toolParts.map((part: Record<string, unknown>) => part.id))
+      .toEqual(['call-grep', undefined, undefined]);
+    expect(toolParts.map((part: Record<string, unknown>) => part.response))
+      .toEqual(['grep with id', 'read without id', 'shell without id']);
+  });
+
   it('guards LLM spans by moving start before the earliest buffered tool call', () => {
     const { records } = assembleTurn([
       {

--- a/tests/unit/hooks/cursor-transcript-assembler.test.mjs
+++ b/tests/unit/hooks/cursor-transcript-assembler.test.mjs
@@ -320,7 +320,7 @@ describe('buildCursorRecordsFromTranscript', () => {
     it('step 2 input preserves the assistant tool call before its matching result', () => {
       const messages = records[5]['gen_ai.input.messages'];
       expect(messages.map(message => message.role)).toEqual(['user', 'assistant', 'tool']);
-      expect(messages[1].parts[0]).toMatchObject({
+      expect(messages[1].parts.find(part => part.type === 'tool_call')).toMatchObject({
         type: 'tool_call',
         id: 'tool-ws-001',
         name: 'WebSearch',
@@ -491,6 +491,44 @@ describe('buildCursorRecordsFromTranscript', () => {
       const parts = lastResp['gen_ai.output.messages'][0].parts;
       expect(parts.some(p => p.type === 'text')).toBe(true);
     });
+  });
+
+  it('expands multiple previous tools into independent assistant/tool message pairs', () => {
+    const transcriptPath = writeTranscript([
+      { role: 'user', message: { content: [{ type: 'text', text: '<user_query>\ninspect\n</user_query>' }] } },
+      {
+        role: 'assistant',
+        message: { content: [
+          { type: 'text', text: 'checking' },
+          { type: 'tool_use', id: 'call-read', name: 'Read', input: { file_path: 'a' } },
+          { type: 'tool_use', id: 'call-shell', name: 'Shell', input: { command: 'pwd' } },
+        ] },
+      },
+      { role: 'assistant', message: { content: [{ type: 'text', text: 'done' }] } },
+      { type: 'turn_ended', status: 'success' },
+    ]);
+    const records = buildCursorRecordsFromTranscript(transcriptPath, [
+      makePromptEvent({ prompt: 'inspect' }),
+      makeThoughtEvent({ text: 'checking' }),
+      makePreToolUse({ tool_name: 'Read', tool_use_id: 'call-read' }),
+      makePostToolUse({ tool_name: 'Read', tool_use_id: 'call-read' }),
+      makePreToolUse({ tool_name: 'Shell', tool_use_id: 'call-shell', _journal_ts: iso(3200) }),
+      makePostToolUse({ tool_name: 'Shell', tool_use_id: 'call-shell', _journal_ts: iso(4000) }),
+      makeResponseEvent({ text: 'done' }),
+      makeStopEvent(),
+    ], { stopConversationId: 'conv-abc' });
+
+    const secondRequest = records.find(record =>
+      record['event.name'] === 'llm.request' &&
+      record['gen_ai.step.id'].endsWith(':s2')
+    );
+    expect(secondRequest['gen_ai.input.messages'].map(message => message.role))
+      .toEqual(['user', 'assistant', 'tool', 'tool']);
+    expect(secondRequest['gen_ai.input.messages'][1].parts.map(part => part.type))
+      .toEqual(['reasoning', 'tool_call', 'tool_call']);
+    expect(secondRequest['gen_ai.input.messages'].slice(2)
+      .map(message => message.parts[0].id))
+      .toEqual(['call-read', 'call-shell']);
   });
 
   describe('SPEC compliance', () => {

--- a/tests/unit/hooks/cursor-transcript-assembler.test.mjs
+++ b/tests/unit/hooks/cursor-transcript-assembler.test.mjs
@@ -531,6 +531,43 @@ describe('buildCursorRecordsFromTranscript', () => {
       .toEqual(['call-read', 'call-shell']);
   });
 
+  it('only pairs tool calls and results when both have non-empty ids', () => {
+    const transcriptPath = writeTranscript([
+      { role: 'user', message: { content: [{ type: 'text', text: '<user_query>inspect</user_query>' }] } },
+      {
+        role: 'assistant',
+        message: { content: [
+          { type: 'text', text: 'checking' },
+          { type: 'tool_use', id: 'transcript-read', name: 'Read', input: {} },
+          { type: 'tool_use', id: 'transcript-shell', name: 'Shell', input: {} },
+          { type: 'tool_use', id: 'transcript-grep', name: 'Grep', input: {} },
+        ] },
+      },
+      { role: 'assistant', message: { content: [{ type: 'text', text: 'done' }] } },
+      { type: 'turn_ended', status: 'success' },
+    ]);
+    const records = buildCursorRecordsFromTranscript(transcriptPath, [
+      makePromptEvent({ prompt: 'inspect' }),
+      makeThoughtEvent({ text: 'checking' }),
+      makePreToolUse({ tool_name: 'Read', tool_use_id: 'call-read', _journal_ts: iso(1500) }),
+      makePreToolUse({ tool_name: 'Shell', tool_use_id: undefined, _journal_ts: iso(1600) }),
+      makePreToolUse({ tool_name: 'Grep', tool_use_id: 'call-grep', _journal_ts: iso(1700) }),
+      makePostToolUse({ tool_name: 'Read', tool_use_id: undefined, _journal_ts: iso(3000) }),
+      makePostToolUse({ tool_name: 'Grep', tool_use_id: 'call-grep', _journal_ts: iso(3100) }),
+      makePostToolUse({ tool_name: 'Shell', tool_use_id: undefined, _journal_ts: iso(3200) }),
+      makeResponseEvent({ text: 'done' }),
+      makeStopEvent(),
+    ], { stopConversationId: 'conv-abc' });
+
+    const secondRequest = records.find(record =>
+      record['event.name'] === 'llm.request' &&
+      record['gen_ai.step.id'].endsWith(':s2')
+    );
+    expect(secondRequest['gen_ai.input.messages'].slice(2)
+      .map(message => message.parts[0].id))
+      .toEqual(['call-grep', undefined, undefined]);
+  });
+
   describe('SPEC compliance', () => {
     it('STEP count == LLM call count', () => {
       const transcriptPath = weatherTranscript();

--- a/tests/unit/hooks/cursor/inject-skill-records.test.mjs
+++ b/tests/unit/hooks/cursor/inject-skill-records.test.mjs
@@ -227,6 +227,82 @@ describe('injectSkillRecords', () => {
       .some(part => part.id === skillCall.id)).toBe(false);
   });
 
+  it('should never backfill a parent Skill exchange into subagent requests', () => {
+    const sourceCall = {
+      type: 'tool_call', id: 'parent-call', name: 'Agent', arguments: { task: 'inspect' },
+    };
+    const firstResponse = makeLlmResponse({
+      'gen_ai.output.messages': [{ role: 'assistant', parts: [sourceCall] }],
+    });
+    const childInput = [
+      { role: 'assistant', parts: [{ type: 'reasoning', content: 'child reasoning' }] },
+    ];
+    const childRequest = makeLlmRequest({
+      'event.id': 'evt-child-request',
+      'gen_ai.turn.id': 'turn-001',
+      'gen_ai.step.id': 'turn-001:sub:child:s1',
+      'gen_ai.agent.scope': 'subagent',
+      'gen_ai.agent.id': 'child-conversation',
+      'gen_ai.input.messages_delta': childInput,
+      'gen_ai.input.messages': childInput,
+    });
+    const originalChildRequest = structuredClone(childRequest);
+    const records = [firstResponse, childRequest];
+
+    injectSkillRecords(records, [makeSkill()]);
+
+    expect(childRequest).toEqual(originalChildRequest);
+    const skillCall = firstResponse['gen_ai.output.messages'][0].parts
+      .find(part => part.type === 'tool_call' && part.name === 'Read');
+    expect(skillCall).toBeDefined();
+    expect(JSON.stringify(childRequest)).not.toContain(skillCall.id);
+  });
+
+  it('should reuse the prior assistant when the source tool call id is null', () => {
+    const reasoning = { type: 'reasoning', content: 'inspect first' };
+    const sourceCall = {
+      type: 'tool_call', id: null, name: 'Read', arguments: { path: '/tmp/a' },
+    };
+    const sourceResponse = {
+      type: 'tool_call_response', id: null, response: 'file body',
+    };
+    const sourceAssistant = { role: 'assistant', parts: [reasoning, sourceCall] };
+    const firstResponse = makeLlmResponse({
+      'gen_ai.output.messages': [sourceAssistant],
+    });
+    const secondRequest = makeLlmRequest({
+      'event.id': 'evt-req-null-id',
+      'gen_ai.turn.id': 'turn-001',
+      'gen_ai.step.id': 'step_2',
+      'gen_ai.input.messages_delta': [
+        structuredClone(sourceAssistant),
+        { role: 'tool', parts: [sourceResponse] },
+      ],
+      'gen_ai.input.messages': [
+        { role: 'user', parts: [{ type: 'text', content: 'prompt' }] },
+        structuredClone(sourceAssistant),
+        { role: 'tool', parts: [sourceResponse] },
+      ],
+    });
+    const records = [firstResponse, secondRequest];
+
+    injectSkillRecords(records, [makeSkill()]);
+
+    const skillCall = firstResponse['gen_ai.output.messages'][0].parts
+      .find(part => part.type === 'tool_call' && part.name === 'Read' && part.id);
+    for (const messages of [
+      secondRequest['gen_ai.input.messages_delta'],
+      secondRequest['gen_ai.input.messages'],
+    ]) {
+      const assistants = messages.filter(message => message.role === 'assistant');
+      expect(assistants).toHaveLength(1);
+      expect(assistants[0].parts).toEqual([reasoning, sourceCall, skillCall]);
+      expect(messages.filter(message => message.role === 'tool')).toHaveLength(2);
+      expect(messages.find(message =>
+        message.role === 'tool' && message.parts[0]?.id === skillCall.id)).toBeDefined();
+    }
+  });
+
   it('should create assistant/tool history when the source response had no ordinary tools', () => {
     const firstResponse = makeLlmResponse();
     const secondRequest = makeLlmRequest({

--- a/tests/unit/hooks/cursor/inject-skill-records.test.mjs
+++ b/tests/unit/hooks/cursor/inject-skill-records.test.mjs
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { convertEventLogToReadableSpans } from '@loongsuite/otel-util-genai';
 import {
   filterSkillsForReadInjection,
   injectSkillRecords,
@@ -141,6 +142,273 @@ describe('injectSkillRecords', () => {
     expect(toolCallRecord['gen_ai.tool.call.id']).toBe(toolResultRecord['gen_ai.tool.call.id']);
   });
 
+  it('should backfill the synthetic skill exchange into subsequent LLM inputs', () => {
+    const sourceCall = {
+      type: 'tool_call',
+      id: 'existing-call',
+      name: 'Grep',
+      arguments: { pattern: 'needle' },
+    };
+    const sourceResponse = {
+      type: 'tool_call_response',
+      id: 'existing-call',
+      response: 'matched',
+    };
+    const firstResponse = makeLlmResponse({
+      'gen_ai.output.messages': [{ role: 'assistant', parts: [sourceCall] }],
+    });
+    const secondRequest = makeLlmRequest({
+      'event.id': 'evt-req-002',
+      'gen_ai.turn.id': 'turn-001',
+      'gen_ai.step.id': 'step_2',
+      'gen_ai.input.messages_delta': [
+        { role: 'assistant', parts: [sourceCall] },
+        { role: 'tool', parts: [sourceResponse] },
+      ],
+      'gen_ai.input.messages': [
+        { role: 'user', parts: [{ type: 'text', content: 'prompt' }] },
+        { role: 'assistant', parts: [sourceCall] },
+        { role: 'tool', parts: [sourceResponse] },
+      ],
+    });
+    const laterRequest = makeLlmRequest({
+      'event.id': 'evt-req-003',
+      'gen_ai.turn.id': 'turn-001',
+      'gen_ai.step.id': 'step_3',
+      'gen_ai.input.messages_delta': [
+        { role: 'assistant', parts: [{ type: 'tool_call', id: 'later-call', name: 'Shell' }] },
+        { role: 'tool', parts: [{ type: 'tool_call_response', id: 'later-call', response: 'ok' }] },
+      ],
+      'gen_ai.input.messages': [
+        { role: 'user', parts: [{ type: 'text', content: 'prompt' }] },
+        { role: 'assistant', parts: [sourceCall] },
+        { role: 'tool', parts: [sourceResponse] },
+        { role: 'assistant', parts: [{ type: 'tool_call', id: 'later-call', name: 'Shell' }] },
+        { role: 'tool', parts: [{ type: 'tool_call_response', id: 'later-call', response: 'ok' }] },
+      ],
+    });
+    const records = [firstResponse, secondRequest, laterRequest];
+
+    injectSkillRecords(records, [makeSkill()]);
+
+    const skillCall = firstResponse['gen_ai.output.messages'][0].parts
+      .find(part => part.type === 'tool_call' && part.name === 'Read');
+    expect(skillCall).toBeDefined();
+
+    const secondDelta = secondRequest['gen_ai.input.messages_delta'];
+    expect(secondDelta.map(message => message.role))
+      .toEqual(['assistant', 'tool', 'tool']);
+    expect(secondDelta[0].parts.map(part => part.id))
+      .toEqual(['existing-call', skillCall.id]);
+    expect(secondDelta.slice(1).map(message => message.parts[0].id))
+      .toEqual(['existing-call', skillCall.id]);
+    expect(secondDelta[2].parts[0]).toMatchObject({
+      type: 'tool_call_response',
+      id: skillCall.id,
+      response: '',
+    });
+
+    for (const request of [secondRequest, laterRequest]) {
+      const fullMessages = request['gen_ai.input.messages'];
+      const assistantParts = fullMessages
+        .find(message => message.role === 'assistant' &&
+          message.parts.some(part => part.id === 'existing-call')).parts;
+      const toolParts = fullMessages
+        .find(message => message.role === 'tool' &&
+          message.parts.some(part => part.id === 'existing-call')).parts;
+      expect(assistantParts.filter(part => part.id === skillCall.id)).toHaveLength(1);
+      expect(toolParts.filter(part => part.id === skillCall.id)).toHaveLength(0);
+      expect(fullMessages.find(message => message.role === 'tool' &&
+        message.parts[0]?.id === skillCall.id)?.parts).toHaveLength(1);
+    }
+
+    // Only the immediate next request receives this exchange in its delta.
+    expect(laterRequest['gen_ai.input.messages_delta'].flatMap(message => message.parts)
+      .some(part => part.id === skillCall.id)).toBe(false);
+  });
+
+  it('should create assistant/tool history when the source response had no ordinary tools', () => {
+    const firstResponse = makeLlmResponse();
+    const secondRequest = makeLlmRequest({
+      'event.id': 'evt-req-002',
+      'gen_ai.turn.id': 'turn-001',
+      'gen_ai.step.id': 'step_2',
+      'gen_ai.input.messages': [
+        { role: 'user', parts: [{ type: 'text', content: 'prompt' }] },
+      ],
+    });
+    const laterRequest = makeLlmRequest({
+      'event.id': 'evt-req-003',
+      'gen_ai.turn.id': 'turn-001',
+      'gen_ai.step.id': 'step_3',
+      'gen_ai.input.messages_delta': [
+        { role: 'assistant', parts: [{ type: 'tool_call', id: 'later-call', name: 'Shell' }] },
+        { role: 'tool', parts: [{ type: 'tool_call_response', id: 'later-call', response: 'ok' }] },
+      ],
+      'gen_ai.input.messages': [
+        { role: 'user', parts: [{ type: 'text', content: 'prompt' }] },
+        { role: 'assistant', parts: [{ type: 'tool_call', id: 'later-call', name: 'Shell' }] },
+        { role: 'tool', parts: [{ type: 'tool_call_response', id: 'later-call', response: 'ok' }] },
+      ],
+    });
+    const records = [firstResponse, secondRequest, laterRequest];
+
+    injectSkillRecords(records, [makeSkill()]);
+
+    const skillCall = firstResponse['gen_ai.output.messages'][0].parts
+      .find(part => part.type === 'tool_call' && part.name === 'Read');
+    expect(secondRequest['gen_ai.input.messages_delta'].map(message => message.role))
+      .toEqual(['assistant', 'tool']);
+    expect(secondRequest['gen_ai.input.messages'].map(message => message.role))
+      .toEqual(['user', 'assistant', 'tool']);
+    expect(secondRequest['gen_ai.input.messages'][1].parts[0].id).toBe(skillCall.id);
+    expect(secondRequest['gen_ai.input.messages'][2].parts[0].id).toBe(skillCall.id);
+    expect(laterRequest['gen_ai.input.messages'].map(message => message.role))
+      .toEqual(['user', 'assistant', 'tool', 'assistant', 'tool']);
+    expect(laterRequest['gen_ai.input.messages'][1].parts[0].id).toBe(skillCall.id);
+    expect(laterRequest['gen_ai.input.messages'][3].parts[0].id).toBe('later-call');
+  });
+
+  it('should preserve the synthetic skill exchange in the converted next LLM span', async () => {
+    const common = {
+      trace_id: '0123456789abcdef0123456789abcdef',
+      'gen_ai.session.id': 'session-conversion',
+      'gen_ai.turn.id': 'turn-conversion',
+      'gen_ai.agent.type': 'cursor',
+      'gen_ai.provider.name': 'openai',
+      'gen_ai.request.model': 'test-model',
+      'user.id': 'user-conversion',
+    };
+    const sourceCall = {
+      type: 'tool_call', id: 'existing-call', name: 'Grep', arguments: { pattern: 'x' },
+    };
+    const sourceResponse = {
+      type: 'tool_call_response', id: 'existing-call', response: 'matched',
+    };
+    const reasoningPart = { type: 'reasoning', content: 'inspect first' };
+    const firstResponse = {
+      ...makeLlmResponse({
+        ...common,
+        'gen_ai.step.id': 'turn-conversion:s1',
+        time_unix_nano: '2000000000',
+        observed_time_unix_nano: '2000000000',
+        'gen_ai.response.model': 'test-model',
+        'gen_ai.response.finish_reasons': ['tool_calls'],
+        'gen_ai.output.messages': [{
+          role: 'assistant',
+          parts: [reasoningPart, sourceCall],
+          finish_reason: 'tool_calls',
+        }],
+      }),
+    };
+    const secondRequest = {
+      ...makeLlmRequest({
+        ...common,
+        'event.id': 'evt-request-2',
+        'gen_ai.step.id': 'turn-conversion:s2',
+        time_unix_nano: '4000000000',
+        observed_time_unix_nano: '4000000000',
+        'gen_ai.input.messages_delta': [
+          { role: 'assistant', parts: [reasoningPart, sourceCall] },
+          { role: 'tool', parts: [sourceResponse] },
+        ],
+        'gen_ai.input.messages': [
+          { role: 'user', parts: [{ type: 'text', content: 'prompt' }] },
+          { role: 'assistant', parts: [reasoningPart, sourceCall] },
+          { role: 'tool', parts: [sourceResponse] },
+        ],
+      }),
+    };
+    const records = [
+      {
+        ...common,
+        'event.id': 'evt-request-1',
+        'event.name': 'llm.request',
+        'gen_ai.step.id': 'turn-conversion:s1',
+        time_unix_nano: '1000000000',
+        observed_time_unix_nano: '1000000000',
+        'gen_ai.input.messages_delta': [
+          { role: 'user', parts: [{ type: 'text', content: 'prompt' }] },
+        ],
+        'gen_ai.input.messages': [
+          { role: 'user', parts: [{ type: 'text', content: 'prompt' }] },
+        ],
+      },
+      {
+        ...common,
+        'event.id': 'evt-tool-call',
+        'event.name': 'tool.call',
+        'gen_ai.step.id': 'turn-conversion:s1',
+        'gen_ai.tool.name': 'Grep',
+        'gen_ai.tool.call.id': 'existing-call',
+        time_unix_nano: '2000000000',
+        observed_time_unix_nano: '2000000000',
+      },
+      {
+        ...common,
+        'event.id': 'evt-tool-result',
+        'event.name': 'tool.result',
+        'gen_ai.step.id': 'turn-conversion:s1',
+        'gen_ai.tool.name': 'Grep',
+        'gen_ai.tool.call.id': 'existing-call',
+        time_unix_nano: '3000000000',
+        observed_time_unix_nano: '3000000000',
+      },
+      firstResponse,
+      secondRequest,
+      {
+        ...common,
+        'event.id': 'evt-response-2',
+        'event.name': 'llm.response',
+        'gen_ai.step.id': 'turn-conversion:s2',
+        'gen_ai.response.model': 'test-model',
+        'gen_ai.response.finish_reasons': ['stop'],
+        time_unix_nano: '5000000000',
+        observed_time_unix_nano: '5000000000',
+        'gen_ai.output.messages': [{
+          role: 'assistant',
+          parts: [{ type: 'text', content: 'done' }],
+          finish_reason: 'stop',
+        }],
+      },
+    ];
+
+    injectSkillRecords(records, [makeSkill()]);
+    const skillCallId = firstResponse['gen_ai.output.messages'][0].parts
+      .find(part => part.type === 'tool_call' && part.name === 'Read').id;
+
+    const previousStability = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+    const previousCapture = process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+    process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'gen_ai_latest_experimental';
+    process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = 'SPAN_ONLY';
+    try {
+      const conversion = await convertEventLogToReadableSpans(records);
+      expect(conversion.warnings).toEqual([]);
+      const llmSpans = conversion.spans
+        .filter(span => span.attributes['gen_ai.span.kind'] === 'LLM');
+      expect(llmSpans).toHaveLength(2);
+      const secondInput = JSON.parse(String(
+        llmSpans[1].attributes['gen_ai.input.messages'],
+      ));
+      expect(secondInput.map(message => message.role))
+        .toEqual(['user', 'assistant', 'tool', 'tool']);
+      expect(secondInput[1].parts.map(part => part.type))
+        .toEqual(['reasoning', 'tool_call', 'tool_call']);
+      const skillParts = secondInput
+        .flatMap(message => message.parts)
+        .filter(part => part.id === skillCallId);
+      expect(skillParts.map(part => part.type)).toEqual([
+        'tool_call',
+        'tool_call_response',
+      ]);
+    } finally {
+      if (previousStability === undefined) delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+      else process.env.OTEL_SEMCONV_STABILITY_OPT_IN = previousStability;
+      if (previousCapture === undefined) delete process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+      else process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = previousCapture;
+    }
+  });
+
   it('should assign strictly increasing timestamps relative to llm.response', () => {
     const baseTime = '1700000000000000000';
     const records = [makeLlmResponse({ time_unix_nano: baseTime })];
@@ -206,6 +474,15 @@ describe('injectSkillRecords', () => {
     expect(records).toHaveLength(0);
   });
 
+  it('should not modify records when the skill list is empty', () => {
+    const records = [makeLlmResponse()];
+    const before = JSON.parse(JSON.stringify(records));
+
+    injectSkillRecords(records, []);
+
+    expect(records).toEqual(before);
+  });
+
   it('should append tool_call parts without overwriting existing output.messages', () => {
     const existingParts = [
       { type: 'text', text: 'existing response' },
@@ -255,7 +532,18 @@ describe('injectSkillRecords', () => {
 
   it('should apply captureMessageContent=false to injected response and tool records', () => {
     const skillPath = '/Users/alice/.cursor/skills/private-skill/SKILL.md';
-    const records = [makeLlmResponse()];
+    const records = [
+      makeLlmResponse(),
+      makeLlmRequest({
+        'event.id': 'evt-req-002',
+        'gen_ai.turn.id': 'turn-001',
+        'gen_ai.step.id': 'step_2',
+        'gen_ai.agent.type': 'cursor',
+        'gen_ai.input.messages': [
+          { role: 'user', parts: [{ type: 'text', content: 'private prompt' }] },
+        ],
+      }),
+    ];
     const runtimeConfig = {
       agents: {
         cursor: { captureMessageContent: false },
@@ -272,7 +560,10 @@ describe('injectSkillRecords', () => {
     expect(records[1]['gen_ai.tool.call.arguments']).toBeUndefined();
     expect(records[1]['gen_ai.skill.name']).toBe('private-skill');
     expect(records[2]['gen_ai.skill.name']).toBe('private-skill');
+    expect(records[3]['gen_ai.input.messages_delta']).toBeUndefined();
+    expect(records[3]['gen_ai.input.messages']).toBeUndefined();
     expect(JSON.stringify(records)).not.toContain(skillPath);
+    expect(JSON.stringify(records)).not.toContain('private prompt');
   });
 
   it('should synthesize Read records for a manually attached skill path', () => {


### PR DESCRIPTION
## Summary

- backfill synthesized Cursor Skill Read calls and responses into subsequent LLM inputs
- preserve each prior LLM output as one assistant message containing reasoning/text and all tool calls
- emit one tool-role message per matching tool response in both React and transcript assembly paths
- keep content-capture policy and Skill response redaction intact

Expected input shape:

```text
assistant [reasoning/text, Read call, Shell call]
tool      [Read response]
tool      [Shell response]
```

## Verification

- `npm test -- tests/unit/hooks/cursor/inject-skill-records.test.mjs tests/unit/hooks/cursor/skill-detector.test.mjs tests/unit/hooks/cursor-react-assembler.test.ts tests/unit/hooks/cursor-transcript-assembler.test.mjs`
- `npm run typecheck`
- Node syntax checks for all modified Cursor hook modules
- `git diff --check`

This is an incremental PR targeting the head branch of #260.