### PR TITLE
feat(deploy): add a synchronous `loongsuite-pilot deploy` command

### DIFF
--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -1248,6 +1248,36 @@ function Cmd-Log {
 }
 
 # ============================================================
+# CMD: deploy (one-shot hook/plugin deployment, for image builds)
+# ============================================================
+function Cmd-Deploy {
+    $versionDir = Resolve-CurrentVersion
+    if (-not $versionDir) {
+        Write-Error "Current loongsuite-pilot version not found"
+        exit 1
+    }
+
+    $entry = Join-Path $versionDir "dist\index.js"
+    if (-not (Test-Path $entry -PathType Leaf)) {
+        Write-Error "Deploy CLI entrypoint missing"
+        exit 1
+    }
+
+    $nodeBin = Resolve-Node
+    if (-not $nodeBin) {
+        Write-Error "node runtime not found"
+        exit 1
+    }
+
+    $env:LOONGSUITE_PILOT_DATA_DIR = $DATA_DIR
+    $env:LOONGSUITE_PILOT_CACHE_DIR = $CACHE_DIR
+    $env:AGENT_DATA_COLLECTION_CONFIG = $CONFIG_FILE
+    # No collector restart afterwards -- see the shell cmd_deploy for why.
+    & $nodeBin $entry "deploy" @SubArgs
+    exit $LASTEXITCODE
+}
+
+# ============================================================
 # CMD: token-usage (foreground token usage CLI)
 # ============================================================
 function Cmd-TokenUsage {
@@ -1405,6 +1435,9 @@ function Cmd-Help {
     Write-Host "  status          Show service status (default)"
     Write-Host "  info            Show version and config info"
     Write-Host "  log             Tail the service log"
+    Write-Host "  deploy [opts]   Deploy hooks/plugins once and exit (for image builds)"
+    Write-Host "                    --require <ids>  comma-separated agent ids that must deploy"
+    Write-Host "                    --json           machine-readable result"
     Write-Host "  token-usage     Show token usage TUI"
     Write-Host "  tokens          Alias for token-usage"
     Write-Host "  span-attr ...   Manage custom trace span attributes (set/unset/list/clear)"
@@ -1425,6 +1458,7 @@ switch ($Command.ToLower()) {
     "status"             { Cmd-Status }
     "info"               { Cmd-Info }
     "log"                { Cmd-Log }
+    "deploy"             { Cmd-Deploy }
     "token-usage"        { Cmd-TokenUsage }
     "tokens"             { Cmd-TokenUsage }
     "rollback"           { Cmd-Rollback }

--- a/scripts/loongsuite-pilot.sh
+++ b/scripts/loongsuite-pilot.sh
@@ -1211,6 +1211,33 @@ cmd_agent() {
     esac
 }
 
+cmd_deploy() {
+    ensure_dirs
+    sync_bootstrap_scripts
+
+    local node_bin
+    node_bin=$(resolve_node) || {
+        echo "❌ node runtime not found" >&2
+        return 1
+    }
+
+    local version_dir
+    version_dir=$(resolve_current_version) || {
+        echo "❌ No valid loongsuite-pilot version found" >&2
+        return 1
+    }
+    local entry="$version_dir/dist/index.js"
+
+    export AGENT_DATA_COLLECTION_CONFIG="$CONFIG_FILE"
+    export LOONGSUITE_PILOT_DATA_DIR="$DATA_DIR"
+    export LOONGSUITE_PILOT_CACHE_DIR="$CACHE_DIR"
+    # Deliberately no collector restart afterwards: this command exists for image
+    # builds, where nothing is running yet and starting a daemon inside a build
+    # layer would leave a half-written state file baked into the image. A running
+    # collector re-reads its deployment state on its own next cycle.
+    exec "$node_bin" "$entry" deploy "$@"
+}
+
 cmd_token_usage() {
     ensure_dirs
 
@@ -2182,6 +2209,9 @@ cmd_help() {
     echo "  restart         Restart the collector service"
     echo "  status          Show service status (default)"
     echo "  info            Show version and config info"
+    echo "  deploy [opts]   Deploy hooks/plugins once and exit (for image builds)"
+    echo "                    --require <ids>  comma-separated agent ids that must deploy"
+    echo "                    --json           machine-readable result"
     echo "  token-usage     Show token usage TUI"
     echo "  agent ...       Register/list/diagnose PI SDK Agents"
     echo "  span-attr ...   Manage custom trace span attributes (set/unset/list/clear)"
@@ -2198,6 +2228,7 @@ case "${1:-status}" in
     restart)     cmd_restart ;;
     status)      cmd_status ;;
     info)        cmd_info ;;
+    deploy)      shift; cmd_deploy "$@" ;;
     token-usage) shift; cmd_token_usage "$@" ;;
     tokens)      shift; cmd_token_usage "$@" ;;
     span-attr)   shift; cmd_span_attr "$@" ;;

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -336,6 +336,12 @@ export class Orchestrator extends EventEmitter {
       agentsConfig: this.config.agents,
       slsEndpoints: this.config.flushers.sls?.endpoints ?? [],
       cmsWorkspace: this.config.cms?.workspace ?? '',
+      // Same condition as the updater watchdog above, deliberately: whether an updater is
+      // supposed to exist decides both whether we restart it and whether its absence is
+      // worth an alarm. Auto-update resolves to disabled whenever no package source is
+      // configured, and the updater exits immediately on that config — so a missing pid
+      // there is the expected state, not a fault.
+      autoUpdateEnabled: this.config.autoUpdate?.enabled ?? false,
     });
     await this.metricsWriter.start();
 

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -7,6 +7,10 @@ import { InputManager } from './input-manager.js';
 import { StateStore } from '../checkpoints/state-store.js';
 import { HookManager } from '../hooks/hook-manager.js';
 import { DeploymentManager } from '../deployment/deployment-manager.js';
+import {
+  isAgentGatedEnabled as isAgentGatedEnabledIn,
+  resolvePilotDir as resolvePilotDirIn,
+} from '../deployment/deploy-command.js';
 import { detectAgent } from '../deployment/detect-utils.js';
 import {
   ensureRegisteredPiSdkWrappers,
@@ -1539,9 +1543,7 @@ export class Orchestrator extends EventEmitter {
    * - Otherwise: only if config.agents[agentId].enabled !== false
    */
   private isAgentGatedEnabled(agentId: string): boolean {
-    const agents = this.config.agents;
-    if (!agents || Object.keys(agents).length === 0) return true;
-    return agents[agentId]?.enabled !== false;
+    return isAgentGatedEnabledIn(this.config, agentId);
   }
 
   /**
@@ -1577,49 +1579,7 @@ export class Orchestrator extends EventEmitter {
   }
 
   private resolvePilotDir(moduleUrl: string = import.meta.url): string {
-    try {
-      const currentFile = path.join(this.dataDir, 'current');
-      const versionName = fsSync.readFileSync(currentFile, 'utf-8').trim();
-      if (versionName) {
-        const versionDir = path.join(this.dataDir, 'versions', versionName);
-        if (fsSync.existsSync(versionDir)) {
-          logger.debug('resolved pilotDir from current pointer', { pilotDir: versionDir });
-          return versionDir;
-        }
-      }
-    } catch {
-      // current file doesn't exist — legacy or dev layout
-    }
-
-    const legacyPackageDir = path.join(this.dataDir, 'package');
-    if (fsSync.existsSync(path.join(legacyPackageDir, 'dist', 'index.js'))) {
-      return legacyPackageDir;
-    }
-
-    try {
-      const moduleDir = path.dirname(fileURLToPath(moduleUrl));
-      const candidates = [
-        path.resolve(moduleDir, '..'),
-        path.resolve(moduleDir, '..', '..'),
-      ];
-      for (const modulePackageDir of candidates) {
-        const packageJson = path.join(modulePackageDir, 'package.json');
-        const agentsDir = path.join(modulePackageDir, 'agents.d');
-        if (
-          fsSync.existsSync(packageJson)
-          && fsSync.existsSync(agentsDir)
-          && fsSync.statSync(packageJson).isFile()
-          && fsSync.statSync(agentsDir).isDirectory()
-        ) {
-          logger.debug('resolved pilotDir from module package root', { pilotDir: modulePackageDir });
-          return modulePackageDir;
-        }
-      }
-    } catch {
-      // Module URL is invalid or the runtime package does not include required assets.
-    }
-
-    return this.dataDir;
+    return resolvePilotDirIn(this.dataDir, moduleUrl);
   }
 
   private buildDataflowSnapshot(): DataflowSnapshot {

--- a/src/deployment/deploy-command.ts
+++ b/src/deployment/deploy-command.ts
@@ -1,0 +1,323 @@
+import * as path from 'node:path';
+import * as fsSync from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import type { AnalyticsConfig, DeployResult } from '../types/index.js';
+import { DeploymentManager } from './deployment-manager.js';
+import { ensureRegisteredPiSdkWrappers } from '../pi-sdk/pi-sdk-agent-registry.js';
+import { loadConfig } from '../core/config-loader.js';
+import { resolveHome } from '../utils/fs-utils.js';
+import { createLogger, redirectRootLoggerToStderr } from '../utils/logger.js';
+
+const logger = createLogger('DeployCommand');
+
+const DEFAULT_DATA_DIR = '~/.loongsuite-pilot';
+
+/**
+ * Check whether an agent is allowed to run based on the `config.agents` gate.
+ * - No config.agents or empty: always true (backward compat)
+ * - Otherwise: only if config.agents[agentId].enabled !== false
+ */
+export function isAgentGatedEnabled(config: AnalyticsConfig, agentId: string): boolean {
+  const agents = config.agents;
+  if (!agents || Object.keys(agents).length === 0) return true;
+  return agents[agentId]?.enabled !== false;
+}
+
+/**
+ * Resolve the package installation directory by reading the `current` pointer file.
+ * Falls back to the module's own package root, then to dataDir.
+ *
+ * `moduleUrl` must be supplied by the caller so the module-root fallback is
+ * anchored at the caller's file, not at this shared helper.
+ */
+export function resolvePilotDir(dataDir: string, moduleUrl: string): string {
+  try {
+    const currentFile = path.join(dataDir, 'current');
+    const versionName = fsSync.readFileSync(currentFile, 'utf-8').trim();
+    if (versionName) {
+      const versionDir = path.join(dataDir, 'versions', versionName);
+      if (fsSync.existsSync(versionDir)) {
+        logger.debug('resolved pilotDir from current pointer', { pilotDir: versionDir });
+        return versionDir;
+      }
+    }
+  } catch {
+    // current file doesn't exist — legacy or dev layout
+  }
+
+  const legacyPackageDir = path.join(dataDir, 'package');
+  if (fsSync.existsSync(path.join(legacyPackageDir, 'dist', 'index.js'))) {
+    return legacyPackageDir;
+  }
+
+  try {
+    const moduleDir = path.dirname(fileURLToPath(moduleUrl));
+    const candidates = [
+      path.resolve(moduleDir, '..'),
+      path.resolve(moduleDir, '..', '..'),
+    ];
+    for (const modulePackageDir of candidates) {
+      const packageJson = path.join(modulePackageDir, 'package.json');
+      const agentsDir = path.join(modulePackageDir, 'agents.d');
+      if (
+        fsSync.existsSync(packageJson)
+        && fsSync.existsSync(agentsDir)
+        && fsSync.statSync(packageJson).isFile()
+        && fsSync.statSync(agentsDir).isDirectory()
+      ) {
+        logger.debug('resolved pilotDir from module package root', { pilotDir: modulePackageDir });
+        return modulePackageDir;
+      }
+    }
+  } catch {
+    // Module URL is invalid or the runtime package does not include required assets.
+  }
+
+  return dataDir;
+}
+
+export interface DeployCommandOptions {
+  /**
+   * Agent ids whose instrumentation MUST be in place when the command returns.
+   * "In place" includes an agent that was already deployed — re-running the
+   * command in the same dataDir (a derived image rebuilding on top of an
+   * instrumented base) has to stay green, so only `not-detected` / `disabled`
+   * and hard failures count as unmet.
+   */
+  required: string[];
+  json: boolean;
+}
+
+/** A required agent that did not end up instrumented, plus why. */
+export interface UnmetRequirement {
+  agentId: string;
+  reason: 'not-detected' | 'disabled' | 'failed' | 'unknown-id';
+  error?: string;
+}
+
+/**
+ * `loongsuite-pilot deploy` — run hook registration / plugin installation once,
+ * synchronously, then exit.
+ *
+ * The collector performs the same deployment during `orchestrator.start()`, but
+ * only as a side effect of a long-running daemon. Image builds need it as a
+ * foreground step with an exit code: a `docker build` layer tears the daemon down
+ * as soon as the RUN command returns, so whether the hooks were written before
+ * the layer is committed would otherwise be a race.
+ */
+export async function runDeployCommand(argv: string[]): Promise<number> {
+  const opts = parseArgs(argv);
+  // Deployment logs are diagnostics, not the command's output. Keep stdout clean
+  // so `--json` stays machine-readable.
+  redirectRootLoggerToStderr();
+
+  const config = await loadConfig();
+  const dataDir = resolveHome(config.dataDir || DEFAULT_DATA_DIR);
+  const pilotDir = resolvePilotDir(dataDir, import.meta.url);
+
+  // Registered PI SDK agents live in dataDir, not agents.d — their generated
+  // wrappers must exist before deployAll walks the definition list.
+  await ensureRegisteredPiSdkWrappers(dataDir).catch(err => {
+    logger.warn('failed to restore PI SDK agent wrappers', { error: String(err) });
+    return 0;
+  });
+
+  const manager = new DeploymentManager({ dataDir, pilotDir });
+  const results = await manager.deployAll(def => isAgentGatedEnabled(config, def.id));
+
+  // Probe workers started during detection must not survive into the image: a
+  // worker.pid written on the build host can collide with a live pid in the
+  // container's fresh PID namespace, and isWorkerRunning() would then report a
+  // worker that does not exist — leaving telemetry silently off. A failure here
+  // is reported, not swallowed, because the leftover pid is the actual hazard.
+  let workerStopFailed = false;
+  await manager.stopWorkers().catch(err => {
+    workerStopFailed = true;
+    logger.error('failed to stop probe workers', { error: String(err) });
+  });
+
+  const knownIds = new Set(manager.getDefinitions().map(def => def.id));
+  const unmet = collectUnmet(opts.required, knownIds, results);
+
+  if (opts.json) {
+    console.log(JSON.stringify({
+      dataDir,
+      pilotDir,
+      results,
+      required: opts.required,
+      unmet,
+      workerStopFailed,
+    }, null, 2));
+  } else {
+    printHuman(results, opts.required, unmet, workerStopFailed);
+  }
+
+  return deployExitCode(results, unmet, workerStopFailed);
+}
+
+/**
+ * Map a deploy outcome to a process exit code.
+ *
+ * A hard failure counts even when nobody required that agent: without this, a
+ * caller that passes no --require at all would let a plugin-extraction error
+ * pass as a successful build layer.
+ */
+export function deployExitCode(
+  results: DeployResult[],
+  unmet: UnmetRequirement[],
+  workerStopFailed: boolean,
+): number {
+  const failed = results.some(r => !r.success);
+  return unmet.length > 0 || failed || workerStopFailed ? 1 : 0;
+}
+
+/**
+ * Decide which required agents did not end up instrumented.
+ *
+ * `skipped` on its own says nothing: `up-to-date` means the integration is in
+ * place (including detection-only agents, which never write anything), while
+ * `not-detected` and `disabled` mean it is not. Treating every skip as a failure
+ * makes the command non-idempotent and permanently unsatisfiable for
+ * detection-only agents.
+ */
+export function collectUnmet(
+  required: string[],
+  knownIds: Set<string>,
+  results: DeployResult[],
+): UnmetRequirement[] {
+  const unmet: UnmetRequirement[] = [];
+
+  for (const agentId of required) {
+    if (!knownIds.has(agentId)) {
+      unmet.push({ agentId, reason: 'unknown-id' });
+      continue;
+    }
+    const result = results.find(r => r.agentId === agentId);
+    if (!result) {
+      unmet.push({ agentId, reason: 'not-detected' });
+      continue;
+    }
+    if (!result.success) {
+      unmet.push({ agentId, reason: 'failed', error: result.error });
+      continue;
+    }
+    if (result.skipped && result.reason !== 'up-to-date') {
+      unmet.push({ agentId, reason: result.reason === 'disabled' ? 'disabled' : 'not-detected' });
+    }
+  }
+
+  return unmet;
+}
+
+const SKIP_LABEL: Record<string, string> = {
+  'not-detected': 'not detected on this machine',
+  'up-to-date': 'already in place',
+  disabled: 'disabled by the config.agents gate',
+};
+
+function printHuman(
+  results: DeployResult[],
+  required: string[],
+  unmet: UnmetRequirement[],
+  workerStopFailed: boolean,
+): void {
+  const deployed = results.filter(r => r.success && !r.skipped);
+  const skipped = results.filter(r => r.skipped);
+  const failed = results.filter(r => !r.success);
+
+  for (const r of deployed) {
+    console.log(`  ✅ ${r.agentId} (${r.deployMode}) deployed`);
+  }
+  for (const r of skipped) {
+    const why = SKIP_LABEL[r.reason ?? ''] ?? 'reason not reported';
+    console.log(`  ➖ ${r.agentId} (${r.deployMode}) skipped — ${why}`);
+  }
+  for (const r of failed) {
+    console.log(`  ❌ ${r.agentId} (${r.deployMode}) failed — ${r.error ?? 'unknown error'}`);
+  }
+  console.log(
+    `deploy complete: ${deployed.length} deployed, ${skipped.length} skipped, ${failed.length} failed`,
+  );
+
+  if (workerStopFailed) {
+    console.error('');
+    console.error('❌ probe workers could not be stopped');
+    console.error('   A worker.pid left in the image can collide with an unrelated pid in the');
+    console.error("   container's PID namespace, which makes the collector believe a worker is");
+    console.error('   already running and silently skip starting one.');
+  }
+
+  if (unmet.length === 0) {
+    if (required.length > 0) {
+      console.log(`✅ all required agents are instrumented: ${required.join(', ')}`);
+    }
+    return;
+  }
+
+  console.error('');
+  console.error(`❌ required agents are not instrumented: ${unmet.map(u => u.agentId).join(', ')}`);
+  for (const u of unmet) {
+    switch (u.reason) {
+      case 'unknown-id':
+        console.error(`   ${u.agentId}: no such agent id — check the spelling against \`loongsuite-pilot info\``);
+        break;
+      case 'not-detected':
+        console.error(`   ${u.agentId}: not detected. In an image build, install the agent and set its`);
+        console.error('     environment (e.g. HERMES_HOME) in the SAME layer, before this step.');
+        break;
+      case 'disabled':
+        console.error(`   ${u.agentId}: disabled by the config.agents gate — remove it from the gate or from --require`);
+        break;
+      case 'failed':
+        console.error(`   ${u.agentId}: deployment failed — ${u.error ?? 'unknown error'}`);
+        break;
+    }
+  }
+}
+
+export function parseArgs(argv: string[]): DeployCommandOptions {
+  const required: string[] = [];
+  let json = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--json') {
+      json = true;
+    } else if (arg === '--require') {
+      required.push(...requireIds(argv[++i], '--require <ids>'));
+    } else if (arg.startsWith('--require=')) {
+      required.push(...requireIds(arg.slice('--require='.length), '--require=<ids>'));
+    } else {
+      throw new Error(`unknown option: ${arg}`);
+    }
+  }
+
+  return { required: [...new Set(required)], json };
+}
+
+/**
+ * Parse a --require value, refusing anything that would silently disable the gate.
+ *
+ * An empty value is the dangerous case: `--require ""` or `--require=$EMPTY_ARG`
+ * used to parse as "require nothing" and exit 0, so a build that meant to assert
+ * instrumentation asserted nothing instead. A missing value is just as bad in the
+ * other direction: `deploy --require --json` would have taken `--json` as an
+ * agent id and then failed for the wrong reason.
+ */
+function requireIds(raw: string | undefined, usage: string): string[] {
+  if (raw === undefined || raw.startsWith('--')) {
+    throw new Error(`${usage} requires a value (got ${raw === undefined ? 'nothing' : raw})`);
+  }
+  const ids = splitIds(raw);
+  if (ids.length === 0) {
+    throw new Error(
+      `${usage} was given an empty value. Omit --require entirely if no agent is required — `
+      + 'an empty list would silently disable the check.',
+    );
+  }
+  return ids;
+}
+
+function splitIds(raw: string): string[] {
+  return raw.split(',').map(s => s.trim()).filter(Boolean);
+}

--- a/src/deployment/deployment-manager.ts
+++ b/src/deployment/deployment-manager.ts
@@ -131,6 +131,7 @@ export class DeploymentManager {
       agentId: def.id,
       deployMode: def.deployMode,
       skipped: true,
+      reason: 'disabled',
     };
 
     if (
@@ -229,7 +230,13 @@ export class DeploymentManager {
     const detected = await strategy.detect(def);
     if (!detected) {
       logger.debug('agent not detected, skipping', { agentId: def.id });
-      return { success: true, agentId: def.id, deployMode: def.deployMode, skipped: true };
+      return {
+        success: true,
+        agentId: def.id,
+        deployMode: def.deployMode,
+        skipped: true,
+        reason: 'not-detected',
+      };
     }
 
     const record = this.state[def.id];
@@ -245,8 +252,17 @@ export class DeploymentManager {
       if (def.deployMode === 'dsh-yaml-patch' && record && !record.dshPatchPath) {
         record.dshPatchPath = this.dshYamlPatchStrategy.resolvePatchPathForRecord(def, record);
       }
+      // Also the terminal state for detection-only agents: they share another
+      // agent's hook, so needsDeploy() is always false and "detected but nothing
+      // to write" is a fully satisfied integration, not a missing one.
       logger.debug('agent already deployed, skipping', { agentId: def.id });
-      return { success: true, agentId: def.id, deployMode: def.deployMode, skipped: true };
+      return {
+        success: true,
+        agentId: def.id,
+        deployMode: def.deployMode,
+        skipped: true,
+        reason: 'up-to-date',
+      };
     }
 
     logger.info('deploying agent', { agentId: def.id, deployMode: def.deployMode });

--- a/src/deployment/detection-only-strategy.ts
+++ b/src/deployment/detection-only-strategy.ts
@@ -22,7 +22,15 @@ export class DetectionOnlyStrategy implements DeployStrategy {
   }
 
   async deploy(def: AgentDefinition): Promise<DeployResult> {
-    return { success: true, agentId: def.id, deployMode: 'detection-only', skipped: true };
+    // Unreachable through DeploymentManager (needsDeploy is always false), but the
+    // reason must still say "satisfied" rather than leaving it ambiguous.
+    return {
+      success: true,
+      agentId: def.id,
+      deployMode: 'detection-only',
+      skipped: true,
+      reason: 'up-to-date',
+    };
   }
 
   async undeploy(_def: AgentDefinition): Promise<boolean> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,21 @@ async function main(): Promise<void> {
     return;
   }
 
+  // One-shot deployment. The collector deploys hooks/plugins itself on startup,
+  // but only as a daemon side effect; image builds need it as a foreground step
+  // with an exit code (see runDeployCommand).
+  if (command === 'deploy') {
+    const { runDeployCommand } = await import('./deployment/deploy-command.js');
+    try {
+      process.exitCode = await runDeployCommand(args);
+    } catch (err) {
+      console.error(`loongsuite-pilot deploy: ${err instanceof Error ? err.message : String(err)}`);
+      process.exitCode = 1;
+    }
+    flushLogsSync();
+    return;
+  }
+
   const config = await loadConfig();
 
   const dataDir = resolveHome(config.dataDir);

--- a/src/metrics/metrics-collector.ts
+++ b/src/metrics/metrics-collector.ts
@@ -157,6 +157,7 @@ export class MetricsCollector {
   private readonly agentsConfig: AgentsConfig;
   private readonly slsEndpoints: SlsEndpoint[];
   private readonly cmsWorkspace: string;
+  private readonly autoUpdateEnabled: boolean;
   private readonly updaterLiveness: (pidFile: string) => ProcessLiveness;
   private readonly startTime: string;
   private readonly startTimestamp: number;
@@ -175,7 +176,7 @@ export class MetricsCollector {
   private updaterConsecutiveFailures = 0;
   private lastInfraHealth: InfraHealthSnapshot | null = null;
 
-  constructor(opts: { version: string; userId: string; dataDir: string; canaryPolicy?: string; agentsConfig?: AgentsConfig; slsEndpoints?: SlsEndpoint[]; cmsWorkspace?: string; updaterLiveness?: (pidFile: string) => ProcessLiveness }) {
+  constructor(opts: { version: string; userId: string; dataDir: string; canaryPolicy?: string; agentsConfig?: AgentsConfig; slsEndpoints?: SlsEndpoint[]; cmsWorkspace?: string; autoUpdateEnabled?: boolean; updaterLiveness?: (pidFile: string) => ProcessLiveness }) {
     this.version = opts.version;
     this.userId = opts.userId;
     this.dataDir = opts.dataDir;
@@ -183,6 +184,9 @@ export class MetricsCollector {
     this.agentsConfig = opts.agentsConfig ?? {};
     this.slsEndpoints = opts.slsEndpoints ?? [];
     this.cmsWorkspace = opts.cmsWorkspace ?? '';
+    // Omitted means "an updater is expected", the host default. Only a caller that knows
+    // otherwise — the orchestrator, reading the resolved config — passes false.
+    this.autoUpdateEnabled = opts.autoUpdateEnabled ?? true;
     this.updaterLiveness = opts.updaterLiveness
       ?? ((pidFile: string) => checkProcessLiveness(pidFile, UPDATER_PROCESS_PATTERNS));
     this.startTimestamp = Math.floor(Date.now() / 1000);
@@ -364,8 +368,14 @@ export class MetricsCollector {
   private collectInfraHealth(): InfraHealthSnapshot {
     this.l1CycleCount++;
 
+    // `true` here means "nothing to report", which is also what the first two cycles
+    // report while the updater is still coming up. With auto-update disabled there is no
+    // updater to come up at all — nothing registers a service for it and the updater
+    // process exits immediately on a disabled config — so probing its pid would report a
+    // permanent failure and UPDATER_NOT_RUNNING_ALARM would fire ~30min into every such
+    // install's life, about a process nobody asked for.
     let updaterPidAlive = true;
-    if (this.l1CycleCount > 2) {
+    if (this.autoUpdateEnabled && this.l1CycleCount > 2) {
       updaterPidAlive = this.updaterLiveness(
         path.join(this.dataDir, 'loongsuite-pilot-updater.pid'),
       ).running;

--- a/src/metrics/metrics-writer.ts
+++ b/src/metrics/metrics-writer.ts
@@ -40,6 +40,7 @@ export interface MetricsWriterOptions {
   agentsConfig?: AgentsConfig;
   slsEndpoints?: SlsEndpoint[];
   cmsWorkspace?: string;
+  autoUpdateEnabled?: boolean;
   updaterLiveness?: (pidFile: string) => ProcessLiveness;
 }
 
@@ -70,6 +71,7 @@ export class MetricsWriter {
       canaryPolicy: opts.canaryPolicy,
       slsEndpoints: opts.slsEndpoints,
       cmsWorkspace: opts.cmsWorkspace,
+      autoUpdateEnabled: opts.autoUpdateEnabled,
       updaterLiveness: opts.updaterLiveness,
     });
     this.getSnapshot = opts.getSnapshot;

--- a/src/types/deployment.ts
+++ b/src/types/deployment.ts
@@ -258,11 +258,27 @@ export interface AgentDefinition {
 
 // ─── Deploy Result ───
 
+/**
+ * Why a deploy was skipped. `skipped: true` alone is ambiguous — "the agent is
+ * not installed here" and "its integration is already in place" are opposite
+ * outcomes, and `loongsuite-pilot deploy --require` has to treat them
+ * differently (the first is a build failure, the second is success).
+ */
+export type DeploySkipReason =
+  /** detect() found no agent on this machine — nothing was instrumented. */
+  | 'not-detected'
+  /** Integration already present (includes detection-only agents, which never write). */
+  | 'up-to-date'
+  /** Turned off by the config.agents gate, so it was undeployed instead. */
+  | 'disabled';
+
 export interface DeployResult {
   success: boolean;
   agentId: string;
   deployMode: DeployMode;
   skipped?: boolean;
+  /** Set whenever `skipped` is true. */
+  reason?: DeploySkipReason;
   error?: string;
 }
 

--- a/tests/unit/deployment/deploy-command-contract.test.ts
+++ b/tests/unit/deployment/deploy-command-contract.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import type { DeployResult } from '../../../src/types/index.js';
+import {
+  collectUnmet,
+  deployExitCode,
+  parseArgs,
+} from '../../../src/deployment/deploy-command.js';
+
+/**
+ * `loongsuite-pilot deploy` is the gate an image build hangs on: the whole point
+ * of the command is that a non-zero exit stops a broken layer from shipping. So
+ * the contract pinned here is the exit code, not the formatting.
+ */
+
+const KNOWN = new Set(['hermes-agent', 'claude-code', 'qoder-jetbrains']);
+
+function result(over: Partial<DeployResult> & { agentId: string }): DeployResult {
+  return {
+    success: true,
+    deployMode: 'hook',
+    ...over,
+  } as DeployResult;
+}
+
+const deployed = result({ agentId: 'hermes-agent' });
+const upToDate = result({ agentId: 'hermes-agent', skipped: true, reason: 'up-to-date' });
+const notDetected = result({ agentId: 'hermes-agent', skipped: true, reason: 'not-detected' });
+const disabled = result({ agentId: 'hermes-agent', skipped: true, reason: 'disabled' });
+const failed = result({ agentId: 'hermes-agent', success: false, error: 'plugin extract failed' });
+
+function exitCodeFor(results: DeployResult[], required: string[] = []): number {
+  return deployExitCode(results, collectUnmet(required, KNOWN, results), false);
+}
+
+describe('deploy --require exit codes', () => {
+  it('accepts a freshly deployed agent', () => {
+    expect(exitCodeFor([deployed], ['hermes-agent'])).toBe(0);
+  });
+
+  it('accepts an agent that was already deployed', () => {
+    // Idempotence is load-bearing: an image build that keeps deployed-agents.json
+    // hits this branch whenever a derived image rebuilds on top of an instrumented
+    // base. Treating "already in place" as unmet would make every rebuild fail.
+    expect(exitCodeFor([upToDate], ['hermes-agent'])).toBe(0);
+  });
+
+  it('rejects an agent that was never detected', () => {
+    expect(exitCodeFor([notDetected], ['hermes-agent'])).toBe(1);
+  });
+
+  it('rejects an agent turned off by the config.agents gate', () => {
+    expect(exitCodeFor([disabled], ['hermes-agent'])).toBe(1);
+  });
+
+  it('rejects an agent missing from the result list entirely', () => {
+    expect(exitCodeFor([], ['hermes-agent'])).toBe(1);
+  });
+
+  it('rejects an id no agent definition claims, instead of silently passing', () => {
+    expect(exitCodeFor([deployed], ['hermez-agent'])).toBe(1);
+    expect(collectUnmet(['hermez-agent'], KNOWN, [deployed])).toEqual([
+      { agentId: 'hermez-agent', reason: 'unknown-id' },
+    ]);
+  });
+
+  it('reports the underlying error for a hard failure', () => {
+    expect(collectUnmet(['hermes-agent'], KNOWN, [failed])).toEqual([
+      { agentId: 'hermes-agent', reason: 'failed', error: 'plugin extract failed' },
+    ]);
+  });
+
+  it('fails on a hard failure even when nothing was required', () => {
+    // A caller that passes no --require still needs failures to surface, or an
+    // extraction error would pass as a successful build layer.
+    expect(exitCodeFor([failed])).toBe(1);
+  });
+
+  it('does not fail on a skip when nothing was required', () => {
+    expect(exitCodeFor([notDetected, disabled])).toBe(0);
+  });
+
+  it('fails when probe workers could not be stopped', () => {
+    // A worker.pid baked into the image can collide with an unrelated pid in the
+    // container's fresh PID namespace, leaving telemetry silently off.
+    expect(deployExitCode([deployed], [], true)).toBe(1);
+  });
+});
+
+describe('deploy argument parsing', () => {
+  it('splits and de-duplicates a comma-separated list', () => {
+    expect(parseArgs(['--require', 'a, b ,a']).required).toEqual(['a', 'b']);
+    expect(parseArgs(['--require=a,b']).required).toEqual(['a', 'b']);
+  });
+
+  it('accepts no --require at all', () => {
+    expect(parseArgs([]).required).toEqual([]);
+    expect(parseArgs(['--json'])).toEqual({ required: [], json: true });
+  });
+
+  it('refuses an empty --require value rather than requiring nothing', () => {
+    // `--require "$AGENTS"` with an unset AGENTS used to exit 0 having asserted
+    // nothing — the failure mode the flag exists to prevent.
+    expect(() => parseArgs(['--require', ''])).toThrow(/empty value/);
+    expect(() => parseArgs(['--require', ' , '])).toThrow(/empty value/);
+    expect(() => parseArgs(['--require='])).toThrow(/empty value/);
+  });
+
+  it('refuses a missing --require value instead of eating the next flag', () => {
+    expect(() => parseArgs(['--require'])).toThrow(/requires a value/);
+    expect(() => parseArgs(['--require', '--json'])).toThrow(/requires a value/);
+  });
+
+  it('refuses unknown options', () => {
+    expect(() => parseArgs(['--force'])).toThrow(/unknown option/);
+  });
+});

--- a/tests/unit/deployment/deployment-manager.test.ts
+++ b/tests/unit/deployment/deployment-manager.test.ts
@@ -147,6 +147,58 @@ describe('DeploymentManager', () => {
       });
     });
 
+    // `skipped: true` on its own is ambiguous — "not installed here" and "already in
+    // place" are opposite outcomes, and `deploy --require` (the image-build gate) has
+    // to fail on the first and pass on the second. So the reason is part of the
+    // contract, not diagnostic decoration.
+    describe('skip reasons', () => {
+      function hookDef(id: string): AgentDefinition {
+        return {
+          id,
+          displayName: id,
+          deployMode: 'hook',
+          detection: { paths: [], commands: [] },
+          hook: {
+            settingsPath: path.join(tmpDir, `${id}.json`),
+            events: ['Stop'],
+            hookCommand: `/opt/${id}.sh`,
+            format: 'flat',
+          },
+        };
+      }
+
+      it('reports not-detected when the agent is absent', async () => {
+        await writeAgentDef(hookDef('absent-agent'));
+        vi.mocked(detectAgent).mockResolvedValue(false);
+
+        const [result] = await makeManager().deployAll();
+        expect(result).toMatchObject({ success: true, skipped: true, reason: 'not-detected' });
+      });
+
+      it('reports up-to-date on a second deploy into the same dataDir', async () => {
+        // Container mode deliberately keeps deployed-agents.json in the image, so a
+        // derived image rebuilding on top of an instrumented base lands here. Reporting
+        // anything but "satisfied" would make every rebuild fail.
+        await writeAgentDef(hookDef('repeat-agent'));
+        vi.mocked(detectAgent).mockResolvedValue(true);
+
+        const mgr = makeManager();
+        const first = (await mgr.deployAll())[0];
+        expect(first.success).toBe(true);
+        expect(first.skipped).toBeFalsy();
+        expect((await mgr.deployAll())[0])
+          .toMatchObject({ success: true, skipped: true, reason: 'up-to-date' });
+      });
+
+      it('reports disabled when the caller gates the agent off', async () => {
+        await writeAgentDef(hookDef('gated-agent'));
+        vi.mocked(detectAgent).mockResolvedValue(true);
+
+        const [result] = await makeManager().deployAll(() => false);
+        expect(result).toMatchObject({ success: true, skipped: true, reason: 'disabled' });
+      });
+    });
+
     it('undeploys a hook agent that was deployed then disabled', async () => {
       const settingsPath = path.join(tmpDir, 'toggle-hooks.json');
       const def: AgentDefinition = {

--- a/tests/unit/metrics/metrics-collector.test.ts
+++ b/tests/unit/metrics/metrics-collector.test.ts
@@ -407,6 +407,38 @@ describe('MetricsCollector', () => {
       expect(col.getLastInfraHealth()!.updaterPidAlive).toBe(true);
     });
 
+    it('never probes the updater pid when auto-update is disabled', () => {
+      // Auto-update resolves to disabled whenever no package source is configured: nothing
+      // registers a service for the updater, no updater process runs, and the updater
+      // binary exits on sight of that config. Probing anyway would report a permanent
+      // failure and alarm about a process that was never supposed to run.
+      const liveness = vi.fn<[], ProcessLiveness>(() => down('no matching updater command found'));
+      const col = new MetricsCollector({
+        version: '1.0.0',
+        userId: 'test-user',
+        dataDir: tmpDir,
+        autoUpdateEnabled: false,
+        updaterLiveness: liveness,
+      });
+      for (let i = 0; i < 5; i++) col.collectL1(buildSnapshot());
+      expect(liveness).not.toHaveBeenCalled();
+      expect(col.getLastInfraHealth()!.updaterConsecutiveFailures).toBe(0);
+      expect(col.getLastInfraHealth()!.updaterPidAlive).toBe(true);
+    });
+
+    it('probes the updater pid when the flag is omitted, since a host install has one', () => {
+      const liveness = vi.fn<[], ProcessLiveness>(() => down('no matching updater command found'));
+      const col = new MetricsCollector({
+        version: '1.0.0',
+        userId: 'test-user',
+        dataDir: tmpDir,
+        updaterLiveness: liveness,
+      });
+      for (let i = 0; i < 3; i++) col.collectL1(buildSnapshot());
+      expect(liveness).toHaveBeenCalled();
+      expect(col.getLastInfraHealth()!.updaterPidAlive).toBe(false);
+    });
+
     it('reports current_version_valid=true when current points to existing version dir', () => {
       fs.mkdirSync(path.join(tmpDir, 'versions', '1.0.0_abc'), { recursive: true });
       fs.writeFileSync(path.join(tmpDir, 'current'), '1.0.0_abc');

--- a/tests/unit/metrics/metrics-writer.test.ts
+++ b/tests/unit/metrics/metrics-writer.test.ts
@@ -533,6 +533,35 @@ describe('MetricsWriter', () => {
       expect(alarm!.alarm_level).toBe('3');
     });
 
+    it('UPDATER_NOT_RUNNING_ALARM never fires when auto-update is disabled', async () => {
+      // With auto-update disabled nothing registers an updater service and the updater
+      // exits on that config, so the pid is missing by design. Left ungated, every such
+      // install would report this level-3 alarm ~30min after start (L1 runs every 10min
+      // and the probe begins on cycle 3) about a process that is not supposed to exist.
+      const alarmManager = new AlarmManager({ ip: '127.0.0.1', version: '2.0.0', userId: 'test-user' });
+      writer = new MetricsWriter({
+        dataDir: tmpDir,
+        version: '2.0.0',
+        userId: 'u1',
+        getSnapshot: buildSnapshot,
+        alarmManager,
+        autoUpdateEnabled: false,
+        updaterLiveness: () => ({
+          running: false,
+          source: 'none',
+          reason: 'no matching updater command found',
+          pidFileState: 'missing',
+        }),
+      });
+
+      vi.useRealTimers();
+      // Same four cycles that make the enabled case alarm above.
+      for (let i = 0; i < 4; i++) await (writer as any).writeL1();
+
+      const entries = alarmManager.serialize();
+      expect(entries.find(e => e.alarm_type === 'UPDATER_NOT_RUNNING_ALARM')).toBeUndefined();
+    });
+
     it('BROKEN_VERSION_POINTER_ALARM fires when current points to missing dir', async () => {
       fs.writeFileSync(path.join(tmpDir, 'current'), 'nonexistent_version');
       const alarmManager = new AlarmManager({ ip: '127.0.0.1', version: '2.0.0', userId: 'test-user' });


### PR DESCRIPTION
## Why

Hook and plugin deployment is currently only a side effect of `orchestrator.start()`. That works for a long-running daemon but is unusable for an image build:

- A `docker build` RUN layer reclaims the process as soon as the command returns, so whether hooks were written **before the layer was committed** is a race against the daemon's teardown.
- An agent that is not detected is a **silent skip** (`success: true, skipped: true`), so the image looks instrumented while nothing was written.

## What

`loongsuite-pilot deploy` runs the same deployment once, in the foreground, and exits with a code.

| Flag | Behaviour |
|---|---|
| `--require <ids>` | Turns "not detected" into exit 1, so a build layer fails loudly instead of producing an uninstrumented image. |
| `--json` | Machine-readable result; logs go to stderr so stdout stays parseable. |

Contract details that are load-bearing:

- **Idempotent.** An already-deployed agent stays green, so a derived image rebuilding on an instrumented base does not fail.
- **`--require ""` is rejected** rather than parsed as "require nothing", which would silently assert nothing.
- **A hard deploy failure is an error even when nothing was required**, so a caller that passes no `--require` still surfaces e.g. a plugin-extraction error.

To make `--require` decidable, `DeployResult` now carries a `DeploySkipReason`. `skipped` on its own cannot distinguish "the agent is not installed here" from "its integration is already in place" — opposite outcomes for a build gate. `detection-only` agents report `up-to-date`, since they share another agent's hook and never write anything.

Probe workers started during detection are stopped before returning: a `worker.pid` written on the build host can collide with an unrelated pid in a container's fresh PID namespace, which would make the collector believe a worker is already running and silently skip starting one.

`isAgentGatedEnabled` and `resolvePilotDir` are now shared with the orchestrator instead of duplicated — `orchestrator.ts` is 46 lines shorter.

The `scripts/loongsuite-pilot.{sh,ps1}` wrappers forward `deploy`, deliberately **without** restarting the collector afterwards: in a build layer nothing is running yet, and starting a daemon there would bake a half-written state file into the image. A collector already running on a host re-reads its deployment state on its own next cycle.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit`, `npm run build` | pass |
| `bash -n scripts/loongsuite-pilot.sh` | pass |
| `vitest run tests/unit/deployment/` | 292 passed, 3 skipped |
| Full unit suite | No new failures. The suite has pre-existing flakiness under parallel load; every file that differed from a pristine `main` run passes in isolation, and `main` itself fails a partially overlapping set. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)