### PR TITLE
feat(qwen): support per-invocation span attributes

### DIFF
--- a/assets/hooks/qwen-code-cli-hook-processor.mjs
+++ b/assets/hooks/qwen-code-cli-hook-processor.mjs
@@ -40,6 +40,7 @@ import { recordUpstreamContextOnce } from './shared/upstream-context.mjs';
 import {
   agentBaseFieldPatch,
   collectResourceAttributesFromEnv,
+  parseSpanAttributesFromEnv,
 } from './shared/resource-context.mjs';
 import {
   sanitizeObject,
@@ -65,14 +66,25 @@ const AGENT_ID = 'qwen-code-cli';
 const INVOCATION_RESOURCE_ATTRIBUTES = collectResourceAttributesFromEnv(process.env, {
   agentId: AGENT_ID,
 });
+const INVOCATION_SPAN_ATTRIBUTES = parseSpanAttributesFromEnv(process.env, {
+  agentId: AGENT_ID,
+});
 
-function bindInvocationResourceContext(state) {
+function bindInvocationContext(state) {
   if (Object.keys(INVOCATION_RESOURCE_ATTRIBUTES).length > 0) {
     state.resource_attributes = INVOCATION_RESOURCE_ATTRIBUTES;
   } else {
     // A session can be resumed without custom identity variables. Do not
     // retain a stale worker identity from an earlier invocation.
     delete state.resource_attributes;
+  }
+
+  if (Object.keys(INVOCATION_SPAN_ATTRIBUTES).length > 0) {
+    state.span_attributes = INVOCATION_SPAN_ATTRIBUTES;
+  } else {
+    // A session can be resumed by another invocation. Clear the previous
+    // invocation's attributes instead of leaking them into the next turn.
+    delete state.span_attributes;
   }
 }
 
@@ -189,7 +201,7 @@ async function cmdStop() {
   recordUpstreamContextOnce({ agentId: AGENT_ID, sessionId, dataDir: pilotDataDir() });
 
   const state = loadState(sessionId);
-  bindInvocationResourceContext(state);
+  bindInvocationContext(state);
   if (!state.transcript_path && event.transcript_path) {
     state.transcript_path = event.transcript_path;
   }
@@ -321,6 +333,7 @@ async function exportSession(state, stopReason) {
     const { records, hash } = buildTurnRecords(
       turn, baseTurnCount + i, sessionId, logHash, userId, turnStopReason, cwd,
       state.resource_attributes,
+      state.span_attributes,
     );
     allRecords.push(...records);
     logHash = hash;
@@ -365,6 +378,7 @@ async function exportSession(state, stopReason) {
  * @param turnStopReason Stop reason for the last LLM call in this turn
  * @param cwd       Optional working dir for agent.qwen-code-cli.cwd
  * @param resourceAttributes  Invocation-scoped resource attributes captured by the Stop hook
+ * @param spanAttributes  Invocation-scoped top-level attributes captured by the Stop hook
  * @returns {{records: object[], hash: string}}
  */
 export function buildTurnRecords(
@@ -376,12 +390,18 @@ export function buildTurnRecords(
   turnStopReason,
   cwd,
   resourceAttributes = {},
+  spanAttributes = {},
 ) {
   const records = [];
   const safeResourceAttributes = resourceAttributes &&
     typeof resourceAttributes === 'object' &&
     !Array.isArray(resourceAttributes)
     ? resourceAttributes
+    : {};
+  const safeSpanAttributes = spanAttributes &&
+    typeof spanAttributes === 'object' &&
+    !Array.isArray(spanAttributes)
+    ? spanAttributes
     : {};
   // [C2] turn.id = <sessionId>:t<N>
   const turnId = `${sessionId}:t${turnIndex + 1}`;
@@ -390,6 +410,9 @@ export function buildTurnRecords(
   const traceId = generateTraceId();
 
   const baseFields = {
+    // Caller-supplied attributes are spread first so structural fields always
+    // win, even though parseSpanAttributesFromEnv already rejects reserved keys.
+    ...safeSpanAttributes,
     trace_id: traceId,
     'gen_ai.session.id': sessionId,
     'gen_ai.turn.id': turnId,

--- a/assets/hooks/qwen-code-cli/state.mjs
+++ b/assets/hooks/qwen-code-cli/state.mjs
@@ -14,6 +14,7 @@
  *     transcript_path, transcript_offset?,
  *     turn_count,                  // turns already exported (incl. skipped historic)
  *     resource_attributes?,         // invocation context captured by the latest Stop hook
+ *     span_attributes?,             // per-invocation span attributes captured by Stop
  *     stop_time?,
  *     events: []                   // v2 subagent_start/stop accumulator (unused in v1)
  *   }

--- a/docs/trace-output.md
+++ b/docs/trace-output.md
@@ -313,8 +313,9 @@ Notes:
 - Unlike source #2 (spans only), passthrough attributes are ordinary top-level record fields, so they appear in **both** the event log (SLS / JSONL) and the trace spans — same behavior as the git fields.
 - Reserved-prefix keys (`gen_ai.`, `git.`, `workspace.`, `event.`, `trace_`, `user.`, `cost_`, `agent.`) and sensitive names (token/secret/password/…) are dropped by the hook. Use a dedicated namespace such as `multica.*`.
 - Values must not contain a comma `,` (it is the pair separator); a value is also capped at 512 chars.
-- Only keys matching a configured prefix are passed through; all other top-level fields are unaffected. Supported for claude-code, codex, qoder, and opencode.
+- Only keys matching a configured prefix are passed through; all other top-level fields are unaffected. Supported for claude-code, codex, qoder, qwen-code-cli, and opencode.
 - Codex snapshots these process-level attributes on `UserPromptSubmit` (with `Stop` as a fail-open fallback) and correlates them to transcript records by session and turn. This prevents a resumed session launched by a different invocation from reusing the previous invocation's attributes.
+- Qwen Code CLI captures them from the current `Stop` hook and clears any saved values when a resumed invocation does not provide the variable, preventing stale attributes from leaking into a later turn.
 
 ## Verify Trace Output
 

--- a/docs/zh-CN/trace-output.md
+++ b/docs/zh-CN/trace-output.md
@@ -312,8 +312,9 @@ Pilot 会将 Trace 发送到 `http://localhost:3000/api/public/otel/v1/traces`�
 说明：
 - 与来源 #2（仅 span）不同，透传属性是普通的顶层 record 字段，因此会**同时**出现在 event log（SLS / JSONL）和 trace span 上——与 git 字段行为一致。
 - 保留前缀 key（`gen_ai.`、`git.`、`workspace.`、`event.`、`trace_`、`user.`、`cost_`、`agent.`）以及敏感命名（token/secret/password/…）会被 hook 丢弃。请使用 `multica.*` 等专用命名空间。
-- 仅匹配所配置前缀的 key 会被透传，其它顶层字段不受影响。目前支持 claude-code、codex、qoder 和 opencode。
+- 仅匹配所配置前缀的 key 会被透传，其它顶层字段不受影响。目前支持 claude-code、codex、qoder、qwen-code-cli 和 opencode。
 - Codex 会在 `UserPromptSubmit` 时保存这些进程级属性（以 `Stop` 作为 fail-open 兜底），并按 session 与 turn 关联到 transcript 记录，避免同一个 session 被不同调用恢复时沿用上一次调用的属性。
+- Qwen Code CLI 会在当前 `Stop` Hook 中读取这些属性；如果恢复同一 session 的新调用未提供该环境变量，则会清除已保存的旧值，避免属性泄漏到后续 turn。
 - value 不能包含逗号 `,`（逗号是键值对分隔符）；单个 value 长度上限 512 字符。
 
 ## 验证 Trace 输出

--- a/tests/unit/hooks/qwen-code-cli/build-turn-records.test.mjs
+++ b/tests/unit/hooks/qwen-code-cli/build-turn-records.test.mjs
@@ -102,6 +102,32 @@ describe('buildTurnRecords — basic shape', () => {
     }
   });
 
+  test('stamps invocation span attributes on every record without overriding structure', () => {
+    const turn = makeTurn({ llmCalls: [makeLlmCall()] });
+    const spanAttributes = {
+      'multica.issue.id': 'AGE-277',
+      'multica.user.id': 'staff-1',
+      trace_id: 'caller-trace-id',
+    };
+    const { records } = buildTurnRecords(
+      turn,
+      0,
+      'sess-1',
+      INITIAL_HASH,
+      'u-1',
+      'end_turn',
+      '/work',
+      {},
+      spanAttributes,
+    );
+    for (const record of records) {
+      expect(record['multica.issue.id']).toBe('AGE-277');
+      expect(record['multica.user.id']).toBe('staff-1');
+      expect(record.trace_id).toMatch(/^[0-9a-f]{32}$/);
+      expect(record.trace_id).not.toBe('caller-trace-id');
+    }
+  });
+
   test('turn.id format = <sessionId>:t<N> (C2)', () => {
     const turn = makeTurn({ llmCalls: [makeLlmCall()] });
     const { records } = buildTurnRecords(turn, 2, 'sess-1', INITIAL_HASH, 'u-1', 'end_turn');

--- a/tests/unit/hooks/qwen-code-cli/hook-processor.test.mjs
+++ b/tests/unit/hooks/qwen-code-cli/hook-processor.test.mjs
@@ -33,6 +33,7 @@ function runHook(subcommand, payload, extraEnv = {}) {
   delete env.AGENTTEAMS_WORKER_NAME;
   delete env.AGENTTEAMS_INSTANCE_ID;
   delete env.AGENTTEAMS_TOKEN;
+  delete env.LOONGSUITE_PILOT_SPAN_ATTRIBUTES;
   Object.assign(env, extraEnv);
   const r = spawnSync('node', [PROCESSOR, subcommand], {
     input: JSON.stringify(payload),
@@ -233,6 +234,59 @@ describe('hook-processor: cmdStop end-to-end', () => {
     expect(turn2.every((record) => record['gen_ai.agent.name'] === 'reviewer')).toBe(true);
     expect(turn1[0].resourceAttributes['agentteams.instance.id']).toBe('qwen-instance-01');
     expect(turn2[0].resourceAttributes['agentteams.instance.id']).toBe('qwen-instance-02');
+    expect(JSON.stringify(records)).not.toContain('must-not-leak');
+  });
+
+  test('binds per-invocation span attributes to each resumed turn without stale values', () => {
+    const sid = 'sess-span-attrs-resume-1';
+    const transcriptPath = writeTranscript(sid, [
+      userRec('u1', 'q1', '2026-06-17T08:00:00.000Z', sid),
+      assistantRec('a1', [{ text: 'a1' }], '2026-06-17T08:00:10.000Z', {}, sid),
+    ]);
+    const payload = {
+      session_id: sid,
+      transcript_path: transcriptPath,
+      cwd: '/work',
+      stop_reason: 'end_turn',
+    };
+
+    runHook('stop', payload, {
+      LOONGSUITE_PILOT_SPAN_ATTRIBUTES: [
+        'multica.issue.id=issue-1',
+        'multica.user.id=staff-1',
+        'gen_ai.agent.name=must-not-overwrite',
+        'multica.api_token=must-not-leak',
+      ].join(','),
+    });
+
+    fs.appendFileSync(transcriptPath, [
+      userRec('u2', 'q2', '2026-06-17T08:01:00.000Z', sid),
+      assistantRec('a2', [{ text: 'a2' }], '2026-06-17T08:01:10.000Z', {}, sid),
+    ].map((record) => JSON.stringify(record)).join('\n') + '\n');
+    runHook('stop', payload, {
+      LOONGSUITE_PILOT_SPAN_ATTRIBUTES: 'multica.issue.id=issue-2,multica.user.id=staff-2',
+    });
+
+    fs.appendFileSync(transcriptPath, [
+      userRec('u3', 'q3', '2026-06-17T08:02:00.000Z', sid),
+      assistantRec('a3', [{ text: 'a3' }], '2026-06-17T08:02:10.000Z', {}, sid),
+    ].map((record) => JSON.stringify(record)).join('\n') + '\n');
+    runHook('stop', payload);
+
+    const records = readEmittedRecords();
+    const turn1 = records.filter((record) => record['gen_ai.turn.id'] === `${sid}:t1`);
+    const turn2 = records.filter((record) => record['gen_ai.turn.id'] === `${sid}:t2`);
+    const turn3 = records.filter((record) => record['gen_ai.turn.id'] === `${sid}:t3`);
+    expect(turn1.length).toBeGreaterThan(0);
+    expect(turn2.length).toBeGreaterThan(0);
+    expect(turn3.length).toBeGreaterThan(0);
+    expect(turn1.every((record) => record['multica.issue.id'] === 'issue-1')).toBe(true);
+    expect(turn1.every((record) => record['multica.user.id'] === 'staff-1')).toBe(true);
+    expect(turn2.every((record) => record['multica.issue.id'] === 'issue-2')).toBe(true);
+    expect(turn2.every((record) => record['multica.user.id'] === 'staff-2')).toBe(true);
+    expect(turn3.every((record) => record['multica.issue.id'] === undefined)).toBe(true);
+    expect(turn3.every((record) => record['multica.user.id'] === undefined)).toBe(true);
+    expect(records.every((record) => record['gen_ai.agent.name'] !== 'must-not-overwrite')).toBe(true);
     expect(JSON.stringify(records)).not.toContain('must-not-leak');
   });
 


### PR DESCRIPTION
## Summary

- parse filtered `LOONGSUITE_PILOT_SPAN_ATTRIBUTES` in the Qwen Code CLI Stop hook
- stamp invocation attributes onto every emitted Qwen record for configured OTLP passthrough
- isolate resumed turns and clear stale values when the next invocation omits the variable
- document Qwen support and add end-to-end/unit coverage

Closes #277

## Testing

- `npm run typecheck`
- `npm run build`
- `npx vitest run tests/unit/hooks/qwen-code-cli/hook-processor.test.mjs tests/unit/hooks/qwen-code-cli/build-turn-records.test.mjs tests/unit/hooks/shared/resource-context.test.mjs` (52 passed)
- `npm test` (3124 passed, 50 skipped, 1 unrelated existing failure in `tests/integration/qwen-work-cn-real-transcript.test.ts`; reproduced unchanged on `origin/main`)