### PR TITLE
fix(checkpoint): serialize input state saves

### DIFF
--- a/src/checkpoints/state-store.ts
+++ b/src/checkpoints/state-store.ts
@@ -17,7 +17,9 @@ function cloneState(s: InputState): InputState {
 export class StateStore {
   private readonly states: Map<string, InputState> = new Map();
   private readonly filePath: string;
-  private dirty = false;
+  private revision = 0;
+  private persistedRevision = 0;
+  private savePromise: Promise<void> | null = null;
 
   constructor(filePath: string) {
     this.filePath = filePath;
@@ -27,7 +29,8 @@ export class StateStore {
     const data = await readJsonFile<StateFileShape | null>(this.filePath);
     this.states.clear();
     if (!data || typeof data !== 'object' || data === null) {
-      this.dirty = false;
+      this.revision = 0;
+      this.persistedRevision = 0;
       return;
     }
     for (const [id, st] of Object.entries(data)) {
@@ -35,19 +38,22 @@ export class StateStore {
         this.states.set(id, cloneState(st as InputState));
       }
     }
-    this.dirty = false;
+    this.revision = 0;
+    this.persistedRevision = 0;
   }
 
-  async save(): Promise<void> {
-    if (!this.dirty) {
-      return;
+  save(): Promise<void> {
+    if (this.persistedRevision === this.revision) {
+      return Promise.resolve();
     }
-    const out: StateFileShape = {};
-    for (const [k, v] of this.states) {
-      out[k] = cloneState(v);
+
+    if (!this.savePromise) {
+      this.savePromise = this.flushPendingRevisions().finally(() => {
+        this.savePromise = null;
+      });
     }
-    await writeJsonFile(this.filePath, out);
-    this.dirty = false;
+
+    return this.savePromise;
   }
 
   get(inputId: string): InputState {
@@ -56,7 +62,7 @@ export class StateStore {
 
   set(inputId: string, state: InputState): void {
     this.states.set(inputId, cloneState(state));
-    this.dirty = true;
+    this.revision++;
   }
 
   update(inputId: string, partial: Partial<InputState>): void {
@@ -66,12 +72,12 @@ export class StateStore {
       merged.extra = { ...current.extra, ...partial.extra };
     }
     this.states.set(inputId, cloneState(merged));
-    this.dirty = true;
+    this.revision++;
   }
 
   delete(inputId: string): boolean {
     const deleted = this.states.delete(inputId);
-    if (deleted) this.dirty = true;
+    if (deleted) this.revision++;
     return deleted;
   }
 
@@ -93,5 +99,18 @@ export class StateStore {
 
   setRowId(inputId: string, rowId: number): void {
     this.update(inputId, { lastRowId: rowId });
+  }
+
+  private async flushPendingRevisions(): Promise<void> {
+    while (this.persistedRevision < this.revision) {
+      const targetRevision = this.revision;
+      const out: StateFileShape = {};
+      for (const [k, v] of this.states) {
+        out[k] = cloneState(v);
+      }
+
+      await writeJsonFile(this.filePath, out);
+      this.persistedRevision = targetRevision;
+    }
   }
 }

--- a/src/utils/fs-utils.ts
+++ b/src/utils/fs-utils.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import { promises as fsp } from 'node:fs';
 import * as os from 'node:os';
 import * as nodePath from 'node:path';
@@ -108,7 +109,7 @@ export async function writeTextFileAtomic(
     }
   }
 
-  const tmp = `${path}.${process.pid}.${Date.now()}.tmp`;
+  const tmp = atomicTmpPath(path);
   try {
     await fsp.writeFile(tmp, text, 'utf8');
     // Re-check after preparing the temporary file. This narrows the remaining
@@ -124,7 +125,7 @@ export async function writeTextFileAtomic(
     if (code === 'ENOENT') {
       await fsp.unlink(tmp).catch(() => {});
       await ensureDir(dir);
-      const tmp2 = `${path}.${process.pid}.${Date.now()}.tmp`;
+      const tmp2 = atomicTmpPath(path);
       try {
         await fsp.writeFile(tmp2, text, 'utf8');
         if (options.expected) {
@@ -169,6 +170,10 @@ export async function writeJsonFile(
   await writeTextFileAtomic(path, `${JSON.stringify(data, null, 2)}\n`);
 }
 
+function atomicTmpPath(path: string): string {
+  return `${path}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`;
+}
+
 /**
  * Removes stale `.tmp` files left behind by interrupted atomic writes (e.g. process
  * killed mid-rename). Call once at startup for directories that use writeJsonFile.
@@ -184,7 +189,7 @@ export async function cleanStaleTmpFiles(dir: string, maxAgeMs = 60_000): Promis
   try {
     const entries = await fsp.readdir(dir);
     for (const f of entries) {
-      if (!/\.(\d+)\.\d+\.tmp$/.test(f)) continue;
+      if (!/\.(\d+)\.\d+(?:\.[^.]+)?\.tmp$/.test(f)) continue;
       const full = nodePath.join(dir, f);
       try {
         const st = await fsp.stat(full);

--- a/tests/unit/checkpoints/state-store.test.ts
+++ b/tests/unit/checkpoints/state-store.test.ts
@@ -1,8 +1,17 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { StateStore } from '../../../src/checkpoints/state-store.js';
+import { writeJsonFile } from '../../../src/utils/fs-utils.js';
+
+vi.mock('../../../src/utils/fs-utils.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../../src/utils/fs-utils.js')>();
+  return {
+    ...actual,
+    writeJsonFile: vi.fn(actual.writeJsonFile),
+  };
+});
 
 describe('StateStore', () => {
   let tmpDir: string;
@@ -10,6 +19,10 @@ describe('StateStore', () => {
   let store: StateStore;
 
   beforeEach(async () => {
+    const actual = await vi.importActual<typeof import('../../../src/utils/fs-utils.js')>(
+      '../../../src/utils/fs-utils.js',
+    );
+    vi.mocked(writeJsonFile).mockReset().mockImplementation(actual.writeJsonFile);
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ss-test-'));
     filePath = path.join(tmpDir, 'state.json');
     store = new StateStore(filePath);
@@ -109,8 +122,8 @@ describe('StateStore', () => {
     });
   });
 
-  describe('dirty flag optimization', () => {
-    it('should not write when not dirty', async () => {
+  describe('revision optimization', () => {
+    it('should not write without a new revision', async () => {
       await store.load();
       await store.save();
 
@@ -119,7 +132,7 @@ describe('StateStore', () => {
       expect(exists).toBe(false);
     });
 
-    it('should write when dirty', async () => {
+    it('should write when the revision changes', async () => {
       await store.load();
       store.set('x', { lastOffset: 1 });
       await store.save();
@@ -128,12 +141,83 @@ describe('StateStore', () => {
       expect(exists).toBe(true);
     });
 
-    it('should clear dirty after save', async () => {
+    it('should not rewrite an already persisted revision', async () => {
       await store.load();
       store.set('x', { lastOffset: 1 });
       await store.save();
-      // Second save should be a no-op (covered by dirty optimization)
+      // Second save should be a no-op because the revision is persisted.
       await store.save();
+    });
+  });
+
+  describe('concurrent saves', () => {
+    it('serializes saves and persists mutations made during an active write', async () => {
+      await store.load();
+      store.set('input-a', { lastOffset: 1 });
+
+      let releaseFirstWrite!: () => void;
+      const firstWriteReleased = new Promise<void>(resolve => {
+        releaseFirstWrite = resolve;
+      });
+      let notifyFirstWriteStarted!: () => void;
+      const firstWriteStarted = new Promise<void>(resolve => {
+        notifyFirstWriteStarted = resolve;
+      });
+      const actual = await vi.importActual<typeof import('../../../src/utils/fs-utils.js')>(
+        '../../../src/utils/fs-utils.js',
+      );
+      let activeWrites = 0;
+      let maxActiveWrites = 0;
+      let writeCount = 0;
+      vi.mocked(writeJsonFile).mockImplementation(async (...args) => {
+        activeWrites++;
+        maxActiveWrites = Math.max(maxActiveWrites, activeWrites);
+        writeCount++;
+        try {
+          if (writeCount === 1) {
+            notifyFirstWriteStarted();
+            await firstWriteReleased;
+          }
+          await actual.writeJsonFile(...args);
+        } finally {
+          activeWrites--;
+        }
+      });
+
+      const firstSave = store.save();
+      await firstWriteStarted;
+      store.update('input-a', { lastOffset: 2 });
+      store.set('input-b', { lastRowId: 3 });
+      const concurrentSave = store.save();
+      releaseFirstWrite();
+      await Promise.all([firstSave, concurrentSave]);
+
+      expect(writeCount).toBe(2);
+      expect(maxActiveWrites).toBe(1);
+      const persisted = JSON.parse(await fs.readFile(filePath, 'utf8')) as Record<string, unknown>;
+      expect(persisted).toEqual({
+        'input-a': { lastOffset: 2 },
+        'input-b': { lastRowId: 3 },
+      });
+    });
+
+    it('retains an unpersisted revision after a failed write', async () => {
+      await store.load();
+      store.set('input-a', { lastOffset: 10 });
+
+      const actual = await vi.importActual<typeof import('../../../src/utils/fs-utils.js')>(
+        '../../../src/utils/fs-utils.js',
+      );
+      vi.mocked(writeJsonFile)
+        .mockRejectedValueOnce(new Error('synthetic write failure'))
+        .mockImplementation(actual.writeJsonFile);
+
+      await expect(store.save()).rejects.toThrow('synthetic write failure');
+      await store.save();
+
+      const persisted = JSON.parse(await fs.readFile(filePath, 'utf8')) as Record<string, unknown>;
+      expect(persisted).toEqual({ 'input-a': { lastOffset: 10 } });
+      expect(writeJsonFile).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/tests/unit/utils/fs-utils.test.ts
+++ b/tests/unit/utils/fs-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -21,6 +21,7 @@ describe('cleanStaleTmpFiles', () => {
     dir = await fs.mkdtemp(path.join(os.tmpdir(), 'stale-tmp-test-'));
   });
   afterEach(async () => {
+    vi.restoreAllMocks();
     await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
   });
 
@@ -41,6 +42,7 @@ describe('cleanStaleTmpFiles', () => {
     const freshSelf = await writeTmp(`state.json.${myPid}.${Date.now()}.tmp`, 5_000);     // 5s ago, self pid
     const staleOther = await writeTmp(`state.json.${otherPid}.${Date.now() - 200000}.tmp`, 120_000); // 120s ago
     const staleSelf = await writeTmp(`state.json.${myPid}.${Date.now() - 200000}.tmp`, 120_000);     // 120s ago, self
+    const staleUnique = await writeTmp(`state.json.${myPid}.${Date.now() - 200000}.unique-id.tmp`, 120_000);
     const notTmp = await writeTmp(`state.json`, 120_000); // not a tmp file
     const nonMatchingTmp = await writeTmp(`foo.tmp`, 120_000); // doesn't match the pid.ts.tmp pattern
 
@@ -50,6 +52,7 @@ describe('cleanStaleTmpFiles', () => {
     await expect(fs.stat(freshSelf)).resolves.toBeTruthy();    // fresh self-pid: KEEP
     await expect(fs.stat(staleOther)).rejects.toBeTruthy();    // stale other-pid: DELETE
     await expect(fs.stat(staleSelf)).rejects.toBeTruthy();     // stale self-pid: DELETE (pid reuse / crashed)
+    await expect(fs.stat(staleUnique)).rejects.toBeTruthy();   // new pid.ts.unique.tmp format: DELETE
     await expect(fs.stat(notTmp)).resolves.toBeTruthy();       // non-tmp: untouched
     await expect(fs.stat(nonMatchingTmp)).resolves.toBeTruthy(); // non-matching tmp: untouched
   });
@@ -69,6 +72,20 @@ describe('cleanStaleTmpFiles', () => {
     )).rejects.toThrow('file changed before write');
 
     await expect(fs.readFile(target, 'utf8')).resolves.toBe('{"model":"new"}\n');
+  });
+
+  it('uses unique temporary files for concurrent writes in the same millisecond', async () => {
+    const target = path.join(dir, 'state.json');
+    vi.spyOn(Date, 'now').mockReturnValue(1_786_000_000_000);
+
+    const contents = Array.from({ length: 20 }, (_, index) => `value-${index}\n`);
+    await expect(Promise.all(
+      contents.map(content => writeTextFileAtomic(target, content)),
+    )).resolves.toHaveLength(contents.length);
+
+    expect(contents).toContain(await fs.readFile(target, 'utf8'));
+    const leftovers = (await fs.readdir(dir)).filter(name => name.endsWith('.tmp'));
+    expect(leftovers).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

- serialize concurrent `StateStore.save()` calls through one in-flight save loop
- track mutation and persisted revisions so updates made during a write are flushed before callers complete
- keep failed revisions pending for a later retry
- give atomic-write temporary files UUID-based unique names while retaining cleanup compatibility with the old format
- add deterministic concurrency and failure-recovery tests

## Why

Each input serializes its own collection cycle, but all inputs share one `StateStore`. Multiple inputs can therefore save `input-state.json` concurrently. The previous `dirty` boolean could be cleared by an older save after a newer mutation, and temporary names based only on PID and millisecond could collide.

## Verification

- `npm test -- tests/unit/checkpoints/state-store.test.ts tests/unit/utils/fs-utils.test.ts tests/unit/inputs/base-input.test.ts tests/integration/restart-recovery.test.ts tests/integration/state-restore.test.ts` (44/44)
- `npm run typecheck`
- `npm run build`