### PR TITLE
fix: support QwenWorkCN token interception on Windows

### DIFF
--- a/assets/hooks/qoderwork-runtime-wrapper.mjs
+++ b/assets/hooks/qoderwork-runtime-wrapper.mjs
@@ -1,9 +1,10 @@
 // QoderWork-family worker runtime wrapper — transparent, app-agnostic shim.
 //
-// Loaded via the SHARED env var QODER_WORKER_RUNTIME_PATH. The ENTIRE
-// @qoder-ai/qoder-agent-sdk family honours this variable (QoderWork,
-// QwenWorkCN, QoderWork CN, ...), and on macOS we set it with `launchctl
-// setenv`, which is GLOBAL to the launchd user domain. Consequences:
+// Loaded through QODER_WORKER_RUNTIME_PATH (QoderWork family) or the dedicated
+// QW_QODER_WORKER_RUNTIME_PATH (QwenWorkCN). These User-level variables can
+// coexist and are inherited globally, so the variable that happened to load us
+// is never valid host identity. On macOS the overrides are also global to the
+// launchd user domain. Consequences:
 //   • Every GUI app inherits the variable, but only apps that actually run the
 //     @qoder-ai SDK ever load this file as their worker entry.
 //   • Therefore this wrapper CAN be the worker entry of ANY sibling app, not
@@ -47,11 +48,13 @@ const HOSTS = [
   {
     id: 'qoder-work-cn',
     appNames: ['QoderWork CN.app', 'QoderWorkCN.app'],
+    windowsAppNames: ['QoderWork CN', 'QoderWorkCN'],
     interceptFile: 'qoderworkcn-intercept.jsonl',
   },
   {
     id: 'qoder-work',
     appNames: ['QoderWork.app'],
+    windowsAppNames: ['QoderWork'],
     interceptFile: 'qoderwork-intercept.jsonl',
   },
 ];
@@ -155,12 +158,24 @@ function classifyHost(resourceRoots) {
         return host;
       }
       if (host.windowsAppNames?.some(appName =>
-        normalizedLower.includes(`/${appName.toLowerCase()}/resources`))) {
+        matchesWindowsResourcePath(normalizedLower, appName))) {
         return host;
       }
     }
   }
   return null;
+}
+
+function matchesWindowsResourcePath(normalizedLower, appName) {
+  const parts = normalizedLower.split('/').filter(Boolean);
+  const appIndex = parts.lastIndexOf(appName.toLowerCase());
+  const resourcesIndex = parts.lastIndexOf('resources');
+  return appIndex >= 0
+    && resourcesIndex === parts.length - 1
+    && resourcesIndex > appIndex
+    // Support both <App>/resources and <App>/<version>/resources. Do not
+    // accept an arbitrary descendant: that could classify a nested sibling.
+    && resourcesIndex - appIndex <= 2;
 }
 
 // Locate the host app's OWN worker runtime. Returns an absolute path or null.

--- a/assets/hooks/qoderwork-runtime-wrapper.mjs
+++ b/assets/hooks/qoderwork-runtime-wrapper.mjs
@@ -41,6 +41,7 @@ const HOSTS = [
   {
     id: 'qwen-work-cn',
     appNames: ['QwenWorkCN.app'],
+    windowsAppNames: ['QwenWorkCN'],
     interceptFile: 'qwenworkcn-intercept.jsonl',
   },
   {
@@ -148,24 +149,16 @@ function candidateResourceRoots() {
 function classifyHost(resourceRoots) {
   for (const root of resourceRoots) {
     const normalized = root.replace(/\\/g, '/');
+    const normalizedLower = normalized.toLowerCase();
     for (const host of HOSTS) {
       if (host.appNames.some(appName => normalized.includes(`/${appName}/Contents/Resources`))) {
         return host;
       }
-    }
-  }
-  // Windows fallback: when QW_QODER_WORKER_RUNTIME_PATH points at this wrapper,
-  // the host is QwenWorkCN. The env var is set per-process by the launcher
-  // script, so it only affects QwenWorkCN workers — never QoderWork.
-  const qwEnv = process.env.QW_QODER_WORKER_RUNTIME_PATH;
-  if (qwEnv) {
-    try {
-      const realEnv = fs.realpathSync(qwEnv);
-      const realSelf = fs.realpathSync(WRAPPER_PATH);
-      if (realEnv === realSelf) {
-        return HOSTS.find(h => h.id === 'qwen-work-cn') || null;
+      if (host.windowsAppNames?.some(appName =>
+        normalizedLower.includes(`/${appName.toLowerCase()}/resources`))) {
+        return host;
       }
-    } catch {}
+    }
   }
   return null;
 }

--- a/assets/hooks/qoderwork-runtime-wrapper.mjs
+++ b/assets/hooks/qoderwork-runtime-wrapper.mjs
@@ -23,7 +23,7 @@
 // process lifecycles belong to different products.
 
 import { createRequire } from 'module';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 const require = createRequire(import.meta.url);
 const fs = require('node:fs');
 const path = require('node:path');
@@ -154,6 +154,19 @@ function classifyHost(resourceRoots) {
       }
     }
   }
+  // Windows fallback: when QW_QODER_WORKER_RUNTIME_PATH points at this wrapper,
+  // the host is QwenWorkCN. The env var is set per-process by the launcher
+  // script, so it only affects QwenWorkCN workers — never QoderWork.
+  const qwEnv = process.env.QW_QODER_WORKER_RUNTIME_PATH;
+  if (qwEnv) {
+    try {
+      const realEnv = fs.realpathSync(qwEnv);
+      const realSelf = fs.realpathSync(WRAPPER_PATH);
+      if (realEnv === realSelf) {
+        return HOSTS.find(h => h.id === 'qwen-work-cn') || null;
+      }
+    } catch {}
+  }
   return null;
 }
 
@@ -194,7 +207,8 @@ if (hostRuntime) {
     installInterceptHooks(interceptFile);
   }
   try {
-    await import(hostRuntime);
+    // Use file:// URL so Windows absolute paths (C:\...) work with ESM import.
+    await import(pathToFileURL(hostRuntime).href);
   } catch (e) {
     // The app's own runtime failed to load — the app would have hit this even
     // without us. Do not throw (module-level throw crashes the worker_thread and

--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -2071,8 +2071,26 @@ function Write-FileUtf8NoBom {
     }
     $tmp = Join-Path $env:TEMP ("lp-write-" + (Get-Random) + ".tmp")
     Set-Content -LiteralPath $tmp -Value $Content -Encoding UTF8 -NoNewline
-    & $script:NODE_BIN -e 'const fs=require("fs");let s=fs.readFileSync(process.argv[1],"utf-8");if(s.charCodeAt(0)===0xFEFF)s=s.slice(1);fs.writeFileSync(process.argv[2],s);' $tmp $Path
-    Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+    # Windows PowerShell 5.1 strips nested double quotes while marshalling a
+    # single-quoted -e argument to a native executable. Keep the JavaScript in a
+    # here-string and use JS single-quoted literals so node receives the quotes.
+    $rewriteScript = @'
+const fs = require('fs');
+let content = fs.readFileSync(process.argv[1], 'utf-8');
+if (content.charCodeAt(0) === 0xFEFF) content = content.slice(1);
+fs.writeFileSync(process.argv[2], content);
+'@
+    $rewriteExit = 1
+    $prevEAP = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        & $script:NODE_BIN -e $rewriteScript $tmp $Path
+        $rewriteExit = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $prevEAP
+        Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+    }
+    if ($rewriteExit -ne 0) { throw "Failed to write UTF-8 file: $Path" }
 }
 
 function Remove-CodexTrustState {
@@ -2491,26 +2509,20 @@ function Cmd-Uninstall {
     Remove-OpenClawPlugin
     Write-Host ""
 
-    Msg "==> 删除安装目录..." "==> Removing installation..."
-    Remove-PilotInstallationFiles
-    Msg "    ✅ 已删除安装文件" "    ✅ Removed installation files"
-
-    Msg "==> 删除 loongsuite-pilot 命令..." "==> Removing loongsuite-pilot command..."
-    $cmdFile = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot.cmd"
-    $ps1File = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot-service.ps1"
-    $legacyPs1File = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot.ps1"
-    $layoutFile = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot-layout.json"
-    if (Test-Path $cmdFile) { Remove-Item $cmdFile -Force }
-    if (Test-Path $ps1File) { Remove-Item $ps1File -Force }
-    if (Test-Path $legacyPs1File) { Remove-Item $legacyPs1File -Force }
-    if (Test-Path $layoutFile) { Remove-Item $layoutFile -Force }
-    Msg "    ✅ loongsuite-pilot 命令已删除" "    ✅ loongsuite-pilot command removed"
-    Write-Host ""
-
     Msg "==> 清理 hook 配置..." "==> Cleaning up hook configs..."
     Remove-HookConfigs
-    Remove-CodexHookConfig
-    Remove-CodexTrustState
+    try {
+        Remove-CodexHookConfig
+    } catch {
+        Msg "    ⚠️  Codex hook 清理失败，继续卸载: $($_.Exception.Message)" `
+            "    ⚠️  Codex hook cleanup failed; continuing uninstall: $($_.Exception.Message)"
+    }
+    try {
+        Remove-CodexTrustState
+    } catch {
+        Msg "    ⚠️  Codex trust 清理失败，继续卸载: $($_.Exception.Message)" `
+            "    ⚠️  Codex trust cleanup failed; continuing uninstall: $($_.Exception.Message)"
+    }
     Write-Host ""
 
     Msg "==> 清理 QoderWork 系列环境变量..." "==> Cleaning up QoderWork-family env vars..."
@@ -2544,6 +2556,25 @@ function Cmd-Uninstall {
 
     Msg "==> 清理 MiMo Code 插件配置..." "==> Cleaning up MiMo Code plugin config..."
     Remove-MimoCodePlugin
+    Write-Host ""
+
+    # Keep the pinned node runtime and deployed helper assets available until
+    # every external config and runtime override has been cleaned. In
+    # particular, never leave a User env var pointing at a deleted wrapper.
+    Msg "==> 删除安装目录..." "==> Removing installation..."
+    Remove-PilotInstallationFiles
+    Msg "    ✅ 已删除安装文件" "    ✅ Removed installation files"
+
+    Msg "==> 删除 loongsuite-pilot 命令..." "==> Removing loongsuite-pilot command..."
+    $cmdFile = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot.cmd"
+    $ps1File = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot-service.ps1"
+    $legacyPs1File = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot.ps1"
+    $layoutFile = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot-layout.json"
+    if (Test-Path $cmdFile) { Remove-Item $cmdFile -Force }
+    if (Test-Path $ps1File) { Remove-Item $ps1File -Force }
+    if (Test-Path $legacyPs1File) { Remove-Item $legacyPs1File -Force }
+    if (Test-Path $layoutFile) { Remove-Item $layoutFile -Force }
+    Msg "    ✅ loongsuite-pilot 命令已删除" "    ✅ loongsuite-pilot command removed"
     Write-Host ""
 
     if ($Purge) {

--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -1049,53 +1049,52 @@ fs.writeFileSync(opts.configPath, JSON.stringify(config, null, 2) + '\n');
 # writes to HKCU\Environment — permanent across reboots and
 # inherited by every new GUI process (same role as macOS
 # launchctl setenv + LaunchAgent plist).
+#
+# Detection is APP-BASED (check if the .exe exists on disk),
+# NOT agent-based ($SELECTED_AGENTS). The probe may not detect
+# QwenWorkCN if ~/.qwenworkcn doesn't exist yet, but the app is
+# still installed and should get interception.
 # ============================================================
 function Inject-QoderworkRuntimeWrapper {
-    $wrapperPath = Join-Path $script:DATA_DIR "hooks\qoderwork-runtime-wrapper.mjs"
+    $wrapperPath = Join-Path $DataDir "hooks\qoderwork-runtime-wrapper.mjs"
     if (-not (Test-Path $wrapperPath)) { return }
 
     $localAppData = $env:LOCALAPPDATA
     if (-not $localAppData) { $localAppData = Join-Path $env:USERPROFILE "AppData\Local" }
 
     # ── QwenWorkCN: QW_QODER_WORKER_RUNTIME_PATH ──
-    if ($script:SELECTED_AGENTS -contains 'qwen-work-cn') {
-        $qwInstallDir = Join-Path $localAppData "Programs\QwenWorkCN"
-        if (Test-Path $qwInstallDir) {
-            $current = [Environment]::GetEnvironmentVariable('QW_QODER_WORKER_RUNTIME_PATH', 'User')
-            if ($current -ne $wrapperPath) {
-                [Environment]::SetEnvironmentVariable('QW_QODER_WORKER_RUNTIME_PATH', $wrapperPath, 'User')
-                Msg "    ✅ QW_QODER_WORKER_RUNTIME_PATH (QwenWorkCN)" `
-                    "    ✅ QW_QODER_WORKER_RUNTIME_PATH (QwenWorkCN)"
-            }
+    $qwenInstalled = Test-Path (Join-Path $localAppData "Programs\QwenWorkCN")
+    if ($qwenInstalled) {
+        $current = [Environment]::GetEnvironmentVariable('QW_QODER_WORKER_RUNTIME_PATH', 'User')
+        if ($current -ne $wrapperPath) {
+            [Environment]::SetEnvironmentVariable('QW_QODER_WORKER_RUNTIME_PATH', $wrapperPath, 'User')
+            Msg "    ✅ QW_QODER_WORKER_RUNTIME_PATH (QwenWorkCN)" `
+                "    ✅ QW_QODER_WORKER_RUNTIME_PATH (QwenWorkCN)"
         }
     } else {
         $current = [Environment]::GetEnvironmentVariable('QW_QODER_WORKER_RUNTIME_PATH', 'User')
-        if ($current -and $current -like '*loongsuite-pilot*') {
+        if ($current -and $current -like '*\hooks\qoderwork-runtime-wrapper.mjs') {
             [Environment]::SetEnvironmentVariable('QW_QODER_WORKER_RUNTIME_PATH', $null, 'User')
             Msg "    ✅ 已清理 QW_QODER_WORKER_RUNTIME_PATH" "    ✅ Cleaned QW_QODER_WORKER_RUNTIME_PATH"
         }
     }
 
     # ── QoderWork / QoderWorkCN: QODER_WORKER_RUNTIME_PATH ──
-    $wantsQoderWork = ($script:SELECTED_AGENTS -contains 'qoder-work') -or `
-                      ($script:SELECTED_AGENTS -contains 'qoder-work-cn')
-    if ($wantsQoderWork) {
-        $qoderPaths = @(
-            (Join-Path $localAppData "Programs\QoderWork\QoderWork.exe"),
-            (Join-Path $localAppData "Programs\QoderWorkCN\QoderWorkCN.exe")
-        )
-        $installed = $qoderPaths | Where-Object { Test-Path $_ }
-        if ($installed) {
-            $current = [Environment]::GetEnvironmentVariable('QODER_WORKER_RUNTIME_PATH', 'User')
-            if ($current -ne $wrapperPath) {
-                [Environment]::SetEnvironmentVariable('QODER_WORKER_RUNTIME_PATH', $wrapperPath, 'User')
-                Msg "    ✅ QODER_WORKER_RUNTIME_PATH (QoderWork)" `
-                    "    ✅ QODER_WORKER_RUNTIME_PATH (QoderWork)"
-            }
+    # Only set when QoderWork is actually installed AND QwenWorkCN is NOT
+    # installed (to avoid both env vars pointing at the same wrapper, which
+    # could cause intercept data to land in the wrong file).
+    $qoderInstalled = (Test-Path (Join-Path $localAppData "Programs\QoderWork\QoderWork.exe")) -or `
+                      (Test-Path (Join-Path $localAppData "Programs\QoderWorkCN\QoderWorkCN.exe"))
+    if ($qoderInstalled -and -not $qwenInstalled) {
+        $current = [Environment]::GetEnvironmentVariable('QODER_WORKER_RUNTIME_PATH', 'User')
+        if ($current -ne $wrapperPath) {
+            [Environment]::SetEnvironmentVariable('QODER_WORKER_RUNTIME_PATH', $wrapperPath, 'User')
+            Msg "    ✅ QODER_WORKER_RUNTIME_PATH (QoderWork)" `
+                "    ✅ QODER_WORKER_RUNTIME_PATH (QoderWork)"
         }
     } else {
         $current = [Environment]::GetEnvironmentVariable('QODER_WORKER_RUNTIME_PATH', 'User')
-        if ($current -and $current -like '*loongsuite-pilot*') {
+        if ($current -and $current -like '*\hooks\qoderwork-runtime-wrapper.mjs') {
             [Environment]::SetEnvironmentVariable('QODER_WORKER_RUNTIME_PATH', $null, 'User')
             Msg "    ✅ 已清理 QODER_WORKER_RUNTIME_PATH" "    ✅ Cleaned QODER_WORKER_RUNTIME_PATH"
         }
@@ -2447,7 +2446,7 @@ function Cmd-Uninstall {
     Msg "==> 清理 QoderWork 系列环境变量..." "==> Cleaning up QoderWork env vars..."
     foreach ($envName in @('QW_QODER_WORKER_RUNTIME_PATH', 'QODER_WORKER_RUNTIME_PATH')) {
         $val = [Environment]::GetEnvironmentVariable($envName, 'User')
-        if ($val -and $val -like '*loongsuite-pilot*') {
+        if ($val -and $val -like '*\hooks\qoderwork-runtime-wrapper.mjs') {
             [Environment]::SetEnvironmentVariable($envName, $null, 'User')
             Msg "    ✅ 已移除 $envName" "    ✅ Removed $envName"
         }

--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -1042,6 +1042,70 @@ fs.writeFileSync(opts.configPath, JSON.stringify(config, null, 2) + '\n');
 # ============================================================
 # Install loongsuite-pilot command (batch wrapper)
 # ============================================================
+# ============================================================
+# QoderWork-family runtime wrapper: set persistent User-level
+# env vars so QwenWorkCN / QoderWork workers load our shim.
+# On Windows [Environment]::SetEnvironmentVariable(…, 'User')
+# writes to HKCU\Environment — permanent across reboots and
+# inherited by every new GUI process (same role as macOS
+# launchctl setenv + LaunchAgent plist).
+# ============================================================
+function Inject-QoderworkRuntimeWrapper {
+    $wrapperPath = Join-Path $script:DATA_DIR "hooks\qoderwork-runtime-wrapper.mjs"
+    if (-not (Test-Path $wrapperPath)) { return }
+
+    $localAppData = $env:LOCALAPPDATA
+    if (-not $localAppData) { $localAppData = Join-Path $env:USERPROFILE "AppData\Local" }
+
+    # ── QwenWorkCN: QW_QODER_WORKER_RUNTIME_PATH ──
+    if ($script:SELECTED_AGENTS -contains 'qwen-work-cn') {
+        $qwInstallDir = Join-Path $localAppData "Programs\QwenWorkCN"
+        if (Test-Path $qwInstallDir) {
+            $current = [Environment]::GetEnvironmentVariable('QW_QODER_WORKER_RUNTIME_PATH', 'User')
+            if ($current -ne $wrapperPath) {
+                [Environment]::SetEnvironmentVariable('QW_QODER_WORKER_RUNTIME_PATH', $wrapperPath, 'User')
+                Msg "    ✅ QW_QODER_WORKER_RUNTIME_PATH (QwenWorkCN)" `
+                    "    ✅ QW_QODER_WORKER_RUNTIME_PATH (QwenWorkCN)"
+            }
+        }
+    } else {
+        $current = [Environment]::GetEnvironmentVariable('QW_QODER_WORKER_RUNTIME_PATH', 'User')
+        if ($current -and $current -like '*loongsuite-pilot*') {
+            [Environment]::SetEnvironmentVariable('QW_QODER_WORKER_RUNTIME_PATH', $null, 'User')
+            Msg "    ✅ 已清理 QW_QODER_WORKER_RUNTIME_PATH" "    ✅ Cleaned QW_QODER_WORKER_RUNTIME_PATH"
+        }
+    }
+
+    # ── QoderWork / QoderWorkCN: QODER_WORKER_RUNTIME_PATH ──
+    $wantsQoderWork = ($script:SELECTED_AGENTS -contains 'qoder-work') -or `
+                      ($script:SELECTED_AGENTS -contains 'qoder-work-cn')
+    if ($wantsQoderWork) {
+        $qoderPaths = @(
+            (Join-Path $localAppData "Programs\QoderWork\QoderWork.exe"),
+            (Join-Path $localAppData "Programs\QoderWorkCN\QoderWorkCN.exe")
+        )
+        $installed = $qoderPaths | Where-Object { Test-Path $_ }
+        if ($installed) {
+            $current = [Environment]::GetEnvironmentVariable('QODER_WORKER_RUNTIME_PATH', 'User')
+            if ($current -ne $wrapperPath) {
+                [Environment]::SetEnvironmentVariable('QODER_WORKER_RUNTIME_PATH', $wrapperPath, 'User')
+                Msg "    ✅ QODER_WORKER_RUNTIME_PATH (QoderWork)" `
+                    "    ✅ QODER_WORKER_RUNTIME_PATH (QoderWork)"
+            }
+        }
+    } else {
+        $current = [Environment]::GetEnvironmentVariable('QODER_WORKER_RUNTIME_PATH', 'User')
+        if ($current -and $current -like '*loongsuite-pilot*') {
+            [Environment]::SetEnvironmentVariable('QODER_WORKER_RUNTIME_PATH', $null, 'User')
+            Msg "    ✅ 已清理 QODER_WORKER_RUNTIME_PATH" "    ✅ Cleaned QODER_WORKER_RUNTIME_PATH"
+        }
+    }
+
+    Msg "    ⚠️  请完全退出并重新打开对应应用以生效" `
+        "    ⚠️  Fully quit and restart the corresponding app for changes to take effect"
+    Write-Host ""
+}
+
 function Install-Command {
     Msg "==> 安装服务管理脚本..." "==> Installing service management script..."
     $binDir = Join-Path $env:USERPROFILE ".local\bin"
@@ -1821,6 +1885,7 @@ function Cmd-Install {
         Deploy-Package $script:INSTALL_SRC
         Write-Config
         Install-Command
+        Inject-QoderworkRuntimeWrapper
 
         Msg "==> 启动服务..." "==> Starting service..."
         $ps1Path = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot-service.ps1"
@@ -1889,6 +1954,7 @@ function Cmd-Upgrade {
 
         Deploy-Package $script:INSTALL_SRC
         Install-Command
+        Inject-QoderworkRuntimeWrapper
 
         Msg "==> 启动新版本..." "==> Starting new version..."
         $ps1Path = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot-service.ps1"
@@ -2376,6 +2442,16 @@ function Cmd-Uninstall {
     Remove-HookConfigs
     Remove-CodexHookConfig
     Remove-CodexTrustState
+    Write-Host ""
+
+    Msg "==> 清理 QoderWork 系列环境变量..." "==> Cleaning up QoderWork env vars..."
+    foreach ($envName in @('QW_QODER_WORKER_RUNTIME_PATH', 'QODER_WORKER_RUNTIME_PATH')) {
+        $val = [Environment]::GetEnvironmentVariable($envName, 'User')
+        if ($val -and $val -like '*loongsuite-pilot*') {
+            [Environment]::SetEnvironmentVariable($envName, $null, 'User')
+            Msg "    ✅ 已移除 $envName" "    ✅ Removed $envName"
+        }
+    }
     Write-Host ""
 
     Msg "==> 清理 Claude/Codex 插件..." "==> Cleaning up Claude/Codex plugins..."

--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -1046,8 +1046,15 @@ fs.writeFileSync(opts.configPath, JSON.stringify(config, null, 2) + '\n');
 # ============================================================
 function Get-PilotRuntimeOverride {
     param([string]$Name)
-    $regOut = reg.exe query "HKCU\Environment" /v $Name 2>$null
-    if ($LASTEXITCODE -ne 0) { return "" }
+    $prevEAP = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        $regOut = reg.exe query "HKCU\Environment" /v $Name 2>$null
+        $regExitCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+    if ($regExitCode -ne 0) { return "" }
     foreach ($line in $regOut) {
         if (($line -match '^\s*(\S+)\s+REG_(?:EXPAND_)?SZ\s+(.*)$') -and $Matches[1] -ieq $Name) {
             return $Matches[2].Trim()

--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -1043,65 +1043,72 @@ fs.writeFileSync(opts.configPath, JSON.stringify(config, null, 2) + '\n');
 # Install loongsuite-pilot command (batch wrapper)
 # ============================================================
 # ============================================================
-# QoderWork-family runtime wrapper: set persistent User-level
-# env vars so QwenWorkCN / QoderWork workers load our shim.
-# On Windows [Environment]::SetEnvironmentVariable(…, 'User')
-# writes to HKCU\Environment — permanent across reboots and
-# inherited by every new GUI process (same role as macOS
-# launchctl setenv + LaunchAgent plist).
-#
-# Detection is APP-BASED (check if the .exe exists on disk),
-# NOT agent-based ($SELECTED_AGENTS). The probe may not detect
-# QwenWorkCN if ~/.qwenworkcn doesn't exist yet, but the app is
-# still installed and should get interception.
+# QwenWorkCN runtime wrapper: persist the dedicated User-level
+# QW_QODER_WORKER_RUNTIME_PATH in HKCU\Environment. Use reg.exe
+# instead of .NET static methods so installation still works in
+# WDAC/AppLocker Constrained Language Mode.
 # ============================================================
-function Inject-QoderworkRuntimeWrapper {
+function Get-QwenWorkCNRuntimeOverride {
+    $regOut = reg query "HKCU\Environment" /v QW_QODER_WORKER_RUNTIME_PATH 2>$null
+    if ($LASTEXITCODE -ne 0) { return "" }
+    foreach ($line in $regOut) {
+        if ($line -match '^\s*QW_QODER_WORKER_RUNTIME_PATH\s+REG_(?:EXPAND_)?SZ\s+(.*)$') {
+            return $Matches[1].Trim()
+        }
+    }
+    return ""
+}
+
+function Test-QwenWorkCNCollectionEnabled {
+    $configFile = Join-Path $DataDir "config.json"
+    if (-not (Test-Path $configFile)) { return $false }
+
+    $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
+    $enabled = & $script:NODE_BIN -e @'
+try {
+  const config = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8').replace(/^\uFEFF/, ''));
+  process.stdout.write(config?.agents?.['qwen-work-cn']?.enabled === false ? 'false' : 'true');
+} catch {
+  process.stdout.write('false');
+}
+'@ $configFile 2>$null
+    $ErrorActionPreference = $prevEAP
+    return "$enabled".Trim() -eq "true"
+}
+
+function Set-QwenWorkCNRuntimeOverride {
+    param([string]$Value)
+    reg add "HKCU\Environment" /v QW_QODER_WORKER_RUNTIME_PATH /t REG_SZ /d "$Value" /f | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "Failed to set QW_QODER_WORKER_RUNTIME_PATH" }
+}
+
+function Remove-QwenWorkCNRuntimeOverride {
+    reg delete "HKCU\Environment" /v QW_QODER_WORKER_RUNTIME_PATH /f 2>$null | Out-Null
+}
+
+function Inject-QwenWorkCNRuntimeWrapper {
     $wrapperPath = Join-Path $DataDir "hooks\qoderwork-runtime-wrapper.mjs"
     if (-not (Test-Path $wrapperPath)) { return }
 
     $localAppData = $env:LOCALAPPDATA
     if (-not $localAppData) { $localAppData = Join-Path $env:USERPROFILE "AppData\Local" }
 
-    # ── QwenWorkCN: QW_QODER_WORKER_RUNTIME_PATH ──
     $qwenInstalled = Test-Path (Join-Path $localAppData "Programs\QwenWorkCN")
-    if ($qwenInstalled) {
-        $current = [Environment]::GetEnvironmentVariable('QW_QODER_WORKER_RUNTIME_PATH', 'User')
-        if ($current -ne $wrapperPath) {
-            [Environment]::SetEnvironmentVariable('QW_QODER_WORKER_RUNTIME_PATH', $wrapperPath, 'User')
+    $qwenEnabled = Test-QwenWorkCNCollectionEnabled
+    $current = Get-QwenWorkCNRuntimeOverride
+    if ($qwenInstalled -and $qwenEnabled) {
+        if ($current -ine $wrapperPath) {
+            Set-QwenWorkCNRuntimeOverride -Value $wrapperPath
             Msg "    ✅ QW_QODER_WORKER_RUNTIME_PATH (QwenWorkCN)" `
                 "    ✅ QW_QODER_WORKER_RUNTIME_PATH (QwenWorkCN)"
         }
-    } else {
-        $current = [Environment]::GetEnvironmentVariable('QW_QODER_WORKER_RUNTIME_PATH', 'User')
-        if ($current -and $current -like '*\hooks\qoderwork-runtime-wrapper.mjs') {
-            [Environment]::SetEnvironmentVariable('QW_QODER_WORKER_RUNTIME_PATH', $null, 'User')
-            Msg "    ✅ 已清理 QW_QODER_WORKER_RUNTIME_PATH" "    ✅ Cleaned QW_QODER_WORKER_RUNTIME_PATH"
-        }
+    } elseif ($current -and $current -ieq $wrapperPath) {
+        Remove-QwenWorkCNRuntimeOverride
+        Msg "    ✅ 已清理 QW_QODER_WORKER_RUNTIME_PATH" "    ✅ Cleaned QW_QODER_WORKER_RUNTIME_PATH"
     }
 
-    # ── QoderWork / QoderWorkCN: QODER_WORKER_RUNTIME_PATH ──
-    # Only set when QoderWork is actually installed AND QwenWorkCN is NOT
-    # installed (to avoid both env vars pointing at the same wrapper, which
-    # could cause intercept data to land in the wrong file).
-    $qoderInstalled = (Test-Path (Join-Path $localAppData "Programs\QoderWork\QoderWork.exe")) -or `
-                      (Test-Path (Join-Path $localAppData "Programs\QoderWorkCN\QoderWorkCN.exe"))
-    if ($qoderInstalled -and -not $qwenInstalled) {
-        $current = [Environment]::GetEnvironmentVariable('QODER_WORKER_RUNTIME_PATH', 'User')
-        if ($current -ne $wrapperPath) {
-            [Environment]::SetEnvironmentVariable('QODER_WORKER_RUNTIME_PATH', $wrapperPath, 'User')
-            Msg "    ✅ QODER_WORKER_RUNTIME_PATH (QoderWork)" `
-                "    ✅ QODER_WORKER_RUNTIME_PATH (QoderWork)"
-        }
-    } else {
-        $current = [Environment]::GetEnvironmentVariable('QODER_WORKER_RUNTIME_PATH', 'User')
-        if ($current -and $current -like '*\hooks\qoderwork-runtime-wrapper.mjs') {
-            [Environment]::SetEnvironmentVariable('QODER_WORKER_RUNTIME_PATH', $null, 'User')
-            Msg "    ✅ 已清理 QODER_WORKER_RUNTIME_PATH" "    ✅ Cleaned QODER_WORKER_RUNTIME_PATH"
-        }
-    }
-
-    Msg "    ⚠️  请完全退出并重新打开对应应用以生效" `
-        "    ⚠️  Fully quit and restart the corresponding app for changes to take effect"
+    Msg "    ⚠️  请完全退出并重新打开 QwenWorkCN 以生效" `
+        "    ⚠️  Fully quit and restart QwenWorkCN for changes to take effect"
     Write-Host ""
 }
 
@@ -1884,7 +1891,7 @@ function Cmd-Install {
         Deploy-Package $script:INSTALL_SRC
         Write-Config
         Install-Command
-        Inject-QoderworkRuntimeWrapper
+        Inject-QwenWorkCNRuntimeWrapper
 
         Msg "==> 启动服务..." "==> Starting service..."
         $ps1Path = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot-service.ps1"
@@ -1953,7 +1960,7 @@ function Cmd-Upgrade {
 
         Deploy-Package $script:INSTALL_SRC
         Install-Command
-        Inject-QoderworkRuntimeWrapper
+        Inject-QwenWorkCNRuntimeWrapper
 
         Msg "==> 启动新版本..." "==> Starting new version..."
         $ps1Path = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot-service.ps1"
@@ -2443,13 +2450,13 @@ function Cmd-Uninstall {
     Remove-CodexTrustState
     Write-Host ""
 
-    Msg "==> 清理 QoderWork 系列环境变量..." "==> Cleaning up QoderWork env vars..."
-    foreach ($envName in @('QW_QODER_WORKER_RUNTIME_PATH', 'QODER_WORKER_RUNTIME_PATH')) {
-        $val = [Environment]::GetEnvironmentVariable($envName, 'User')
-        if ($val -and $val -like '*\hooks\qoderwork-runtime-wrapper.mjs') {
-            [Environment]::SetEnvironmentVariable($envName, $null, 'User')
-            Msg "    ✅ 已移除 $envName" "    ✅ Removed $envName"
-        }
+    Msg "==> 清理 QwenWorkCN 环境变量..." "==> Cleaning up QwenWorkCN env var..."
+    $wrapperPath = Join-Path $DataDir "hooks\qoderwork-runtime-wrapper.mjs"
+    $currentQwenRuntime = Get-QwenWorkCNRuntimeOverride
+    if ($currentQwenRuntime -and $currentQwenRuntime -ieq $wrapperPath) {
+        Remove-QwenWorkCNRuntimeOverride
+        Msg "    ✅ 已移除 QW_QODER_WORKER_RUNTIME_PATH" `
+            "    ✅ Removed QW_QODER_WORKER_RUNTIME_PATH"
     }
     Write-Host ""
 

--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -1040,26 +1040,24 @@ fs.writeFileSync(opts.configPath, JSON.stringify(config, null, 2) + '\n');
 }
 
 # ============================================================
-# Install loongsuite-pilot command (batch wrapper)
+# QoderWork-family runtime wrapper: persist the dedicated User-level overrides
+# in HKCU\Environment. reg.exe is the CLM-safe source of truth; the guarded
+# .NET call broadcasts WM_SETTINGCHANGE so Explorer-spawned apps see updates.
 # ============================================================
-# ============================================================
-# QwenWorkCN runtime wrapper: persist the dedicated User-level
-# QW_QODER_WORKER_RUNTIME_PATH in HKCU\Environment. Use reg.exe
-# instead of .NET static methods so installation still works in
-# WDAC/AppLocker Constrained Language Mode.
-# ============================================================
-function Get-QwenWorkCNRuntimeOverride {
-    $regOut = reg query "HKCU\Environment" /v QW_QODER_WORKER_RUNTIME_PATH 2>$null
+function Get-PilotRuntimeOverride {
+    param([string]$Name)
+    $regOut = reg.exe query "HKCU\Environment" /v $Name 2>$null
     if ($LASTEXITCODE -ne 0) { return "" }
     foreach ($line in $regOut) {
-        if ($line -match '^\s*QW_QODER_WORKER_RUNTIME_PATH\s+REG_(?:EXPAND_)?SZ\s+(.*)$') {
-            return $Matches[1].Trim()
+        if (($line -match '^\s*(\S+)\s+REG_(?:EXPAND_)?SZ\s+(.*)$') -and $Matches[1] -ieq $Name) {
+            return $Matches[2].Trim()
         }
     }
     return ""
 }
 
-function Test-QwenWorkCNCollectionEnabled {
+function Test-AgentCollectionEnabled {
+    param([string]$AgentId)
     $configFile = Join-Path $DataDir "config.json"
     if (-not (Test-Path $configFile)) { return $false }
 
@@ -1067,51 +1065,109 @@ function Test-QwenWorkCNCollectionEnabled {
     $enabled = & $script:NODE_BIN -e @'
 try {
   const config = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8').replace(/^\uFEFF/, ''));
-  process.stdout.write(config?.agents?.['qwen-work-cn']?.enabled === false ? 'false' : 'true');
+  const agentId = process.argv[2];
+  process.stdout.write(config?.agents?.[agentId]?.enabled === false ? 'false' : 'true');
 } catch {
   process.stdout.write('false');
 }
-'@ $configFile 2>$null
+'@ $configFile $AgentId 2>$null
     $ErrorActionPreference = $prevEAP
     return "$enabled".Trim() -eq "true"
 }
 
-function Set-QwenWorkCNRuntimeOverride {
-    param([string]$Value)
-    reg add "HKCU\Environment" /v QW_QODER_WORKER_RUNTIME_PATH /t REG_SZ /d "$Value" /f | Out-Null
-    if ($LASTEXITCODE -ne 0) { throw "Failed to set QW_QODER_WORKER_RUNTIME_PATH" }
+function Set-PilotRuntimeOverride {
+    param([string]$Name, [string]$Value)
+    reg.exe add "HKCU\Environment" /v $Name /t REG_SZ /d "$Value" /f | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "Failed to set $Name" }
+    try {
+        [Environment]::SetEnvironmentVariable($Name, $Value, 'User')
+        return $true
+    } catch {
+        return $false
+    }
 }
 
-function Remove-QwenWorkCNRuntimeOverride {
-    reg delete "HKCU\Environment" /v QW_QODER_WORKER_RUNTIME_PATH /f 2>$null | Out-Null
+function Remove-PilotRuntimeOverride {
+    param([string]$Name)
+    reg.exe delete "HKCU\Environment" /v $Name /f 2>$null | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "Failed to remove $Name" }
+    try {
+        [Environment]::SetEnvironmentVariable($Name, $null, 'User')
+        return $true
+    } catch {
+        return $false
+    }
 }
 
-function Inject-QwenWorkCNRuntimeWrapper {
+function Sync-PilotRuntimeOverride {
+    param(
+        [string]$Name,
+        [bool]$ShouldEnable,
+        [string]$WrapperPath,
+        [string]$ProductName
+    )
+    $current = Get-PilotRuntimeOverride -Name $Name
+    if (-not (Test-Path $WrapperPath)) {
+        $script:RUNTIME_WRAPPER_MISSING = $true
+        if ($current -and $current -ieq $WrapperPath) {
+            $broadcasted = Remove-PilotRuntimeOverride -Name $Name
+            if (-not $broadcasted) { $script:RUNTIME_ENV_BROADCAST_FAILED = $true }
+            Msg "    ⚠️  wrapper 缺失，已清理 $Name" "    ⚠️  Wrapper missing; cleaned $Name"
+        } else {
+            Msg "    ⚠️  wrapper 缺失，未设置 $Name" "    ⚠️  Wrapper missing; did not set $Name"
+        }
+        return
+    }
+
+    if ($ShouldEnable) {
+        if ($current -ine $WrapperPath) {
+            $broadcasted = Set-PilotRuntimeOverride -Name $Name -Value $WrapperPath
+            if (-not $broadcasted) { $script:RUNTIME_ENV_BROADCAST_FAILED = $true }
+            Msg "    ✅ $Name ($ProductName)" "    ✅ $Name ($ProductName)"
+        }
+    } elseif ($current -and $current -ieq $WrapperPath) {
+        $broadcasted = Remove-PilotRuntimeOverride -Name $Name
+        if (-not $broadcasted) { $script:RUNTIME_ENV_BROADCAST_FAILED = $true }
+        Msg "    ✅ 已清理 $Name" "    ✅ Cleaned $Name"
+    }
+}
+
+function Inject-QoderworkRuntimeWrapper {
     $wrapperPath = Join-Path $DataDir "hooks\qoderwork-runtime-wrapper.mjs"
-    if (-not (Test-Path $wrapperPath)) { return }
-
     $localAppData = $env:LOCALAPPDATA
     if (-not $localAppData) { $localAppData = Join-Path $env:USERPROFILE "AppData\Local" }
 
     $qwenInstalled = Test-Path (Join-Path $localAppData "Programs\QwenWorkCN")
-    $qwenEnabled = Test-QwenWorkCNCollectionEnabled
-    $current = Get-QwenWorkCNRuntimeOverride
-    if ($qwenInstalled -and $qwenEnabled) {
-        if ($current -ine $wrapperPath) {
-            Set-QwenWorkCNRuntimeOverride -Value $wrapperPath
-            Msg "    ✅ QW_QODER_WORKER_RUNTIME_PATH (QwenWorkCN)" `
-                "    ✅ QW_QODER_WORKER_RUNTIME_PATH (QwenWorkCN)"
-        }
-    } elseif ($current -and $current -ieq $wrapperPath) {
-        Remove-QwenWorkCNRuntimeOverride
-        Msg "    ✅ 已清理 QW_QODER_WORKER_RUNTIME_PATH" "    ✅ Cleaned QW_QODER_WORKER_RUNTIME_PATH"
-    }
+    $qoderInstalled = Test-Path (Join-Path $localAppData "Programs\QoderWork")
+    $qoderCNInstalled = (Test-Path (Join-Path $localAppData "Programs\QoderWorkCN")) -or `
+                        (Test-Path (Join-Path $localAppData "Programs\QoderWork CN"))
+    $qwenShouldEnable = $qwenInstalled -and (Test-AgentCollectionEnabled -AgentId 'qwen-work-cn')
+    $qoderShouldEnable = ($qoderInstalled -and (Test-AgentCollectionEnabled -AgentId 'qoder-work')) -or `
+                         ($qoderCNInstalled -and (Test-AgentCollectionEnabled -AgentId 'qoder-work-cn'))
 
-    Msg "    ⚠️  请完全退出并重新打开 QwenWorkCN 以生效" `
-        "    ⚠️  Fully quit and restart QwenWorkCN for changes to take effect"
+    $script:RUNTIME_ENV_BROADCAST_FAILED = $false
+    $script:RUNTIME_WRAPPER_MISSING = $false
+    Sync-PilotRuntimeOverride -Name 'QW_QODER_WORKER_RUNTIME_PATH' `
+        -ShouldEnable $qwenShouldEnable -WrapperPath $wrapperPath -ProductName 'QwenWorkCN'
+    Sync-PilotRuntimeOverride -Name 'QODER_WORKER_RUNTIME_PATH' `
+        -ShouldEnable $qoderShouldEnable -WrapperPath $wrapperPath -ProductName 'QoderWork'
+
+    if ($script:RUNTIME_WRAPPER_MISSING) {
+        Msg "    ⚠️  runtime wrapper 未完整部署，已跳过 token 拦截以避免影响应用" `
+            "    ⚠️  Runtime wrapper is missing; token interception was skipped to protect the apps"
+    } elseif ($script:RUNTIME_ENV_BROADCAST_FAILED) {
+        Msg "    ⚠️  环境变量已持久化，但无法通知 Explorer；请注销并重新登录 Windows" `
+            "    ⚠️  Environment persisted but Explorer could not be notified; sign out and back in"
+    } else {
+        Msg "    ⚠️  请完全退出并重新打开对应应用以生效" `
+            "    ⚠️  Fully quit and restart the corresponding apps for changes to take effect"
+    }
     Write-Host ""
 }
 
+# ============================================================
+# Install loongsuite-pilot command (batch wrapper)
+# ============================================================
 function Install-Command {
     Msg "==> 安装服务管理脚本..." "==> Installing service management script..."
     $binDir = Join-Path $env:USERPROFILE ".local\bin"
@@ -1891,7 +1947,7 @@ function Cmd-Install {
         Deploy-Package $script:INSTALL_SRC
         Write-Config
         Install-Command
-        Inject-QwenWorkCNRuntimeWrapper
+        Inject-QoderworkRuntimeWrapper
 
         Msg "==> 启动服务..." "==> Starting service..."
         $ps1Path = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot-service.ps1"
@@ -1960,7 +2016,7 @@ function Cmd-Upgrade {
 
         Deploy-Package $script:INSTALL_SRC
         Install-Command
-        Inject-QwenWorkCNRuntimeWrapper
+        Inject-QoderworkRuntimeWrapper
 
         Msg "==> 启动新版本..." "==> Starting new version..."
         $ps1Path = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot-service.ps1"
@@ -2450,13 +2506,20 @@ function Cmd-Uninstall {
     Remove-CodexTrustState
     Write-Host ""
 
-    Msg "==> 清理 QwenWorkCN 环境变量..." "==> Cleaning up QwenWorkCN env var..."
+    Msg "==> 清理 QoderWork 系列环境变量..." "==> Cleaning up QoderWork-family env vars..."
     $wrapperPath = Join-Path $DataDir "hooks\qoderwork-runtime-wrapper.mjs"
-    $currentQwenRuntime = Get-QwenWorkCNRuntimeOverride
-    if ($currentQwenRuntime -and $currentQwenRuntime -ieq $wrapperPath) {
-        Remove-QwenWorkCNRuntimeOverride
-        Msg "    ✅ 已移除 QW_QODER_WORKER_RUNTIME_PATH" `
-            "    ✅ Removed QW_QODER_WORKER_RUNTIME_PATH"
+    $script:RUNTIME_ENV_BROADCAST_FAILED = $false
+    foreach ($envName in @('QW_QODER_WORKER_RUNTIME_PATH', 'QODER_WORKER_RUNTIME_PATH')) {
+        $currentRuntime = Get-PilotRuntimeOverride -Name $envName
+        if ($currentRuntime -and $currentRuntime -ieq $wrapperPath) {
+            $broadcasted = Remove-PilotRuntimeOverride -Name $envName
+            if (-not $broadcasted) { $script:RUNTIME_ENV_BROADCAST_FAILED = $true }
+            Msg "    ✅ 已移除 $envName" "    ✅ Removed $envName"
+        }
+    }
+    if ($script:RUNTIME_ENV_BROADCAST_FAILED) {
+        Msg "    ⚠️  请注销并重新登录 Windows 以刷新 Explorer 环境" `
+            "    ⚠️  Sign out and back in to refresh the Explorer environment"
     }
     Write-Host ""
 

--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -2528,12 +2528,19 @@ function Cmd-Uninstall {
     Msg "==> 清理 QoderWork 系列环境变量..." "==> Cleaning up QoderWork-family env vars..."
     $wrapperPath = Join-Path $DataDir "hooks\qoderwork-runtime-wrapper.mjs"
     $script:RUNTIME_ENV_BROADCAST_FAILED = $false
+    $runtimeEnvCleanupFailed = $false
     foreach ($envName in @('QW_QODER_WORKER_RUNTIME_PATH', 'QODER_WORKER_RUNTIME_PATH')) {
-        $currentRuntime = Get-PilotRuntimeOverride -Name $envName
-        if ($currentRuntime -and $currentRuntime -ieq $wrapperPath) {
-            $broadcasted = Remove-PilotRuntimeOverride -Name $envName
-            if (-not $broadcasted) { $script:RUNTIME_ENV_BROADCAST_FAILED = $true }
-            Msg "    ✅ 已移除 $envName" "    ✅ Removed $envName"
+        try {
+            $currentRuntime = Get-PilotRuntimeOverride -Name $envName
+            if ($currentRuntime -and $currentRuntime -ieq $wrapperPath) {
+                $broadcasted = Remove-PilotRuntimeOverride -Name $envName
+                if (-not $broadcasted) { $script:RUNTIME_ENV_BROADCAST_FAILED = $true }
+                Msg "    ✅ 已移除 $envName" "    ✅ Removed $envName"
+            }
+        } catch {
+            $runtimeEnvCleanupFailed = $true
+            Msg "    ⚠️  清理 $envName 失败，已保留安装文件以便重试: $($_.Exception.Message)" `
+                "    ⚠️  Failed to clean $envName; installation files will be preserved for retry: $($_.Exception.Message)"
         }
     }
     if ($script:RUNTIME_ENV_BROADCAST_FAILED) {
@@ -2557,6 +2564,10 @@ function Cmd-Uninstall {
     Msg "==> 清理 MiMo Code 插件配置..." "==> Cleaning up MiMo Code plugin config..."
     Remove-MimoCodePlugin
     Write-Host ""
+
+    if ($runtimeEnvCleanupFailed) {
+        throw "Runtime environment cleanup failed; installation files were preserved for retry"
+    }
 
     # Keep the pinned node runtime and deployed helper assets available until
     # every external config and runtime override has been cleaned. In

--- a/src/core/hook-watchdog.ts
+++ b/src/core/hook-watchdog.ts
@@ -732,7 +732,16 @@ export class HookWatchdog {
           enabled: () => def.agentIds.some(agentId => isAgentEnabled(agentId)),
           precondition: async () => {
             if (!await fileExists(wrapperPath)) {
-              const removed = await cleanupOwnedWindowsUserEnv(def.envName, wrapperPath).catch(() => false);
+              let removed = false;
+              try {
+                removed = await cleanupOwnedWindowsUserEnv(def.envName, wrapperPath);
+              } catch (err) {
+                logger.debug('windows runtime override cleanup failed', {
+                  envName: def.envName,
+                  reason: 'wrapper-missing',
+                  error: String(err),
+                });
+              }
               if (removed) {
                 logger.warn('windows runtime wrapper missing; removed owned override', {
                   envName: def.envName,
@@ -744,7 +753,15 @@ export class HookWatchdog {
             for (const appPath of def.appInstallPaths) {
               if (await directoryExists(appPath)) return true;
             }
-            await cleanupOwnedWindowsUserEnv(def.envName, wrapperPath).catch(() => {});
+            try {
+              await cleanupOwnedWindowsUserEnv(def.envName, wrapperPath);
+            } catch (err) {
+              logger.debug('windows runtime override cleanup failed', {
+                envName: def.envName,
+                reason: 'app-missing',
+                error: String(err),
+              });
+            }
             return false;
           },
           check: async () => {
@@ -755,7 +772,7 @@ export class HookWatchdog {
             await setWindowsUserEnv(def.envName, wrapperPath);
           },
           cleanup: async () => {
-            await cleanupOwnedWindowsUserEnv(def.envName, wrapperPath).catch(() => {});
+            await cleanupOwnedWindowsUserEnv(def.envName, wrapperPath);
           },
         });
       }

--- a/src/core/hook-watchdog.ts
+++ b/src/core/hook-watchdog.ts
@@ -94,6 +94,18 @@ export function stripMarkerBlock(content: string, begin: string, end: string): s
   return out.join('\n');
 }
 
+export function parseWindowsUserEnv(output: string, envName: string): string {
+  for (const line of output.split(/\r?\n/)) {
+    const match = line.match(/^\s*(\S+)\s+REG_(?:EXPAND_)?SZ\s+(.*)$/);
+    if (match?.[1]?.toLowerCase() === envName.toLowerCase()) return match[2]?.trim() ?? '';
+  }
+  return '';
+}
+
+function windowsPathsEqual(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
 export interface CheckResult {
   checked: number;
   repaired: number;
@@ -648,10 +660,9 @@ export class HookWatchdog {
       }
     }
 
-    // ── QoderWork-family Windows User env vars ──
-    // On Windows, [Environment]::SetEnvironmentVariable(…, 'User') writes to
-    // HKCU\Environment — permanent across reboots, inherited by every new GUI
-    // process. Mirrors the macOS launchctl setenv + LaunchAgent plist pattern.
+    // ── QwenWorkCN Windows User env var ──
+    // HKCU\Environment is permanent across reboots and inherited by every new
+    // GUI process. Native reg.exe keeps this path compatible with CLM/WDAC.
     if (process.platform === 'win32') {
       const wrapperPath = path.join(dataDir, 'hooks', 'qoderwork-runtime-wrapper.mjs');
       for (const def of HookWatchdog.winRuntimeInterceptDefs()) {
@@ -667,35 +678,31 @@ export class HookWatchdog {
           },
           check: async () => {
             try {
-              const { execFileSync } = await import('child_process');
-              const current = execFileSync('powershell.exe', [
-                '-NoProfile', '-NonInteractive', '-Command',
-                `[Environment]::GetEnvironmentVariable('${def.envName}', 'User')`,
-              ], { encoding: 'utf8', timeout: 10_000 }).trim();
-              return current === wrapperPath;
+              const { stdout } = await execFileAsync('reg.exe', [
+                'query', 'HKCU\\Environment', '/v', def.envName,
+              ], { encoding: 'utf8', timeout: 10_000, windowsHide: true });
+              const current = parseWindowsUserEnv(stdout, def.envName);
+              return windowsPathsEqual(current, wrapperPath);
             } catch {
               return false;
             }
           },
           repair: async () => {
-            const { execFileSync } = await import('child_process');
-            execFileSync('powershell.exe', [
-              '-NoProfile', '-NonInteractive', '-Command',
-              `[Environment]::SetEnvironmentVariable('${def.envName}', '${wrapperPath}', 'User')`,
-            ], { timeout: 10_000 });
+            await execFileAsync('reg.exe', [
+              'add', 'HKCU\\Environment', '/v', def.envName,
+              '/t', 'REG_SZ', '/d', wrapperPath, '/f',
+            ], { timeout: 10_000, windowsHide: true });
           },
           cleanup: async () => {
             try {
-              const { execFileSync } = await import('child_process');
-              const current = execFileSync('powershell.exe', [
-                '-NoProfile', '-NonInteractive', '-Command',
-                `[Environment]::GetEnvironmentVariable('${def.envName}', 'User')`,
-              ], { encoding: 'utf8', timeout: 10_000 }).trim();
-              if (current === wrapperPath) {
-                execFileSync('powershell.exe', [
-                  '-NoProfile', '-NonInteractive', '-Command',
-                  `[Environment]::SetEnvironmentVariable('${def.envName}', $null, 'User')`,
-                ], { timeout: 10_000 });
+              const { stdout } = await execFileAsync('reg.exe', [
+                'query', 'HKCU\\Environment', '/v', def.envName,
+              ], { encoding: 'utf8', timeout: 10_000, windowsHide: true });
+              const current = parseWindowsUserEnv(stdout, def.envName);
+              if (windowsPathsEqual(current, wrapperPath)) {
+                await execFileAsync('reg.exe', [
+                  'delete', 'HKCU\\Environment', '/v', def.envName, '/f',
+                ], { timeout: 10_000, windowsHide: true });
               }
             } catch {
               // Best-effort cleanup.
@@ -800,7 +807,7 @@ export class HookWatchdog {
     ];
   }
 
-  /** Windows equivalent of macRuntimeInterceptDefs — User-level env vars. */
+  /** Windows QwenWorkCN User-level runtime override. */
   static winRuntimeInterceptDefs(): WinRuntimeInterceptDefinition[] {
     const localAppData = process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
     return [
@@ -809,15 +816,6 @@ export class HookWatchdog {
         envName: 'QW_QODER_WORKER_RUNTIME_PATH',
         agentIds: ['qwen-work-cn'],
         appInstallPaths: [path.join(localAppData, 'Programs', 'QwenWorkCN')],
-      },
-      {
-        id: 'qoderwork-win-env',
-        envName: 'QODER_WORKER_RUNTIME_PATH',
-        agentIds: ['qoder-work', 'qoder-work-cn'],
-        appInstallPaths: [
-          path.join(localAppData, 'Programs', 'QoderWork'),
-          path.join(localAppData, 'Programs', 'QoderWorkCN'),
-        ],
       },
     ];
   }

--- a/src/core/hook-watchdog.ts
+++ b/src/core/hook-watchdog.ts
@@ -106,6 +106,67 @@ function windowsPathsEqual(left: string, right: string): boolean {
   return left.toLowerCase() === right.toLowerCase();
 }
 
+async function readWindowsUserEnv(envName: string): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync('reg.exe', [
+      'query', 'HKCU\\Environment', '/v', envName,
+    ], { encoding: 'utf8', timeout: 10_000, windowsHide: true });
+    return parseWindowsUserEnv(stdout, envName);
+  } catch {
+    return '';
+  }
+}
+
+async function broadcastWindowsUserEnv(envName: string, value: string | null): Promise<boolean> {
+  const valueExpr = value === null ? '$null' : '$env:LOONGSUITE_PILOT_RUNTIME_ENV_VALUE';
+  const command = [
+    "$ErrorActionPreference = 'Stop'",
+    `try { [Environment]::SetEnvironmentVariable($env:LOONGSUITE_PILOT_RUNTIME_ENV_NAME, ${valueExpr}, 'User'); exit 0 } catch { exit 1 }`,
+  ].join('; ');
+  try {
+    await execFileAsync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', command], {
+      timeout: 10_000,
+      windowsHide: true,
+      env: {
+        ...process.env,
+        LOONGSUITE_PILOT_RUNTIME_ENV_NAME: envName,
+        ...(value === null ? {} : { LOONGSUITE_PILOT_RUNTIME_ENV_VALUE: value }),
+      },
+    });
+    return true;
+  } catch {
+    logger.warn('windows runtime environment persisted but broadcast failed', {
+      envName,
+      action: 'sign out and back in to refresh Explorer',
+    });
+    return false;
+  }
+}
+
+async function setWindowsUserEnv(envName: string, value: string): Promise<void> {
+  await execFileAsync('reg.exe', [
+    'add', 'HKCU\\Environment', '/v', envName,
+    '/t', 'REG_SZ', '/d', value, '/f',
+  ], { timeout: 10_000, windowsHide: true });
+  await broadcastWindowsUserEnv(envName, value);
+}
+
+async function removeWindowsUserEnv(envName: string): Promise<void> {
+  await execFileAsync('reg.exe', [
+    'delete', 'HKCU\\Environment', '/v', envName, '/f',
+  ], { timeout: 10_000, windowsHide: true });
+  await broadcastWindowsUserEnv(envName, null);
+}
+
+async function cleanupOwnedWindowsUserEnv(envName: string, wrapperPath: string): Promise<boolean> {
+  const current = await readWindowsUserEnv(envName);
+  if (current && windowsPathsEqual(current, wrapperPath)) {
+    await removeWindowsUserEnv(envName);
+    return true;
+  }
+  return false;
+}
+
 export interface CheckResult {
   checked: number;
   repaired: number;
@@ -660,7 +721,7 @@ export class HookWatchdog {
       }
     }
 
-    // ── QwenWorkCN Windows User env var ──
+    // ── QoderWork-family Windows User env vars ──
     // HKCU\Environment is permanent across reboots and inherited by every new
     // GUI process. Native reg.exe keeps this path compatible with CLM/WDAC.
     if (process.platform === 'win32') {
@@ -670,43 +731,31 @@ export class HookWatchdog {
           id: def.id,
           enabled: () => def.agentIds.some(agentId => isAgentEnabled(agentId)),
           precondition: async () => {
-            if (!await fileExists(wrapperPath)) return false;
+            if (!await fileExists(wrapperPath)) {
+              const removed = await cleanupOwnedWindowsUserEnv(def.envName, wrapperPath).catch(() => false);
+              if (removed) {
+                logger.warn('windows runtime wrapper missing; removed owned override', {
+                  envName: def.envName,
+                  wrapperPath,
+                });
+              }
+              return false;
+            }
             for (const appPath of def.appInstallPaths) {
               if (await directoryExists(appPath)) return true;
             }
+            await cleanupOwnedWindowsUserEnv(def.envName, wrapperPath).catch(() => {});
             return false;
           },
           check: async () => {
-            try {
-              const { stdout } = await execFileAsync('reg.exe', [
-                'query', 'HKCU\\Environment', '/v', def.envName,
-              ], { encoding: 'utf8', timeout: 10_000, windowsHide: true });
-              const current = parseWindowsUserEnv(stdout, def.envName);
-              return windowsPathsEqual(current, wrapperPath);
-            } catch {
-              return false;
-            }
+            const current = await readWindowsUserEnv(def.envName);
+            return windowsPathsEqual(current, wrapperPath);
           },
           repair: async () => {
-            await execFileAsync('reg.exe', [
-              'add', 'HKCU\\Environment', '/v', def.envName,
-              '/t', 'REG_SZ', '/d', wrapperPath, '/f',
-            ], { timeout: 10_000, windowsHide: true });
+            await setWindowsUserEnv(def.envName, wrapperPath);
           },
           cleanup: async () => {
-            try {
-              const { stdout } = await execFileAsync('reg.exe', [
-                'query', 'HKCU\\Environment', '/v', def.envName,
-              ], { encoding: 'utf8', timeout: 10_000, windowsHide: true });
-              const current = parseWindowsUserEnv(stdout, def.envName);
-              if (windowsPathsEqual(current, wrapperPath)) {
-                await execFileAsync('reg.exe', [
-                  'delete', 'HKCU\\Environment', '/v', def.envName, '/f',
-                ], { timeout: 10_000, windowsHide: true });
-              }
-            } catch {
-              // Best-effort cleanup.
-            }
+            await cleanupOwnedWindowsUserEnv(def.envName, wrapperPath).catch(() => {});
           },
         });
       }
@@ -807,7 +856,7 @@ export class HookWatchdog {
     ];
   }
 
-  /** Windows QwenWorkCN User-level runtime override. */
+  /** Windows product-specific User-level runtime overrides. */
   static winRuntimeInterceptDefs(): WinRuntimeInterceptDefinition[] {
     const localAppData = process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
     return [
@@ -816,6 +865,16 @@ export class HookWatchdog {
         envName: 'QW_QODER_WORKER_RUNTIME_PATH',
         agentIds: ['qwen-work-cn'],
         appInstallPaths: [path.join(localAppData, 'Programs', 'QwenWorkCN')],
+      },
+      {
+        id: 'qoderwork-win-env',
+        envName: 'QODER_WORKER_RUNTIME_PATH',
+        agentIds: ['qoder-work', 'qoder-work-cn'],
+        appInstallPaths: [
+          path.join(localAppData, 'Programs', 'QoderWork'),
+          path.join(localAppData, 'Programs', 'QoderWorkCN'),
+          path.join(localAppData, 'Programs', 'QoderWork CN'),
+        ],
       },
     ];
   }

--- a/src/core/hook-watchdog.ts
+++ b/src/core/hook-watchdog.ts
@@ -71,6 +71,13 @@ export interface MacRuntimeInterceptDefinition {
   appNames: string[];
 }
 
+export interface WinRuntimeInterceptDefinition {
+  id: string;
+  envName: string;
+  agentIds: string[];
+  appInstallPaths: string[];
+}
+
 /**
  * Remove a marker-delimited block (inclusive of the BEGIN/END marker lines)
  * from rc-file content. Any line containing `begin` starts the cut and any
@@ -641,6 +648,63 @@ export class HookWatchdog {
       }
     }
 
+    // ── QoderWork-family Windows User env vars ──
+    // On Windows, [Environment]::SetEnvironmentVariable(…, 'User') writes to
+    // HKCU\Environment — permanent across reboots, inherited by every new GUI
+    // process. Mirrors the macOS launchctl setenv + LaunchAgent plist pattern.
+    if (process.platform === 'win32') {
+      const wrapperPath = path.join(dataDir, 'hooks', 'qoderwork-runtime-wrapper.mjs');
+      for (const def of HookWatchdog.winRuntimeInterceptDefs()) {
+        targets.push({
+          id: def.id,
+          enabled: () => def.agentIds.some(agentId => isAgentEnabled(agentId)),
+          precondition: async () => {
+            if (!await fileExists(wrapperPath)) return false;
+            for (const appPath of def.appInstallPaths) {
+              if (await directoryExists(appPath)) return true;
+            }
+            return false;
+          },
+          check: async () => {
+            try {
+              const { execFileSync } = await import('child_process');
+              const current = execFileSync('powershell.exe', [
+                '-NoProfile', '-NonInteractive', '-Command',
+                `[Environment]::GetEnvironmentVariable('${def.envName}', 'User')`,
+              ], { encoding: 'utf8', timeout: 10_000 }).trim();
+              return current === wrapperPath;
+            } catch {
+              return false;
+            }
+          },
+          repair: async () => {
+            const { execFileSync } = await import('child_process');
+            execFileSync('powershell.exe', [
+              '-NoProfile', '-NonInteractive', '-Command',
+              `[Environment]::SetEnvironmentVariable('${def.envName}', '${wrapperPath}', 'User')`,
+            ], { timeout: 10_000 });
+          },
+          cleanup: async () => {
+            try {
+              const { execFileSync } = await import('child_process');
+              const current = execFileSync('powershell.exe', [
+                '-NoProfile', '-NonInteractive', '-Command',
+                `[Environment]::GetEnvironmentVariable('${def.envName}', 'User')`,
+              ], { encoding: 'utf8', timeout: 10_000 }).trim();
+              if (current === wrapperPath) {
+                execFileSync('powershell.exe', [
+                  '-NoProfile', '-NonInteractive', '-Command',
+                  `[Environment]::SetEnvironmentVariable('${def.envName}', $null, 'User')`,
+                ], { timeout: 10_000 });
+              }
+            } catch {
+              // Best-effort cleanup.
+            }
+          },
+        });
+      }
+    }
+
     // ── Shell rc intercept targets (qodercli + claude-code) ──
     // Check BOTH .zshrc and .bashrc regardless of daemon's $SHELL — the
     // daemon is launchd-started and its $SHELL may not match the user's
@@ -732,6 +796,28 @@ export class HookWatchdog {
         plistLabel: 'com.loongsuite-pilot.qwenworkcn-env',
         agentIds: ['qwen-work-cn'],
         appNames: ['QwenWorkCN.app'],
+      },
+    ];
+  }
+
+  /** Windows equivalent of macRuntimeInterceptDefs — User-level env vars. */
+  static winRuntimeInterceptDefs(): WinRuntimeInterceptDefinition[] {
+    const localAppData = process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
+    return [
+      {
+        id: 'qwenworkcn-win-env',
+        envName: 'QW_QODER_WORKER_RUNTIME_PATH',
+        agentIds: ['qwen-work-cn'],
+        appInstallPaths: [path.join(localAppData, 'Programs', 'QwenWorkCN')],
+      },
+      {
+        id: 'qoderwork-win-env',
+        envName: 'QODER_WORKER_RUNTIME_PATH',
+        agentIds: ['qoder-work', 'qoder-work-cn'],
+        appInstallPaths: [
+          path.join(localAppData, 'Programs', 'QoderWork'),
+          path.join(localAppData, 'Programs', 'QoderWorkCN'),
+        ],
       },
     ];
   }

--- a/tests/unit/core/hook-watchdog-intercept.test.ts
+++ b/tests/unit/core/hook-watchdog-intercept.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import {
   HookWatchdog,
+  parseWindowsUserEnv,
   stripMarkerBlock,
   type InterceptCheckTarget,
 } from '../../../src/core/hook-watchdog.js';
@@ -302,6 +303,30 @@ describe('HookWatchdog.defaultInterceptTargets', () => {
       expect(installer).toContain(def.plistLabel);
       for (const appName of def.appNames) expect(installer).toContain(appName);
     }
+  });
+
+  it('keeps the Windows runtime target scoped to QwenWorkCN', () => {
+    const defs = HookWatchdog.winRuntimeInterceptDefs();
+    expect(defs).toHaveLength(1);
+    expect(defs[0]).toMatchObject({
+      id: 'qwenworkcn-win-env',
+      envName: 'QW_QODER_WORKER_RUNTIME_PATH',
+      agentIds: ['qwen-work-cn'],
+    });
+    expect(defs.flatMap(def => def.agentIds)).not.toContain('qoder-work');
+    expect(defs.flatMap(def => def.agentIds)).not.toContain('qoder-work-cn');
+  });
+
+  it('parses a Windows User environment value from reg.exe output', () => {
+    const output = [
+      '',
+      'HKEY_CURRENT_USER\\Environment',
+      '    QW_QODER_WORKER_RUNTIME_PATH    REG_SZ    C:\\Pilot Data\\hooks\\qoderwork-runtime-wrapper.mjs',
+      '',
+    ].join('\r\n');
+    expect(parseWindowsUserEnv(output, 'QW_QODER_WORKER_RUNTIME_PATH')).toBe(
+      'C:\\Pilot Data\\hooks\\qoderwork-runtime-wrapper.mjs',
+    );
   });
 
   it('defaults every target to enabled when no gate is passed', () => {

--- a/tests/unit/core/hook-watchdog-intercept.test.ts
+++ b/tests/unit/core/hook-watchdog-intercept.test.ts
@@ -322,16 +322,36 @@ describe('HookWatchdog.defaultInterceptTargets', () => {
     ]));
   });
 
-  it('parses a Windows User environment value from reg.exe output', () => {
+  it.each(['REG_SZ', 'REG_EXPAND_SZ'])('parses a Windows %s User environment value', (registryType) => {
     const output = [
       '',
       'HKEY_CURRENT_USER\\Environment',
-      '    QW_QODER_WORKER_RUNTIME_PATH    REG_SZ    C:\\Pilot Data\\hooks\\qoderwork-runtime-wrapper.mjs',
+      `    QW_QODER_WORKER_RUNTIME_PATH    ${registryType}    C:\\Pilot Data\\hooks\\qoderwork-runtime-wrapper.mjs`,
       '',
     ].join('\r\n');
     expect(parseWindowsUserEnv(output, 'QW_QODER_WORKER_RUNTIME_PATH')).toBe(
       'C:\\Pilot Data\\hooks\\qoderwork-runtime-wrapper.mjs',
     );
+  });
+
+  it('returns an empty value when the Windows User environment override is absent', () => {
+    expect(parseWindowsUserEnv('', 'QW_QODER_WORKER_RUNTIME_PATH')).toBe('');
+    expect(parseWindowsUserEnv(
+      '    UNRELATED_RUNTIME_PATH    REG_SZ    C:\\vendor\\runtime.mjs',
+      'QW_QODER_WORKER_RUNTIME_PATH',
+    )).toBe('');
+  });
+
+  it('keeps Windows runtime cleanup failures observable', () => {
+    const source = readFileSync(resolve('src/core/hook-watchdog.ts'), 'utf-8');
+    const windowsSection = source.slice(
+      source.indexOf('// ── QoderWork-family Windows User env vars'),
+      source.indexOf('// ── Shell rc intercept targets'),
+    );
+    expect(windowsSection).toContain("logger.debug('windows runtime override cleanup failed'");
+    expect(windowsSection).toContain("reason: 'wrapper-missing'");
+    expect(windowsSection).toContain("reason: 'app-missing'");
+    expect(windowsSection).not.toContain('cleanupOwnedWindowsUserEnv(def.envName, wrapperPath).catch');
   });
 
   it('defaults every target to enabled when no gate is passed', () => {

--- a/tests/unit/core/hook-watchdog-intercept.test.ts
+++ b/tests/unit/core/hook-watchdog-intercept.test.ts
@@ -305,16 +305,21 @@ describe('HookWatchdog.defaultInterceptTargets', () => {
     }
   });
 
-  it('keeps the Windows runtime target scoped to QwenWorkCN', () => {
+  it('keeps independent Windows runtime targets for QwenWorkCN and QoderWork', () => {
     const defs = HookWatchdog.winRuntimeInterceptDefs();
-    expect(defs).toHaveLength(1);
-    expect(defs[0]).toMatchObject({
-      id: 'qwenworkcn-win-env',
-      envName: 'QW_QODER_WORKER_RUNTIME_PATH',
-      agentIds: ['qwen-work-cn'],
-    });
-    expect(defs.flatMap(def => def.agentIds)).not.toContain('qoder-work');
-    expect(defs.flatMap(def => def.agentIds)).not.toContain('qoder-work-cn');
+    expect(defs).toHaveLength(2);
+    expect(defs).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'qwenworkcn-win-env',
+        envName: 'QW_QODER_WORKER_RUNTIME_PATH',
+        agentIds: ['qwen-work-cn'],
+      }),
+      expect.objectContaining({
+        id: 'qoderwork-win-env',
+        envName: 'QODER_WORKER_RUNTIME_PATH',
+        agentIds: ['qoder-work', 'qoder-work-cn'],
+      }),
+    ]));
   });
 
   it('parses a Windows User environment value from reg.exe output', () => {

--- a/tests/unit/deploy/installer-uninstall-cleanup.test.mjs
+++ b/tests/unit/deploy/installer-uninstall-cleanup.test.mjs
@@ -515,35 +515,53 @@ describe('uninstall only cleans the managed Hermes directory plugin', () => {
   });
 });
 
-describe('Windows QwenWorkCN runtime override lifecycle', () => {
-  const qwenRuntimeSection = ps1.slice(
-    ps1.indexOf('function Get-QwenWorkCNRuntimeOverride'),
+describe('Windows QoderWork-family runtime override lifecycle', () => {
+  const runtimeSection = ps1.slice(
+    ps1.indexOf('function Get-PilotRuntimeOverride'),
     ps1.indexOf('function Install-Command'),
   );
   const uninstall = ps1.slice(ps1.indexOf('function Cmd-Uninstall'));
 
-  it('uses the final agent config and the dedicated Qwen environment variable', () => {
-    expect(qwenRuntimeSection).toContain("config?.agents?.['qwen-work-cn']?.enabled === false");
-    expect(qwenRuntimeSection).toContain('QW_QODER_WORKER_RUNTIME_PATH');
-    expect(qwenRuntimeSection).not.toMatch(/\bQODER_WORKER_RUNTIME_PATH\b/);
-    expect(ps1.match(/Inject-QwenWorkCNRuntimeWrapper/g)).toHaveLength(3);
+  it('uses the final agent config and independently maintains both environment variables', () => {
+    expect(runtimeSection).toContain('config?.agents?.[agentId]?.enabled === false');
+    expect(runtimeSection).toContain('QW_QODER_WORKER_RUNTIME_PATH');
+    expect(runtimeSection).toMatch(/\bQODER_WORKER_RUNTIME_PATH\b/);
+    expect(runtimeSection).toContain("Test-AgentCollectionEnabled -AgentId 'qwen-work-cn'");
+    expect(runtimeSection).toContain("Test-AgentCollectionEnabled -AgentId 'qoder-work'");
+    expect(runtimeSection).toContain("Test-AgentCollectionEnabled -AgentId 'qoder-work-cn'");
+    expect(ps1.match(/Inject-QoderworkRuntimeWrapper/g)).toHaveLength(3);
   });
 
-  it('uses CLM-safe registry commands instead of Environment static methods', () => {
-    expect(qwenRuntimeSection).toContain('reg query "HKCU\\Environment"');
-    expect(qwenRuntimeSection).toContain('reg add "HKCU\\Environment"');
-    expect(qwenRuntimeSection).toContain('reg delete "HKCU\\Environment"');
-    expect(qwenRuntimeSection).not.toContain('[Environment]::');
+  it('uses CLM-safe registry persistence with a guarded Explorer broadcast', () => {
+    expect(runtimeSection).toContain('reg.exe query "HKCU\\Environment"');
+    expect(runtimeSection).toContain('reg.exe add "HKCU\\Environment"');
+    expect(runtimeSection).toContain('reg.exe delete "HKCU\\Environment"');
+    expect(runtimeSection).toContain('[Environment]::SetEnvironmentVariable');
+    expect(runtimeSection).toContain('catch {');
+    expect(runtimeSection).toContain('sign out and back in');
   });
 
-  it('does not add Windows QoderWork runtime lifecycle management', () => {
-    expect(ps1).not.toMatch(/\bQODER_WORKER_RUNTIME_PATH\b/);
-    expect(ps1).not.toContain('QoderWork\\QoderWork.exe');
-    expect(ps1).not.toContain('QoderWorkCN\\QoderWorkCN.exe');
+  it('detects app roots without assuming executables are outside version directories', () => {
+    expect(runtimeSection).toContain('Programs\\QwenWorkCN');
+    expect(runtimeSection).toContain('Programs\\QoderWork');
+    expect(runtimeSection).toContain('Programs\\QoderWorkCN');
+    expect(runtimeSection).toContain('Programs\\QoderWork CN');
+    expect(runtimeSection).not.toContain('QoderWork\\QoderWork.exe');
+    expect(runtimeSection).not.toContain('QoderWorkCN\\QoderWorkCN.exe');
   });
 
-  it('uninstalls only the override owned by the current dataDir', () => {
-    expect(uninstall).toContain('$currentQwenRuntime -ieq $wrapperPath');
+  it('cleans an owned override before returning when the wrapper is missing', () => {
+    const sync = runtimeSection.slice(runtimeSection.indexOf('function Sync-PilotRuntimeOverride'));
+    expect(sync.indexOf('Get-PilotRuntimeOverride')).toBeLessThan(sync.indexOf('Test-Path $WrapperPath'));
+    expect(sync).toContain('Remove-PilotRuntimeOverride -Name $Name');
+    expect(sync).toContain('Wrapper missing; cleaned $Name');
+    expect(sync).toContain('Wrapper missing; did not set $Name');
+    expect(sync).toContain('$script:RUNTIME_WRAPPER_MISSING = $true');
+  });
+
+  it('uninstalls both overrides only when owned by the current dataDir', () => {
+    expect(uninstall).toContain("@('QW_QODER_WORKER_RUNTIME_PATH', 'QODER_WORKER_RUNTIME_PATH')");
+    expect(uninstall).toContain('$currentRuntime -ieq $wrapperPath');
     expect(uninstall).not.toContain("*\\hooks\\qoderwork-runtime-wrapper.mjs");
   });
 });

--- a/tests/unit/deploy/installer-uninstall-cleanup.test.mjs
+++ b/tests/unit/deploy/installer-uninstall-cleanup.test.mjs
@@ -514,3 +514,36 @@ describe('uninstall only cleans the managed Hermes directory plugin', () => {
       .toContain('Remove-HermesPluginForRollback');
   });
 });
+
+describe('Windows QwenWorkCN runtime override lifecycle', () => {
+  const qwenRuntimeSection = ps1.slice(
+    ps1.indexOf('function Get-QwenWorkCNRuntimeOverride'),
+    ps1.indexOf('function Install-Command'),
+  );
+  const uninstall = ps1.slice(ps1.indexOf('function Cmd-Uninstall'));
+
+  it('uses the final agent config and the dedicated Qwen environment variable', () => {
+    expect(qwenRuntimeSection).toContain("config?.agents?.['qwen-work-cn']?.enabled === false");
+    expect(qwenRuntimeSection).toContain('QW_QODER_WORKER_RUNTIME_PATH');
+    expect(qwenRuntimeSection).not.toMatch(/\bQODER_WORKER_RUNTIME_PATH\b/);
+    expect(ps1.match(/Inject-QwenWorkCNRuntimeWrapper/g)).toHaveLength(3);
+  });
+
+  it('uses CLM-safe registry commands instead of Environment static methods', () => {
+    expect(qwenRuntimeSection).toContain('reg query "HKCU\\Environment"');
+    expect(qwenRuntimeSection).toContain('reg add "HKCU\\Environment"');
+    expect(qwenRuntimeSection).toContain('reg delete "HKCU\\Environment"');
+    expect(qwenRuntimeSection).not.toContain('[Environment]::');
+  });
+
+  it('does not add Windows QoderWork runtime lifecycle management', () => {
+    expect(ps1).not.toMatch(/\bQODER_WORKER_RUNTIME_PATH\b/);
+    expect(ps1).not.toContain('QoderWork\\QoderWork.exe');
+    expect(ps1).not.toContain('QoderWorkCN\\QoderWorkCN.exe');
+  });
+
+  it('uninstalls only the override owned by the current dataDir', () => {
+    expect(uninstall).toContain('$currentQwenRuntime -ieq $wrapperPath');
+    expect(uninstall).not.toContain("*\\hooks\\qoderwork-runtime-wrapper.mjs");
+  });
+});

--- a/tests/unit/deploy/installer-uninstall-cleanup.test.mjs
+++ b/tests/unit/deploy/installer-uninstall-cleanup.test.mjs
@@ -331,6 +331,38 @@ describe('Windows uninstall has dedicated Codex hook cleanup', () => {
     expect(uninstall.indexOf('Remove-CodexHookConfig'))
       .toBeLessThan(uninstall.indexOf('Remove-CodexTrustState'));
   });
+
+  it('passes a valid fs module literal to node when rewriting Codex files', () => {
+    const writer = ps1.slice(
+      ps1.indexOf('function Write-FileUtf8NoBom'),
+      ps1.indexOf('function Remove-CodexTrustState'),
+    );
+    expect(writer).toContain("$rewriteScript = @'");
+    expect(writer).toContain("const fs = require('fs');");
+    expect(writer).not.toContain("-e 'const fs=require(\"fs\")");
+    expect(writer).toContain('if ($rewriteExit -ne 0)');
+
+    const script = writer.match(/\$rewriteScript = @'\r?\n([\s\S]*?)\r?\n'@/)?.[1];
+    expect(script).toBeDefined();
+    const root = mkdtempSync(join(tmpdir(), 'pilot-codex-rewrite-'));
+    try {
+      const input = join(root, 'input.txt');
+      const output = join(root, 'output.txt');
+      writeFileSync(input, '\uFEFFcodex-hook-config', 'utf8');
+      const run = spawnSync(process.execPath, ['-e', script, input, output], { encoding: 'utf8' });
+      expect(run.status, run.stderr).toBe(0);
+      expect(readFileSync(output, 'utf8')).toBe('codex-hook-config');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('continues uninstall when dedicated Codex cleanup fails', () => {
+    const uninstall = ps1.slice(ps1.indexOf('function Cmd-Uninstall'));
+    expect(uninstall).toMatch(/try\s*\{\s*Remove-CodexHookConfig\s*\}\s*catch\s*\{/);
+    expect(uninstall).toMatch(/try\s*\{\s*Remove-CodexTrustState\s*\}\s*catch\s*\{/);
+    expect(uninstall).toContain('Codex hook cleanup failed; continuing uninstall');
+  });
 });
 
 describe('uninstall cleans the MiMo Code plugin-inject spec', () => {
@@ -576,5 +608,14 @@ describe('Windows QoderWork-family runtime override lifecycle', () => {
     expect(uninstall).toContain("@('QW_QODER_WORKER_RUNTIME_PATH', 'QODER_WORKER_RUNTIME_PATH')");
     expect(uninstall).toContain('$currentRuntime -ieq $wrapperPath');
     expect(uninstall).not.toContain("*\\hooks\\qoderwork-runtime-wrapper.mjs");
+  });
+
+  it('cleans hook configs and runtime overrides before deleting their files and pinned node', () => {
+    expect(uninstall.indexOf('Remove-HookConfigs'))
+      .toBeLessThan(uninstall.indexOf("@('QW_QODER_WORKER_RUNTIME_PATH', 'QODER_WORKER_RUNTIME_PATH')"));
+    expect(uninstall.indexOf("@('QW_QODER_WORKER_RUNTIME_PATH', 'QODER_WORKER_RUNTIME_PATH')"))
+      .toBeLessThan(uninstall.indexOf('Remove-PilotInstallationFiles'));
+    expect(uninstall.indexOf('Remove-MimoCodePlugin'))
+      .toBeLessThan(uninstall.indexOf('Remove-PilotInstallationFiles'));
   });
 });

--- a/tests/unit/deploy/installer-uninstall-cleanup.test.mjs
+++ b/tests/unit/deploy/installer-uninstall-cleanup.test.mjs
@@ -541,6 +541,19 @@ describe('Windows QoderWork-family runtime override lifecycle', () => {
     expect(runtimeSection).toContain('sign out and back in');
   });
 
+  it('treats a missing runtime override as absent instead of aborting under ErrorActionPreference Stop', () => {
+    const getter = runtimeSection.slice(
+      runtimeSection.indexOf('function Get-PilotRuntimeOverride'),
+      runtimeSection.indexOf('function Test-AgentCollectionEnabled'),
+    );
+    expect(getter).toContain('$prevEAP = $ErrorActionPreference');
+    expect(getter).toContain('$ErrorActionPreference = "Continue"');
+    expect(getter).toContain('$regExitCode = $LASTEXITCODE');
+    expect(getter).toContain('$ErrorActionPreference = $prevEAP');
+    expect(getter.indexOf('$ErrorActionPreference = $prevEAP'))
+      .toBeLessThan(getter.indexOf('if ($regExitCode -ne 0)'));
+  });
+
   it('detects app roots without assuming executables are outside version directories', () => {
     expect(runtimeSection).toContain('Programs\\QwenWorkCN');
     expect(runtimeSection).toContain('Programs\\QoderWork');

--- a/tests/unit/deploy/installer-uninstall-cleanup.test.mjs
+++ b/tests/unit/deploy/installer-uninstall-cleanup.test.mjs
@@ -610,6 +610,20 @@ describe('Windows QoderWork-family runtime override lifecycle', () => {
     expect(uninstall).not.toContain("*\\hooks\\qoderwork-runtime-wrapper.mjs");
   });
 
+  it('continues external cleanup but preserves retry assets when runtime env cleanup fails', () => {
+    const envCleanup = uninstall.slice(
+      uninstall.indexOf("foreach ($envName in @('QW_QODER_WORKER_RUNTIME_PATH', 'QODER_WORKER_RUNTIME_PATH'))"),
+      uninstall.indexOf('if ($script:RUNTIME_ENV_BROADCAST_FAILED)'),
+    );
+    expect(envCleanup).toMatch(/foreach[\s\S]*try\s*\{[\s\S]*Remove-PilotRuntimeOverride[\s\S]*\}\s*catch\s*\{/);
+    expect(envCleanup).toContain('$runtimeEnvCleanupFailed = $true');
+    expect(uninstall.indexOf('Remove-MimoCodePlugin'))
+      .toBeLessThan(uninstall.indexOf('if ($runtimeEnvCleanupFailed)'));
+    expect(uninstall.indexOf('if ($runtimeEnvCleanupFailed)'))
+      .toBeLessThan(uninstall.indexOf('Remove-PilotInstallationFiles'));
+    expect(uninstall).toContain('installation files were preserved for retry');
+  });
+
   it('cleans hook configs and runtime overrides before deleting their files and pinned node', () => {
     expect(uninstall.indexOf('Remove-HookConfigs'))
       .toBeLessThan(uninstall.indexOf("@('QW_QODER_WORKER_RUNTIME_PATH', 'QODER_WORKER_RUNTIME_PATH')"));

--- a/tests/unit/hooks/qoderwork-runtime-wrapper.test.mjs
+++ b/tests/unit/hooks/qoderwork-runtime-wrapper.test.mjs
@@ -63,7 +63,7 @@ describe('QoderWork-family runtime wrapper forwarding', () => {
     });
   });
 
-  it('recognizes QwenWorkCN from a Windows resources path', async () => {
+  it('recognizes QwenWorkCN from a direct Windows resources path', async () => {
     const marker = path.join(root, 'windows-qwen-runtime-loaded');
     const resources = await createWindowsHostRuntime('QwenWorkCN', marker);
 
@@ -80,15 +80,43 @@ describe('QoderWork-family runtime wrapper forwarding', () => {
     });
   });
 
-  it('does not classify a Windows sibling from the global Qwen env var', async () => {
-    const marker = path.join(root, 'windows-qoder-runtime-loaded');
-    const resources = await createWindowsHostRuntime('QoderWork', marker);
+  it.each([
+    ['QwenWorkCN', '0.1.8-26081406', 'qwenworkcn-intercept.jsonl'],
+    ['QoderWork', '0.1.8-26081406', 'qoderwork-intercept.jsonl'],
+    ['QoderWorkCN', '0.1.8-26081406', 'qoderworkcn-intercept.jsonl'],
+    ['QoderWork CN', '0.1.8-26081406', 'qoderworkcn-intercept.jsonl'],
+  ])('classifies versioned Windows %s resources without cross-agent writes', async (
+    appName,
+    version,
+    expectedIntercept,
+  ) => {
+    const marker = path.join(root, `windows-${appName}-runtime-loaded`);
+    const resources = await createWindowsHostRuntime(appName, marker, version);
+
+    runWrapper(resources, marker, {
+      QW_QODER_WORKER_RUNTIME_PATH: wrapper,
+      QODER_WORKER_RUNTIME_PATH: wrapper,
+    });
+
+    expect(await fs.readFile(marker, 'utf-8')).toBe('loaded');
+    for (const intercept of [
+      'qwenworkcn-intercept.jsonl',
+      'qoderwork-intercept.jsonl',
+      'qoderworkcn-intercept.jsonl',
+    ]) {
+      expect(existsSync(path.join(dataDir, 'logs', intercept))).toBe(intercept === expectedIntercept);
+    }
+  });
+
+  it('does not classify a deeper unrelated Windows descendant as an app host', async () => {
+    const marker = path.join(root, 'windows-nested-runtime-loaded');
+    const resources = path.join(root, 'Programs', 'QwenWorkCN', 'version', 'nested', 'resources');
+    await createRuntimeAt(resources, marker);
 
     runWrapper(resources, marker, { QW_QODER_WORKER_RUNTIME_PATH: wrapper });
 
     expect(await fs.readFile(marker, 'utf-8')).toBe('loaded');
     expect(existsSync(path.join(dataDir, 'logs', 'qwenworkcn-intercept.jsonl'))).toBe(false);
-    expect(existsSync(path.join(dataDir, 'logs', 'qoderwork-intercept.jsonl'))).toBe(false);
   });
 
   async function createHostRuntime(appName, marker) {
@@ -97,8 +125,8 @@ describe('QoderWork-family runtime wrapper forwarding', () => {
     return resources;
   }
 
-  async function createWindowsHostRuntime(appName, marker) {
-    const resources = path.join(root, 'Programs', appName, 'resources');
+  async function createWindowsHostRuntime(appName, marker, version) {
+    const resources = path.join(root, 'Programs', appName, ...(version ? [version] : []), 'resources');
     await createRuntimeAt(resources, marker);
     return resources;
   }

--- a/tests/unit/hooks/qoderwork-runtime-wrapper.test.mjs
+++ b/tests/unit/hooks/qoderwork-runtime-wrapper.test.mjs
@@ -63,8 +63,47 @@ describe('QoderWork-family runtime wrapper forwarding', () => {
     });
   });
 
+  it('recognizes QwenWorkCN from a Windows resources path', async () => {
+    const marker = path.join(root, 'windows-qwen-runtime-loaded');
+    const resources = await createWindowsHostRuntime('QwenWorkCN', marker);
+
+    runWrapper(resources, marker);
+
+    expect(await fs.readFile(marker, 'utf-8')).toBe('loaded');
+    const intercept = await fs.readFile(
+      path.join(dataDir, 'logs', 'qwenworkcn-intercept.jsonl'),
+      'utf-8',
+    );
+    expect(JSON.parse(intercept.trim())).toMatchObject({
+      id: 'chatcmpl-wrapper-test',
+      total_tokens: 3,
+    });
+  });
+
+  it('does not classify a Windows sibling from the global Qwen env var', async () => {
+    const marker = path.join(root, 'windows-qoder-runtime-loaded');
+    const resources = await createWindowsHostRuntime('QoderWork', marker);
+
+    runWrapper(resources, marker, { QW_QODER_WORKER_RUNTIME_PATH: wrapper });
+
+    expect(await fs.readFile(marker, 'utf-8')).toBe('loaded');
+    expect(existsSync(path.join(dataDir, 'logs', 'qwenworkcn-intercept.jsonl'))).toBe(false);
+    expect(existsSync(path.join(dataDir, 'logs', 'qoderwork-intercept.jsonl'))).toBe(false);
+  });
+
   async function createHostRuntime(appName, marker) {
     const resources = path.join(root, appName, 'Contents', 'Resources');
+    await createRuntimeAt(resources, marker);
+    return resources;
+  }
+
+  async function createWindowsHostRuntime(appName, marker) {
+    const resources = path.join(root, 'Programs', appName, 'resources');
+    await createRuntimeAt(resources, marker);
+    return resources;
+  }
+
+  async function createRuntimeAt(resources, marker) {
     const runtimeDir = path.join(resources, sdkWorkerRelative);
     await fs.mkdir(runtimeDir, { recursive: true });
     await fs.writeFile(
@@ -79,10 +118,9 @@ JSON.parse(JSON.stringify({
 }));
 `,
     );
-    return resources;
   }
 
-  function runWrapper(resources, marker) {
+  function runWrapper(resources, marker, extraEnv = {}) {
     const launcher = `
 process.resourcesPath = process.env.PILOT_TEST_RESOURCES;
 import(process.env.PILOT_TEST_WRAPPER).catch(error => {
@@ -97,6 +135,7 @@ import(process.env.PILOT_TEST_WRAPPER).catch(error => {
         PILOT_TEST_RESOURCES: resources,
         PILOT_TEST_WRAPPER: wrapper,
         PILOT_WRAPPER_MARKER: marker,
+        ...extraEnv,
       },
     });
     expect(result.status, result.stderr).toBe(0);


### PR DESCRIPTION
## Summary

- persist the dedicated `QW_QODER_WORKER_RUNTIME_PATH` User environment override for enabled Windows QwenWorkCN installations
- identify QwenWorkCN from its Windows resources path and load its bundled worker runtime through a Windows-safe file URL
- align installer, upgrade, watchdog, and uninstall lifecycle while leaving Windows QoderWork runtime handling unchanged
- use CLM-safe `reg.exe` operations and exact dataDir ownership checks for cleanup
- add regression coverage for Windows host classification, Qoder sibling isolation, watchdog scope, registry parsing, and installer lifecycle

## Verification

- `npm test -- --run tests/unit/hooks/qoderwork-runtime-wrapper.test.mjs tests/unit/core/hook-watchdog-intercept.test.ts tests/unit/deploy/installer-uninstall-cleanup.test.mjs tests/unit/scripts/ps1-clm-safe.test.mjs tests/unit/hooks/qwen-work-cn-wrapper-path.test.mjs` — 133 tests passed
- `npm run typecheck`
- `npm run build`
- `git diff --check`