### PR TITLE
fix(dsh): exclude injected context from root inputs

### DIFF
--- a/src/inputs/dsh/dsh-event-transform.ts
+++ b/src/inputs/dsh/dsh-event-transform.ts
@@ -375,7 +375,15 @@ export function transformDshRecord(
       const content = data.content;
       const msgId = asString((asObject(data) ?? {}).id);
       const userParts = normalizeUserParts(content);
+      const sourceKind = asString(asObject(data.source)?.kind);
+
+      // Every user-role message is part of the model-visible conversation,
+      // including context injected by plugins. Only a native human prompt,
+      // however, is a top-level ENTRY/AGENT input. Source-less records retain
+      // the legacy behavior for JSONL captured before DSH exposed `source`.
       addInputMessage(state, { role: 'user', parts: userParts });
+      if (data.source !== undefined && sourceKind !== 'user') return null;
+
       return buildAgentActivityEntry({
         ...common,
         'event.name': 'other',

--- a/tests/unit/inputs/dsh-log/dsh-event-transform.test.ts
+++ b/tests/unit/inputs/dsh-log/dsh-event-transform.test.ts
@@ -135,13 +135,25 @@ describe('dsh-event-transform (real fixture)', () => {
     expect([...traceIds][0]).toMatch(/^[a-f0-9]{32}$/);
   });
 
-  it('user/message emits an "other" event with input.messages_delta', async () => {
-    const { entries } = await loadAll();
+  it('emits top-level input only for the original source.kind=user message', async () => {
+    const { records, entries } = await loadAll();
+    const messageSources = records
+      .filter(record => record.type === 'user/message')
+      .map(record => (record.data as { source?: { kind?: string } }).source?.kind);
+    expect(messageSources).toEqual(['user', 'plugin']);
+
     const userEvents = entries.filter(e => e['event.name'] === 'other');
-    expect(userEvents.length).toBeGreaterThan(0);
+    expect(userEvents).toHaveLength(1);
     const delta = userEvents[0]['gen_ai.input.messages_delta'] as { role: string; parts: unknown[] }[];
     expect(delta[0].role).toBe('user');
     expect(delta[0].parts.length).toBeGreaterThan(0);
+    expect(JSON.stringify(delta)).toContain('Create a hello.txt file');
+    expect(JSON.stringify(delta)).not.toContain('Current runtime context');
+
+    const requests = entries.filter(e => e['event.name'] === 'llm.request');
+    const firstInput = JSON.stringify(requests[0]['gen_ai.input.messages']);
+    expect(firstInput).toContain('Create a hello.txt file');
+    expect(firstInput).toContain('Current runtime context');
   });
 
   it('llm.request and llm.response timestamps differ (non-zero LLM duration)', async () => {
@@ -465,6 +477,63 @@ describe('dsh-event-transform (real fixture)', () => {
     expect(request?.['event.name']).toBe('llm.request');
     expect(request?.['gen_ai.request.model']).toBeUndefined();
     expect(request?.['gen_ai.system_instructions']).toBeUndefined();
+  });
+});
+
+describe('dsh-event-transform (message sources)', () => {
+  it.each(['plugin', 'future-injected-source'])(
+    'keeps source.kind=%s in LLM context without emitting top-level user input',
+    (kind) => {
+      const state = newState();
+      state.currentTurn = 1;
+      state.currentStep = 1;
+
+      const injected = transformDshRecord({
+        type: 'user/message',
+        sid: 'session-a',
+        time: 1,
+        data: {
+          turn: 1,
+          source: { kind },
+          content: [{ type: 'text', text: 'injected context' }],
+        },
+      }, ClientType.Dsh, state);
+      expect(injected).toBeNull();
+
+      const request = transformDshRecord({
+        type: 'assistant/chunk',
+        sid: 'session-a',
+        time: 2,
+        data: { turn: 1, step: 1, chunk: { type: 'block-start' } },
+      }, ClientType.Dsh, state);
+      expect(JSON.stringify(request?.['gen_ai.input.messages'])).toContain('injected context');
+    },
+  );
+
+  it('preserves the top-level projection for legacy records without source', () => {
+    const entry = transformDshRecord({
+      type: 'user/message',
+      sid: 'legacy-session',
+      time: 1,
+      data: { content: [{ type: 'text', text: 'legacy prompt' }] },
+    }, ClientType.Dsh, newState());
+
+    expect(entry?.['event.name']).toBe('other');
+    expect(JSON.stringify(entry?.['gen_ai.input.messages_delta'])).toContain('legacy prompt');
+  });
+
+  it('does not treat a malformed present source as a human prompt', () => {
+    const entry = transformDshRecord({
+      type: 'user/message',
+      sid: 'session-a',
+      time: 1,
+      data: {
+        source: {},
+        content: [{ type: 'text', text: 'unclassified context' }],
+      },
+    }, ClientType.Dsh, newState());
+
+    expect(entry).toBeNull();
   });
 });
 

--- a/tests/unit/inputs/dsh-log/dsh-otlp-grouping.test.ts
+++ b/tests/unit/inputs/dsh-log/dsh-otlp-grouping.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 import { ExportResultCode } from '@opentelemetry/core';
 import type { ExportResult } from '@opentelemetry/core';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
@@ -16,7 +18,12 @@ function transformTurn(sid: string, baseTime: number): AgentActivityEntry[] {
   const records: Record<string, unknown>[] = [
     { type: 'turn/start', sid, time: baseTime, data: { turn: 1 } },
     { type: 'step/start', sid, time: baseTime + 1, data: { turn: 1, step: 1 } },
-    { type: 'user/message', sid, time: baseTime + 2, data: { content: [{ type: 'text', text: 'hello' }] } },
+    {
+      type: 'user/message',
+      sid,
+      time: baseTime + 2,
+      data: { source: { kind: 'user' }, content: [{ type: 'text', text: 'hello' }] },
+    },
     {
       type: 'request/header', sid, time: baseTime + 3,
       data: { header: { config: { provider: 'deepseek', model: 'deepseek-test' } } },
@@ -49,7 +56,24 @@ function transformTurn(sid: string, baseTime: number): AgentActivityEntry[] {
     .filter((entry): entry is AgentActivityEntry => entry !== null);
 }
 
-describe('DSH session-scoped turn ids in OTLP buffering', () => {
+interface SpanMessage {
+  role?: string;
+  parts?: Array<{ content?: string }>;
+}
+
+function readInputMessages(span: ReadableSpan): SpanMessage[] {
+  return JSON.parse(String(span.attributes['gen_ai.input.messages'])) as SpanMessage[];
+}
+
+function messageText(message: SpanMessage): string {
+  return message.parts?.map(part => part.content ?? '').join('') ?? '';
+}
+
+function compareSpanStart(a: ReadableSpan, b: ReadableSpan): number {
+  return a.startTime[0] - b.startTime[0] || a.startTime[1] - b.startTime[1];
+}
+
+describe('DSH event-to-span OTLP flow', () => {
   let captured: ReadableSpan[];
   let flusher: OtlpTraceFlusher;
 
@@ -98,5 +122,43 @@ describe('DSH session-scoped turn ids in OTLP buffering', () => {
       expect(span.resource.attributes['gen_ai.agent.type']).toBe('dsh');
       expect(span.resource.attributes['gen_ai.agent.system']).toBe('dsh');
     }
+  });
+
+  it('keeps injected context on LLM spans but excludes it from ENTRY and AGENT', async () => {
+    const fixturePath = path.resolve('tests/fixtures/dsh/dsh-probe-events-real.jsonl');
+    const fixture = await fs.readFile(fixturePath, 'utf8');
+    const records = fixture.split('\n').filter(Boolean).map(line => JSON.parse(line));
+    const state = newState();
+    const entries = records
+      .map(record => transformDshRecord(record, ClientType.Dsh, state))
+      .filter((entry): entry is AgentActivityEntry => entry !== null);
+
+    await flusher.sendBatch(entries);
+    await flusher.flush();
+
+    const entry = captured.find(span => span.attributes['gen_ai.span.kind'] === 'ENTRY');
+    const agent = captured.find(span => span.attributes['gen_ai.span.kind'] === 'AGENT');
+    expect(entry).toBeDefined();
+    expect(agent).toBeDefined();
+
+    const entryInput = readInputMessages(entry!);
+    const agentInput = readInputMessages(agent!);
+    expect(entryInput).toHaveLength(1);
+    expect(agentInput).toEqual(entryInput);
+    expect(messageText(entryInput[0])).toContain('Create a hello.txt file');
+    expect(messageText(entryInput[0])).not.toContain('Current runtime context');
+
+    const llmSpans = captured
+      .filter(span => span.attributes['gen_ai.span.kind'] === 'LLM')
+      .sort(compareSpanStart);
+    expect(llmSpans).toHaveLength(3);
+    const llmInputs = llmSpans.map(readInputMessages);
+    expect(llmInputs.map(messages => messages.map(message => message.role))).toEqual([
+      ['user', 'user'],
+      ['user', 'user', 'assistant', 'tool'],
+      ['user', 'user', 'assistant', 'tool', 'assistant', 'tool'],
+    ]);
+    expect(messageText(llmInputs[0][0])).toContain('Create a hello.txt file');
+    expect(messageText(llmInputs[0][1])).toContain('Current runtime context');
   });
 });


### PR DESCRIPTION
## Summary

- keep every DSH `user/message` in the model-visible LLM input accumulator
- emit top-level `other + gen_ai.input.messages_delta` only for original human prompts
- exclude plugin, malformed, and future non-user sources from ENTRY/AGENT input while preserving source-less legacy JSONL behavior
- add real-fixture event and final OTLP Span regression coverage

## Why

DSH uses `user/message` for both direct human prompts and injected model context. The source distinction is carried by `data.source.kind`, but Pilot previously projected every such record as top-level user input. The GenAI converter consequently merged injected runtime context into both ENTRY and AGENT `gen_ai.input.messages`.

The fix keeps the two semantics separate:

- ENTRY/AGENT: original human input only
- LLM: the complete model-visible conversation, including injected context and multi-step assistant/tool history

## Compatibility

Current DSH messages carry `source`. Records captured before that field was available continue to use the previous top-level projection behavior. If a `source` field is present but is non-user, unknown, or malformed, it is retained only in the LLM input accumulator.

## Validation

- DSH专项：7 test files, 90 tests passed
- `npm run typecheck`
- `npm run build`
- Full suite: 3127 passed, 50 skipped, 1 unrelated local-fixture failure
  - `tests/integration/qwen-work-cn-real-transcript.test.ts` also fails identically on untouched `origin/main` at `590f32267a507f1f48119eccffbf80e9881c0f69`

Closes #275
