### PR TITLE
fix: address dsh runtime review cases

### DIFF
--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -631,6 +631,9 @@ export class Orchestrator extends EventEmitter {
           if (!result.success) {
             throw new Error(result.error ?? `DSH YAML patch repair failed for ${def.id}`);
           }
+          if (result.skipped && result.reason !== 'up-to-date') {
+            throw new Error(`DSH YAML patch repair skipped for ${def.id}: ${result.reason ?? 'unknown'}`);
+          }
         },
         cleanup: async () => {
           const removed = await this.deploymentManager.undeployAgent(def);

--- a/src/deployment/dsh-runtime-locator.ts
+++ b/src/deployment/dsh-runtime-locator.ts
@@ -159,9 +159,11 @@ export class DshRuntimeLocator {
     const executable = path.basename(args[0] ?? '').toLowerCase();
     if (executable === 'dsh' || executable === 'dsh.exe') return true;
     if (executable !== 'node' && executable !== 'node.exe' && executable !== 'nodejs') return false;
-    const script = args[1] ?? '';
-    return path.basename(script).toLowerCase() === 'dsh'
-      || script.replace(/\\/g, '/').endsWith('/@deepseek-ai/dsh/lib/bin.js');
+    return args.slice(1).some(arg => {
+      if (arg.startsWith('-')) return false;
+      return path.basename(arg).toLowerCase() === 'dsh'
+        || arg.replace(/\\/g, '/').endsWith('/@deepseek-ai/dsh/lib/bin.js');
+    });
   }
 
   private readEnvironmentValue(bytes: Buffer, name: string): string | undefined {

--- a/tests/unit/core/orchestrator-dsh-watchdog.test.ts
+++ b/tests/unit/core/orchestrator-dsh-watchdog.test.ts
@@ -135,4 +135,28 @@ describe('Orchestrator.buildDshYamlPatchInterceptTargets', () => {
     await expect(target.repair()).rejects.toThrow('repair failed');
     await expect(target.cleanup?.()).rejects.toThrow('failed to remove DSH YAML patch');
   });
+
+  it('treats a skipped repair as failed unless the patch is already up to date', async () => {
+    deploySingle.mockResolvedValueOnce({
+      success: true,
+      agentId: 'dsh',
+      deployMode: 'dsh-yaml-patch',
+      skipped: true,
+      reason: 'not-detected',
+    });
+    const [target] = buildTargets(makeOrchestrator({
+      getDefinitions, isAgentDetected, needsRedeploy, deploySingle, undeployAgent,
+    }));
+
+    await expect(target.repair()).rejects.toThrow('not-detected');
+
+    deploySingle.mockResolvedValueOnce({
+      success: true,
+      agentId: 'dsh',
+      deployMode: 'dsh-yaml-patch',
+      skipped: true,
+      reason: 'up-to-date',
+    });
+    await expect(target.repair()).resolves.toBeUndefined();
+  });
 });

--- a/tests/unit/deployment/dsh-runtime-locator.test.ts
+++ b/tests/unit/deployment/dsh-runtime-locator.test.ts
@@ -57,6 +57,7 @@ describe('DshRuntimeLocator', () => {
     home?: string;
     cwd?: string;
     dsh?: boolean;
+    args?: string[];
   }): Promise<void> {
     const processDir = path.join(procRoot, String(pid));
     await fs.mkdir(processDir);
@@ -65,7 +66,7 @@ describe('DshRuntimeLocator', () => {
       : '/code/node_modules/@deepseek-ai/dsh/lib/bin.js';
     await fs.writeFile(
       path.join(processDir, 'cmdline'),
-      Buffer.from(['node', script, 'web', '--port', '13080', ''].join('\0')),
+      Buffer.from([...(options.args ?? ['node', script, 'web', '--port', '13080']), ''].join('\0')),
     );
     await fs.writeFile(
       path.join(processDir, 'environ'),
@@ -104,6 +105,29 @@ describe('DshRuntimeLocator', () => {
       pid: 321,
     });
     expect(detectAgent).not.toHaveBeenCalled();
+  });
+
+  it('discovers Node-launched DSH even when Node flags precede the script', async () => {
+    const home = path.join(tmpDir, 'runtime-home');
+    await writeProcess(324, {
+      home,
+      args: [
+        'node',
+        '--enable-source-maps',
+        '--inspect=127.0.0.1:0',
+        '/code/node_modules/@deepseek-ai/dsh/lib/bin.js',
+        'web',
+      ],
+    });
+
+    const target = await locator().locate(makeDef());
+
+    expect(target).toEqual({
+      home,
+      patchPath: path.join(home, 'cordis.patch.yml'),
+      source: 'running-process',
+      pid: 324,
+    });
   });
 
   it('writes the managed patch to the home discovered from a running DSH process', async () => {


### PR DESCRIPTION
Stacked fix for #298.\n\nThis addresses the two blocking review comments:\n- scan Node cmdline arguments past Node flags when locating @deepseek-ai/dsh/lib/bin.js\n- make the watchdog treat skipped repairs such as not-detected as failed, while still allowing up-to-date skips\n\nValidation:\n- npm test -- tests/unit/deployment/dsh-runtime-locator.test.ts tests/unit/core/orchestrator-dsh-watchdog.test.ts\n- npm run typecheck