### PR TITLE
feat: standardize workspace and Git context across agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Pilot is designed to answer practical questions:
 | Qoder Work    | Hook / local data polling | Yes          | Yes        | Yes         | Yes                       |
 | Qoder Work CN | Hook / local data polling | Yes          | Yes        | Yes         | Yes                       |
 | Qwen Code CLI | Hook                      | Yes          | Yes        | Yes         | Yes                       |
+| Qwen Work CN  | Hook / local data polling | Yes          | Yes        | Yes         | Yes                       |
 | Wukong        | CLI API polling           | Yes          | Yes        | Yes         | Yes                       |
 | WorkBuddy     | Hook wakeup + local transcript watch/poll fallback | Yes          | Yes        | Yes         | Yes                       |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -57,6 +57,7 @@ Pilot 主要帮助回答这些问题：
 | Qoder Work | Hook / 本地数据轮询 | Yes | Yes | Yes | Yes |
 | Qoder Work CN | Hook / 本地数据轮询 | Yes | Yes | Yes | Yes |
 | Qwen Code CLI | Hook | Yes | Yes | Yes | Yes |
+| Qwen Work CN | Hook / 本地数据轮询 | Yes | Yes | Yes | Yes |
 | Wukong | CLI API 轮询 | Yes | Yes | Yes | Yes |
 | WorkBuddy | Hook 唤醒 + 本地 transcript 监听/轮询兜底 | Yes | Yes | Yes | Yes |
 

--- a/assets/hooks/cursor-hook-processor.mjs
+++ b/assets/hooks/cursor-hook-processor.mjs
@@ -196,13 +196,17 @@ function injectSkillRecords(records, skills, runtimeConfig = {}) {
     const { skill, toolCallId } = skillEntries[index];
     const callOffset = BigInt(index * 2 + 1);
     const resultOffset = callOffset + 1n;
+    const agentType = llmRecord['gen_ai.agent.type'];
+    const agentCwdKey = `agent.${agentType}.cwd`;
+    const agentCwd = llmRecord[agentCwdKey];
     const baseFields = {
       trace_id: llmRecord.trace_id,
       'gen_ai.session.id': llmRecord['gen_ai.session.id'],
       'gen_ai.turn.id': llmRecord['gen_ai.turn.id'],
       'gen_ai.step.id': llmRecord['gen_ai.step.id'] || 'step_1',
-      'gen_ai.agent.type': llmRecord['gen_ai.agent.type'],
+      'gen_ai.agent.type': agentType,
       'user.id': llmRecord['user.id'],
+      ...(agentCwd ? { [agentCwdKey]: agentCwd } : {}),
     };
 
     // tool.call
@@ -399,7 +403,7 @@ async function main() {
         const transcriptRecords = buildCursorRecordsFromTranscript(
           internalEvent.transcript_path,
           allEvents,
-          { runtimeConfig, stopConversationId: convId }
+          { runtimeConfig, stopConversationId: convId, variant }
         );
         if (transcriptRecords && transcriptRecords.length > 0) {
           records = transcriptRecords;

--- a/assets/hooks/cursor/react-assembler.mjs
+++ b/assets/hooks/cursor/react-assembler.mjs
@@ -19,6 +19,7 @@ import {
   toJsonValue,
   parseMaybeJson,
 } from '../agent-event-normalizer.mjs';
+import { cursorWorkspaceFields, resolveWorkspacePath } from './workspace-context.mjs';
 
 // ─── Public API ───
 
@@ -80,6 +81,7 @@ export function assembleTurn(journalEvents, options = {}) {
     .filter(e => e.conversation_id === parentConvId)
     .filter(e => e.hook_event !== 'sessionStart')
     .sort((a, b) => tsMs(a) - tsMs(b));
+  const workspacePath = resolveWorkspacePath(parentEvents);
 
   const baseFields = {
     trace_id: traceId,
@@ -87,6 +89,7 @@ export function assembleTurn(journalEvents, options = {}) {
     'gen_ai.turn.id': turnId,
     'gen_ai.agent.type': variant,
     'user.id': userId,
+    ...cursorWorkspaceFields(variant, workspacePath),
   };
 
   const records = [];
@@ -191,8 +194,10 @@ export function assembleTurn(journalEvents, options = {}) {
   for (const link of childLinks) {
     const { childConvId, childEvents, parentToolCallId } = link;
     const childConvShort = childConvId.slice(0, 8);
+    const childWorkspacePath = resolveWorkspacePath(childEvents) || workspacePath;
     const childBaseFields = {
       ...baseFields,
+      ...cursorWorkspaceFields(variant, childWorkspacePath),
       'gen_ai.agent.scope': 'subagent',
       'gen_ai.agent.depth': 1,
       'gen_ai.agent.id': childConvId,

--- a/assets/hooks/cursor/source-event.mjs
+++ b/assets/hooks/cursor/source-event.mjs
@@ -118,6 +118,7 @@ export function toInternalEvent(payload) {
   // common metadata
   event.cursor_version = payload.cursor_version || undefined;
   event.user_email = payload.user_email || undefined;
+  event.cwd = payload.cwd || event.cwd || undefined;
   event.workspace_roots = payload.workspace_roots || undefined;
   event.transcript_path = payload.transcript_path || undefined;
 

--- a/assets/hooks/cursor/transcript-assembler.mjs
+++ b/assets/hooks/cursor/transcript-assembler.mjs
@@ -31,6 +31,7 @@ import {
   parseMaybeJson,
   inferProviderName,
 } from '../agent-event-normalizer.mjs';
+import { cursorWorkspaceFields, resolveWorkspacePath } from './workspace-context.mjs';
 
 // ─── Public API ───
 
@@ -50,6 +51,7 @@ export function buildCursorRecordsFromTranscript(transcriptPath, journalEvents, 
 
   const runtimeConfig = options.runtimeConfig || {};
   const stopConversationId = options.stopConversationId;
+  const variant = options.variant || 'cursor';
 
   const promptEvent = stopConversationId
     ? journalEvents.find(e => e.hook_event === 'beforeSubmitPrompt' && e.conversation_id === stopConversationId)
@@ -65,6 +67,7 @@ export function buildCursorRecordsFromTranscript(transcriptPath, journalEvents, 
     .filter(e => e.conversation_id === parentConvId)
     .filter(e => e.hook_event !== 'sessionStart')
     .sort((a, b) => tsMs(a) - tsMs(b));
+  const workspacePath = resolveWorkspacePath(parentEvents);
 
   // T5: Resolve model from journal events (afterAgentThought/Response carry real model)
   const model = parentEvents.find(e =>
@@ -76,9 +79,10 @@ export function buildCursorRecordsFromTranscript(transcriptPath, journalEvents, 
     trace_id: traceId,
     'gen_ai.session.id': parentConvId,
     'gen_ai.turn.id': turnId,
-    'gen_ai.agent.type': 'cursor',
+    'gen_ai.agent.type': variant,
     'gen_ai.agent.id': parentConvId,
     'user.id': userId,
+    ...cursorWorkspaceFields(variant, workspacePath),
   };
 
   const records = [];

--- a/assets/hooks/cursor/workspace-context.mjs
+++ b/assets/hooks/cursor/workspace-context.mjs
@@ -1,0 +1,41 @@
+/** Resolve the best working directory captured by Cursor hook events. */
+export function resolveWorkspacePath(events) {
+  for (const event of events || []) {
+    const cwd = normalizeString(event?.cwd);
+    if (cwd) return cwd;
+  }
+
+  for (const event of events || []) {
+    const roots = normalizeRoots(event?.workspace_roots);
+    if (roots.length > 0) return roots[0];
+  }
+
+  return undefined;
+}
+
+/** Build the stable Agent-specific cwd attribute consumed by Pilot. */
+export function cursorWorkspaceFields(variant, workspacePath) {
+  const cwd = normalizeString(workspacePath);
+  return cwd ? { [`agent.${variant || 'cursor'}.cwd`]: cwd } : {};
+}
+
+function normalizeString(value) {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function normalizeRoots(value) {
+  if (Array.isArray(value)) {
+    return value.map(normalizeString).filter(Boolean);
+  }
+  if (typeof value !== 'string') return [];
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed)) return parsed.map(normalizeString).filter(Boolean);
+  } catch {
+    // A single plain path is also accepted.
+  }
+  const root = normalizeString(value);
+  return root ? [root] : [];
+}

--- a/assets/plugins/mimo-code/plugin.mjs
+++ b/assets/plugins/mimo-code/plugin.mjs
@@ -175,6 +175,9 @@ function resolveUserId(cfg) {
 // ---------------------------------------------------------------------------
 
 let _logDirReady = false;
+// MiMo passes the project directory at server initialization. Individual
+// message.updated events can provide a more precise per-session path.
+let agentCwd;
 
 function writeRecord(record) {
   try {
@@ -227,6 +230,7 @@ function getSession(sessionID) {
       stepStartTimeMs: null,
       stepFinishData: null,
       stepEmittedResponse: false,
+      cwd: agentCwd,
     };
     sessions.set(sessionID, s);
     if (sessions.size > MAX_SESSIONS) {
@@ -256,6 +260,7 @@ function clearSession(sessionID) {
 
 function buildCommonFields(sessionID, session, userId) {
   const turn = session.currentTurn;
+  const cwd = session.cwd || agentCwd;
   return {
     time_unix_nano: nowNanos(),
     "event.id": crypto.randomUUID(),
@@ -266,6 +271,7 @@ function buildCommonFields(sessionID, session, userId) {
     "gen_ai.agent.type": AGENT_TYPE,
     "gen_ai.agent.name": session.agentMeta?.name || AGENT_TYPE,
     "gen_ai.agent.id": session.agentMeta?.id || undefined,
+    ...(cwd ? { [`agent.${AGENT_TYPE}.cwd`]: cwd } : {}),
     // ARMS GenAI semconv: every span should carry gen_ai.framework so CMS can
     // route the trace to the right pipeline. The OTLP trace flusher also sets
     // it as a resource attribute, but mirroring it here on every record keeps
@@ -438,6 +444,13 @@ function handleChatMessage(inp, out, userId) {
   if (!sessionID) return;
 
   const session = getSession(sessionID);
+  session.cwd = selectCwd(
+    out?.message?.path?.cwd,
+    inp?.directory,
+    inp?.cwd,
+    session.cwd,
+    agentCwd,
+  );
 
   const msg = out?.message;
   const userMessageID = msg?.id || inp.messageID;
@@ -757,6 +770,7 @@ function handleMessageUpdated(props, userId) {
   if (!sessionID) return;
 
   const session = getSession(sessionID);
+  session.cwd = selectCwd(info.path?.cwd, session.cwd, agentCwd);
 
   // User message: turn boundary. This is the fallback path when the
   // chat.message hook did not fire (e.g. --pure mode). When chat.message
@@ -1062,6 +1076,13 @@ function safe(fn) {
   };
 }
 
+function selectCwd(...values) {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
 // ---------------------------------------------------------------------------
 // Plugin entry point
 // ---------------------------------------------------------------------------
@@ -1071,6 +1092,8 @@ export default {
 
   server: async (input, _options) => {
     ensureDir(logDir());
+
+    agentCwd = selectCwd(input?.directory, input?.cwd, process.cwd());
 
     const cfg = loadPilotConfig();
     const userId = resolveUserId(cfg);

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -30,6 +30,7 @@ type differences are called out in the notes.
 | Qoder Work | `qoder-work` | Hook and local data sources. |
 | Qoder Work CN | `qoder-work-cn` | Hook and local data sources. |
 | Qwen Code CLI | `qwen-code-cli` | Hook integration; parses qwen-code transcript JSONL on Stop. |
+| Qwen Work CN | `qwen-work-cn` | Hook and local data sources. |
 | Wukong | `wukong` | Runtime auto-discovery and CLI API polling via local `wukong-cli`; it is not an `agents.d` installer selection. |
 | WorkBuddy | `workbuddy` | Structural Hook/file wakeups with a 30-second local transcript polling fallback. Verified on WorkBuddy Desktop 5.2.6 for macOS and 5.3.5.0 for Windows 11. |
 

--- a/docs/output-event-schema.md
+++ b/docs/output-event-schema.md
@@ -99,6 +99,8 @@ Required levels follow OpenTelemetry wording:
 | `workspace.path` | string | Recommended | Absolute working directory the agent ran in (process cwd), independent of git. Present even when the directory is not a git repository. |
 | `agent.*` | json | Opt-In | Agent-specific extension attributes. Stable high-query dimensions should become structured fields over time. |
 
+Automatic working-directory collection covers Claude Code, Codex, Cursor / Cursor CLI, Kiro CLI, MiMo Code, OpenClaw, OpenCode, Pi Coding Agent, the Qoder family, Qoder Work / Qoder Work CN, Qwen Code CLI, Qwen Work CN, and WorkBuddy. This context is not message content: `workspace.*` and any inferred `git.*` fields remain available when `captureMessageContent` is `false` for the Agent.
+
 ## Multimodal Message Parts
 
 When global multimodal infrastructure and the agent `uploadMode` are enabled (see [Configuration Guide](configuration.md#multimodal-object-storage) and [Multimodal Collection](multimodal.md)), media in message `parts` uses object-storage references instead of inline base64:

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -39,6 +39,7 @@ LoongSuite Pilot runs on a developer machine and collects telemetry from support
 | Qoder Work | Hook / local data polling | Yes | Yes | Yes | Yes |
 | Qoder Work CN | Hook / local data polling | Yes | Yes | Yes | Yes |
 | Qwen Code CLI | Hook | Yes | Yes | Yes | Yes |
+| Qwen Work CN | Hook / local data polling | Yes | Yes | Yes | Yes |
 | Wukong | CLI API polling | Yes | Yes | Yes | Yes |
 | WorkBuddy | Hook wakeup + local transcript watch/poll fallback | Yes | Yes | Yes | Yes |
 

--- a/docs/zh-CN/agents.md
+++ b/docs/zh-CN/agents.md
@@ -29,6 +29,7 @@
 | Qoder Work | `qoder-work` | Hook 和本地数据源。 |
 | Qoder Work CN | `qoder-work-cn` | Hook 和本地数据源。 |
 | Qwen Code CLI | `qwen-code-cli` | Hook 集成；Stop 时解析 qwen-code transcript JSONL。 |
+| Qwen Work CN | `qwen-work-cn` | Hook 和本地数据源。 |
 | Wukong | `wukong` | 运行时自动发现并通过本地 `wukong-cli` 进行 CLI API 轮询；它不是 `agents.d` 安装选择项。 |
 | WorkBuddy | `workbuddy` | 结构化 Hook 和文件变化触发即时采集，本地 transcript 每 30 秒轮询兜底；已在 macOS WorkBuddy Desktop 5.2.6 和 Windows 11 WorkBuddy Desktop 5.3.5.0 验证。 |
 

--- a/docs/zh-CN/output-event-schema.md
+++ b/docs/zh-CN/output-event-schema.md
@@ -97,6 +97,8 @@ LoongSuite Pilot 会将采集到的活动归一化为 GenAI 遥测事件。Pilot
 | `workspace.path` | string | Recommended | agent 进程实际运行的工作目录（cwd），与 git 无关。即使目录不是 git 仓库也会带上。 |
 | `agent.*` | json | Opt-In | Agent-specific 扩展属性。稳定且高频查询的维度应逐步沉淀为结构化字段。 |
 
+工作目录自动采集覆盖 Claude Code、Codex、Cursor / Cursor CLI、Kiro CLI、MiMo Code、OpenClaw、OpenCode、Pi Coding Agent、Qoder 系列、Qoder Work / Qoder Work CN、Qwen Code CLI、Qwen Work CN 和 WorkBuddy。该上下文不属于消息内容；即使对应 Agent 配置了 `captureMessageContent: false`，`workspace.*` 和可推断的 `git.*` 字段也会保留。
+
 ## 多模态消息 Parts
 
 当全局多模态基础设施与 Agent `uploadMode` 已开启时（见 [配置总览](configuration.md#多模态对象存储) 与 [多模态采集](multimodal.md)），消息 `parts` 中的媒体使用对象存储引用，而不是内联 base64：

--- a/docs/zh-CN/overview.md
+++ b/docs/zh-CN/overview.md
@@ -39,6 +39,7 @@ LoongSuite Pilot 运行在开发者本机，用于采集支持的 AI Coding Agen
 | Qoder Work | Hook / 本地数据轮询 | Yes | Yes | Yes | Yes |
 | Qoder Work CN | Hook / 本地数据轮询 | Yes | Yes | Yes | Yes |
 | Qwen Code CLI | Hook | Yes | Yes | Yes | Yes |
+| Qwen Work CN | Hook / 本地数据轮询 | Yes | Yes | Yes | Yes |
 | Wukong | CLI API 轮询 | Yes | Yes | Yes | Yes |
 | WorkBuddy | Hook 唤醒 + 本地 transcript 监听/轮询兜底 | Yes | Yes | Yes | Yes |
 

--- a/src/core/input-manager.ts
+++ b/src/core/input-manager.ts
@@ -230,7 +230,14 @@ export class InputManager extends EventEmitter {
   ): Promise<void> {
     if (entries.length === 0) return;
 
-    await enrichCanonicalEntriesWithGit(entries as Record<string, unknown>[]);
+    try {
+      await enrichCanonicalEntriesWithGit(entries as Record<string, unknown>[]);
+    } catch (err) {
+      logger.warn('git context enrichment failed (skipped)', {
+        inputId,
+        error: String(err),
+      });
+    }
 
     const counter = this.counters.get(inputId);
     let batchBytes = 0;

--- a/src/core/input-manager.ts
+++ b/src/core/input-manager.ts
@@ -11,6 +11,7 @@ import type { AlarmManager } from '../metrics/alarm-manager.js';
 import { createLogger } from '../utils/logger.js';
 import { formatTime } from '../utils/time-utils.js';
 import { applyAgentContentPolicy } from '../normalization/agent-content-policy.js';
+import { enrichCanonicalEntriesWithGit } from '../normalization/enrich-git-context.js';
 import { maskAgentActivityEntry } from '../mask/entry-masker.js';
 import { loadMaskPlan } from '../mask/rule-loader.js';
 import type { MaskPlan } from '../mask/types.js';
@@ -227,6 +228,8 @@ export class InputManager extends EventEmitter {
     entries: AgentActivityEntry[],
   ): Promise<void> {
     if (entries.length === 0) return;
+
+    await enrichCanonicalEntriesWithGit(entries as Record<string, unknown>[]);
 
     const counter = this.counters.get(inputId);
     let batchBytes = 0;

--- a/src/inputs/codex-transcript/codex-transcript-input.ts
+++ b/src/inputs/codex-transcript/codex-transcript-input.ts
@@ -2673,6 +2673,9 @@ function codexTurnEndMarker(
     ...(source['agent.codex.transcript_turn_id']
       ? { 'agent.codex.transcript_turn_id': source['agent.codex.transcript_turn_id'] }
       : {}),
+    ...(source['agent.codex.cwd']
+      ? { 'agent.codex.cwd': source['agent.codex.cwd'] }
+      : {}),
     'agent.codex.turn_status': status,
   };
 }

--- a/src/inputs/cursor-hook/cursor-hook-input.ts
+++ b/src/inputs/cursor-hook/cursor-hook-input.ts
@@ -67,7 +67,7 @@ export class CursorHookInput extends BaseHookInput {
     if (hookEvent.toLowerCase() === 'stop') {
       stripTokenFields(canonicalEntry);
     }
-    const gitNamespace = variant === ClientType.CursorCli ? 'cursor_cli' : 'cursor';
+    const gitNamespace = variant === ClientType.CursorCli ? 'cursor-cli' : 'cursor';
     await enrichCanonicalEntryWithGit(canonicalEntry, record, gitNamespace);
     return canonicalEntry;
   }

--- a/src/inputs/qoder-cn-trace/qoder-cn-trace-input.ts
+++ b/src/inputs/qoder-cn-trace/qoder-cn-trace-input.ts
@@ -249,7 +249,7 @@ export class QoderCnTraceInput extends BaseInput {
   private async transformRecord(record: Record<string, unknown>): Promise<AgentActivityEntry | null> {
     const canonicalEntry = buildCanonicalHookEntry(record, ClientType.QoderCn);
     if (canonicalEntry) {
-      await enrichCanonicalEntryWithGit(canonicalEntry, record, 'qodercn');
+      await enrichCanonicalEntryWithGit(canonicalEntry, record, 'qoder-cn');
       return canonicalEntry;
     }
     return null;

--- a/src/inputs/qwen-work-cn/qwen-work-cn-input.ts
+++ b/src/inputs/qwen-work-cn/qwen-work-cn-input.ts
@@ -1,6 +1,7 @@
 import { ClientType } from '../../types/index.js';
 import type { AgentActivityEntry } from '../../types/index.js';
 import { BaseHookInput, type HookInputOptions } from '../base/base-hook-input.js';
+import { enrichCanonicalEntryWithGit } from '../../normalization/enrich-git-context.js';
 import { directoryExists, resolveHome } from '../../utils/fs-utils.js';
 
 export interface QwenWorkCNInputOptions extends Partial<HookInputOptions> {
@@ -42,9 +43,15 @@ export class QwenWorkCNInput extends BaseHookInput {
     const version = record.version;
     if (typeof version === 'string' && version) this.lastAgentVersion = version;
 
-    return {
+    const entry = {
       ...record,
       'gen_ai.agent.type': ClientType.QwenWorkCN,
     } as AgentActivityEntry;
+    await enrichCanonicalEntryWithGit(
+      entry as Record<string, unknown>,
+      record,
+      'qwen-work-cn',
+    );
+    return entry;
   }
 }

--- a/src/normalization/enrich-git-context.ts
+++ b/src/normalization/enrich-git-context.ts
@@ -1,10 +1,22 @@
 import path from 'node:path';
 import { inferGitContext } from '../utils/git-context.js';
 
+const NAMESPACE_ALIASES: Readonly<Record<string, readonly string[]>> = {
+  'cursor-cli': ['cursor-cli', 'cursor_cli'],
+  cursor_cli: ['cursor_cli', 'cursor-cli'],
+  'qoder-cli': ['qoder-cli', 'qoder'],
+  'qoder-idea': ['qoder-idea', 'qoder'],
+  'qoder-cn': ['qoder-cn', 'qodercn', 'qoder'],
+  qodercn: ['qodercn', 'qoder-cn', 'qoder'],
+  'qoder-work': ['qoder-work', 'qoderwork'],
+  'qoder-work-cn': ['qoder-work-cn', 'qoderwork'],
+  'qwen-work-cn': ['qwen-work-cn', 'qwenworkcn'],
+};
+
 export async function enrichCanonicalEntryWithGit(
   entry: Record<string, unknown>,
   record: Record<string, unknown>,
-  namespace: string,
+  namespace: string | readonly string[],
 ): Promise<void> {
   const probeDir = extractProbeDir(entry, record, namespace);
   if (probeDir && !entry['workspace.path']) entry['workspace.path'] = probeDir;
@@ -19,21 +31,58 @@ export async function enrichCanonicalEntryWithGit(
   if (!entry['workspace.current_root'] && inferred.root) entry['workspace.current_root'] = inferred.root;
 }
 
+/**
+ * Last-mile enrichment for inputs that emit canonical Agent records directly.
+ *
+ * Hook-based inputs normally enrich before reaching InputManager. Transcript
+ * inputs such as Codex can emit from several recovery/fusion paths, so doing a
+ * guarded pass at the shared dispatch boundary keeps those paths consistent.
+ * Enrichment only fills missing canonical values, while inferGitContext caches
+ * repeated probes (including non-repository directories), so this is safe for
+ * entries that were already enriched upstream.
+ */
+export async function enrichCanonicalEntriesWithGit(
+  entries: Record<string, unknown>[],
+): Promise<void> {
+  for (const entry of entries) {
+    const agentType = normalizeString(entry['gen_ai.agent.type']);
+    if (!agentType) continue;
+    await enrichCanonicalEntryWithGit(entry, entry, agentType);
+  }
+}
+
 function extractProbeDir(
   entry: Record<string, unknown>,
   record: Record<string, unknown>,
-  namespace: string,
+  namespace: string | readonly string[],
 ): string | undefined {
-  const cwd = normalizeString(entry[`agent.${namespace}.cwd`])
-    ?? normalizeString(record[`agent.${namespace}.cwd`]);
-  if (cwd && isAbsolutePath(cwd)) return cwd;
+  const workspacePath = normalizeString(entry['workspace.path'])
+    ?? normalizeString(record['workspace.path']);
+  if (workspacePath && isAbsolutePath(workspacePath)) return workspacePath;
 
-  const roots = entry[`agent.${namespace}.workspace_roots`]
-    ?? record[`agent.${namespace}.workspace_roots`];
-  const rootList = normalizeStringArray(roots);
-  if (rootList.length > 0 && isAbsolutePath(rootList[0])) return rootList[0];
+  for (const candidate of expandNamespaces(namespace)) {
+    const cwd = normalizeString(entry[`agent.${candidate}.cwd`])
+      ?? normalizeString(record[`agent.${candidate}.cwd`]);
+    if (cwd && isAbsolutePath(cwd)) return cwd;
+
+    const roots = entry[`agent.${candidate}.workspace_roots`]
+      ?? record[`agent.${candidate}.workspace_roots`];
+    const rootList = normalizeStringArray(roots);
+    if (rootList.length > 0 && isAbsolutePath(rootList[0])) return rootList[0];
+  }
 
   return undefined;
+}
+
+function expandNamespaces(namespace: string | readonly string[]): string[] {
+  const requested = typeof namespace === 'string' ? [namespace] : namespace;
+  const expanded: string[] = [];
+  for (const value of requested) {
+    for (const candidate of NAMESPACE_ALIASES[value] ?? [value]) {
+      if (!expanded.includes(candidate)) expanded.push(candidate);
+    }
+  }
+  return expanded;
 }
 
 function isAbsolutePath(value: string): boolean {

--- a/src/normalization/enrich-git-context.ts
+++ b/src/normalization/enrich-git-context.ts
@@ -1,5 +1,8 @@
 import path from 'node:path';
 import { inferGitContext } from '../utils/git-context.js';
+import { createLogger } from '../utils/logger.js';
+
+const logger = createLogger('GitContextEnrichment');
 
 const NAMESPACE_ALIASES: Readonly<Record<string, readonly string[]>> = {
   'cursor-cli': ['cursor-cli', 'cursor_cli'],
@@ -45,9 +48,15 @@ export async function enrichCanonicalEntriesWithGit(
   entries: Record<string, unknown>[],
 ): Promise<void> {
   for (const entry of entries) {
-    const agentType = normalizeString(entry['gen_ai.agent.type']);
-    if (!agentType) continue;
-    await enrichCanonicalEntryWithGit(entry, entry, agentType);
+    try {
+      const agentType = normalizeString(entry['gen_ai.agent.type']);
+      if (!agentType) continue;
+      await enrichCanonicalEntryWithGit(entry, entry, agentType);
+    } catch (err) {
+      logger.warn('git context enrichment failed for entry (skipped)', {
+        error: String(err),
+      });
+    }
   }
 }
 

--- a/tests/integration/qwen-work-cn-real-transcript.test.ts
+++ b/tests/integration/qwen-work-cn-real-transcript.test.ts
@@ -56,7 +56,10 @@ function findTranscript(root: string): string | undefined {
   visit(root);
   return candidates
     .sort((left, right) => statSync(right).mtimeMs - statSync(left).mtimeMs)
-    .find(file => readFileSync(file, 'utf-8').includes('"type":"user"'));
+    .find(file => {
+      const content = readFileSync(file, 'utf-8');
+      return content.includes('"type":"user"') && content.includes('"type":"assistant"');
+    });
 }
 
 function deployQwenHooks(hooksDir: string): void {

--- a/tests/unit/core/input-manager.test.ts
+++ b/tests/unit/core/input-manager.test.ts
@@ -63,6 +63,41 @@ describe('InputManager', () => {
       expect(flusher.batchCalls.length).toBeGreaterThanOrEqual(1);
     });
 
+    it('last-mile enriches every Codex transcript path before dispatch', async () => {
+      const input = new StubInput('codex-transcript');
+      manager.registerInput(input as any);
+      manager.setAgentsConfig({
+        [ClientType.CodexCliHook]: { captureMessageContent: false },
+      });
+      const cwd = '/tmp/codex-workspace-context-test';
+      const entries = [
+        buildTestEntry({
+          'event.id': 'codex-completed',
+          'gen_ai.agent.type': ClientType.CodexCliHook,
+          'agent.codex.cwd': cwd,
+        }),
+        buildTestEntry({
+          'event.id': 'codex-interrupted',
+          'gen_ai.agent.type': ClientType.CodexCliHook,
+          'agent.codex.cwd': cwd,
+          'agent.codex.turn_status': 'interrupted',
+        }),
+        buildTestEntry({
+          'event.id': 'codex-subagent',
+          'gen_ai.agent.type': ClientType.CodexCliHook,
+          'gen_ai.agent.scope': 'subagent',
+          'agent.codex.cwd': cwd,
+        }),
+      ];
+
+      input.emit('entries', entries);
+      await manager.stopAll();
+
+      expect(flusher.batchCalls).toHaveLength(1);
+      expect(flusher.batchCalls[0]).toHaveLength(3);
+      expect(flusher.batchCalls[0].every(entry => entry['workspace.path'] === cwd)).toBe(true);
+    });
+
     it('serializes multiple entry batches from the same input', async () => {
       const input = new StubInput('test-input');
       const order: string[] = [];

--- a/tests/unit/core/input-manager.test.ts
+++ b/tests/unit/core/input-manager.test.ts
@@ -102,6 +102,29 @@ describe('InputManager', () => {
       expect(flusher.batchCalls[0].every(entry => entry['workspace.path'] === cwd)).toBe(true);
     });
 
+    it('dispatches the batch when last-mile git enrichment fails unexpectedly', async () => {
+      const input = new StubInput('fail-open-input');
+      manager.registerInput(input as any);
+
+      const entries = [buildTestEntry({ 'event.id': 'fail-open' })];
+      const originalIterator = entries[Symbol.iterator].bind(entries);
+      let iteratorCalls = 0;
+      Object.defineProperty(entries, Symbol.iterator, {
+        value: () => {
+          iteratorCalls++;
+          if (iteratorCalls === 1) throw new Error('enrichment iterator failed');
+          return originalIterator();
+        },
+      });
+
+      input.emit('entries', entries);
+      await manager.stopAll();
+
+      expect(flusher.batchCalls).toHaveLength(1);
+      expect(flusher.batchCalls[0]).toHaveLength(1);
+      expect(flusher.batchCalls[0][0]['event.id']).toBe('fail-open');
+    });
+
     it('serializes multiple entry batches from the same input', async () => {
       const input = new StubInput('test-input');
       const order: string[] = [];

--- a/tests/unit/hooks/cursor-react-assembler.test.ts
+++ b/tests/unit/hooks/cursor-react-assembler.test.ts
@@ -14,6 +14,38 @@ function ns(ms: number): string {
 }
 
 describe('Cursor react assembler', () => {
+  it('propagates Cursor CLI workspace roots to every parent record', () => {
+    const { records } = assembleTurn([
+      {
+        _journal_ts: iso(0),
+        hook_event: 'beforeSubmitPrompt',
+        conversation_id: 'conv-cli-workspace',
+        generation_id: 'turn-cli-workspace',
+        model: 'composer-cli',
+        prompt: 'inspect the workspace',
+        workspace_roots: ['C:\\Users\\alice\\project'],
+      },
+      {
+        _journal_ts: iso(100),
+        hook_event: 'afterAgentResponse',
+        conversation_id: 'conv-cli-workspace',
+        generation_id: 'turn-cli-workspace',
+        model: 'composer-cli',
+        text: 'done',
+      },
+      {
+        _journal_ts: iso(200),
+        hook_event: 'stop',
+        conversation_id: 'conv-cli-workspace',
+        generation_id: 'turn-cli-workspace',
+      },
+    ], { stopConversationId: 'conv-cli-workspace', variant: 'cursor-cli' });
+
+    expect(records.length).toBeGreaterThan(0);
+    expect(records.every(record => record['gen_ai.agent.type'] === 'cursor-cli')).toBe(true);
+    expect(records.every(record => record['agent.cursor-cli.cwd'] === 'C:\\Users\\alice\\project')).toBe(true);
+  });
+
   it('derives LLM and tool span timing from hook captured time and duration', () => {
     const { records } = assembleTurn([
       {

--- a/tests/unit/hooks/cursor-source-event.test.mjs
+++ b/tests/unit/hooks/cursor-source-event.test.mjs
@@ -27,4 +27,17 @@ describe('Cursor source event', () => {
 
     expect(event.duration_ms).toBe(0);
   });
+
+  it('preserves cwd and workspace roots on non-tool events', () => {
+    const event = toInternalEvent({
+      hook_event_name: 'beforeSubmitPrompt',
+      conversation_id: 'conv-workspace',
+      prompt: 'inspect this project',
+      cwd: 'C:\\Users\\alice\\project',
+      workspace_roots: ['C:\\Users\\alice\\project'],
+    });
+
+    expect(event.cwd).toBe('C:\\Users\\alice\\project');
+    expect(event.workspace_roots).toEqual(['C:\\Users\\alice\\project']);
+  });
 });

--- a/tests/unit/hooks/cursor-transcript-assembler.test.mjs
+++ b/tests/unit/hooks/cursor-transcript-assembler.test.mjs
@@ -177,6 +177,23 @@ describe('buildCursorRecordsFromTranscript', () => {
     expect(result).toBeNull();
   });
 
+  it('preserves Cursor CLI identity and cwd on the Windows transcript path', () => {
+    const transcriptPath = simpleTranscript('inspect', 'done');
+    const records = buildCursorRecordsFromTranscript(
+      transcriptPath,
+      [
+        makePromptEvent({ cwd: 'C:\\Users\\alice\\project' }),
+        makeResponseEvent({ text: 'done' }),
+        makeStopEvent(),
+      ],
+      { stopConversationId: 'conv-abc', variant: 'cursor-cli' },
+    );
+
+    expect(records).not.toBeNull();
+    expect(records.every(record => record['gen_ai.agent.type'] === 'cursor-cli')).toBe(true);
+    expect(records.every(record => record['agent.cursor-cli.cwd'] === 'C:\\Users\\alice\\project')).toBe(true);
+  });
+
   describe('simple turn (no tool calls)', () => {
     let records;
     let transcriptPath;

--- a/tests/unit/hooks/cursor/inject-skill-records.test.mjs
+++ b/tests/unit/hooks/cursor/inject-skill-records.test.mjs
@@ -125,6 +125,19 @@ describe('injectSkillRecords', () => {
     expect(toolResult['agent.cursor.skill_detection_source']).toBe('transcript_post_assembly');
   });
 
+  it('should preserve the variant-specific cwd on synthesized skill records', () => {
+    const records = [makeLlmResponse({
+      'gen_ai.agent.type': 'cursor-cli',
+      'agent.cursor-cli.cwd': 'C:\\Users\\alice\\project',
+    })];
+
+    injectSkillRecords(records, [makeSkill()]);
+
+    expect(records.slice(1).every(record => (
+      record['agent.cursor-cli.cwd'] === 'C:\\Users\\alice\\project'
+    ))).toBe(true);
+  });
+
   it('should share the same toolCallId across output.messages, tool.call, and tool.result', () => {
     const records = [makeLlmResponse()];
     const skills = [makeSkill()];

--- a/tests/unit/hooks/mimo-code/plugin-replay.test.mjs
+++ b/tests/unit/hooks/mimo-code/plugin-replay.test.mjs
@@ -83,6 +83,20 @@ describe('MiMo Code plugin — end-to-end fixture replay', () => {
     expect(capture.length).toBeGreaterThan(0);
   });
 
+  it('emits a stable namespaced cwd and adopts the per-session message path', async () => {
+    for (const e of events) {
+      await hooks.event({ event: e });
+    }
+    const records = capture.map((c) => parseRecord(c.data));
+    const llmRecords = records.filter((record) =>
+      record['event.name'] === 'llm.request' || record['event.name'] === 'llm.response'
+    );
+
+    expect(records.every((record) => typeof record['agent.mimo-code.cwd'] === 'string')).toBe(true);
+    expect(llmRecords.length).toBeGreaterThan(0);
+    expect(llmRecords.every((record) => record['agent.mimo-code.cwd'] === '/home/admin/mimo-fixtures/proj2')).toBe(true);
+  });
+
   it('builds a 5-layer span tree: session > turn > step > {llm, tool}', async () => {
     for (const e of events) {
       await hooks.event({ event: e });

--- a/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
+++ b/tests/unit/inputs/codex-transcript/codex-transcript-input.test.ts
@@ -2600,6 +2600,10 @@ describe('CodexTranscriptInput', () => {
     });
     expect(secondResponse?.['gen_ai.system_instructions']).toBeUndefined();
     expect(secondResponse?.['gen_ai.tool.definitions']).toBeUndefined();
+    expect(restarted.entries.find(entry => entry['gen_ai.turn.end'] === true)).toMatchObject({
+      'agent.codex.cwd': '/tmp/project',
+      'agent.codex.turn_status': 'completed',
+    });
   });
 
   it('rebuilds an oversized persisted delta from transcript offsets', async () => {
@@ -4144,4 +4148,3 @@ describe('Codex transcript multimodal extraction', () => {
     expect([...cache.keys()][0]).toMatch(/^\d+:\d+$/);
   });
 });
-

--- a/tests/unit/inputs/cursor-hook-input.test.ts
+++ b/tests/unit/inputs/cursor-hook-input.test.ts
@@ -92,6 +92,7 @@ describe('CursorHookInput', () => {
       'gen_ai.tool.call.id': 'tool-canonical',
       'gen_ai.tool.call.arguments': { command: 'pwd' },
       'agent.cursor.hook_event_name': 'preToolUse',
+      'agent.cursor.cwd': '/workspace/cursor-project',
     };
     await fs.writeFile(logFile, `${JSON.stringify(record)}\n`);
 
@@ -112,6 +113,33 @@ describe('CursorHookInput', () => {
       'gen_ai.tool.call.id': 'tool-canonical',
       'gen_ai.tool.call.arguments': { command: 'pwd' },
       'agent.cursor.hook_event_name': 'preToolUse',
+      'agent.cursor.cwd': '/workspace/cursor-project',
+      'workspace.path': '/workspace/cursor-project',
+    });
+  });
+
+  it('enriches Cursor CLI records from the hyphenated producer namespace', async () => {
+    const today = getTodayDateString();
+    const logFile = path.join(tmpDir, `cursor-${today}.jsonl`);
+    await fs.writeFile(logFile, `${JSON.stringify({
+      'event.id': 'cursor-cli-workspace',
+      'event.name': 'llm.response',
+      'gen_ai.agent.type': ClientType.CursorCli,
+      'gen_ai.session.id': 'cursor-cli-session',
+      'agent.cursor.cursor_version': '2026.08.19',
+      'agent.cursor-cli.cwd': 'C:\\Users\\alice\\project',
+    })}\n`);
+
+    const entries: AgentActivityEntry[] = [];
+    input.on('entries', (batch: AgentActivityEntry[]) => entries.push(...batch));
+    await input.start();
+    await input.stop();
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      'gen_ai.agent.type': ClientType.CursorCli,
+      'agent.cursor-cli.cwd': 'C:\\Users\\alice\\project',
+      'workspace.path': 'C:\\Users\\alice\\project',
     });
   });
 

--- a/tests/unit/inputs/mimo-code-log-input.test.ts
+++ b/tests/unit/inputs/mimo-code-log-input.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { MimoCodeLogInput } from '../../../src/inputs/mimo-code-log/mimo-code-log-input.js';
+import { ClientType, type AgentActivityEntry } from '../../../src/types/index.js';
+import { MockStateStore } from '../../helpers/mock-state-store.js';
+
+describe('MimoCodeLogInput', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mimo-code-input-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('normalizes plugin cwd into canonical workspace and Git fields', async () => {
+    const today = new Date();
+    const date = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+    await fs.writeFile(path.join(tmpDir, `mimo-code-${date}.jsonl`), `${JSON.stringify({
+      time_unix_nano: '1784188800000000000',
+      'event.id': 'mimo-event-1',
+      'event.name': 'llm.response',
+      'gen_ai.session.id': 'mimo-session-1',
+      'gen_ai.agent.type': ClientType.MimoCode,
+      'agent.mimo-code.cwd': tmpDir,
+    })}\n`);
+
+    const input = new MimoCodeLogInput({
+      stateStore: new MockStateStore() as never,
+      logDir: tmpDir,
+      pollIntervalMs: 60_000,
+    });
+    const entries: AgentActivityEntry[] = [];
+    input.on('entries', batch => entries.push(...batch));
+
+    await input.start();
+    await input.stop();
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      'event.id': 'mimo-event-1',
+      'gen_ai.agent.type': ClientType.MimoCode,
+      'agent.mimo-code.cwd': tmpDir,
+      'workspace.path': tmpDir,
+    });
+  });
+});

--- a/tests/unit/inputs/qoder-cli-input.test.ts
+++ b/tests/unit/inputs/qoder-cli-input.test.ts
@@ -70,6 +70,7 @@ describe('QoderCliInput', () => {
       'gen_ai.response.model': 'qwen-max',
       'gen_ai.output.messages': [{ type: 'text', content: 'hello' }],
       'agent.source': 'qoder-transcript-hook',
+      'agent.qoder.cwd': '/workspace/qoder-project',
     }]);
 
     expect(entries).toHaveLength(1);
@@ -83,6 +84,7 @@ describe('QoderCliInput', () => {
       'gen_ai.response.model': 'qwen-max',
       'gen_ai.output.messages': [{ role: 'assistant', parts: [{ type: 'text', content: 'hello' }] }],
       'agent.source': 'qoder-transcript-hook',
+      'workspace.path': '/workspace/qoder-project',
     });
   });
 

--- a/tests/unit/inputs/qoder-work-input.test.ts
+++ b/tests/unit/inputs/qoder-work-input.test.ts
@@ -195,6 +195,7 @@ describe('QoderWorkInput', () => {
         'gen_ai.session.id': 'sess-work',
         'gen_ai.output.messages': [{ role: 'assistant', parts: [{ type: 'text', content: 'hello work' }] }],
         'agent.source': 'qoder-transcript-hook',
+        'agent.qoderwork.cwd': '/workspace/qoder-work',
       };
       await fs.writeFile(logFile, JSON.stringify(record) + '\n');
 
@@ -210,6 +211,7 @@ describe('QoderWorkInput', () => {
         'gen_ai.agent.type': ClientType.QoderWork,
         'gen_ai.session.id': 'sess-work',
         'gen_ai.output.messages': [{ role: 'assistant', parts: [{ type: 'text', content: 'hello work' }] }],
+        'workspace.path': '/workspace/qoder-work',
       });
       await input.stop();
     });

--- a/tests/unit/inputs/qoder-work-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-work-trace-input.test.ts
@@ -149,6 +149,7 @@ describe('QoderWorkTraceInput', () => {
     expect(entries.length).toBe(1);
     expect(entries[0].trace_id).toBeDefined();
     expect((entries[0].trace_id as string).length).toBe(32);
+    expect(entries[0]['workspace.path']).toBe(TEST_CWD);
   });
 
   it('resumes from offset on second poll', async () => {

--- a/tests/unit/inputs/qwen-work-cn-input.test.ts
+++ b/tests/unit/inputs/qwen-work-cn-input.test.ts
@@ -42,6 +42,7 @@ describe('QwenWorkCNInput', () => {
       time_unix_nano: '1770000000000000000',
       observed_time_unix_nano: '1770000000000000000',
       version: '0.1.5',
+      'agent.qwenworkcn.cwd': '/workspace/qwen-work-cn',
     })}\n`);
     const entries: AgentActivityEntry[] = [];
     input.on('entries', batch => entries.push(...batch));
@@ -51,6 +52,7 @@ describe('QwenWorkCNInput', () => {
     expect(entries).toHaveLength(1);
     expect(entries[0]!['gen_ai.agent.type']).toBe(ClientType.QwenWorkCN);
     expect(entries[0]!['gen_ai.session.id']).toBe('qwen-session-1');
+    expect(entries[0]!['workspace.path']).toBe('/workspace/qwen-work-cn');
     expect(input.getAgentVersion()).toBe('0.1.5');
   });
 });

--- a/tests/unit/inputs/qwen-work-cn-trace-input.test.ts
+++ b/tests/unit/inputs/qwen-work-cn-trace-input.test.ts
@@ -128,6 +128,7 @@ describe('QwenWorkCNTraceInput', () => {
     expect(response['gen_ai.usage.output_tokens']).toBe(667);
     expect(response['gen_ai.usage.cache_read.input_tokens']).toBe(24_576);
     expect(response['gen_ai.usage.reasoning_tokens']).toBe(285);
+    expect(response['workspace.path']).toBe(cwd);
     expect(response['gen_ai.usage.total_tokens']).toBe(32_911);
     expect(response['gen_ai.request.model']).toBe('qmodel_latest');
     expect(response['gen_ai.response.model']).toBe('qmodel_latest');

--- a/tests/unit/normalization/enrich-git-context.test.ts
+++ b/tests/unit/normalization/enrich-git-context.test.ts
@@ -4,6 +4,9 @@ const inferGitContext = vi.fn();
 vi.mock('../../../src/utils/git-context.js', () => ({
   inferGitContext: (...args: unknown[]) => inferGitContext(...args),
 }));
+vi.mock('../../../src/utils/logger.js', () => ({
+  createLogger: () => ({ warn: vi.fn() }),
+}));
 
 import {
   enrichCanonicalEntriesWithGit,
@@ -153,5 +156,38 @@ describe('enrichCanonicalEntryWithGit', () => {
     });
     expect(inferGitContext).toHaveBeenNthCalledWith(1, '/workspace/codex-project/src');
     expect(inferGitContext).toHaveBeenNthCalledWith(2, '/workspace/cursor-project');
+  });
+
+  it('continues enriching later entries when one git probe fails', async () => {
+    inferGitContext
+      .mockRejectedValueOnce(new Error('git probe failed'))
+      .mockResolvedValueOnce({
+        repo: 'org/healthy-project',
+        branch: 'main',
+        domain: 'github.com',
+        root: '/workspace/healthy-project',
+      });
+    const entries: Record<string, unknown>[] = [
+      {
+        'gen_ai.agent.type': 'codex',
+        'agent.codex.cwd': '/workspace/failing-project',
+      },
+      {
+        'gen_ai.agent.type': 'codex',
+        'agent.codex.cwd': '/workspace/healthy-project',
+      },
+    ];
+
+    await expect(enrichCanonicalEntriesWithGit(entries)).resolves.toBeUndefined();
+
+    expect(entries[0]['workspace.path']).toBe('/workspace/failing-project');
+    expect(entries[0]['git.repo']).toBeUndefined();
+    expect(entries[1]).toMatchObject({
+      'workspace.path': '/workspace/healthy-project',
+      'workspace.current_root': '/workspace/healthy-project',
+      'git.repo': 'org/healthy-project',
+      'git.branch': 'main',
+      'git.domain': 'github.com',
+    });
   });
 });

--- a/tests/unit/normalization/enrich-git-context.test.ts
+++ b/tests/unit/normalization/enrich-git-context.test.ts
@@ -5,7 +5,10 @@ vi.mock('../../../src/utils/git-context.js', () => ({
   inferGitContext: (...args: unknown[]) => inferGitContext(...args),
 }));
 
-import { enrichCanonicalEntryWithGit } from '../../../src/normalization/enrich-git-context.js';
+import {
+  enrichCanonicalEntriesWithGit,
+  enrichCanonicalEntryWithGit,
+} from '../../../src/normalization/enrich-git-context.js';
 
 describe('enrichCanonicalEntryWithGit', () => {
   beforeEach(() => {
@@ -102,5 +105,53 @@ describe('enrichCanonicalEntryWithGit', () => {
 
     expect(entry['workspace.path']).toBeUndefined();
     expect(inferGitContext).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['qoder-work', 'agent.qoderwork.cwd'],
+    ['qoder-work-cn', 'agent.qoderwork.cwd'],
+    ['qwen-work-cn', 'agent.qwenworkcn.cwd'],
+    ['qoder-cn', 'agent.qoder.cwd'],
+    ['cursor-cli', 'agent.cursor_cli.cwd'],
+  ])('resolves %s producer namespace aliases', async (namespace, cwdKey) => {
+    inferGitContext.mockResolvedValue({});
+    const entry: Record<string, unknown> = {};
+
+    await enrichCanonicalEntryWithGit(entry, { [cwdKey]: '/workspace/aliased' }, namespace);
+
+    expect(entry['workspace.path']).toBe('/workspace/aliased');
+    expect(inferGitContext).toHaveBeenCalledWith('/workspace/aliased');
+  });
+
+  it('last-mile enriches entries from agent type or an existing canonical workspace path', async () => {
+    inferGitContext.mockResolvedValueOnce({
+      repo: 'org/codex-project',
+      branch: 'feature/codex',
+      domain: 'github.com',
+      root: '/workspace/codex-project',
+    }).mockResolvedValueOnce({});
+    const entries: Record<string, unknown>[] = [
+      {
+        'gen_ai.agent.type': 'codex',
+        'agent.codex.cwd': '/workspace/codex-project/src',
+      },
+      {
+        'gen_ai.agent.type': 'cursor',
+        'agent.cursor.cwd': '/workspace/cursor-project',
+        'workspace.path': '/workspace/cursor-project',
+      },
+    ];
+
+    await enrichCanonicalEntriesWithGit(entries);
+
+    expect(entries[0]).toMatchObject({
+      'workspace.path': '/workspace/codex-project/src',
+      'workspace.current_root': '/workspace/codex-project',
+      'git.repo': 'org/codex-project',
+      'git.branch': 'feature/codex',
+      'git.domain': 'github.com',
+    });
+    expect(inferGitContext).toHaveBeenNthCalledWith(1, '/workspace/codex-project/src');
+    expect(inferGitContext).toHaveBeenNthCalledWith(2, '/workspace/cursor-project');
   });
 });


### PR DESCRIPTION
## Summary

- add alias-aware, last-mile workspace and Git enrichment for canonical Agent events
- propagate cwd through Codex transcript recovery, Cursor IDE/CLI assemblers, Qoder variants, Qwen Work CN, and MiMo Code
- retain existing Qoder behavior with regression coverage and document automatic workspace collection

## Behavior

- an absolute cwd produces workspace.path even outside a Git repository
- accessible Git repositories additionally produce workspace.current_root, git.repo, git.branch, and git.domain when available
- workspace and Git context remain available when captureMessageContent is false

## Validation

- npm test -- --reporter=dot: 3207 passed, 50 skipped
- npm run typecheck
- npm run build
- node syntax checks for modified MJS entry points
- git diff --check

Closes #286