### PR TITLE
fix(claude-code): propagate synthetic skill history

### DIFF
--- a/assets/hooks/claude-code-hook-processor.mjs
+++ b/assets/hooks/claude-code-hook-processor.mjs
@@ -335,20 +335,92 @@ function skillAttributes(skillLoad, fallbackName) {
   };
 }
 
-function positiveSkillLoadTimes(skillLoad, fallbackTimestamp) {
+function skillLoadTimesAtLlmEnd(llmEndTimestamp) {
   const minDurationNanos = 1_000_000n; // converter uses millisecond start/end times
-  let call = BigInt(isoToUnixNanos(
-    skillLoad?.commandTimestamp || skillLoad?.metaTimestamp || fallbackTimestamp,
-  ));
-  let result = BigInt(isoToUnixNanos(
-    skillLoad?.metaTimestamp || fallbackTimestamp || skillLoad?.commandTimestamp,
-  ));
-
-  if (call === 0n && result > minDurationNanos) call = result - minDurationNanos;
+  let call = BigInt(isoToUnixNanos(llmEndTimestamp));
   if (call === 0n) call = BigInt(Date.now()) * 1_000_000n;
-  if (result <= call) result = call + minDurationNanos;
+  const result = call + minDurationNanos;
 
   return { call: String(call), result: String(result) };
+}
+
+function syntheticSkillCallPart(skill) {
+  return {
+    type: 'tool_call',
+    id: skill.callId,
+    name: 'load_skill',
+    arguments: { skill: skill.name },
+  };
+}
+
+function syntheticSkillResultMessage(skill) {
+  return {
+    role: 'tool',
+    parts: [{
+      type: 'tool_call_response',
+      id: skill.callId,
+      response: { success: true },
+    }],
+  };
+}
+
+function appendSyntheticSkillCalls(outputMessages, syntheticSkills) {
+  const assistant = outputMessages.find((message) => message.role === 'assistant');
+  if (!assistant) return outputMessages;
+  assistant.parts = Array.isArray(assistant.parts) ? assistant.parts : [];
+  const existingIds = new Set(assistant.parts
+    .filter((part) => part.type === 'tool_call')
+    .map((part) => part.id));
+  for (const skill of syntheticSkills) {
+    if (!existingIds.has(skill.callId)) assistant.parts.push(syntheticSkillCallPart(skill));
+  }
+  return outputMessages;
+}
+
+function injectSyntheticSkillHistory(inputMessages, firstOutputMessages, syntheticSkills) {
+  if (syntheticSkills.length === 0) return inputMessages;
+  const firstAssistant = firstOutputMessages.find((message) => message.role === 'assistant');
+  if (!firstAssistant) return inputMessages;
+
+  const nativeCallIds = new Set((firstAssistant.parts || [])
+    .filter((part) => part.type === 'tool_call')
+    .map((part) => part.id)
+    .filter(Boolean));
+  let assistantIndex = inputMessages.findIndex((message) => {
+    if (message.role !== 'assistant') return false;
+    const ids = new Set((message.parts || [])
+      .filter((part) => part.type === 'tool_call')
+      .map((part) => part.id)
+      .filter(Boolean));
+    return nativeCallIds.size > 0 && [...nativeCallIds].every((id) => ids.has(id));
+  });
+  if (assistantIndex < 0) {
+    const expectedParts = JSON.stringify(firstAssistant.parts || []);
+    assistantIndex = inputMessages.findIndex((message) =>
+      message.role === 'assistant' && JSON.stringify(message.parts || []) === expectedParts);
+  }
+  if (assistantIndex < 0) return inputMessages;
+
+  const assistant = inputMessages[assistantIndex];
+  assistant.parts = Array.isArray(assistant.parts) ? assistant.parts : [];
+  const existingCallIds = new Set(assistant.parts
+    .filter((part) => part.type === 'tool_call')
+    .map((part) => part.id));
+  for (const skill of syntheticSkills) {
+    if (!existingCallIds.has(skill.callId)) assistant.parts.push(syntheticSkillCallPart(skill));
+  }
+
+  const existingResultIds = new Set(inputMessages
+    .flatMap((message) => message.parts || [])
+    .filter((part) => part.type === 'tool_call_response')
+    .map((part) => part.id));
+  const resultMessages = syntheticSkills
+    .filter((skill) => !existingResultIds.has(skill.callId))
+    .map(syntheticSkillResultMessage);
+  let insertAt = assistantIndex + 1;
+  while (insertAt < inputMessages.length && inputMessages[insertAt]?.role === 'tool') insertAt++;
+  inputMessages.splice(insertAt, 0, ...resultMessages);
+  return inputMessages;
 }
 
 // ─── cmd handlers ───
@@ -872,9 +944,40 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
   // Phase 1: 为每个 llm_call 创建 step + 生成 LLM 事件
   const toolIdToStep = new Map(); // tool_use_id → { stepId, stepSpanId }
   const llmCalls = turn.llmCalls || [];
+  const skillLoads = Array.isArray(turn.skillLoads) ? turn.skillLoads : [];
+  const realSkillToolIds = new Set();
+  for (const ev of llmCalls) {
+    for (const block of (ev.output_content || [])) {
+      if (block?.type === 'tool_use' && block.name === 'Skill'
+          && block.id && ev.toolDetails?.has(block.id)) {
+        realSkillToolIds.add(block.id);
+      }
+    }
+  }
+  const synthesizedCallIds = new Set();
+  const syntheticSkills = [];
+  for (const skillLoad of skillLoads) {
+    if (skillLoad.sourceToolUseId && realSkillToolIds.has(skillLoad.sourceToolUseId)) continue;
+    const callId = deterministicSkillLoadId(
+      sessionId,
+      skillLoad.promptId || turn.promptId,
+      skillLoad.metaUuid || skillLoad.metaTimestamp,
+      skillLoad.rootPath,
+    );
+    if (synthesizedCallIds.has(callId)) continue;
+    synthesizedCallIds.add(callId);
+    syntheticSkills.push({
+      callId,
+      load: skillLoad,
+      name: skillLoad.name || skillLoad.id || 'unknown',
+    });
+  }
+  const firstOutputMessages = llmCalls[0]
+    ? convertOutputMessages(llmCalls[0].output_content, llmCalls[0].stop_reason)
+    : [];
   let firstStepOwner = null;
 
-  for (const ev of llmCalls) {
+  for (const [llmIndex, ev] of llmCalls.entries()) {
     stepRound++;
     const currentStepId = `${turnId}:s${stepRound}`;
     const currentStepSpanId = generateSpanId();
@@ -891,6 +994,9 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
 
     // input messages delta/full hash
     const inputMsgs = convertInputMessages(ev.input_messages, ev.protocol || 'anthropic');
+    if (llmIndex > 0) {
+      injectSyntheticSkillHistory(inputMsgs, firstOutputMessages, syntheticSkills);
+    }
     let currentFullHash;
     let delta;
     let logFull;
@@ -962,7 +1068,12 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
       'gen_ai.usage.cache_read.input_tokens': cacheRead,
       'gen_ai.usage.cache_creation.input_tokens': cacheCreation,
       'gen_ai.usage.total_tokens': totalTokens,
-      'gen_ai.output.messages': convertOutputMessages(ev.output_content, ev.stop_reason),
+      'gen_ai.output.messages': llmIndex === 0
+        ? appendSyntheticSkillCalls(
+          convertOutputMessages(ev.output_content, ev.stop_reason),
+          syntheticSkills,
+        )
+        : convertOutputMessages(ev.output_content, ev.stop_reason),
     };
     if (interceptData && typeof interceptData.ttft_ns === 'number'
         && Number.isFinite(interceptData.ttft_ns) && interceptData.ttft_ns >= 0) {
@@ -974,7 +1085,6 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
     prevInputMsgs = ev._input_is_delta ? [] : inputMsgs;
   }
 
-  const skillLoads = Array.isArray(turn.skillLoads) ? turn.skillLoads : [];
   const skillLoadsByToolId = new Map(
     skillLoads
       .filter((load) => load.sourceToolUseId)
@@ -1051,26 +1161,14 @@ function buildTurnRecords(turn, turnIndex, sessionId, prevHash, userId, turnStop
   }
 
   // /skill 和其他 runtime meta 注入没有 LLM tool_use。将加载事实建模成
-  // extension TOOL span,但不篡改 LLM output.messages。
+  // extension TOOL span，并补入首轮 LLM output 与后续请求历史。
   if (firstStepOwner) {
-    const synthesizedCallIds = new Set();
-    for (const skillLoad of skillLoads) {
+    for (const skill of syntheticSkills) {
+      const { callId, load: skillLoad } = skill;
       if (consumedSkillLoads.has(skillLoad)) continue;
-      const callId = deterministicSkillLoadId(
-        sessionId,
-        skillLoad.promptId || turn.promptId,
-        skillLoad.metaUuid || skillLoad.metaTimestamp,
-        skillLoad.rootPath,
-      );
-      if (synthesizedCallIds.has(callId)) continue;
-      synthesizedCallIds.add(callId);
-
       const toolSpanId = generateSpanId();
       const skillFields = skillAttributes(skillLoad);
-      const times = positiveSkillLoadTimes(
-        skillLoad,
-        llmCalls[0]?.request_start_time || llmCalls[0]?.timestamp,
-      );
+      const times = skillLoadTimesAtLlmEnd(llmCalls[0]?.timestamp);
       records.push({
         time_unix_nano: times.call,
         'event.id': crypto.randomUUID(),

--- a/tests/unit/hooks/claude-code/skill-read.test.mjs
+++ b/tests/unit/hooks/claude-code/skill-read.test.mjs
@@ -23,8 +23,6 @@ const SKILL_NAME = 'e2e-build-push';
 const BASE_DIR = `/abs/workdir/.claude/skills/${SKILL_NAME}`;
 const ROOT_SKILL = `${BASE_DIR}/SKILL.md`;
 const META_BODY = `Base directory for this skill: ${BASE_DIR}\n\n# Title\n\nskill body secret`;
-const SYNTH_PREFIX = 'toolu_skillload_';
-
 let DATA_DIR;
 let TRANSCRIPT_DIR;
 
@@ -170,14 +168,6 @@ function events(records, eventName, toolName) {
   return records.filter((record) =>
     record['event.name'] === eventName &&
     (!toolName || record['gen_ai.tool.name'] === toolName));
-}
-
-function outputToolCalls(records) {
-  return records
-    .filter((record) => record['event.name'] === 'llm.response')
-    .flatMap((record) => record['gen_ai.output.messages'] || [])
-    .flatMap((message) => message.parts || [])
-    .filter((part) => part.type === 'tool_call');
 }
 
 function collectStrings(value) {
@@ -346,7 +336,7 @@ describe('Claude Code Skill TOOL events', () => {
     expect(collectStrings(events(records, 'llm.request')[1])).toContain(META_BODY);
   });
 
-  test('direct slash creates one deterministic load_skill extension TOOL without fake LLM output', () => {
+  test('direct slash adds one deterministic load_skill to s1 output and s2 input history', () => {
     const sourceRecords = [
       slashPrompt('p1', SKILL_NAME, 'run it', '2026-07-29T02:00:00.000Z'),
       skillMeta({ promptId: 'p1', timestamp: '2026-07-29T02:00:00.100Z' }),
@@ -380,10 +370,49 @@ describe('Claude Code Skill TOOL events', () => {
         }));
         expect(loadResults[0]['gen_ai.tool.call.id']).toBe(loadCalls[0]['gen_ai.tool.call.id']);
         expect(BigInt(loadResults[0].time_unix_nano)).toBeGreaterThan(BigInt(loadCalls[0].time_unix_nano));
+        const llmResponses = events(records, 'llm.response');
+        expect(loadCalls[0].time_unix_nano).toBe(llmResponses[0].time_unix_nano);
         expect(events(records, 'tool.call', 'Read').map((record) =>
           record['gen_ai.tool.call.id'])).toEqual(['toolu_reference']);
-        expect(outputToolCalls(records).some((part) =>
-          part.name === 'load_skill' || part.id?.startsWith(SYNTH_PREFIX))).toBe(false);
+        const s1Parts = llmResponses[0]['gen_ai.output.messages'][0].parts;
+        expect(s1Parts.filter((part) => part.type === 'tool_call').map((part) => part.name))
+          .toEqual(['Read', 'load_skill']);
+        const s2Delta = events(records, 'llm.request')[1]['gen_ai.input.messages_delta'];
+        expect(s2Delta).toEqual([
+          {
+            role: 'assistant',
+            parts: [
+              {
+                type: 'tool_call',
+                id: 'toolu_reference',
+                name: 'Read',
+                arguments: { file_path: `${BASE_DIR}/references/guide.md` },
+              },
+              {
+                type: 'tool_call',
+                id: loadCalls[0]['gen_ai.tool.call.id'],
+                name: 'load_skill',
+                arguments: { skill: SKILL_NAME },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            parts: [{
+              type: 'tool_call_response',
+              id: 'toolu_reference',
+              response: 'reference body',
+            }],
+          },
+          {
+            role: 'tool',
+            parts: [{
+              type: 'tool_call_response',
+              id: loadCalls[0]['gen_ai.tool.call.id'],
+              response: { success: true },
+            }],
+          },
+        ]);
         return loadCalls[0]['gen_ai.tool.call.id'];
       } finally {
         try { fs.rmSync(DATA_DIR, { recursive: true, force: true }); } catch {}


### PR DESCRIPTION
## Summary
- append synthetic `load_skill` calls to the first Claude Code LLM output
- preserve the complete assistant output and per-tool responses in subsequent LLM inputs
- start synthetic Skill spans exactly when the first LLM span ends

## Verification
- `npx vitest run tests/unit/hooks/claude-code/skill-read.test.mjs tests/unit/hooks/claude-code/hook-processor.test.mjs tests/unit/hooks/claude-code/transcript-parser.test.mjs tests/integration/claude-code-tool-context-flow.test.mjs`
- `npm run typecheck`
- `npm run build`

This is an independent incremental PR based directly on #260 and does not depend on #273.