### PR TITLE
fix(installer): resolve postinstall from deployed package

### DIFF
--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -890,15 +890,18 @@ deploy_package() {
     echo ""
 
     msg "==> 部署 hook 脚本..." "==> Deploying hook scripts..."
-    if [ -f scripts/postinstall.js ]; then
-        "$NODE_BIN" scripts/postinstall.js || {
+    if [ -f "$PERMANENT_DIR/scripts/postinstall.js" ]; then
+        "$NODE_BIN" "$PERMANENT_DIR/scripts/postinstall.js" || {
             msg "    ❌ Hook 脚本部署失败" "    ❌ Hook script deployment failed"
             return 1
         }
+        msg "    ✅ Hook 脚本已部署" "    ✅ Hook scripts deployed"
+        msg "    如使用 Codex 桌面版，首次启动需在桌面端手动信任 hooks" \
+            "    If using Codex desktop app, please manually trust hooks on first launch"
+    else
+        msg "    ⚠️ postinstall.js 未找到，跳过 Hook 部署" \
+            "    ⚠️ postinstall.js not found, skipping hook deployment"
     fi
-    msg "    ✅ Hook 脚本已部署" "    ✅ Hook scripts deployed"
-    msg "    如使用 Codex 桌面版，首次启动需在桌面端手动信任 hooks" \
-        "    If using Codex desktop app, please manually trust hooks on first launch"
     echo ""
 
     # Write current pointer only after all deploy steps succeed

--- a/tests/unit/deploy/installer-postinstall-path.test.mjs
+++ b/tests/unit/deploy/installer-postinstall-path.test.mjs
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const installer = readFileSync(resolve('deploy', 'installer-opensource.sh'), 'utf8');
+
+function hookDeploymentBlock() {
+  const start = installer.indexOf('msg "==> 部署 hook 脚本..."');
+  const end = installer.indexOf('    echo ""', start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return installer.slice(start, end);
+}
+
+describe('public installer postinstall path', () => {
+  it('deploys hooks from the installed package regardless of the caller cwd', () => {
+    const block = hookDeploymentBlock();
+
+    expect(block).toContain('[ -f "$PERMANENT_DIR/scripts/postinstall.js" ]');
+    expect(block).toContain('"$NODE_BIN" "$PERMANENT_DIR/scripts/postinstall.js"');
+    expect(block).not.toContain('[ -f scripts/postinstall.js ]');
+    expect(block).not.toContain('"$NODE_BIN" scripts/postinstall.js');
+  });
+
+  it('warns without reporting success when postinstall is missing', () => {
+    const block = hookDeploymentBlock();
+    const invocation = block.indexOf('"$NODE_BIN" "$PERMANENT_DIR/scripts/postinstall.js"');
+    const success = block.indexOf('msg "    ✅ Hook 脚本已部署"');
+    const elseBranch = block.indexOf('\n    else\n');
+    const warning = block.indexOf('msg "    ⚠️ postinstall.js 未找到，跳过 Hook 部署"');
+
+    expect(invocation).toBeGreaterThanOrEqual(0);
+    expect(success).toBeGreaterThan(invocation);
+    expect(elseBranch).toBeGreaterThan(success);
+    expect(warning).toBeGreaterThan(elseBranch);
+  });
+});


### PR DESCRIPTION
## Summary
- resolve `scripts/postinstall.js` from `$PERMANENT_DIR` so hook deployment is independent of installer cwd
- only print hook deployment and Codex trust success after postinstall runs successfully
- warn without reporting success when postinstall is missing
- add a regression contract test for the absolute path and message placement

## Testing
- `bash -n deploy/installer-opensource.sh`
- `npm test -- tests/unit/deploy/installer-postinstall-path.test.mjs tests/unit/deploy/installer-profile-selection.test.mjs tests/unit/deploy/installer-edr-safety.test.mjs tests/unit/deploy/installer-managed-node.test.mjs tests/unit/deploy/installer-sls-config.test.ts tests/unit/deploy/installer-uninstall-cleanup.test.mjs`
- `npm run typecheck`
- `npm run build`

Fixes #290