### PR TITLE
feat: support invocation-scoped GenAI identity

### DIFF
--- a/assets/hooks/claude-code-hook-processor.mjs
+++ b/assets/hooks/claude-code-hook-processor.mjs
@@ -76,7 +76,10 @@ const RESOURCE_ATTRIBUTE_FIELDS = Object.keys(RESOURCE_ATTRIBUTES).length > 0
   : {};
 // Caller-supplied span attributes (e.g. multica.*) stamped as top-level record
 // fields so the trace flusher can pass matching keys through to span attributes.
-const SPAN_ATTRIBUTES = parseSpanAttributesFromEnv(process.env, { agentId: AGENT_ID });
+const SPAN_ATTRIBUTES = parseSpanAttributesFromEnv(process.env, {
+  agentId: AGENT_ID,
+  allowInvocationIdentity: true,
+});
 // Retain recent completion tombstones to ignore delayed duplicate SubagentStop
 // events while keeping the persisted session state bounded.
 const FINALIZED_SUBAGENT_LIMIT = 128;

--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -43,7 +43,10 @@ const RESOURCE_ATTRIBUTE_FIELDS = Object.keys(RESOURCE_ATTRIBUTES).length > 0
   : {};
 // Caller-supplied span attributes (e.g. multica.*) stamped as top-level record
 // fields so the trace flusher can pass matching keys through to span attributes.
-const SPAN_ATTRIBUTES = parseSpanAttributesFromEnv(process.env, { agentId: 'qoder' });
+const SPAN_ATTRIBUTES = parseSpanAttributesFromEnv(process.env, {
+  agentId: 'qoder',
+  allowInvocationIdentity: true,
+});
 
 // --- Per-transcript processing lock -----------------------------------------
 // Every Stop can create a detached retry. Serialize the complete read -> append

--- a/assets/hooks/shared/resource-context.mjs
+++ b/assets/hooks/shared/resource-context.mjs
@@ -15,6 +15,16 @@ export const DEFAULT_RESOURCE_ENV_FIELD_MAP = {
 // flusher can pass matching keys through to span attributes.
 const DEFAULT_SPAN_ATTRIBUTES_ENV = 'LOONGSUITE_PILOT_SPAN_ATTRIBUTES';
 
+// Exact managed identity keys accepted only when an adapter explicitly opts in.
+// They are mapped to internal transport fields and consumed by InputManager,
+// rather than being treated as generic span passthrough attributes.
+export const INVOCATION_SESSION_ID_FIELD = 'agent.pilot.invocation.session.id';
+export const INVOCATION_USER_ID_FIELD = 'agent.pilot.invocation.user.id';
+const INVOCATION_IDENTITY_FIELD_MAP = {
+  'gen_ai.session.id': INVOCATION_SESSION_ID_FIELD,
+  'gen_ai.user.id': INVOCATION_USER_ID_FIELD,
+};
+
 // Prefixes reserved for converter-managed / pipeline fields. Caller-supplied
 // keys matching these are dropped so they can't clobber pipeline semantics.
 // Mirrors RESERVED_PREFIXES in src/normalization/global-attributes.ts.
@@ -83,6 +93,7 @@ export function collectResourceAttributesFromEnv(env = process.env, opts = {}) {
 export function parseSpanAttributesFromEnv(env = process.env, opts = {}) {
   const agentId = opts.agentId || 'hook';
   const envName = opts.envName || DEFAULT_SPAN_ATTRIBUTES_ENV;
+  const allowInvocationIdentity = opts.allowInvocationIdentity === true;
   const out = {};
 
   const raw = env[envName];
@@ -95,6 +106,18 @@ export function parseSpanAttributesFromEnv(env = process.env, opts = {}) {
     const key = pair.slice(0, idx).trim();
     const value = pair.slice(idx + 1).trim();
     if (!key || !value) continue;
+
+    const invocationIdentityField = allowInvocationIdentity
+      ? INVOCATION_IDENTITY_FIELD_MAP[key]
+      : undefined;
+    if (invocationIdentityField) {
+      if (value.length > MAX_RESOURCE_FIELD_VALUE_LENGTH) {
+        warnSkip(agentId, key, 'value too long');
+        continue;
+      }
+      out[invocationIdentityField] = value;
+      continue;
+    }
 
     if (isReservedSpanAttrKey(key)) {
       warnSkip(agentId, key, 'reserved prefix');

--- a/assets/plugins/openclaw/plugin.mjs
+++ b/assets/plugins/openclaw/plugin.mjs
@@ -57,6 +57,10 @@ const SPAN_ATTR_RESERVED_PREFIXES = [
 const SPAN_ATTR_MAX_VALUE_LENGTH = 512;
 const SPAN_ATTR_SENSITIVE_RE =
   /(^|[_.-])(TOKEN|SECRET|PASSWORD|CREDENTIAL|COOKIE)([_.-]|$)|^(API_KEY|API_HEADER)$/i;
+const INVOCATION_IDENTITY_FIELD_MAP = {
+  "gen_ai.session.id": "agent.pilot.invocation.session.id",
+  "gen_ai.user.id": "agent.pilot.invocation.user.id",
+};
 
 function parseSpanAttributesFromEnv(env = process.env) {
   const out = {};
@@ -68,6 +72,13 @@ function parseSpanAttributesFromEnv(env = process.env) {
     const key = pair.slice(0, idx).trim();
     const value = pair.slice(idx + 1).trim();
     if (!key || !value) continue;
+    const invocationIdentityField = INVOCATION_IDENTITY_FIELD_MAP[key];
+    if (invocationIdentityField) {
+      if (value.length <= SPAN_ATTR_MAX_VALUE_LENGTH) {
+        out[invocationIdentityField] = value;
+      }
+      continue;
+    }
     if (SPAN_ATTR_RESERVED_PREFIXES.some((p) => key === p || key.startsWith(p))) continue;
     if (SPAN_ATTR_SENSITIVE_RE.test(key)) continue;
     if (value.length > SPAN_ATTR_MAX_VALUE_LENGTH) continue;

--- a/assets/plugins/opencode/plugin.mjs
+++ b/assets/plugins/opencode/plugin.mjs
@@ -60,6 +60,10 @@ const SPAN_ATTR_RESERVED_PREFIXES = [
 const SPAN_ATTR_MAX_VALUE_LENGTH = 512;
 const SPAN_ATTR_SENSITIVE_RE =
   /(^|[_.-])(TOKEN|SECRET|PASSWORD|CREDENTIAL|COOKIE)([_.-]|$)|^(API_KEY|API_HEADER)$/i;
+const INVOCATION_IDENTITY_FIELD_MAP = {
+  "gen_ai.session.id": "agent.pilot.invocation.session.id",
+  "gen_ai.user.id": "agent.pilot.invocation.user.id",
+};
 
 function parseSpanAttributesFromEnv(env = process.env) {
   const out = {};
@@ -71,6 +75,13 @@ function parseSpanAttributesFromEnv(env = process.env) {
     const key = pair.slice(0, idx).trim();
     const value = pair.slice(idx + 1).trim();
     if (!key || !value) continue;
+    const invocationIdentityField = INVOCATION_IDENTITY_FIELD_MAP[key];
+    if (invocationIdentityField) {
+      if (value.length <= SPAN_ATTR_MAX_VALUE_LENGTH) {
+        out[invocationIdentityField] = value;
+      }
+      continue;
+    }
     if (SPAN_ATTR_RESERVED_PREFIXES.some((p) => key === p || key.startsWith(p))) continue;
     if (SPAN_ATTR_SENSITIVE_RE.test(key)) continue;
     if (value.length > SPAN_ATTR_MAX_VALUE_LENGTH) continue;

--- a/docs/trace-output.md
+++ b/docs/trace-output.md
@@ -303,6 +303,17 @@ Notes:
   { "otlpTrace": { "spanAttributePassthroughPrefixes": ["multica."] } }
   ```
 
+**Standard per-invocation identity.** `gen_ai.session.id` and `gen_ai.user.id` are the two exact reserved-key exceptions supported by `LOONGSUITE_PILOT_SPAN_ATTRIBUTES`:
+
+  ```bash
+  export LOONGSUITE_PILOT_SPAN_ATTRIBUTES="gen_ai.session.id=session-123,gen_ai.user.id=user-456"
+  ```
+
+- The values become the canonical event-log identity fields (`gen_ai.session.id` and `user.id`) and the standard trace-span attributes (`gen_ai.session.id` and `gen_ai.user.id`) on every span kind. No `spanAttributePassthroughPrefixes` entry is required.
+- Invocation identity wins over the configured user id and agent-native identity. Native turn and step ids are not changed.
+- Phase-one support covers OpenCode, Claude Code, Qoder/Qoder-CN, and OpenClaw. Codex and Qwen Code CLI continue to reject these reserved keys.
+- All other `gen_ai.*` and `user.*` keys remain reserved and are dropped.
+
 **Built-in OpenCode attribute (`opencode.message.id`).** The OpenCode plugin always stamps `opencode.message.id` (the opencode assistant-message id) on its `llm.request`, `llm.response`, `tool.call` and `tool.result` records — no launcher env var required. To surface it on spans, just list the `opencode.` prefix; it then appears on ENTRY / AGENT / STEP / LLM / TOOL spans (LLM and TOOL take the value from their own records; ENTRY / AGENT / STEP take the turn-level value):
 
   ```json
@@ -311,9 +322,9 @@ Notes:
 
 Notes:
 - Unlike source #2 (spans only), passthrough attributes are ordinary top-level record fields, so they appear in **both** the event log (SLS / JSONL) and the trace spans — same behavior as the git fields.
-- Reserved-prefix keys (`gen_ai.`, `git.`, `workspace.`, `event.`, `trace_`, `user.`, `cost_`, `agent.`) and sensitive names (token/secret/password/…) are dropped by the hook. Use a dedicated namespace such as `multica.*`.
+- Except for the two standard identity keys documented above, reserved-prefix keys (`gen_ai.`, `git.`, `workspace.`, `event.`, `trace_`, `user.`, `cost_`, `agent.`) and sensitive names (token/secret/password/…) are dropped by the hook. Use a dedicated namespace such as `multica.*`.
 - Values must not contain a comma `,` (it is the pair separator); a value is also capped at 512 chars.
-- Only keys matching a configured prefix are passed through; all other top-level fields are unaffected. Supported for claude-code, codex, qoder, qwen-code-cli, and opencode.
+- Only keys matching a configured prefix are passed through; all other top-level fields are unaffected. Generic passthrough is supported for claude-code, codex, qoder/qoder-cn, qwen-code-cli, opencode, and openclaw.
 - Codex snapshots these process-level attributes on `UserPromptSubmit` (with `Stop` as a fail-open fallback) and correlates them to transcript records by session and turn. This prevents a resumed session launched by a different invocation from reusing the previous invocation's attributes.
 - Qwen Code CLI captures them from the current `Stop` hook and clears any saved values when a resumed invocation does not provide the variable, preventing stale attributes from leaking into a later turn.
 

--- a/docs/zh-CN/trace-output.md
+++ b/docs/zh-CN/trace-output.md
@@ -303,6 +303,17 @@ Pilot 会将 Trace 发送到 `http://localhost:3000/api/public/otel/v1/traces`�
   { "otlpTrace": { "spanAttributePassthroughPrefixes": ["multica."] } }
   ```
 
+**按次调用的标准身份属性。** `gen_ai.session.id` 和 `gen_ai.user.id` 是 `LOONGSUITE_PILOT_SPAN_ATTRIBUTES` 支持的两个精确保留 key 例外：
+
+  ```bash
+  export LOONGSUITE_PILOT_SPAN_ATTRIBUTES="gen_ai.session.id=session-123,gen_ai.user.id=user-456"
+  ```
+
+- 它们会转换为 event log 中的标准身份字段（`gen_ai.session.id` 和 `user.id`），并成为所有类型 trace span 上的标准属性（`gen_ai.session.id` 和 `gen_ai.user.id`）。无需配置 `spanAttributePassthroughPrefixes`。
+- 按次调用身份的优先级高于已配置的 user id 和 agent 原生身份；原生 turn id 和 step id 不变。
+- 一期支持 OpenCode、Claude Code、Qoder/Qoder-CN 和 OpenClaw。Codex 和 Qwen Code CLI 仍会拒绝这两个保留 key。
+- 除这两个精确 key 之外，其他 `gen_ai.*` 和 `user.*` 字段仍为保留字段并会被丢弃。
+
 **OpenCode 内置属性（`opencode.message.id`）。** OpenCode 插件会在其 `llm.request`、`llm.response`、`tool.call`、`tool.result` 记录上自动打上 `opencode.message.id`（opencode 的 assistant 消息 id）——无需启动器 env 变量。要让它出现在 span 上，只需列出 `opencode.` 前缀；随后它会出现在 ENTRY / AGENT / STEP / LLM / TOOL span 上（LLM、TOOL 取各自记录的值，ENTRY / AGENT / STEP 取 turn 级值）：
 
   ```json
@@ -311,8 +322,8 @@ Pilot 会将 Trace 发送到 `http://localhost:3000/api/public/otel/v1/traces`�
 
 说明：
 - 与来源 #2（仅 span）不同，透传属性是普通的顶层 record 字段，因此会**同时**出现在 event log（SLS / JSONL）和 trace span 上——与 git 字段行为一致。
-- 保留前缀 key（`gen_ai.`、`git.`、`workspace.`、`event.`、`trace_`、`user.`、`cost_`、`agent.`）以及敏感命名（token/secret/password/…）会被 hook 丢弃。请使用 `multica.*` 等专用命名空间。
-- 仅匹配所配置前缀的 key 会被透传，其它顶层字段不受影响。目前支持 claude-code、codex、qoder、qwen-code-cli 和 opencode。
+- 除上述两个标准身份 key 外，保留前缀 key（`gen_ai.`、`git.`、`workspace.`、`event.`、`trace_`、`user.`、`cost_`、`agent.`）以及敏感命名（token/secret/password/…）会被 hook 丢弃。请使用 `multica.*` 等专用命名空间。
+- 仅匹配所配置前缀的 key 会被透传，其它顶层字段不受影响。普通透传目前支持 claude-code、codex、qoder/qoder-cn、qwen-code-cli、opencode 和 openclaw。
 - Codex 会在 `UserPromptSubmit` 时保存这些进程级属性（以 `Stop` 作为 fail-open 兜底），并按 session 与 turn 关联到 transcript 记录，避免同一个 session 被不同调用恢复时沿用上一次调用的属性。
 - Qwen Code CLI 会在当前 `Stop` Hook 中读取这些属性；如果恢复同一 session 的新调用未提供该环境变量，则会清除已保存的旧值，避免属性泄漏到后续 turn。
 - value 不能包含逗号 `,`（逗号是键值对分隔符）；单个 value 长度上限 512 字符。

--- a/src/core/input-manager.ts
+++ b/src/core/input-manager.ts
@@ -16,6 +16,7 @@ import { loadMaskPlan } from '../mask/rule-loader.js';
 import type { MaskPlan } from '../mask/types.js';
 import type { TraceLinker } from './upstream-link/trace-linker.js';
 import type { MultimodalProcessor } from '../multimodal/processor.js';
+import { applyInvocationIdentity } from '../normalization/invocation-identity.js';
 
 const logger = createLogger('InputManager');
 
@@ -243,11 +244,7 @@ export class InputManager extends EventEmitter {
     }
 
     for (const entry of entries) {
-      if (this.configuredUserId) {
-        entry['user.id'] = this.configuredUserId;
-      } else if (!entry['user.id'] && this.userId) {
-        entry['user.id'] = this.userId;
-      }
+      applyInvocationIdentity(entry, this.configuredUserId, this.userId);
     }
 
     // Upstream trace linking: stamp trace_id / parent_span_id from correlation

--- a/src/normalization/invocation-identity.ts
+++ b/src/normalization/invocation-identity.ts
@@ -1,0 +1,55 @@
+import type { AgentActivityEntry } from '../types/index.js';
+
+/**
+ * Internal transport fields written by invocation-scoped hooks/plugins.
+ *
+ * They deliberately live under agent.pilot.* so raw producer records can carry
+ * them without colliding with canonical event fields. InputManager consumes and
+ * removes both fields before any output sink sees the entry.
+ *
+ * Keep these values in sync with assets/hooks/shared/resource-context.mjs and
+ * the standalone plugin parsers.
+ */
+export const INVOCATION_SESSION_ID_FIELD = 'agent.pilot.invocation.session.id';
+export const INVOCATION_USER_ID_FIELD = 'agent.pilot.invocation.user.id';
+
+const MAX_INVOCATION_ID_LENGTH = 512;
+
+function consumeIdentityValue(entry: AgentActivityEntry, key: string): string | undefined {
+  const raw = entry[key];
+  delete entry[key];
+  if (typeof raw !== 'string') return undefined;
+  const value = raw.trim();
+  return value.length > 0 && value.length <= MAX_INVOCATION_ID_LENGTH
+    ? value
+    : undefined;
+}
+
+/**
+ * Apply invocation-scoped identity with the shared precedence contract:
+ *
+ * invocation env > configured user id > agent-native id > fallback user id.
+ *
+ * Session identity has no collector-level configured fallback, so an injected
+ * value replaces the native session id while native turn/step ids stay intact.
+ */
+export function applyInvocationIdentity(
+  entry: AgentActivityEntry,
+  configuredUserId: string,
+  fallbackUserId: string,
+): void {
+  const sessionId = consumeIdentityValue(entry, INVOCATION_SESSION_ID_FIELD);
+  const userId = consumeIdentityValue(entry, INVOCATION_USER_ID_FIELD);
+
+  if (sessionId) {
+    entry['gen_ai.session.id'] = sessionId;
+  }
+
+  if (userId) {
+    entry['user.id'] = userId;
+  } else if (configuredUserId) {
+    entry['user.id'] = configuredUserId;
+  } else if (!entry['user.id'] && fallbackUserId) {
+    entry['user.id'] = fallbackUserId;
+  }
+}

--- a/tests/unit/core/input-manager.test.ts
+++ b/tests/unit/core/input-manager.test.ts
@@ -6,6 +6,10 @@ import { EventEmitter } from 'node:events';
 import { ClientType, CollectionMethod } from '../../../src/types/index.js';
 import type { AgentActivityEntry, InputState } from '../../../src/types/index.js';
 import { MultiFlusher } from '../../../src/flushers/multi-flusher.js';
+import {
+  INVOCATION_SESSION_ID_FIELD,
+  INVOCATION_USER_ID_FIELD,
+} from '../../../src/normalization/invocation-identity.js';
 
 vi.mock('../../../src/utils/logger.js', () => ({
   createLogger: () => ({
@@ -143,6 +147,25 @@ describe('InputManager', () => {
 
       const dispatched = flusher.batchCalls[0][0];
       expect(dispatched['user.id']).toBe('installer-user');
+    });
+
+    it('invocation env identity overrides configured/native identity and is consumed', async () => {
+      const input = new StubInput('input-1');
+      manager.registerInput(input as any);
+      manager.setUserId('fallback-user');
+      manager.setConfiguredUserId('installer-user');
+
+      const entry = buildTestEntry({ userId: 'native-user', sessionId: 'native-session' });
+      entry[INVOCATION_SESSION_ID_FIELD] = 'customer-session';
+      entry[INVOCATION_USER_ID_FIELD] = 'customer-user';
+      input.emit('entries', [entry]);
+      await new Promise(r => setTimeout(r, 50));
+
+      const dispatched = flusher.batchCalls[0][0];
+      expect(dispatched['gen_ai.session.id']).toBe('customer-session');
+      expect(dispatched['user.id']).toBe('customer-user');
+      expect(dispatched).not.toHaveProperty(INVOCATION_SESSION_ID_FIELD);
+      expect(dispatched).not.toHaveProperty(INVOCATION_USER_ID_FIELD);
     });
   });
 

--- a/tests/unit/hooks/claude-code/hook-processor.test.mjs
+++ b/tests/unit/hooks/claude-code/hook-processor.test.mjs
@@ -5,6 +5,10 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { OtlpTraceFlusher } from '../../../../src/flushers/otlp-trace-flusher.ts';
+import {
+  INVOCATION_SESSION_ID_FIELD,
+  INVOCATION_USER_ID_FIELD,
+} from '../../../../assets/hooks/shared/resource-context.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROCESSOR = path.resolve(__dirname, '../../../../assets/hooks/claude-code-hook-processor.mjs');
@@ -195,6 +199,45 @@ function enableToolPropagation() {
 }
 
 describe('claude-code-hook-processor v2 端到端', () => {
+  test('accepts invocation-scoped GenAI identity from env', () => {
+    const transcriptPath = writeTranscript('native-session', [
+      {
+        type: 'user',
+        timestamp: '2026-06-04T02:57:32.000Z',
+        message: { content: [{ type: 'text', text: 'hello' }] },
+      },
+      {
+        type: 'assistant',
+        timestamp: '2026-06-04T02:57:33.000Z',
+        message: {
+          id: 'msg_identity',
+          content: [{ type: 'text', text: 'hi' }],
+          usage: { input_tokens: 10, output_tokens: 2 },
+          stop_reason: 'end_turn',
+        },
+      },
+    ]);
+
+    const result = runHook('stop', {
+      session_id: 'native-session',
+      stop_reason: 'end_turn',
+      transcript_path: transcriptPath,
+    }, {
+      LOONGSUITE_PILOT_SPAN_ATTRIBUTES:
+        'gen_ai.session.id=env-session,gen_ai.user.id=env-user,gen_ai.agent.name=blocked',
+    });
+
+    expect(result.status).toBe(0);
+    const records = readJsonlRecords();
+    expect(records.length).toBeGreaterThan(0);
+    for (const record of records) {
+      expect(record[INVOCATION_SESSION_ID_FIELD]).toBe('env-session');
+      expect(record[INVOCATION_USER_ID_FIELD]).toBe('env-user');
+      expect(record['gen_ai.session.id']).toBe('native-session');
+      expect(record['gen_ai.agent.name']).not.toBe('blocked');
+    }
+  });
+
   test('PreToolUse 注入 per-tool traceparent，Stop 复用其 span id', () => {
     enableToolPropagation();
     const upstreamTraceId = '4bf92f3577b34da6a3ce929d0e0e4736';

--- a/tests/unit/hooks/openclaw/plugin.test.mjs
+++ b/tests/unit/hooks/openclaw/plugin.test.mjs
@@ -21,6 +21,10 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  INVOCATION_SESSION_ID_FIELD,
+  INVOCATION_USER_ID_FIELD,
+} from '../../../../assets/hooks/shared/resource-context.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PLUGIN_PATH = path.resolve(__dirname, '../../../../assets/plugins/openclaw/plugin.mjs');
@@ -49,6 +53,7 @@ afterEach(async () => {
   delete process.env.LOONGSUITE_PILOT_DATA_DIR;
   delete process.env.LOONGSUITE_USER_ID;
   delete process.env.LOONGSUITE_PILOT_DEBUG;
+  delete process.env.LOONGSUITE_PILOT_SPAN_ATTRIBUTES;
   vi.restoreAllMocks();
   await fs.promises.rm(tmpDir, { recursive: true, force: true });
 });
@@ -265,6 +270,21 @@ describe('OpenClaw plugin stateful pipeline', () => {
     expect(eventNames.filter((n) => n === 'llm.request').length).toBe(1);
     expect(eventNames.filter((n) => n === 'llm.response').length).toBe(1);
     expect(eventNames.includes('other')).toBe(true);
+  });
+
+  it('accepts invocation-scoped GenAI identity from env', async () => {
+    process.env.LOONGSUITE_PILOT_SPAN_ATTRIBUTES =
+      'gen_ai.session.id=env-session,gen_ai.user.id=env-user,gen_ai.agent.name=blocked';
+    const plugin = await loadPlugin();
+    const records = await replay(plugin, readJsonl('pilot-probe-events-smoke.jsonl'));
+
+    expect(records.length).toBeGreaterThan(0);
+    for (const record of records) {
+      expect(record[INVOCATION_SESSION_ID_FIELD]).toBe('env-session');
+      expect(record[INVOCATION_USER_ID_FIELD]).toBe('env-user');
+      expect(record['gen_ai.session.id']).not.toBe('env-session');
+      expect(record['gen_ai.agent.name']).not.toBe('blocked');
+    }
   });
 
   it('attaches the user prompt to the first request and tool results to the next request', async () => {

--- a/tests/unit/hooks/opencode-plugin-session.test.mjs
+++ b/tests/unit/hooks/opencode-plugin-session.test.mjs
@@ -3,6 +3,10 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
+import {
+  INVOCATION_SESSION_ID_FIELD,
+  INVOCATION_USER_ID_FIELD,
+} from '../../../assets/hooks/shared/resource-context.mjs';
 
 const PLUGIN_PATH = path.resolve(
   fileURLToPath(import.meta.url),
@@ -109,6 +113,7 @@ describe('opencode plugin session turnSeq persistence', () => {
   });
 
   afterEach(() => {
+    delete process.env.LOONGSUITE_PILOT_SPAN_ATTRIBUTES;
     vi.restoreAllMocks();
   });
 
@@ -194,5 +199,20 @@ describe('opencode plugin session turnSeq persistence', () => {
       .toEqual(requests[0]['gen_ai.input.messages']);
     expect(requests[1]['gen_ai.input.messages']).toBeUndefined();
     expect(requests[1]['gen_ai.input.messages_delta']).toBeTruthy();
+  });
+
+  it('accepts invocation-scoped GenAI identity from env', async () => {
+    process.env.LOONGSUITE_PILOT_SPAN_ATTRIBUTES =
+      'gen_ai.session.id=env-session,gen_ai.user.id=env-user,gen_ai.agent.name=blocked';
+
+    const records = await replayPluginFixture();
+
+    expect(records.length).toBeGreaterThan(0);
+    for (const record of records) {
+      expect(record[INVOCATION_SESSION_ID_FIELD]).toBe('env-session');
+      expect(record[INVOCATION_USER_ID_FIELD]).toBe('env-user');
+      expect(record['gen_ai.session.id']).not.toBe('env-session');
+      expect(record['gen_ai.agent.name']).not.toBe('blocked');
+    }
   });
 });

--- a/tests/unit/hooks/qoder-hook-processor-cold-start.test.mjs
+++ b/tests/unit/hooks/qoder-hook-processor-cold-start.test.mjs
@@ -4,6 +4,10 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  INVOCATION_SESSION_ID_FIELD,
+  INVOCATION_USER_ID_FIELD,
+} from '../../../assets/hooks/shared/resource-context.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROCESSOR = path.resolve(__dirname, '../../../assets/hooks/qoder-hook-processor.mjs');
@@ -50,14 +54,14 @@ function lastPrompt(index) {
   return { type: 'last-prompt', sessionId: 'session-old', lastPrompt: `prompt ${index}` };
 }
 
-function runProcessor(sessionId = 'session-old') {
+function runProcessor(sessionId = 'session-old', extraEnv = {}) {
   return spawnSync('node', [PROCESSOR, '--agent-id', 'qoder', '--log-prefix', 'qoder'], {
     input: JSON.stringify({
       session_id: sessionId,
       transcript_path: transcriptPath,
       cwd: '/tmp/qoder-project',
     }),
-    env: { ...process.env, LOONGSUITE_PILOT_DATA_DIR: dataDir },
+    env: { ...process.env, LOONGSUITE_PILOT_DATA_DIR: dataDir, ...extraEnv },
     encoding: 'utf-8',
     timeout: 30_000,
   });
@@ -135,6 +139,28 @@ function userBoundaryPrompts(records) {
 }
 
 describe('qoder-hook-processor cold-start recovery', () => {
+  it('accepts invocation-scoped GenAI identity from env', () => {
+    fs.writeFileSync(transcriptPath, [
+      ...turnRows(1, 'identity prompt'),
+      lastPrompt(1),
+    ].map(row => JSON.stringify(row)).join('\n') + '\n');
+
+    const result = runProcessor('session-old', {
+      LOONGSUITE_PILOT_SPAN_ATTRIBUTES:
+        'gen_ai.session.id=env-session,gen_ai.user.id=env-user,gen_ai.agent.name=blocked',
+    });
+
+    expect(result.status).toBe(0);
+    const records = readHistory();
+    expect(records.length).toBeGreaterThan(0);
+    for (const record of records) {
+      expect(record[INVOCATION_SESSION_ID_FIELD]).toBe('env-session');
+      expect(record[INVOCATION_USER_ID_FIELD]).toBe('env-user');
+      expect(record['gen_ai.session.id']).toBe('session-old');
+      expect(record['gen_ai.agent.name']).not.toBe('blocked');
+    }
+  });
+
   it('does not replay old turns when each old session first appears after redeployment', () => {
     fs.writeFileSync(transcriptPath, [
       ...turnRows(1, 'historical prompt 1'),

--- a/tests/unit/hooks/qoder-turn-boundary.test.mjs
+++ b/tests/unit/hooks/qoder-turn-boundary.test.mjs
@@ -5,6 +5,11 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  applyInvocationIdentity,
+  INVOCATION_SESSION_ID_FIELD,
+  INVOCATION_USER_ID_FIELD,
+} from '../../../src/normalization/invocation-identity.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROCESSOR = path.resolve(__dirname, '../../../assets/hooks/qoder-hook-processor.mjs');
@@ -88,14 +93,14 @@ function writeTranscript(rows) {
   fs.writeFileSync(transcriptPath, rows.map(row => JSON.stringify(row)).join('\n') + '\n');
 }
 
-function runProcessor(agentId = 'qoder') {
+function runProcessor(agentId = 'qoder', extraEnv = {}) {
   return spawnSync('node', [PROCESSOR, '--agent-id', agentId, '--log-prefix', agentId], {
     input: JSON.stringify({
       session_id: 'session-ide',
       transcript_path: transcriptPath,
       cwd: '/tmp/qoder-project',
     }),
-    env: { ...process.env, LOONGSUITE_PILOT_DATA_DIR: dataDir },
+    env: { ...process.env, LOONGSUITE_PILOT_DATA_DIR: dataDir, ...extraEnv },
     encoding: 'utf-8',
     timeout: 30_000,
   });
@@ -179,13 +184,18 @@ describe('qoder-hook-processor turn boundary markers', () => {
     }
   });
 
-  it('marks a qoder-cn turn the same way', () => {
+  it('applies invocation-scoped identity to every qoder-cn span', async () => {
     writeTranscript(ideTurnRows());
 
-    expect(runProcessor('qoder-cn').status).toBe(0);
+    expect(runProcessor('qoder-cn', {
+      LOONGSUITE_PILOT_SPAN_ATTRIBUTES:
+        'gen_ai.session.id=env-session,gen_ai.user.id=env-user',
+    }).status).toBe(0);
     const records = readHistory('qoder-cn');
     expect(records.length).toBeGreaterThan(0);
     expect(new Set(records.map(r => r['gen_ai.agent.type']))).toEqual(new Set(['qoder-cn']));
+    expect(records.every(r => r[INVOCATION_SESSION_ID_FIELD] === 'env-session')).toBe(true);
+    expect(records.every(r => r[INVOCATION_USER_ID_FIELD] === 'env-user')).toBe(true);
 
     const starts = records.filter(r => r['gen_ai.turn.start'] === true);
     const ends = records.filter(r => r['gen_ai.turn.end'] === true);
@@ -201,6 +211,27 @@ describe('qoder-hook-processor turn boundary markers', () => {
     for (const record of records.slice(1, -1)) {
       expect(record['gen_ai.turn.start']).toBeUndefined();
       expect(record['gen_ai.turn.end']).toBeUndefined();
+    }
+
+    for (const record of records) {
+      applyInvocationIdentity(record, 'configured-user', 'fallback-user');
+    }
+    expect(records.every(r => r['gen_ai.session.id'] === 'env-session')).toBe(true);
+    expect(records.every(r => r['user.id'] === 'env-user')).toBe(true);
+    expect(records.every(r => !(INVOCATION_SESSION_ID_FIELD in r))).toBe(true);
+    expect(records.every(r => !(INVOCATION_USER_ID_FIELD in r))).toBe(true);
+
+    const previousStability = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+    process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'gen_ai_latest_experimental';
+    try {
+      const conversion = await convertEventLogToReadableSpans(records);
+      expect(conversion.spans.length).toBeGreaterThan(0);
+      expect(conversion.spans.every(span =>
+        span.attributes['gen_ai.session.id'] === 'env-session'
+        && span.attributes['gen_ai.user.id'] === 'env-user')).toBe(true);
+    } finally {
+      if (previousStability === undefined) delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+      else process.env.OTEL_SEMCONV_STABILITY_OPT_IN = previousStability;
     }
   });
 

--- a/tests/unit/hooks/shared/resource-context.test.mjs
+++ b/tests/unit/hooks/shared/resource-context.test.mjs
@@ -5,6 +5,8 @@ import { fileURLToPath } from 'node:url';
 
 import {
   DEFAULT_RESOURCE_ENV_FIELD_MAP,
+  INVOCATION_SESSION_ID_FIELD,
+  INVOCATION_USER_ID_FIELD,
   agentBaseFieldPatch,
   collectResourceAttributesFromEnv,
   parseSpanAttributesFromEnv,
@@ -120,6 +122,42 @@ describe('parseSpanAttributesFromEnv', () => {
     }
   });
 
+  test('accepts only the two managed identity keys when explicitly enabled', () => {
+    const warn = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const attrs = parseSpanAttributesFromEnv({
+        LOONGSUITE_PILOT_SPAN_ATTRIBUTES: [
+          'gen_ai.session.id=customer-session',
+          'gen_ai.user.id=customer-user',
+          'gen_ai.agent.name=must-stay-reserved',
+          'user.id=must-stay-reserved',
+          'multica.issue.id=AGE-287',
+        ].join(','),
+      }, { allowInvocationIdentity: true });
+
+      expect(attrs).toEqual({
+        [INVOCATION_SESSION_ID_FIELD]: 'customer-session',
+        [INVOCATION_USER_ID_FIELD]: 'customer-user',
+        'multica.issue.id': 'AGE-287',
+      });
+      expect(JSON.stringify(attrs)).not.toContain('must-stay-reserved');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test('keeps managed identity keys reserved without explicit opt-in', () => {
+    const warn = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      expect(parseSpanAttributesFromEnv({
+        LOONGSUITE_PILOT_SPAN_ATTRIBUTES:
+          'gen_ai.session.id=customer-session,gen_ai.user.id=customer-user',
+      })).toEqual({});
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   test('drops sensitive names, over-long values, and malformed pairs', () => {
     const warn = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     try {
@@ -144,16 +182,18 @@ describe('parseSpanAttributesFromEnv', () => {
 });
 
 describe('reserved-prefix list stays in sync across copies', () => {
-  // The reserved-prefix list is intentionally duplicated in three places
-  // (shared hook util, standalone opencode plugin, and the TS normalizer).
+  // The reserved-prefix list is intentionally duplicated in four places
+  // (shared hook util, standalone plugins, and the TS normalizer).
   // This guards against silent drift between them.
   test('shared mjs, opencode plugin, and global-attributes.ts agree', () => {
     const canonical = extractPrefixArray('src/normalization/global-attributes.ts', 'RESERVED_PREFIXES');
     const sharedHook = extractPrefixArray('assets/hooks/shared/resource-context.mjs', 'SPAN_ATTR_RESERVED_PREFIXES');
     const opencode = extractPrefixArray('assets/plugins/opencode/plugin.mjs', 'SPAN_ATTR_RESERVED_PREFIXES');
+    const openclaw = extractPrefixArray('assets/plugins/openclaw/plugin.mjs', 'SPAN_ATTR_RESERVED_PREFIXES');
 
     expect(canonical.length).toBeGreaterThan(0);
     expect(sharedHook).toEqual(canonical);
     expect(opencode).toEqual(canonical);
+    expect(openclaw).toEqual(canonical);
   });
 });

--- a/tests/unit/normalization/invocation-identity.test.ts
+++ b/tests/unit/normalization/invocation-identity.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { buildTestEntry } from '../../helpers/fixture-builder.js';
+import {
+  applyInvocationIdentity,
+  INVOCATION_SESSION_ID_FIELD,
+  INVOCATION_USER_ID_FIELD,
+} from '../../../src/normalization/invocation-identity.js';
+
+describe('applyInvocationIdentity', () => {
+  it('gives invocation identity precedence and removes transport fields', () => {
+    const entry = buildTestEntry({
+      userId: 'native-user',
+      sessionId: 'native-session',
+    });
+    entry[INVOCATION_SESSION_ID_FIELD] = ' invocation-session ';
+    entry[INVOCATION_USER_ID_FIELD] = ' invocation-user ';
+
+    applyInvocationIdentity(entry, 'configured-user', 'fallback-user');
+
+    expect(entry['gen_ai.session.id']).toBe('invocation-session');
+    expect(entry['user.id']).toBe('invocation-user');
+    expect(entry).not.toHaveProperty(INVOCATION_SESSION_ID_FIELD);
+    expect(entry).not.toHaveProperty(INVOCATION_USER_ID_FIELD);
+  });
+
+  it('preserves the existing configured/native/fallback user precedence without an override', () => {
+    const configured = buildTestEntry({ userId: 'native-user' });
+    applyInvocationIdentity(configured, 'configured-user', 'fallback-user');
+    expect(configured['user.id']).toBe('configured-user');
+
+    const native = buildTestEntry({ userId: 'native-user' });
+    applyInvocationIdentity(native, '', 'fallback-user');
+    expect(native['user.id']).toBe('native-user');
+
+    const fallback = buildTestEntry({ userId: '' });
+    applyInvocationIdentity(fallback, '', 'fallback-user');
+    expect(fallback['user.id']).toBe('fallback-user');
+  });
+
+  it('ignores invalid transport values but always removes them', () => {
+    const entry = buildTestEntry({ userId: 'native-user', sessionId: 'native-session' });
+    entry[INVOCATION_SESSION_ID_FIELD] = ' ';
+    entry[INVOCATION_USER_ID_FIELD] = 'x'.repeat(513);
+
+    applyInvocationIdentity(entry, 'configured-user', 'fallback-user');
+
+    expect(entry['gen_ai.session.id']).toBe('native-session');
+    expect(entry['user.id']).toBe('configured-user');
+    expect(entry).not.toHaveProperty(INVOCATION_SESSION_ID_FIELD);
+    expect(entry).not.toHaveProperty(INVOCATION_USER_ID_FIELD);
+  });
+});


### PR DESCRIPTION
## Summary

- accept the exact gen_ai.session.id and gen_ai.user.id keys from LOONGSUITE_PILOT_SPAN_ATTRIBUTES for OpenCode, Claude Code, Qoder/Qoder-CN, and OpenClaw
- transport the values through adapter records and apply them centrally before JSONL, SLS, and trace output
- use the precedence invocation env > configured user id > agent-native identity > fallback user id, without changing native turn or step ids
- keep every other reserved gen_ai.* and user.* key blocked; Codex and Qwen Code CLI remain excluded from phase one
- document the behavior in English and Chinese

## Validation

- targeted identity and adapter suites: 130 tests passed
- Qoder/Qoder-CN turn and all-span conversion suite: 3 tests passed
- npm run typecheck
- npm run build
- full npm test: 3202 passed, 50 skipped; one machine-local QwenWorkCN real-transcript test failed because the latest local transcript produced no llm.request. This test exercises local ~/.qwenworkcn data and no QwenWorkCN path is changed by this PR.

Closes #287