### PR TITLE
fix(installer): keep npm install failures diagnosable

### DIFF
--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -390,6 +390,20 @@ function Ensure-NodeModules {
 }
 # <<< managed-node-runtime <<<
 
+function Show-NpmFailure {
+    # Show-NpmFailure <path of the captured npm output>
+    #
+    # npm's own failure report ends in a single line naming a debug log under the npm
+    # cache. Where the npm install fallback actually runs unattended -- a container
+    # build layer, a CI runner -- that file is discarded before anyone can read it, so
+    # the pointer is all that survives and the cause is lost. Print what npm printed.
+    param([string]$LogPath)
+    if ($LogPath -and (Test-Path $LogPath)) {
+        Msg "    ---- npm 输出（末 40 行）----" "    ---- npm output (last 40 lines) ----"
+        Get-Content $LogPath -Tail 40 -ErrorAction SilentlyContinue | ForEach-Object { Write-Host $_ }
+    }
+}
+
 # ============================================================
 # Check dependencies
 # ============================================================
@@ -830,10 +844,15 @@ function Deploy-Package {
         $nodeDir = Split-Path $script:NODE_BIN
         $savedPath = $env:PATH
         if ($env:PATH -notlike "*$nodeDir*") { $env:PATH = "$nodeDir;$env:PATH" }
+        $npmLog = Join-Path ([System.IO.Path]::GetTempPath()) "loongsuite-pilot-npm-install-$PID.log"
         Push-Location $script:PERMANENT_DIR
         try {
             $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
-            & $script:NPM_BIN install --omit=dev --omit=optional 2>&1 | Select-Object -Last 1
+            # Retries: this path pulls ~185 packages from the registry and npm only
+            # retries twice by default, so one reset connection failed the whole install.
+            # The output is captured, not discarded, so Show-NpmFailure can name the cause.
+            & $script:NPM_BIN install --omit=dev --omit=optional --fetch-retries 5 --fetch-retry-mintimeout 2000 --fetch-retry-maxtimeout 60000 2>&1 |
+                Out-File -FilePath $npmLog -Encoding UTF8
             $npmExit = $LASTEXITCODE
             $ErrorActionPreference = $prevEAP
         } finally {
@@ -841,8 +860,13 @@ function Deploy-Package {
             $env:PATH = $savedPath
         }
         if ($npmExit -ne 0) {
-            Msg "❌ 依赖安装失败 (exit=$npmExit)，请检查 npm 日志" "❌ Dependencies installation failed (exit=$npmExit), check npm logs"
+            Msg "❌ 依赖安装失败 (exit=$npmExit)" "❌ Dependencies installation failed (exit=$npmExit)"
+            Show-NpmFailure $npmLog
             exit 1
+        }
+        if (Test-Path $npmLog) {
+            Get-Content $npmLog -Tail 1 -ErrorAction SilentlyContinue | ForEach-Object { Write-Host $_ }
+            Remove-Item $npmLog -Force -ErrorAction SilentlyContinue
         }
     }
 

--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -488,6 +488,28 @@ run_npm() {
 }
 # <<< managed-node-runtime <<<
 
+dump_npm_failure() {
+    # dump_npm_failure <file-with-npm-output>
+    #
+    # npm's own failure report ends in a single line pointing at
+    # ~/.npm/_logs/<ts>-debug-0.log. Where this fallback actually runs unattended — a
+    # container build layer, a CI runner — that file is discarded before anyone can read
+    # it, so the pointer is all that survives and the cause is lost. Print the captured
+    # output instead, plus the debug log's error lines while the filesystem still has them.
+    local out="$1" log="" logs_dir=""
+    if [ -s "$out" ]; then
+        msg "    ---- npm 输出（末 40 行）----" "    ---- npm output (last 40 lines) ----"
+        tail -n 40 "$out"
+    fi
+    logs_dir="${npm_config_cache:-$HOME/.npm}/_logs"
+    log=$(ls -t "$logs_dir"/*.log 2>/dev/null | head -1 || true)
+    if [ -n "$log" ] && [ -f "$log" ]; then
+        msg "    ---- npm 调试日志 $log（末 40 条 error 行）----" \
+            "    ---- npm debug log $log (last 40 error lines) ----"
+        grep -E '^[0-9]+ error' "$log" | tail -n 40 || tail -n 40 "$log"
+    fi
+}
+
 check_deps() {
     msg "==> 检查依赖..." "==> Checking dependencies..."
 
@@ -881,10 +903,20 @@ deploy_package() {
     else
         msg "    ⚠️ 预编译 node_modules 不可用，回退 npm install" \
             "    ⚠️ Prebuilt node_modules unavailable, falling back to npm install"
-        if ! (cd "$PERMANENT_DIR" && run_npm install --production --no-optional 2>&1 | tail -1); then
+        # Retries: this path pulls ~185 packages from the registry, so a single reset
+        # connection used to fail the whole install (npm defaults to 2 retries).
+        local npm_out
+        npm_out=$(mktemp) || npm_out="${TMPDIR:-/tmp}/loongsuite-pilot-npm-install.log"
+        if ! (cd "$PERMANENT_DIR" && run_npm install --production --no-optional \
+                --fetch-retries 5 --fetch-retry-mintimeout 2000 --fetch-retry-maxtimeout 60000 \
+                >"$npm_out" 2>&1); then
             msg "    ❌ 依赖安装失败" "    ❌ Dependency installation failed"
+            dump_npm_failure "$npm_out"
+            rm -f "$npm_out"
             return 1
         fi
+        tail -n 1 "$npm_out"
+        rm -f "$npm_out"
         msg "    ✅ 依赖安装完成" "    ✅ Dependencies installed"
     fi
     echo ""

--- a/tests/unit/deploy/managed-node-wiring.test.mjs
+++ b/tests/unit/deploy/managed-node-wiring.test.mjs
@@ -126,6 +126,49 @@ describe('ps1 installer variants wire the managed node runtime', () => {
   }
 });
 
+// The npm install fallback is the only path that can fail for a reason the user
+// has to read. Piping it through `tail -1` / `Select-Object -Last 1` left exactly
+// one line of npm's failure report -- the path of a debug log that a container
+// build layer or CI runner throws away -- so real failures arrived unexplainable.
+describe('npm install fallback stays diagnosable', () => {
+  for (const f of SH_VARIANTS) {
+    const present = existsSync(resolve('deploy', f));
+    const sh = present ? readFileSync(resolve('deploy', f), 'utf-8') : '';
+    it.skipIf(!present)(`${f} does not discard npm output through tail`, () => {
+      expect(sh).not.toMatch(/install --production --no-optional[^\n]*\|\s*tail/);
+    });
+    it.skipIf(!present)(`${f} dumps npm output and ~/.npm/_logs on failure`, () => {
+      expect(sh).toMatch(/dump_npm_failure\(\)\s*\{/);
+      const helper = sh.slice(sh.indexOf('dump_npm_failure() {'));
+      expect(helper).toContain('_logs');
+      expect(helper).toMatch(/tail -n 40/);
+      const fallback = sh.slice(sh.indexOf('预编译 node_modules 不可用，回退 npm install'));
+      expect(fallback).toContain('dump_npm_failure');
+    });
+    it.skipIf(!present)(`${f} retries registry fetches beyond the npm default`, () => {
+      expect(sh).toContain('--fetch-retries 5');
+      expect(sh).toContain('--fetch-retry-maxtimeout');
+    });
+  }
+
+  for (const f of PS1_VARIANTS) {
+    const present = existsSync(resolve('deploy', f));
+    const ps1 = present ? readFileSync(resolve('deploy', f), 'utf-8') : '';
+    it.skipIf(!present)(`${f} does not discard npm output through Select-Object`, () => {
+      expect(ps1).not.toMatch(/install --omit=dev[^\n]*\|\s*Select-Object -Last 1/);
+    });
+    it.skipIf(!present)(`${f} dumps the captured npm output on failure`, () => {
+      expect(ps1).toMatch(/function Show-NpmFailure\s*\{/);
+      const fallback = ps1.slice(ps1.indexOf('Prebuilt node_modules unavailable'));
+      expect(fallback).toContain('Show-NpmFailure $npmLog');
+    });
+    it.skipIf(!present)(`${f} retries registry fetches beyond the npm default`, () => {
+      expect(ps1).toContain('--fetch-retries 5');
+      expect(ps1).toContain('--fetch-retry-maxtimeout');
+    });
+  }
+});
+
 describe('hook fallbacks prefer the managed runtime node', () => {
   for (const f of HOOK_SH) {
     const sh = readFileSync(resolve(f), 'utf-8');


### PR DESCRIPTION
## Problem

When the prebuilt `node_modules` tarball is missing from OSS, the installer falls back to a full `npm install`. That fallback was piped through `tail -1` (sh) / `Select-Object -Last 1` (ps1), so a **failure** printed exactly one line of npm's report:

```
npm error A complete log of this run can be found in:
npm error     /home/node/.npm/_logs/2026-08-18T06_57_31_722Z-debug-0.log
❌ Dependency installation failed
```

The place this fallback actually runs unattended is a container build layer or a CI runner — and both throw that log file away with the failed layer. The pointer is all that survives, and the cause is gone. This is not hypothetical: an openclaw image build failed exactly this way, and re-running it was the only way to learn anything (the re-run passed, which is itself the answer — see below).

## Changes

**Print the failure instead of discarding it.** npm's output is captured to a temp file; on failure the installer prints its last 40 lines plus the `error` lines of the newest debug log under the npm cache, while the filesystem still has them. `dump_npm_failure` (sh) / `Show-NpmFailure` (ps1). The success path still prints only npm's one-line `added N packages` summary, so a normal install is exactly as quiet as before.

**Retry registry fetches.** `--fetch-retries 5 --fetch-retry-mintimeout 2000 --fetch-retry-maxtimeout 60000`. This path pulls ~185 packages and npm retries twice by default, so a single reset connection fails the whole install — which is what happened; an identical re-run succeeded with no other change.

## Tests

`tests/unit/deploy/managed-node-wiring.test.mjs` gains a `npm install fallback stays diagnosable` block asserting, per variant: no `| tail` / `| Select-Object -Last 1` on the npm line, the dump helper exists and is reached from the fallback, and the retry flags are present. It follows the file's existing skip-when-absent pattern, so it also covers the internal-only variants where those exist.

| Check | Result |
|---|---|
| `bash -n deploy/installer-opensource.sh` | pass |
| `vitest run tests/unit/deploy/managed-node-wiring.test.mjs` | 44 passed, 46 skipped |
| `vitest run tests/unit/scripts/ps1-{clm-safe,comments-ascii,json-encoding}` | 60 passed |

The `.ps1` change keeps comments ASCII-only and uses no CLM-unsafe construct. It is statically checked only — no PowerShell on the machine this was written on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
