### PR TITLE
fix: prevent duplicate collectors when lock holder command differs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,11 +54,19 @@ async function main(): Promise<void> {
   // Lock file is runtime state, not a log — keep it in the dataDir root alongside
   // the pid file, not under logs/.
   const lockPath = path.join(dataDir, 'collector.lock');
-  const { lock, holderPid } = acquireSingleInstanceLock(lockPath, COLLECTOR_PROCESS_PATTERNS);
+  const {
+    lock,
+    holderPid,
+    holderProcessStartState,
+    holderCommandState,
+    recoveredStaleLock,
+  } = acquireSingleInstanceLock(lockPath, COLLECTOR_PROCESS_PATTERNS);
   if (!lock) {
     logger.warn('another collector instance already holds the lock; exiting', {
       pid: process.pid,
       holderPid,
+      holderProcessStartState,
+      holderCommandState,
       lockPath,
     });
     // See the disabled-config branch above: the pino-roll rotation timer keeps the
@@ -66,6 +74,14 @@ async function main(): Promise<void> {
     // a peer already holds the lock. Exit explicitly.
     flushLogsSync();
     process.exit(0);
+  }
+  if (recoveredStaleLock) {
+    logger.warn('stale single-instance lock recovered', {
+      pid: process.pid,
+      previousHolderPid: recoveredStaleLock.previousPid,
+      recoveryReason: recoveredStaleLock.reason,
+      lockPath,
+    });
   }
   logger.info('single-instance lock acquired', { pid: process.pid, lockPath });
 

--- a/src/utils/pid-utils.ts
+++ b/src/utils/pid-utils.ts
@@ -177,6 +177,48 @@ export function readProcessCommand(pid: number): string {
   }
 }
 
+/**
+ * Return a stable, boot-scoped identity for one concrete process lifetime.
+ *
+ * Unlike a pid, this value changes when the OS recycles the pid. Callers must
+ * fail closed when it is unavailable: command lines are useful diagnostics but
+ * are not strong enough to prove that a pid was reused.
+ */
+export function readProcessStartToken(pid: number): string {
+  if (!Number.isInteger(pid) || pid <= 0) return '';
+  try {
+    if (process.platform === 'linux') {
+      // /proc/<pid>/stat field 22 is the process start time in clock ticks since
+      // boot. Include boot_id so a stale lock cannot accidentally match after a
+      // reboot. Locate the final ')' because comm may itself contain spaces or ')'.
+      const stat = fs.readFileSync(`/proc/${pid}/stat`, 'utf-8');
+      const commEnd = stat.lastIndexOf(')');
+      if (commEnd < 0) return '';
+      const fieldsAfterComm = stat.slice(commEnd + 1).trim().split(/\s+/);
+      const startTicks = fieldsAfterComm[19];
+      const bootId = fs.readFileSync('/proc/sys/kernel/random/boot_id', 'utf-8').trim();
+      return startTicks && bootId ? `linux-proc-v1:${bootId}:${startTicks}` : '';
+    }
+    if (process.platform === 'win32') {
+      const creationDate = execFileSync('powershell.exe', [
+        '-NoProfile',
+        '-WindowStyle',
+        'Hidden',
+        '-Command',
+        `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"; if ($p) { $p.CreationDate.ToUniversalTime().ToString("O") }`,
+      ], { timeout: 5000, encoding: 'utf-8', windowsHide: true }).trim();
+      return creationDate ? `win32-cim-v1:${creationDate}` : '';
+    }
+    const startedAt = execFileSync('ps', ['-p', String(pid), '-o', 'lstart='], {
+      timeout: 5000,
+      encoding: 'utf-8',
+    }).trim().replace(/\s+/g, ' ');
+    return startedAt ? `${process.platform}-ps-lstart-v1:${startedAt}` : '';
+  } catch {
+    return '';
+  }
+}
+
 function findUnixProcessByCommand(patterns: readonly ProcessCommandPattern[]): ProcessLiveness {
   try {
     const out = execFileSync('ps', ['-axo', 'pid=,command='], {

--- a/src/utils/pid-utils.ts
+++ b/src/utils/pid-utils.ts
@@ -21,7 +21,7 @@ export const COLLECTOR_PROCESS_PATTERNS: readonly ProcessCommandPattern[] = [
   'collector-daemon.js',
   '/bin/collector-daemon',
   '\\bin\\collector-daemon',
-  /(?:^|[\s/\\])loongsuite-pilot(?:\.ps1)?\s+run(?:\s|$)/,
+  /(?:^|[\s/\\])loongsuite-pilot(?:\.ps1)?\s+(?:run|run-service)(?:\s|$)/,
 ];
 
 export const UPDATER_PROCESS_PATTERNS: readonly ProcessCommandPattern[] = [

--- a/src/utils/single-instance-lock.ts
+++ b/src/utils/single-instance-lock.ts
@@ -3,8 +3,6 @@ import * as path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import {
   isProcessAlive,
-  readProcessCommand,
-  isCommandMatch,
   type ProcessCommandPattern,
 } from './pid-utils.js';
 
@@ -64,46 +62,28 @@ function readLock(lockPath: string): LockPayload | null {
   return null;
 }
 
-// A lock is stale when its recorded holder is no longer a daemon we expect. For a *healthy*
-// holder age is deliberately NOT part of the check: these are long-running daemons, so any age
-// threshold on a matching holder would eventually evict a perfectly healthy one and reopen the
-// very duplication window this lock exists to close.
+// A lock is stale only when its recorded holder is no longer alive. Command-line identity is
+// deliberately not used to evict a live holder: launchers and wrappers can introduce new command
+// shapes (for example `loongsuite-pilot run-service`) that lag behind the process-pattern list.
+// Treating an unknown-but-live command as stale lets a second collector delete a valid lock and
+// duplicate every record. Prefer failing closed until the live pid exits.
 //
 // Conditions that make a lock stale:
 //  1. The recorded pid is not alive. `isProcessAlive` treats EPERM as alive (matters on
 //     Windows, where a foreign-owned process still means "occupied").
-//  2. The pid IS alive but its command line is readable and is not one of our daemons. On Unix a
-//     pid can be recycled after the holder crashes without releasing; the recycled pid would
-//     otherwise be misread as a live holder and block every future start. A readable command line
-//     that still matches is a genuine second daemon — exactly what we want to keep out.
-//  3. The pid is alive but its command line is UNREADABLE (foreign-owned / permission-denied /
-//     transient) AND the lock is implausibly old. We can't confirm identity, so we stay
-//     conservative (held) for a fresh lock; but an unreadable holder older than
-//     UNREADABLE_HOLDER_MAX_AGE_MS is almost certainly a crashed daemon whose pid was reused by an
-//     uninspectable process — without this escape valve such a lock would deadlock every future
-//     start forever. Healthy daemons of ours expose a readable, matching command line and take
-//     branch 2, so they are never aged out here.
-const UNREADABLE_HOLDER_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24h — generous; only breaks true deadlocks
+//  2. A lock carrying this process's pid has no matching process-local owner token, which means
+//     it belongs to an older process instance whose pid was reused.
 
 function isStale(
   lockPath: string,
   lock: LockPayload | null,
-  patterns?: readonly ProcessCommandPattern[],
+  _patterns?: readonly ProcessCommandPattern[],
 ): boolean {
   if (!lock) return true;
   if (lock.pid === process.pid) {
     return !lock.ownerId || activeLockOwners.get(lockPath) !== lock.ownerId;
   }
-  if (!isProcessAlive(lock.pid)) return true;
-  if (!patterns || patterns.length === 0) return false;
-  const command = readProcessCommand(lock.pid);
-  if (!command) {
-    return (
-      typeof lock.startedAt === 'number' &&
-      Date.now() - lock.startedAt > UNREADABLE_HOLDER_MAX_AGE_MS
-    );
-  }
-  return !isCommandMatch(command, patterns);
+  return !isProcessAlive(lock.pid);
 }
 
 function writeOwnLock(lockPath: string, ownerId: string): void {
@@ -161,12 +141,12 @@ function makeHandle(lockPath: string, ownerId: string): SingleInstanceLock {
  *
  * - No live holder → creates the lockfile atomically and returns a handle.
  * - Live holder → returns `{ lock: null, holderPid }`; the caller should log and exit.
- * - Stale lockfile (dead holder, or a reused pid running a different program) → the
+ * - Stale lockfile (dead holder, or this process's pid with no live owner token) → the
  *   stale file is removed and the lock is taken.
  *
- * When `patterns` are supplied, a lockfile whose pid is alive is only honored if that
- * process's command line matches one of the patterns — closing the Unix pid-reuse
- * window. Omit `patterns` to fall back to a pid-liveness-only check.
+ * `patterns` is retained for API compatibility with callers. It is not used to evict a
+ * live holder: an incomplete command allowlist must never reopen the duplicate-collector
+ * window this lock exists to close.
  */
 export function acquireSingleInstanceLock(
   lockPath: string,

--- a/src/utils/single-instance-lock.ts
+++ b/src/utils/single-instance-lock.ts
@@ -2,7 +2,10 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import {
+  isCommandMatch,
   isProcessAlive,
+  readProcessCommand,
+  readProcessStartToken,
   type ProcessCommandPattern,
 } from './pid-utils.js';
 
@@ -17,7 +20,7 @@ import {
 // input/output pipeline.
 //
 // The lockfile lives at a caller-chosen path (e.g. <dataDir>/collector.lock)
-// and holds JSON `{ pid, startedAt, ownerId }`. It is published atomically (temp file + hardlink)
+// and holds JSON `{ pid, startedAt, ownerId, processStartToken? }`. It is published atomically (temp file + hardlink)
 // so a peer never observes a created-but-empty lockfile — see `writeOwnLock`.
 
 // Distinguish a lock genuinely held by another async operation in this process
@@ -37,17 +40,40 @@ export interface SingleInstanceLock {
   release(): void;
 }
 
+export interface StaleLockRecovery {
+  previousPid?: number;
+  reason: 'malformed-lock' | 'dead-holder' | 'pid-reused' | 'same-pid-owner-mismatch';
+}
+
 export interface LockAcquireResult {
   /** The acquired lock, or null when a live peer already holds it (or on fs error). */
   lock: SingleInstanceLock | null;
   /** pid of the live holder when acquisition failed because one exists. */
   holderPid?: number;
+  /** Whether the live holder's process lifetime could be verified against the lock. */
+  holderProcessStartState?:
+    | 'same-process-owner'
+    | 'matched'
+    | 'lock-token-missing'
+    | 'current-token-unreadable';
+  /** Command identity is diagnostic only and is never used to evict a live holder. */
+  holderCommandState?: 'matched' | 'mismatched' | 'unreadable' | 'not-checked';
+  /** Present only when this acquisition removed a stale lock and then won the retry. */
+  recoveredStaleLock?: StaleLockRecovery;
 }
 
 interface LockPayload {
   pid: number;
   startedAt: number;
   ownerId?: string;
+  processStartToken?: string;
+}
+
+interface LockInspection {
+  stale: boolean;
+  staleReason?: StaleLockRecovery['reason'];
+  holderProcessStartState?: LockAcquireResult['holderProcessStartState'];
+  holderCommandState?: LockAcquireResult['holderCommandState'];
 }
 
 function readLock(lockPath: string): LockPayload | null {
@@ -62,7 +88,8 @@ function readLock(lockPath: string): LockPayload | null {
   return null;
 }
 
-// A lock is stale only when its recorded holder is no longer alive. Command-line identity is
+// A lock is stale only when its recorded holder is no longer alive or the OS process-start
+// identity proves that the pid has been recycled. Command-line identity is
 // deliberately not used to evict a live holder: launchers and wrappers can introduce new command
 // shapes (for example `loongsuite-pilot run-service`) that lag behind the process-pattern list.
 // Treating an unknown-but-live command as stale lets a second collector delete a valid lock and
@@ -73,21 +100,62 @@ function readLock(lockPath: string): LockPayload | null {
 //     Windows, where a foreign-owned process still means "occupied").
 //  2. A lock carrying this process's pid has no matching process-local owner token, which means
 //     it belongs to an older process instance whose pid was reused.
+//  3. Both the lock and the live pid expose process-start tokens and they differ. A missing token
+//     (legacy lock) or an unreadable current token fails closed and never triggers eviction.
 
-function isStale(
+function inspectLock(
   lockPath: string,
   lock: LockPayload | null,
-  _patterns?: readonly ProcessCommandPattern[],
-): boolean {
-  if (!lock) return true;
+  patterns?: readonly ProcessCommandPattern[],
+): LockInspection {
+  if (!lock) return { stale: true, staleReason: 'malformed-lock' };
   if (lock.pid === process.pid) {
-    return !lock.ownerId || activeLockOwners.get(lockPath) !== lock.ownerId;
+    const owned = Boolean(lock.ownerId) && activeLockOwners.get(lockPath) === lock.ownerId;
+    return owned
+      ? {
+        stale: false,
+        holderProcessStartState: 'same-process-owner',
+        holderCommandState: commandState(lock.pid, patterns),
+      }
+      : { stale: true, staleReason: 'same-pid-owner-mismatch' };
   }
-  return !isProcessAlive(lock.pid);
+  if (!isProcessAlive(lock.pid)) return { stale: true, staleReason: 'dead-holder' };
+
+  const currentStartToken = readProcessStartToken(lock.pid);
+  if (lock.processStartToken && currentStartToken && lock.processStartToken !== currentStartToken) {
+    return { stale: true, staleReason: 'pid-reused' };
+  }
+
+  return {
+    stale: false,
+    holderProcessStartState: !lock.processStartToken
+      ? 'lock-token-missing'
+      : currentStartToken
+        ? 'matched'
+        : 'current-token-unreadable',
+    holderCommandState: commandState(lock.pid, patterns),
+  };
+}
+
+function commandState(
+  pid: number,
+  patterns?: readonly ProcessCommandPattern[],
+): LockAcquireResult['holderCommandState'] {
+  if (!patterns || patterns.length === 0) return 'not-checked';
+  const command = readProcessCommand(pid);
+  if (!command) return 'unreadable';
+  return isCommandMatch(command, patterns) ? 'matched' : 'mismatched';
 }
 
 function writeOwnLock(lockPath: string, ownerId: string): void {
-  const payload = JSON.stringify({ pid: process.pid, startedAt: Date.now(), ownerId });
+  const startedAt = Date.now(); // Wall-clock evidence for operators; not an eviction timeout.
+  const processStartToken = readProcessStartToken(process.pid);
+  const payload = JSON.stringify({
+    pid: process.pid,
+    startedAt,
+    ownerId,
+    ...(processStartToken ? { processStartToken } : {}),
+  });
   // Atomic publish: write the full payload to a temp file, then hardlink it into place.
   // link(2) is atomic and fails with EEXIST when a holder already exists, so a concurrent
   // reader never observes a created-but-empty lockfile. `openSync(..,'wx')` + `writeSync`
@@ -141,18 +209,19 @@ function makeHandle(lockPath: string, ownerId: string): SingleInstanceLock {
  *
  * - No live holder → creates the lockfile atomically and returns a handle.
  * - Live holder → returns `{ lock: null, holderPid }`; the caller should log and exit.
- * - Stale lockfile (dead holder, or this process's pid with no live owner token) → the
- *   stale file is removed and the lock is taken.
+ * - Stale lockfile (dead holder, a provably reused pid, or this process's pid with no
+ *   live owner token) → the stale file is removed and the lock is taken.
  *
- * `patterns` is retained for API compatibility with callers. It is not used to evict a
- * live holder: an incomplete command allowlist must never reopen the duplicate-collector
- * window this lock exists to close.
+ * `patterns` only classifies the holder for diagnostics. It is not used to evict a live
+ * holder: an incomplete command allowlist must never reopen the duplicate-collector window
+ * this lock exists to close.
  */
 export function acquireSingleInstanceLock(
   lockPath: string,
   patterns?: readonly ProcessCommandPattern[],
 ): LockAcquireResult {
   lockPath = path.resolve(lockPath);
+  let pendingRecovery: LockAcquireResult['recoveredStaleLock'];
   try {
     fs.mkdirSync(path.dirname(lockPath), { recursive: true });
   } catch {
@@ -163,19 +232,32 @@ export function acquireSingleInstanceLock(
     try {
       const ownerId = randomUUID();
       writeOwnLock(lockPath, ownerId);
-      return { lock: makeHandle(lockPath, ownerId) };
+      return {
+        lock: makeHandle(lockPath, ownerId),
+        ...(pendingRecovery ? { recoveredStaleLock: pendingRecovery } : {}),
+      };
     } catch (err) {
       if ((err as NodeJS.ErrnoException)?.code !== 'EEXIST') {
         // Unexpected fs error: fail closed (do not run) but report no holder.
         return { lock: null };
       }
       const existing = readLock(lockPath);
-      if (isStale(lockPath, existing, patterns)) {
+      const inspection = inspectLock(lockPath, existing, patterns);
+      if (inspection.stale) {
         // Holder is gone — drop the stale file and try once more to take over.
+        pendingRecovery = {
+          previousPid: existing?.pid,
+          reason: inspection.staleReason ?? 'malformed-lock',
+        };
         try { fs.unlinkSync(lockPath); } catch { /* ignore */ }
         return 'retry';
       }
-      return { lock: null, holderPid: existing?.pid };
+      return {
+        lock: null,
+        holderPid: existing?.pid,
+        holderProcessStartState: inspection.holderProcessStartState,
+        holderCommandState: inspection.holderCommandState,
+      };
     }
   };
 

--- a/tests/unit/utils/pid-utils.test.ts
+++ b/tests/unit/utils/pid-utils.test.ts
@@ -6,6 +6,7 @@ import {
   COLLECTOR_PROCESS_PATTERNS,
   isCommandMatch,
   isProcessAlive,
+  readProcessStartToken,
   UPDATER_PROCESS_PATTERNS,
 } from '../../../src/utils/pid-utils.js';
 
@@ -52,6 +53,19 @@ describe('pid-utils identity-first liveness', () => {
     });
 
     expect(isProcessAlive(123)).toBe(true);
+  });
+
+  it('reads a stable process-start token from the platform process identity', () => {
+    if (process.platform === 'linux') {
+      readFileSyncMock
+        .mockReturnValueOnce('123 (node worker) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 4242 20 21')
+        .mockReturnValueOnce('boot-id-1\n');
+      expect(readProcessStartToken(123)).toBe('linux-proc-v1:boot-id-1:4242');
+      return;
+    }
+
+    execFileSyncMock.mockReturnValueOnce('Tue Aug 18 15:03:36 2026\n');
+    expect(readProcessStartToken(123)).toContain('-v1:Tue Aug 18 15:03:36 2026');
   });
 
   it('uses pid file as fast path when pid command matches identity', () => {

--- a/tests/unit/utils/pid-utils.test.ts
+++ b/tests/unit/utils/pid-utils.test.ts
@@ -37,6 +37,8 @@ describe('pid-utils identity-first liveness', () => {
 
   it('matches strict collector and updater command identities', () => {
     expect(isCommandMatch('/usr/bin/node /home/a/.loongsuite-pilot/bin/collector-daemon.js', COLLECTOR_PROCESS_PATTERNS)).toBe(true);
+    expect(isCommandMatch('/home/a/.local/bin/loongsuite-pilot run-service', COLLECTOR_PROCESS_PATTERNS)).toBe(true);
+    expect(isCommandMatch('/home/a/.local/bin/loongsuite-pilot run-service-helper', COLLECTOR_PROCESS_PATTERNS)).toBe(false);
     expect(isCommandMatch('/usr/bin/node /home/a/.loongsuite-pilot/bin/updater-daemon.js', UPDATER_PROCESS_PATTERNS)).toBe(true);
     expect(isCommandMatch('/usr/bin/node unrelated.js', COLLECTOR_PROCESS_PATTERNS)).toBe(false);
     expect(isCommandMatch('/usr/bin/node unrelated.js', UPDATER_PROCESS_PATTERNS)).toBe(false);

--- a/tests/unit/utils/single-instance-lock.test.ts
+++ b/tests/unit/utils/single-instance-lock.test.ts
@@ -6,7 +6,7 @@ import * as os from 'node:os';
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
 import { acquireSingleInstanceLock } from '../../../src/utils/single-instance-lock.js';
-import { readProcessCommand } from '../../../src/utils/pid-utils.js';
+import { readProcessCommand, readProcessStartToken } from '../../../src/utils/pid-utils.js';
 
 describe('acquireSingleInstanceLock', () => {
   let dir: string;
@@ -29,6 +29,7 @@ describe('acquireSingleInstanceLock', () => {
     expect(payload.pid).toBe(process.pid);
     expect(typeof payload.startedAt).toBe('number');
     expect(typeof payload.ownerId).toBe('string');
+    expect(typeof payload.processStartToken).toBe('string');
   });
 
   it('refuses a second acquisition while a live holder exists', () => {
@@ -81,7 +82,7 @@ describe('acquireSingleInstanceLock', () => {
     expect(JSON.parse(fs.readFileSync(lockPath, 'utf-8')).pid).toBe(process.pid + 1);
   });
 
-  it('with patterns, refuses to evict a live external pid whose command does not match', async () => {
+  it('keeps a legacy lock without ownerId or start token when its external pid is alive', async () => {
     const holder = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
       stdio: 'ignore',
     });
@@ -91,16 +92,84 @@ describe('acquireSingleInstanceLock', () => {
       fs.mkdirSync(path.dirname(lockPath), { recursive: true });
       fs.writeFileSync(lockPath, JSON.stringify({ pid: holder.pid, startedAt: Date.now() }));
 
-      const { lock, holderPid } = acquireSingleInstanceLock(
+      const { lock, holderPid, holderProcessStartState, holderCommandState } = acquireSingleInstanceLock(
         lockPath,
         ['collector-daemon-never-matches-node-child'],
       );
       expect(lock).toBeNull();
       expect(holderPid).toBe(holder.pid);
+      expect(holderProcessStartState).toBe('lock-token-missing');
+      expect(holderCommandState).toBe('mismatched');
       expect(JSON.parse(fs.readFileSync(lockPath, 'utf-8')).pid).toBe(holder.pid);
     } finally {
       const exited = once(holder, 'exit');
       holder.kill();
+      await exited;
+    }
+  });
+
+  it('refuses a live external holder when its start token matches even if its command does not', async () => {
+    const holder = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+      stdio: 'ignore',
+    });
+    await once(holder, 'spawn');
+
+    try {
+      const processStartToken = readProcessStartToken(holder.pid!);
+      expect(processStartToken).not.toBe('');
+      fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+      fs.writeFileSync(lockPath, JSON.stringify({
+        pid: holder.pid,
+        startedAt: Date.now(),
+        ownerId: 'external-holder',
+        processStartToken,
+      }));
+
+      const result = acquireSingleInstanceLock(
+        lockPath,
+        ['collector-daemon-never-matches-node-child'],
+      );
+
+      expect(result.lock).toBeNull();
+      expect(result.holderPid).toBe(holder.pid);
+      expect(result.holderProcessStartState).toBe('matched');
+      expect(result.holderCommandState).toBe('mismatched');
+    } finally {
+      const exited = once(holder, 'exit');
+      holder.kill();
+      await exited;
+    }
+  });
+
+  it('takes over only when the live pid process-start token proves pid reuse', async () => {
+    const recycled = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+      stdio: 'ignore',
+    });
+    await once(recycled, 'spawn');
+
+    try {
+      const currentToken = readProcessStartToken(recycled.pid!);
+      expect(currentToken).not.toBe('');
+      fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+      fs.writeFileSync(lockPath, JSON.stringify({
+        pid: recycled.pid,
+        startedAt: Date.now() - 60_000,
+        ownerId: 'crashed-holder',
+        processStartToken: `${currentToken}:previous-lifetime`,
+      }));
+
+      const result = acquireSingleInstanceLock(lockPath, ['collector-daemon-never-matches-node-child']);
+
+      expect(result.lock).not.toBeNull();
+      expect(result.recoveredStaleLock).toEqual({
+        previousPid: recycled.pid,
+        reason: 'pid-reused',
+      });
+      expect(JSON.parse(fs.readFileSync(lockPath, 'utf-8')).pid).toBe(process.pid);
+      result.lock!.release();
+    } finally {
+      const exited = once(recycled, 'exit');
+      recycled.kill();
       await exited;
     }
   });
@@ -130,9 +199,16 @@ describe('acquireSingleInstanceLock', () => {
 
     // The process-local owner token must win even when the test command is a
     // valid holder pattern, preserving same-process mutual exclusion.
-    const { lock, holderPid } = acquireSingleInstanceLock(lockPath, [selfCmd]);
+    const {
+      lock,
+      holderPid,
+      holderProcessStartState,
+      holderCommandState,
+    } = acquireSingleInstanceLock(lockPath, [selfCmd]);
     expect(lock).toBeNull();
     expect(holderPid).toBe(process.pid);
+    expect(holderProcessStartState).toBe('same-process-owner');
+    expect(holderCommandState).toBe('matched');
     first.lock!.release();
   });
 

--- a/tests/unit/utils/single-instance-lock.test.ts
+++ b/tests/unit/utils/single-instance-lock.test.ts
@@ -3,6 +3,8 @@ import * as fs from 'node:fs';
 import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
 import { acquireSingleInstanceLock } from '../../../src/utils/single-instance-lock.js';
 import { readProcessCommand } from '../../../src/utils/pid-utils.js';
 
@@ -79,17 +81,28 @@ describe('acquireSingleInstanceLock', () => {
     expect(JSON.parse(fs.readFileSync(lockPath, 'utf-8')).pid).toBe(process.pid + 1);
   });
 
-  it('with patterns, takes over a lock whose live pid runs a non-matching command (pid reuse)', () => {
-    // Our own pid is alive, but its command line is the test runner — not a
-    // collector. This simulates a recycled pid after the real holder crashed: the
-    // pid-liveness check alone would wrongly block, but the command-identity check
-    // recognizes it as stale and lets us take over.
-    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
-    fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid, startedAt: Date.now() }));
+  it('with patterns, refuses to evict a live external pid whose command does not match', async () => {
+    const holder = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+      stdio: 'ignore',
+    });
+    await once(holder, 'spawn');
 
-    const { lock } = acquireSingleInstanceLock(lockPath, ['collector-daemon-never-matches-vitest']);
-    expect(lock).not.toBeNull();
-    expect(JSON.parse(fs.readFileSync(lockPath, 'utf-8')).pid).toBe(process.pid);
+    try {
+      fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+      fs.writeFileSync(lockPath, JSON.stringify({ pid: holder.pid, startedAt: Date.now() }));
+
+      const { lock, holderPid } = acquireSingleInstanceLock(
+        lockPath,
+        ['collector-daemon-never-matches-node-child'],
+      );
+      expect(lock).toBeNull();
+      expect(holderPid).toBe(holder.pid);
+      expect(JSON.parse(fs.readFileSync(lockPath, 'utf-8')).pid).toBe(holder.pid);
+    } finally {
+      const exited = once(holder, 'exit');
+      holder.kill();
+      await exited;
+    }
   });
 
   it('takes over a stale lock from an older process instance that reused our pid', () => {


### PR DESCRIPTION
## Summary

- recognize `loongsuite-pilot run-service` as a collector process shape
- fail closed for live holders when identity is missing or unreadable; command allowlists are diagnostic only
- persist an OS process-start token and reclaim a stale lock only when the live PID token proves PID reuse
- record holder start-token state and command-match state when a competing collector is rejected
- record `recoveryReason=pid-reused` when a recycled PID lock is safely reclaimed
- cover legacy locks, healthy live holders, command mismatches, PID reuse, and shared lock consumers

## Why

The agentshell launch path uses `loongsuite-pilot run-service`. An incomplete command allowlist previously let a second collector classify the live lock as stale, delete it, and start duplicate collection. Pure PID liveness avoids that duplicate window but can deadlock if a crashed holder PID is later recycled by a long-lived process.

This change avoids both failure modes without a time-based escape hatch: it stores a boot-scoped process-start identity in new locks and only evicts a live PID when the current identity is readable and differs. Legacy locks and unreadable identities remain fail-closed. Full command lines are not logged; only matched/mismatched/unreadable state is recorded.

## Validation

- `npm test -- --run tests/unit/utils/pid-utils.test.ts tests/unit/utils/single-instance-lock.test.ts tests/unit/pi-sdk/pi-sdk-agent-registry.test.ts` (35 tests passed)
- `npm run typecheck`
- `npm run build`
- isolated local competition: `run-service` held the lock and concurrent `run` exited with `holderProcessStartState=matched`
- isolated PID-reuse simulation: a live PID with a different stored start token was reclaimed and logged as `recoveryReason=pid-reused`