### PR TITLE
fix(dsh): discover non-standard runtime home

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -46,10 +46,17 @@ best-effort wakeup and is not required for directory discovery.
 
 ## DeepSeek Harness Collection And Lifecycle
 
-Pilot detects DeepSeek Harness from `~/.dsh` or the `dsh` command. When `dsh`
-is enabled, Pilot appends one marked, Pilot-owned block to
-`$DSH_HOME/cordis.patch.yml` when `DSH_HOME` is set, otherwise
-`~/.dsh/cordis.patch.yml`. That block loads the packaged plugin
+Pilot resolves one exact Harness home for both detection and deployment. It
+keeps a previously deployed patch path for repair and cleanup, then checks an
+explicit local-definition `patchPath`, the Pilot service's `DSH_HOME`, and — on
+Linux — the `DSH_HOME` of a unique same-user running DSH process. Standard
+`~/.dsh` and `dsh` command detection remain the fallback. Pilot does not scan
+temporary directories or assume a fixed non-default home; multiple distinct
+running homes found during initial discovery are reported as ambiguous instead
+of selecting one silently.
+
+When `dsh` is enabled, Pilot appends one marked, Pilot-owned block to the
+resolved `<DSH_HOME>/cordis.patch.yml`. That block loads the packaged plugin
 from `$PILOT_DATA/plugins/dsh/plugin.mjs`; bytes outside the marked block are
 preserved. Start a new DSH process after first enabling or reinstalling the
 integration so the host loads the current patch.

--- a/docs/zh-CN/agents.md
+++ b/docs/zh-CN/agents.md
@@ -44,9 +44,14 @@ Codex 使用 transcript 作为采集事实源。Pilot 通过轻量的
 
 ## DeepSeek Harness 采集与生命周期
 
-Pilot 通过 `~/.dsh` 目录或 `dsh` 命令检测 DeepSeek Harness。启用
-`dsh` 后，Pilot 会在已设置 `DSH_HOME` 时修改 `$DSH_HOME/cordis.patch.yml`，
-否则修改 `~/.dsh/cordis.patch.yml`，并在其中追加一个
+Pilot 会为检测和部署解析同一个准确的 Harness home：已部署过的补丁路径
+用于后续修复和清理，其次依次检查本地 Agent 定义中显式设置的 `patchPath`、
+Pilot 服务进程的 `DSH_HOME`，以及 Linux 上唯一、同用户运行中 DSH 进程的
+`DSH_HOME`；标准的 `~/.dsh` 目录和 `dsh` 命令仍作为兜底。Pilot 不会扫描
+临时目录或假定某个固定的非默认 home；若初次发现时同时存在多个不同的运行中
+home，会报告歧义而不会静默选择其中一个。
+
+启用 `dsh` 后，Pilot 会在解析出的 `<DSH_HOME>/cordis.patch.yml` 中追加一个
 带 marker 的 Pilot 专属 block，用于加载
 `$PILOT_DATA/plugins/dsh/plugin.mjs`；marker 外的用户及第三方内容保持原样。
 首次启用或重新安装后，需要启动新的 DSH 进程，使宿主加载当前 patch。

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -628,6 +628,14 @@ export class Orchestrator extends EventEmitter {
         check: async () => !(await this.deploymentManager.needsRedeploy(def)),
         repair: async () => {
           const result = await this.deploymentManager.deploySingle(def);
+          // Process discovery is intentionally best-effort. If DSH exits
+          // between precondition() and repair(), deploySingle reports a
+          // successful not-detected skip for deployAll compatibility. Surface
+          // that transient miss here so the watchdog does not consume its
+          // cooldown or daily repair budget without writing the patch.
+          if (result.skipped && result.reason === 'not-detected') {
+            throw new Error(`DSH disappeared before YAML patch repair for ${def.id}`);
+          }
           if (!result.success) {
             throw new Error(result.error ?? `DSH YAML patch repair failed for ${def.id}`);
           }

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -624,7 +624,7 @@ export class Orchestrator extends EventEmitter {
         enabled: () => this.isAgentGatedEnabled(def.id),
         precondition: async () =>
           (await fileExists(pluginPath))
-          && (await detectAgent(def.detection)),
+          && (await this.deploymentManager.isAgentDetected(def)),
         check: async () => !(await this.deploymentManager.needsRedeploy(def)),
         repair: async () => {
           const result = await this.deploymentManager.deploySingle(def);

--- a/src/deployment/deployment-manager.ts
+++ b/src/deployment/deployment-manager.ts
@@ -200,6 +200,17 @@ export class DeploymentManager {
     return this.definitions;
   }
 
+  /** Strategy-aware detection used by lifecycle watchdogs. */
+  isAgentDetected(def: AgentDefinition): Promise<boolean> {
+    return this.runExclusive(async () => {
+      await this.loadState();
+      if (def.deployMode === 'dsh-yaml-patch') {
+        return this.dshYamlPatchStrategy.detect(def, this.state[def.id]);
+      }
+      return this.getStrategy(def).detect(def);
+    });
+  }
+
   /**
    * Whether the agent's integration is currently missing and needs to be
    * (re)deployed. Used by the watchdog to detect specs overwritten by other
@@ -208,6 +219,10 @@ export class DeploymentManager {
   needsRedeploy(def: AgentDefinition): Promise<boolean> {
     return this.runExclusive(async () => {
       await this.loadState();
+      if (def.deployMode === 'dsh-yaml-patch') {
+        const target = await this.dshYamlPatchStrategy.resolveTarget(def, this.state[def.id]);
+        return target ? this.dshYamlPatchStrategy.needsDeployAt(def, target) : true;
+      }
       const strategy = this.getStrategy(def);
       return strategy.needsDeploy(def, this.state[def.id]);
     });
@@ -226,8 +241,14 @@ export class DeploymentManager {
 
   private async deployAgent(def: AgentDefinition): Promise<DeployResult> {
     const strategy = this.getStrategy(def);
+    const record = this.state[def.id];
+    const dshTarget = def.deployMode === 'dsh-yaml-patch'
+      ? await this.dshYamlPatchStrategy.resolveTarget(def, record)
+      : null;
 
-    const detected = await strategy.detect(def);
+    const detected = def.deployMode === 'dsh-yaml-patch'
+      ? dshTarget !== null
+      : await strategy.detect(def);
     if (!detected) {
       logger.debug('agent not detected, skipping', { agentId: def.id });
       return {
@@ -239,18 +260,19 @@ export class DeploymentManager {
       };
     }
 
-    const record = this.state[def.id];
     const isRemote = def.deployMode === 'plugin-probe'
       && def.pluginProbe
       && this.pluginProbeStrategy.isRemoteOnly(def.pluginProbe.source);
 
-    const needs = await strategy.needsDeploy(def, record);
+    const needs = def.deployMode === 'dsh-yaml-patch' && dshTarget
+      ? await this.dshYamlPatchStrategy.needsDeployAt(def, dshTarget)
+      : await strategy.needsDeploy(def, record);
     if (!needs) {
       if (isRemote && record && this.pluginProbeStrategy.isRemoteCheckDue(record)) {
         record.lastRemoteCheckedAt = new Date().toISOString();
       }
       if (def.deployMode === 'dsh-yaml-patch' && record && !record.dshPatchPath) {
-        record.dshPatchPath = this.dshYamlPatchStrategy.resolvePatchPathForRecord(def, record);
+        record.dshPatchPath = dshTarget?.patchPath;
       }
       // Also the terminal state for detection-only agents: they share another
       // agent's hook, so needsDeploy() is always false and "detected but nothing
@@ -266,8 +288,8 @@ export class DeploymentManager {
     }
 
     logger.info('deploying agent', { agentId: def.id, deployMode: def.deployMode });
-    const result = def.deployMode === 'dsh-yaml-patch'
-      ? await this.dshYamlPatchStrategy.deploy(def, record)
+    const result = def.deployMode === 'dsh-yaml-patch' && dshTarget
+      ? await this.dshYamlPatchStrategy.deployAt(def, dshTarget)
       : await strategy.deploy(def);
 
     if (result.success) {
@@ -291,8 +313,8 @@ export class DeploymentManager {
         newRecord.targetDir = path.resolve(def.directoryPlugin.targetDir);
       }
 
-      if (def.deployMode === 'dsh-yaml-patch') {
-        newRecord.dshPatchPath = this.dshYamlPatchStrategy.resolvePatchPathForRecord(def, record);
+      if (def.deployMode === 'dsh-yaml-patch' && dshTarget) {
+        newRecord.dshPatchPath = dshTarget.patchPath;
       }
 
       this.state[def.id] = newRecord;

--- a/src/deployment/dsh-runtime-locator.ts
+++ b/src/deployment/dsh-runtime-locator.ts
@@ -1,0 +1,194 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { AgentDefinition, DeployedAgentRecord } from '../types/index.js';
+import { resolveHome } from '../utils/fs-utils.js';
+import { detectAgent } from './detect-utils.js';
+
+const DSH_PATCH_FILENAME = 'cordis.patch.yml';
+const MAX_PROC_FILE_BYTES = 4 * 1024 * 1024;
+
+export type DshRuntimeTargetSource =
+  | 'persisted'
+  | 'configured-patch'
+  | 'pilot-env'
+  | 'running-process'
+  | 'standard-detection';
+
+/** One deterministic Harness home and the machine-wide patch it consumes. */
+export interface DshRuntimeTarget {
+  home: string;
+  patchPath: string;
+  source: DshRuntimeTargetSource;
+  pid?: number;
+}
+
+export interface DshRuntimeLocatorOptions {
+  /** Injectable Linux procfs root for deterministic tests. */
+  procRoot?: string;
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  cwd?: () => string;
+  uid?: number;
+}
+
+/**
+ * Locate the exact Harness home used by the DSH YAML-patch lifecycle.
+ *
+ * This is intentionally DSH-specific. Generic Agent detection returns only a
+ * boolean and cannot carry the home that must later receive the patch. Keeping
+ * discovery and target selection together prevents a running DSH process from
+ * being detected at one path while Pilot writes another.
+ */
+export class DshRuntimeLocator {
+  private readonly procRoot: string;
+  private readonly platform: NodeJS.Platform;
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly cwd: () => string;
+  private readonly uid: number | undefined;
+
+  constructor(options: DshRuntimeLocatorOptions = {}) {
+    this.procRoot = options.procRoot ?? '/proc';
+    this.platform = options.platform ?? process.platform;
+    this.env = options.env ?? process.env;
+    this.cwd = options.cwd ?? (() => process.cwd());
+    this.uid = options.uid ?? process.getuid?.();
+  }
+
+  async locate(def: AgentDefinition, record?: DeployedAgentRecord): Promise<DshRuntimeTarget | null> {
+    const cfg = def.dshYamlPatch;
+    if (!cfg) return null;
+
+    // A persisted path is lifecycle ownership: repair and uninstall must keep
+    // managing the exact file Pilot originally changed even if service env drifts.
+    if (record?.dshPatchPath && path.isAbsolute(record.dshPatchPath)) {
+      const patchPath = path.resolve(record.dshPatchPath);
+      return this.targetFromPatchPath(patchPath, 'persisted');
+    }
+
+    // Explicit definition configuration remains the highest-ranked initial target.
+    if (cfg.patchPath) {
+      const patchPath = path.resolve(resolveHome(cfg.patchPath));
+      return this.targetFromPatchPath(patchPath, 'configured-patch');
+    }
+
+    const pilotHome = this.resolveHomeValue(this.env.DSH_HOME, this.cwd());
+    if (pilotHome) return this.targetFromHome(pilotHome, 'pilot-env');
+
+    const running = await this.locateRunningProcess();
+    if (running) return running;
+
+    // Preserve the existing standard-install contract. A detected command uses
+    // DSH's default home because no overriding home was discoverable.
+    if (await detectAgent(def.detection)) {
+      return this.targetFromHome(path.join(os.homedir(), '.dsh'), 'standard-detection');
+    }
+
+    return null;
+  }
+
+  private async locateRunningProcess(): Promise<DshRuntimeTarget | null> {
+    if (this.platform !== 'linux') return null;
+
+    let entries: string[];
+    try {
+      entries = await fs.readdir(this.procRoot);
+    } catch {
+      return null;
+    }
+
+    const candidates = new Map<string, number[]>();
+    for (const entry of entries.filter(name => /^\d+$/.test(name)).sort((a, b) => Number(a) - Number(b))) {
+      const pid = Number(entry);
+      const processDir = path.join(this.procRoot, entry);
+      if (!(await this.isOwnedProcess(processDir))) continue;
+
+      const cmdline = await this.readProcFile(path.join(processDir, 'cmdline'));
+      if (!cmdline || !this.isDshCommandLine(cmdline)) continue;
+
+      const environ = await this.readProcFile(path.join(processDir, 'environ'));
+      const rawHome = environ ? this.readEnvironmentValue(environ, 'DSH_HOME') : undefined;
+      if (!rawHome) continue;
+
+      let processCwd: string | undefined;
+      if (!path.isAbsolute(resolveHome(rawHome))) {
+        try {
+          processCwd = await fs.readlink(path.join(processDir, 'cwd'));
+        } catch {
+          continue;
+        }
+      }
+      const home = this.resolveHomeValue(rawHome, processCwd);
+      if (!home) continue;
+      const pids = candidates.get(home) ?? [];
+      pids.push(pid);
+      candidates.set(home, pids);
+    }
+
+    if (candidates.size === 0) return null;
+    if (candidates.size > 1) {
+      const homes = [...candidates.keys()].sort().map(home => JSON.stringify(home)).join(', ');
+      throw new Error(`ambiguous DSH runtime homes discovered from running processes: ${homes}`);
+    }
+
+    const [[home, pids]] = [...candidates.entries()];
+    return this.targetFromHome(home, 'running-process', pids[0]);
+  }
+
+  private async isOwnedProcess(processDir: string): Promise<boolean> {
+    if (this.uid === undefined) return true;
+    try {
+      return (await fs.stat(processDir)).uid === this.uid;
+    } catch {
+      return false;
+    }
+  }
+
+  private async readProcFile(filename: string): Promise<Buffer | null> {
+    try {
+      const bytes = await fs.readFile(filename);
+      return bytes.length <= MAX_PROC_FILE_BYTES ? bytes : null;
+    } catch {
+      // Processes may exit between procfs enumeration and reads; discovery is best effort.
+      return null;
+    }
+  }
+
+  private isDshCommandLine(bytes: Buffer): boolean {
+    const args = bytes.toString('utf8').split('\0').filter(Boolean);
+    const executable = path.basename(args[0] ?? '').toLowerCase();
+    if (executable === 'dsh' || executable === 'dsh.exe') return true;
+    if (executable !== 'node' && executable !== 'node.exe' && executable !== 'nodejs') return false;
+    const script = args[1] ?? '';
+    return path.basename(script).toLowerCase() === 'dsh'
+      || script.replace(/\\/g, '/').endsWith('/@deepseek-ai/dsh/lib/bin.js');
+  }
+
+  private readEnvironmentValue(bytes: Buffer, name: string): string | undefined {
+    const prefix = `${name}=`;
+    for (const field of bytes.toString('utf8').split('\0')) {
+      if (field.startsWith(prefix)) return field.slice(prefix.length);
+    }
+    return undefined;
+  }
+
+  private resolveHomeValue(raw: string | undefined, cwd: string | undefined): string | null {
+    if (!raw || raw.trim().length === 0) return null;
+    const expanded = resolveHome(raw);
+    if (path.isAbsolute(expanded)) return path.resolve(expanded);
+    return cwd ? path.resolve(cwd, expanded) : null;
+  }
+
+  private targetFromHome(home: string, source: DshRuntimeTargetSource, pid?: number): DshRuntimeTarget {
+    return {
+      home,
+      patchPath: path.join(home, DSH_PATCH_FILENAME),
+      source,
+      ...(pid === undefined ? {} : { pid }),
+    };
+  }
+
+  private targetFromPatchPath(patchPath: string, source: DshRuntimeTargetSource): DshRuntimeTarget {
+    return { home: path.dirname(patchPath), patchPath, source };
+  }
+}

--- a/src/deployment/dsh-runtime-locator.ts
+++ b/src/deployment/dsh-runtime-locator.ts
@@ -159,9 +159,15 @@ export class DshRuntimeLocator {
     const executable = path.basename(args[0] ?? '').toLowerCase();
     if (executable === 'dsh' || executable === 'dsh.exe') return true;
     if (executable !== 'node' && executable !== 'node.exe' && executable !== 'nodejs') return false;
-    const script = args[1] ?? '';
-    return path.basename(script).toLowerCase() === 'dsh'
-      || script.replace(/\\/g, '/').endsWith('/@deepseek-ai/dsh/lib/bin.js');
+    // Node/V8 flags may precede the entry script (for example --inspect or
+    // --require <preload>). Match the exact DSH entry token without assuming
+    // it is argv[1]. The same-user and DSH_HOME gates still apply before a
+    // process becomes a runtime-home candidate.
+    return args.slice(1).some(arg => {
+      const normalized = arg.replace(/\\/g, '/');
+      return path.posix.basename(normalized).toLowerCase() === 'dsh'
+        || normalized.endsWith('/@deepseek-ai/dsh/lib/bin.js');
+    });
   }
 
   private readEnvironmentValue(bytes: Buffer, name: string): string | undefined {

--- a/src/deployment/dsh-yaml-patch-strategy.ts
+++ b/src/deployment/dsh-yaml-patch-strategy.ts
@@ -1,6 +1,5 @@
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs/promises';
-import * as os from 'node:os';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type {
@@ -10,13 +9,12 @@ import type {
   DeployedAgentRecord,
   DshYamlPatchConfig,
 } from '../types/index.js';
-import { detectAgent } from './detect-utils.js';
 import { fileExists, resolveHome } from '../utils/fs-utils.js';
 import { createLogger } from '../utils/logger.js';
+import { DshRuntimeLocator, type DshRuntimeTarget } from './dsh-runtime-locator.js';
 
 const logger = createLogger('DshYamlPatchStrategy');
 
-const DEFAULT_PATCH_PATH = path.join(os.homedir(), '.dsh', 'cordis.patch.yml');
 export const DSH_ENABLED_MARKER = '.collection-enabled';
 
 const BEGIN_PREFIX = '# BEGIN ';
@@ -50,16 +48,29 @@ const STALE_LOCK_MS = 30_000;
  */
 export class DshYamlPatchStrategy implements DeployStrategy {
   private readonly dataDir: string;
+  private readonly runtimeLocator: DshRuntimeLocator;
 
-  constructor(dataDir: string) {
+  constructor(dataDir: string, runtimeLocator = new DshRuntimeLocator()) {
     this.dataDir = dataDir;
+    this.runtimeLocator = runtimeLocator;
   }
 
-  async detect(def: AgentDefinition): Promise<boolean> {
-    return detectAgent(def.detection);
+  resolveTarget(def: AgentDefinition, record?: DeployedAgentRecord): Promise<DshRuntimeTarget | null> {
+    return this.runtimeLocator.locate(def, record);
+  }
+
+  async detect(def: AgentDefinition, record?: DeployedAgentRecord): Promise<boolean> {
+    return (await this.resolveTarget(def, record)) !== null;
   }
 
   async needsDeploy(def: AgentDefinition, record?: DeployedAgentRecord): Promise<boolean> {
+    if (!def.dshYamlPatch) return false;
+    const target = await this.resolveTarget(def, record);
+    if (!target) return true;
+    return this.needsDeployAt(def, target);
+  }
+
+  async needsDeployAt(def: AgentDefinition, target: DshRuntimeTarget): Promise<boolean> {
     const cfg = def.dshYamlPatch;
     if (!cfg) return false;
     const pluginPath = this.resolvePluginPath(cfg);
@@ -67,7 +78,7 @@ export class DshYamlPatchStrategy implements DeployStrategy {
     if (!pluginHash) return true;
     if (!(await fileExists(this.resolveEnabledMarkerPath(cfg)))) return true;
     const pluginUrl = pathToFileURL(pluginPath).href;
-    const fileBytes = await this.readBytes(this.resolvePatchPath(cfg, record?.dshPatchPath));
+    const fileBytes = await this.readBytes(target.patchPath);
     const parsed = this.splitOnPilotBlock(fileBytes, cfg.marker);
     const block = parsed.existingBlock;
     if (parsed.conflictBlock || !block) return true;
@@ -78,6 +89,22 @@ export class DshYamlPatchStrategy implements DeployStrategy {
   }
 
   async deploy(def: AgentDefinition, record?: DeployedAgentRecord): Promise<DeployResult> {
+    if (!def.dshYamlPatch) {
+      return { success: false, agentId: def.id, deployMode: 'dsh-yaml-patch', error: 'missing dshYamlPatch config' };
+    }
+    const target = await this.resolveTarget(def, record);
+    if (!target) {
+      return {
+        success: false,
+        agentId: def.id,
+        deployMode: 'dsh-yaml-patch',
+        error: 'DSH runtime target is unavailable',
+      };
+    }
+    return this.deployAt(def, target);
+  }
+
+  async deployAt(def: AgentDefinition, target: DshRuntimeTarget): Promise<DeployResult> {
     const cfg = def.dshYamlPatch;
     if (!cfg) {
       return { success: false, agentId: def.id, deployMode: 'dsh-yaml-patch', error: 'missing dshYamlPatch config' };
@@ -93,7 +120,7 @@ export class DshYamlPatchStrategy implements DeployStrategy {
       };
     }
 
-    const patchPath = this.resolvePatchPath(cfg, record?.dshPatchPath);
+    const patchPath = target.patchPath;
     const lockToken = await this.acquirePatchLock(patchPath);
     if (!lockToken) {
       return {
@@ -176,13 +203,15 @@ export class DshYamlPatchStrategy implements DeployStrategy {
   async undeploy(def: AgentDefinition, record?: DeployedAgentRecord): Promise<boolean> {
     const cfg = def.dshYamlPatch;
     if (!cfg) return false;
+    const target = await this.resolveTarget(def, record);
+    if (!target) return false;
     try {
       await this.removeEnabledMarker(cfg);
     } catch (err) {
       logger.warn('failed to disable DSH collection marker', { error: String(err) });
       return false;
     }
-    const patchPath = this.resolvePatchPath(cfg, record?.dshPatchPath);
+    const patchPath = target.patchPath;
     const lockToken = await this.acquirePatchLock(patchPath);
     if (!lockToken) return false;
 
@@ -331,20 +360,6 @@ export class DshYamlPatchStrategy implements DeployStrategy {
 
   private resolvePluginPath(cfg: DshYamlPatchConfig): string {
     return resolveHome(cfg.pluginSource);
-  }
-
-  resolvePatchPathForRecord(def: AgentDefinition, record?: DeployedAgentRecord): string | undefined {
-    return def.dshYamlPatch
-      ? this.resolvePatchPath(def.dshYamlPatch, record?.dshPatchPath)
-      : undefined;
-  }
-
-  private resolvePatchPath(cfg: DshYamlPatchConfig, persistedPath?: string): string {
-    if (persistedPath && path.isAbsolute(persistedPath)) return persistedPath;
-    const fromEnv = process.env.DSH_HOME;
-    if (cfg.patchPath) return path.resolve(resolveHome(cfg.patchPath));
-    if (fromEnv) return path.resolve(fromEnv, 'cordis.patch.yml');
-    return DEFAULT_PATCH_PATH;
   }
 
   private resolveEnabledMarkerPath(cfg: DshYamlPatchConfig): string {

--- a/tests/unit/core/hook-watchdog-intercept.test.ts
+++ b/tests/unit/core/hook-watchdog-intercept.test.ts
@@ -107,6 +107,22 @@ describe('HookWatchdog intercept targets', () => {
     expect(result.repaired).toBe(0);
   });
 
+  it('does not apply cooldown or daily budget after repair throws', async () => {
+    const repair = vi.fn().mockRejectedValue(new Error('transient target disappeared'));
+    const target = makeTarget({
+      check: vi.fn().mockResolvedValue(false),
+      repair,
+    });
+    const wd = new HookWatchdog(defaultConfig, [], [target]);
+
+    const first = await wd.runCheck();
+    const second = await wd.runCheck();
+
+    expect(first.repaired).toBe(0);
+    expect(second.repaired).toBe(0);
+    expect(repair).toHaveBeenCalledTimes(2);
+  });
+
   it('handles multiple intercept targets independently', async () => {
     const healthy = makeTarget({ id: 'ok', check: vi.fn().mockResolvedValue(true) });
     const broken = makeTarget({ id: 'broken', check: vi.fn().mockResolvedValue(false) });

--- a/tests/unit/core/orchestrator-dsh-watchdog.test.ts
+++ b/tests/unit/core/orchestrator-dsh-watchdog.test.ts
@@ -135,4 +135,19 @@ describe('Orchestrator.buildDshYamlPatchInterceptTargets', () => {
     await expect(target.repair()).rejects.toThrow('repair failed');
     await expect(target.cleanup?.()).rejects.toThrow('failed to remove DSH YAML patch');
   });
+
+  it('treats a transient not-detected skip as a failed repair', async () => {
+    deploySingle.mockResolvedValue({
+      success: true,
+      agentId: 'dsh',
+      deployMode: 'dsh-yaml-patch',
+      skipped: true,
+      reason: 'not-detected',
+    });
+    const [target] = buildTargets(makeOrchestrator({
+      getDefinitions, isAgentDetected, needsRedeploy, deploySingle, undeployAgent,
+    }));
+
+    await expect(target.repair()).rejects.toThrow('DSH disappeared before YAML patch repair');
+  });
 });

--- a/tests/unit/core/orchestrator-dsh-watchdog.test.ts
+++ b/tests/unit/core/orchestrator-dsh-watchdog.test.ts
@@ -21,7 +21,6 @@ vi.mock('../../../src/utils/fs-utils.js', async (importOriginal) => {
 });
 
 import { Orchestrator } from '../../../src/core/orchestrator.js';
-import { detectAgent } from '../../../src/deployment/detect-utils.js';
 import { fileExists } from '../../../src/utils/fs-utils.js';
 
 const DATA_DIR = '/tmp/orchestrator-dsh-watchdog';
@@ -63,6 +62,7 @@ function buildTargets(orchestrator: Orchestrator) {
 
 describe('Orchestrator.buildDshYamlPatchInterceptTargets', () => {
   let getDefinitions: ReturnType<typeof vi.fn>;
+  let isAgentDetected: ReturnType<typeof vi.fn>;
   let needsRedeploy: ReturnType<typeof vi.fn>;
   let deploySingle: ReturnType<typeof vi.fn>;
   let undeployAgent: ReturnType<typeof vi.fn>;
@@ -70,6 +70,7 @@ describe('Orchestrator.buildDshYamlPatchInterceptTargets', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getDefinitions = vi.fn().mockReturnValue([dshDef()]);
+    isAgentDetected = vi.fn().mockResolvedValue(true);
     needsRedeploy = vi.fn();
     deploySingle = vi.fn();
     undeployAgent = vi.fn();
@@ -82,22 +83,22 @@ describe('Orchestrator.buildDshYamlPatchInterceptTargets', () => {
       { id: 'other', displayName: 'Other', deployMode: 'detection-only', detection: { paths: [], commands: [] } },
     ]);
     const targets = buildTargets(makeOrchestrator({
-      getDefinitions, needsRedeploy, deploySingle, undeployAgent,
+      getDefinitions, isAgentDetected, needsRedeploy, deploySingle, undeployAgent,
     }));
     expect(targets.map(target => target.id)).toEqual(['dsh-yaml-patch:dsh']);
   });
 
   it('checks asset, detection, health, repair, cleanup, and enabled gate', async () => {
     vi.mocked(fileExists).mockResolvedValue(true);
-    vi.mocked(detectAgent).mockResolvedValue(true);
     needsRedeploy.mockResolvedValue(true);
     deploySingle.mockResolvedValue({ success: true, agentId: 'dsh', deployMode: 'dsh-yaml-patch' });
     undeployAgent.mockResolvedValue(true);
-    const manager = { getDefinitions, needsRedeploy, deploySingle, undeployAgent };
+    const manager = { getDefinitions, isAgentDetected, needsRedeploy, deploySingle, undeployAgent };
     const [target] = buildTargets(makeOrchestrator(manager, true));
 
     expect(target.enabled?.()).toBe(true);
     await expect(target.precondition()).resolves.toBe(true);
+    expect(isAgentDetected).toHaveBeenCalledWith(expect.objectContaining({ id: 'dsh' }));
     await expect(target.check()).resolves.toBe(false);
     await expect(target.repair()).resolves.toBeUndefined();
     await expect(target.cleanup?.()).resolves.toBeUndefined();
@@ -106,6 +107,18 @@ describe('Orchestrator.buildDshYamlPatchInterceptTargets', () => {
 
     const [disabled] = buildTargets(makeOrchestrator(manager, false));
     expect(disabled.enabled?.()).toBe(false);
+  });
+
+  it('rechecks strategy-aware detection when DSH starts after Pilot', async () => {
+    vi.mocked(fileExists).mockResolvedValue(true);
+    isAgentDetected.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const [target] = buildTargets(makeOrchestrator({
+      getDefinitions, isAgentDetected, needsRedeploy, deploySingle, undeployAgent,
+    }));
+
+    await expect(target.precondition()).resolves.toBe(false);
+    await expect(target.precondition()).resolves.toBe(true);
+    expect(isAgentDetected).toHaveBeenCalledTimes(2);
   });
 
   it('surfaces deployment and cleanup failures to the watchdog', async () => {
@@ -117,7 +130,7 @@ describe('Orchestrator.buildDshYamlPatchInterceptTargets', () => {
     });
     undeployAgent.mockResolvedValue(false);
     const [target] = buildTargets(makeOrchestrator({
-      getDefinitions, needsRedeploy, deploySingle, undeployAgent,
+      getDefinitions, isAgentDetected, needsRedeploy, deploySingle, undeployAgent,
     }));
     await expect(target.repair()).rejects.toThrow('repair failed');
     await expect(target.cleanup?.()).rejects.toThrow('failed to remove DSH YAML patch');

--- a/tests/unit/deployment/deployment-manager.test.ts
+++ b/tests/unit/deployment/deployment-manager.test.ts
@@ -265,6 +265,45 @@ describe('DeploymentManager', () => {
         .toBeUndefined();
     });
 
+    it('deploys DSH from a custom DSH_HOME when standard detection is false', async () => {
+      const originalDshHome = process.env.DSH_HOME;
+      const pluginPath = path.join(dataDir, 'plugins', 'dsh', 'plugin.mjs');
+      const customHome = path.join(tmpDir, 'fc-runtime-home');
+      const expectedPatch = path.join(customHome, 'cordis.patch.yml');
+      await fs.mkdir(path.dirname(pluginPath), { recursive: true });
+      await fs.writeFile(pluginPath, 'export default function apply() {}\n');
+      const def: AgentDefinition = {
+        id: 'dsh',
+        displayName: 'DeepSeek Harness',
+        deployMode: 'dsh-yaml-patch',
+        detection: {
+          paths: [path.join(tmpDir, 'missing-default-home')],
+          commands: ['missing-dsh-command'],
+        },
+        dshYamlPatch: {
+          pluginSource: pluginPath,
+          entryId: 'loongsuite-pilot-observability',
+          marker: 'PILOT-OBSERVABILITY-MANAGED',
+        },
+      };
+      await writeAgentDef(def);
+      vi.mocked(detectAgent).mockResolvedValue(false);
+
+      try {
+        process.env.DSH_HOME = customHome;
+        const [result] = await makeManager().deployAll(() => true);
+
+        expect(result).toMatchObject({ success: true });
+        expect(result.skipped).toBeFalsy();
+        expect(await fs.readFile(expectedPatch, 'utf-8')).toContain('PILOT-OBSERVABILITY-MANAGED');
+        const deployed = JSON.parse(await fs.readFile(path.join(dataDir, 'deployed-agents.json'), 'utf-8'));
+        expect(deployed.dsh.dshPatchPath).toBe(expectedPatch);
+      } finally {
+        if (originalDshHome === undefined) delete process.env.DSH_HOME;
+        else process.env.DSH_HOME = originalDshHome;
+      }
+    });
+
     it('persists the resolved DSH patch path and cleans it after DSH_HOME changes', async () => {
       const originalDshHome = process.env.DSH_HOME;
       const pluginPath = path.join(dataDir, 'plugins', 'dsh', 'plugin.mjs');

--- a/tests/unit/deployment/dsh-runtime-locator.test.ts
+++ b/tests/unit/deployment/dsh-runtime-locator.test.ts
@@ -57,6 +57,7 @@ describe('DshRuntimeLocator', () => {
     home?: string;
     cwd?: string;
     dsh?: boolean;
+    nodeArgs?: string[];
   }): Promise<void> {
     const processDir = path.join(procRoot, String(pid));
     await fs.mkdir(processDir);
@@ -65,7 +66,7 @@ describe('DshRuntimeLocator', () => {
       : '/code/node_modules/@deepseek-ai/dsh/lib/bin.js';
     await fs.writeFile(
       path.join(processDir, 'cmdline'),
-      Buffer.from(['node', script, 'web', '--port', '13080', ''].join('\0')),
+      Buffer.from(['node', ...(options.nodeArgs ?? []), script, 'web', '--port', '13080', ''].join('\0')),
     );
     await fs.writeFile(
       path.join(processDir, 'environ'),
@@ -103,6 +104,22 @@ describe('DshRuntimeLocator', () => {
       source: 'running-process',
       pid: 321,
     });
+    expect(detectAgent).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['a V8 heap limit', ['--max-old-space-size=4096']],
+    ['source maps', ['--enable-source-maps']],
+    ['the inspector', ['--inspect']],
+    ['a short require preload', ['-r', '/code/preload.cjs']],
+    ['a long require preload', ['--require', '/code/preload.cjs']],
+  ])('discovers DSH when Node starts with %s before the entry script', async (_label, nodeArgs) => {
+    const home = path.join(tmpDir, 'runtime-home');
+    await writeProcess(322, { home, nodeArgs });
+
+    const target = await locator().locate(makeDef());
+
+    expect(target).toMatchObject({ home, source: 'running-process', pid: 322 });
     expect(detectAgent).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/deployment/dsh-runtime-locator.test.ts
+++ b/tests/unit/deployment/dsh-runtime-locator.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { AgentDefinition, DeployedAgentRecord } from '../../../src/types/index.js';
+
+vi.mock('../../../src/deployment/detect-utils.js', () => ({
+  detectAgent: vi.fn(),
+}));
+
+import { detectAgent } from '../../../src/deployment/detect-utils.js';
+import { DshRuntimeLocator } from '../../../src/deployment/dsh-runtime-locator.js';
+import { DshYamlPatchStrategy } from '../../../src/deployment/dsh-yaml-patch-strategy.js';
+
+describe('DshRuntimeLocator', () => {
+  let tmpDir: string;
+  let procRoot: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'dsh-runtime-locator-'));
+    procRoot = path.join(tmpDir, 'proc');
+    await fs.mkdir(procRoot);
+    vi.mocked(detectAgent).mockResolvedValue(false);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeDef(patchPath?: string): AgentDefinition {
+    return {
+      id: 'dsh',
+      displayName: 'DeepSeek Harness',
+      deployMode: 'dsh-yaml-patch',
+      detection: { paths: ['~/.dsh'], commands: ['dsh'] },
+      dshYamlPatch: {
+        pluginSource: '/pilot/plugins/dsh/plugin.mjs',
+        ...(patchPath === undefined ? {} : { patchPath }),
+        entryId: 'loongsuite-pilot-observability',
+        marker: 'PILOT-OBSERVABILITY-MANAGED',
+      },
+    };
+  }
+
+  function locator(env: NodeJS.ProcessEnv = {}, platform: NodeJS.Platform = 'linux') {
+    return new DshRuntimeLocator({
+      procRoot,
+      platform,
+      env,
+      cwd: () => tmpDir,
+      uid: process.getuid?.(),
+    });
+  }
+
+  async function writeProcess(pid: number, options: {
+    home?: string;
+    cwd?: string;
+    dsh?: boolean;
+  }): Promise<void> {
+    const processDir = path.join(procRoot, String(pid));
+    await fs.mkdir(processDir);
+    const script = options.dsh === false
+      ? '/code/node_modules/some-other-package/lib/bin.js'
+      : '/code/node_modules/@deepseek-ai/dsh/lib/bin.js';
+    await fs.writeFile(
+      path.join(processDir, 'cmdline'),
+      Buffer.from(['node', script, 'web', '--port', '13080', ''].join('\0')),
+    );
+    await fs.writeFile(
+      path.join(processDir, 'environ'),
+      Buffer.from([
+        'PATH=/usr/bin',
+        ...(options.home === undefined ? [] : [`DSH_HOME=${options.home}`]),
+        'DEEPSEEK_API_KEY=must-not-be-read-or-logged',
+        '',
+      ].join('\0')),
+    );
+    if (options.cwd) await fs.symlink(options.cwd, path.join(processDir, 'cwd'));
+  }
+
+  it('uses the Pilot service DSH_HOME without requiring a PATH command or default home', async () => {
+    const home = path.join(tmpDir, 'custom-home');
+    const target = await locator({ DSH_HOME: home }).locate(makeDef());
+
+    expect(target).toEqual({
+      home,
+      patchPath: path.join(home, 'cordis.patch.yml'),
+      source: 'pilot-env',
+    });
+    expect(detectAgent).not.toHaveBeenCalled();
+  });
+
+  it('discovers a non-standard home from the environment of a running DSH process', async () => {
+    const home = path.join(tmpDir, 'runtime-home');
+    await writeProcess(321, { home });
+
+    const target = await locator().locate(makeDef());
+
+    expect(target).toEqual({
+      home,
+      patchPath: path.join(home, 'cordis.patch.yml'),
+      source: 'running-process',
+      pid: 321,
+    });
+    expect(detectAgent).not.toHaveBeenCalled();
+  });
+
+  it('writes the managed patch to the home discovered from a running DSH process', async () => {
+    const home = path.join(tmpDir, 'runtime-home');
+    const dataDir = path.join(tmpDir, 'pilot-data');
+    const pluginPath = path.join(dataDir, 'plugins', 'dsh', 'plugin.mjs');
+    await fs.mkdir(path.dirname(pluginPath), { recursive: true });
+    await fs.writeFile(pluginPath, 'export default function apply() {}\n');
+    await writeProcess(323, { home });
+    const def = makeDef();
+    if (!def.dshYamlPatch) throw new Error('test definition is missing dshYamlPatch');
+    def.dshYamlPatch.pluginSource = pluginPath;
+
+    const result = await new DshYamlPatchStrategy(dataDir, locator()).deploy(def);
+
+    expect(result.success).toBe(true);
+    expect(await fs.readFile(path.join(home, 'cordis.patch.yml'), 'utf-8'))
+      .toContain('PILOT-OBSERVABILITY-MANAGED');
+    expect(await fs.readFile(path.join(path.dirname(pluginPath), '.collection-enabled'), 'utf-8'))
+      .toBe('enabled\n');
+  });
+
+  it('resolves a relative process DSH_HOME against that DSH process cwd', async () => {
+    if (process.platform === 'win32') return;
+    const cwd = path.join(tmpDir, 'dsh-cwd');
+    await fs.mkdir(cwd);
+    await writeProcess(322, { home: '.state/dsh', cwd });
+
+    const target = await locator().locate(makeDef());
+
+    expect(target?.home).toBe(path.join(cwd, '.state', 'dsh'));
+  });
+
+  it('accepts several DSH processes when they use the same home', async () => {
+    const home = path.join(tmpDir, 'shared-home');
+    await writeProcess(401, { home });
+    await writeProcess(402, { home });
+
+    const target = await locator().locate(makeDef());
+
+    expect(target?.home).toBe(home);
+    expect(target?.pid).toBe(401);
+  });
+
+  it('rejects several distinct running DSH homes instead of choosing one', async () => {
+    await writeProcess(501, { home: path.join(tmpDir, 'home-a') });
+    await writeProcess(502, { home: path.join(tmpDir, 'home-b') });
+
+    await expect(locator().locate(makeDef())).rejects.toThrow(/ambiguous DSH runtime homes/);
+  });
+
+  it('ignores unrelated Node processes and preserves standard detection fallback', async () => {
+    await writeProcess(601, { home: path.join(tmpDir, 'unrelated-home'), dsh: false });
+    vi.mocked(detectAgent).mockResolvedValue(true);
+
+    const target = await locator().locate(makeDef());
+
+    expect(target).toEqual({
+      home: path.join(os.homedir(), '.dsh'),
+      patchPath: path.join(os.homedir(), '.dsh', 'cordis.patch.yml'),
+      source: 'standard-detection',
+    });
+  });
+
+  it('keeps persisted lifecycle ownership ahead of changed runtime discovery', async () => {
+    const ownedPath = path.join(tmpDir, 'owned-home', 'cordis.patch.yml');
+    const record: DeployedAgentRecord = {
+      deployMode: 'dsh-yaml-patch',
+      deployedAt: new Date().toISOString(),
+      dshPatchPath: ownedPath,
+    };
+    await writeProcess(701, { home: path.join(tmpDir, 'other-home') });
+
+    const target = await locator({ DSH_HOME: path.join(tmpDir, 'pilot-home') })
+      .locate(makeDef(path.join(tmpDir, 'configured', 'cordis.patch.yml')), record);
+
+    expect(target).toEqual({
+      home: path.dirname(ownedPath),
+      patchPath: ownedPath,
+      source: 'persisted',
+    });
+  });
+
+  it('uses an explicit patchPath before environment or process discovery', async () => {
+    const configured = path.join(tmpDir, 'configured-home', 'cordis.patch.yml');
+    await writeProcess(801, { home: path.join(tmpDir, 'runtime-home') });
+
+    const target = await locator({ DSH_HOME: path.join(tmpDir, 'pilot-home') })
+      .locate(makeDef(configured));
+
+    expect(target?.patchPath).toBe(configured);
+    expect(target?.source).toBe('configured-patch');
+  });
+
+  it('does not inspect procfs on non-Linux platforms', async () => {
+    await writeProcess(901, { home: path.join(tmpDir, 'runtime-home') });
+
+    await expect(locator({}, 'darwin').locate(makeDef())).resolves.toBeNull();
+    expect(detectAgent).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- add a DSH-specific runtime locator that resolves one concrete Harness home and patch path instead of separating boolean detection from target selection
- preserve persisted lifecycle ownership and explicit configuration, then support Pilot-service `DSH_HOME`, a unique same-user Linux DSH process `DSH_HOME`, and the existing standard `~/.dsh` / PATH fallback
- make DSH deployment, state persistence, repair, disable, uninstall, and watchdog checks consume the same resolved target
- document non-standard home discovery and explicitly avoid fixed `/tmp/.dsh` assumptions or broad temporary-directory scans

On Linux, process fallback matches the real DSH Node entry point, reads only `DSH_HOME` from `/proc/<pid>/environ`, resolves relative values against that process cwd, ignores other users, and fails safely when initial discovery finds several distinct homes.

Fixes #297

## Validation

- DSH-focused suite: 9 files, 129 tests passed
- full test suite: 264 files passed, 3 skipped; 3239 tests passed, 50 skipped
- `npm run typecheck`
- `npm run build`

## Acceptance cases covered

- custom Pilot-service `DSH_HOME` while standard path/command detection is false
- custom home discovered only from a running `node .../@deepseek-ai/dsh/lib/bin.js web` process
- relative process `DSH_HOME`
- several DSH processes sharing one home
- distinct homes fail as ambiguous during initial discovery
- persisted path remains authoritative for repair and cleanup
- Watchdog rechecks discovery after DSH starts later
- standard install fallback, disable, uninstall, locking, and user-byte preservation regressions