### PR TITLE
fix(dsh): avoid creating home during cleanup

### DIFF
--- a/assets/plugins/dsh/cleanup.mjs
+++ b/assets/plugins/dsh/cleanup.mjs
@@ -220,6 +220,17 @@ export async function cleanupDshIntegration(options = {}) {
     if (error?.code !== 'ENOENT') return { success: false, error: String(error) };
   }
 
+  // A cleanup-only path must not create the DSH home merely to coordinate a
+  // no-op. This is especially visible on Windows, where the uninstaller always
+  // invokes this helper with %USERPROFILE%\.dsh\cordis.patch.yml even when DSH
+  // has never been installed. There is no Pilot-owned block to race when the
+  // target is absent, so return before acquireLock() creates the parent.
+  try {
+    if (!(await exists(patchPath))) return { success: true, changed: false };
+  } catch (error) {
+    return { success: false, error: String(error) };
+  }
+
   const token = await acquireLock(patchPath);
   if (!token) return { success: false, error: 'timed out waiting for DSH patch lock' };
   try {

--- a/src/deployment/dsh-yaml-patch-strategy.ts
+++ b/src/deployment/dsh-yaml-patch-strategy.ts
@@ -212,6 +212,12 @@ export class DshYamlPatchStrategy implements DeployStrategy {
       return false;
     }
     const patchPath = target.patchPath;
+    // A stale deployment record may outlive a user-removed DSH home. Check the
+    // target before acquiring the in-directory lock so disable/undeploy remains
+    // a true no-op instead of recreating that home as an empty directory.
+    const initialBytes = await this.readBytes(patchPath);
+    if (initialBytes.length === 0 && !(await fileExists(patchPath))) return true;
+
     const lockToken = await this.acquirePatchLock(patchPath);
     if (!lockToken) return false;
 

--- a/tests/unit/deploy/dsh-uninstall-cleanup.test.mjs
+++ b/tests/unit/deploy/dsh-uninstall-cleanup.test.mjs
@@ -57,6 +57,22 @@ describe('DSH uninstall cleanup helper', () => {
     await expect(fs.stat(patchPath)).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
+  it('does not create a DSH home when the patch file is already absent', async () => {
+    const missingHome = path.join(tmpDir, 'missing-dsh-home');
+    const missingPatch = path.join(missingHome, 'cordis.patch.yml');
+
+    const result = await cleanupDshIntegration({
+      patchPath: missingPatch,
+      pluginDir,
+      marker: MARKER,
+    });
+
+    expect(result).toEqual({ success: true, changed: false });
+    await expect(fs.stat(missingHome)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fs.stat(path.join(pluginDir, '.collection-enabled')))
+      .rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
   it('fails closed and preserves an incomplete marker block', async () => {
     const invalid = `# BEGIN ${MARKER}\n- insert: []\n`;
     await fs.writeFile(patchPath, invalid);

--- a/tests/unit/deployment/dsh-yaml-patch-strategy.test.ts
+++ b/tests/unit/deployment/dsh-yaml-patch-strategy.test.ts
@@ -399,6 +399,19 @@ describe('DshYamlPatchStrategy', () => {
     expect(ok).toBe(true);
   });
 
+  it('undeploy does not recreate a missing persisted DSH home', async () => {
+    const missingHome = path.join(tmpDir, 'missing-persisted-home');
+    const missingPatch = path.join(missingHome, 'cordis.patch.yml');
+    const record = {
+      deployMode: 'dsh-yaml-patch' as const,
+      deployedAt: new Date().toISOString(),
+      dshPatchPath: missingPatch,
+    };
+
+    expect(await strategy.undeploy(makeDef(), record)).toBe(true);
+    await expect(fs.stat(missingHome)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
   it('returns false from needsDeploy when dshYamlPatch is missing', async () => {
     const def = makeDef({ dshYamlPatch: undefined } as Partial<AgentDefinition>);
     expect(await strategy.needsDeploy(def)).toBe(false);


### PR DESCRIPTION
## Summary

- make the shared DSH uninstall cleanup return before acquiring an in-directory lock when `cordis.patch.yml` is absent
- apply the same no-op boundary to runtime DSH disable/undeploy when a persisted patch path has already disappeared
- add regressions proving neither lifecycle path creates the missing DSH home while preserving enabled-marker cleanup

## Cross-platform impact

This is not Windows-specific. macOS/Linux and Windows installers both execute the same packaged `assets/plugins/dsh/cleanup.mjs` helper:

- macOS and Linux default to `~/.dsh/cordis.patch.yml`
- Windows defaults to `%USERPROFILE%\\.dsh\\cordis.patch.yml`

The runtime `DshYamlPatchStrategy.undeploy()` path is also shared across platforms. Fixing both shared paths prevents new empty DSH homes on macOS, Linux, and Windows.

## Root cause

Both cleanup paths acquired a lock under the target DSH home before checking whether the patch existed. Lock acquisition creates its parent recursively, so cleanup could leave an empty `.dsh` directory on a machine where DSH had never been installed, or recreate a previously removed custom DSH home from stale deployment state.

The fix remains local to the DSH cleanup helper and DSH YAML patch strategy; shared Agent detection and deployment modules are unchanged.

## Validation

- reproduced the original filesystem side effect locally on macOS
- regression proof before the fix: both new missing-parent assertions failed because the directories were created
- DSH-focused suite: 8 files, 111 tests passed
- full suite: 265 files passed, 3 skipped; 3285 tests passed, 50 skipped
- `npm run typecheck`
- `npm run build`

The regression is covered through the shared platform-neutral Node cleanup code. No separate real Windows or Linux host E2E was run for this filesystem-ordering change.

Closes #307