### PR TITLE
fix(installer): install on non-ASCII Windows paths, and stop claiming success

### DIFF
--- a/assets/hooks/claude-code-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/claude-code-loongsuite-pilot-hook.ps1
@@ -64,7 +64,9 @@ function Test-NodeSuitable {
 function Resolve-NodeBin {
     $pinFile = Join-Path $env:USERPROFILE ".loongsuite-pilot\node-bin"
     if (Test-Path $pinFile) {
-        $pinned = (Get-Content $pinFile -ErrorAction SilentlyContinue).Trim()
+        # -Encoding UTF8 + BOM strip: the pin file can hold a non-ASCII path and 5.1
+        # defaults Get-Content to ANSI, which turns it into "??".
+        $pinned = ([string](Get-Content -LiteralPath $pinFile -Raw -Encoding UTF8 -ErrorAction SilentlyContinue)).Trim([char]0xFEFF).Trim()
         if ($pinned -and (Test-NodeSuitable $pinned)) { return $pinned }
     }
 

--- a/assets/hooks/codex-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/codex-loongsuite-pilot-hook.ps1
@@ -103,8 +103,10 @@ function Resolve-NodeBin {
     }
     $pinFile = Join-Path $dataDir "node-bin"
     if (Test-Path -LiteralPath $pinFile) {
-        $pinContent = Get-Content -LiteralPath $pinFile -Raw -ErrorAction SilentlyContinue
-        $pinned = Convert-NodePath ([string]$pinContent)
+        # -Encoding UTF8 + BOM strip: the pin file can hold a non-ASCII path and 5.1
+        # defaults Get-Content to ANSI, which turns it into "??".
+        $pinContent = Get-Content -LiteralPath $pinFile -Raw -Encoding UTF8 -ErrorAction SilentlyContinue
+        $pinned = Convert-NodePath (([string]$pinContent).Trim([char]0xFEFF))
         if (Test-NodeSuitable $pinned) { return $pinned }
     }
 

--- a/assets/hooks/cursor-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/cursor-loongsuite-pilot-hook.ps1
@@ -57,7 +57,9 @@ function Test-NodeSuitable {
 function Resolve-NodeBin {
     $pinFile = Join-Path $env:USERPROFILE ".loongsuite-pilot\node-bin"
     if (Test-Path $pinFile) {
-        $pinned = (Get-Content $pinFile -ErrorAction SilentlyContinue).Trim()
+        # -Encoding UTF8 + BOM strip: the pin file can hold a non-ASCII path and 5.1
+        # defaults Get-Content to ANSI, which turns it into "??".
+        $pinned = ([string](Get-Content -LiteralPath $pinFile -Raw -Encoding UTF8 -ErrorAction SilentlyContinue)).Trim([char]0xFEFF).Trim()
         if ($pinned -and (Test-NodeSuitable $pinned)) { return $pinned }
     }
     $candidates = @()

--- a/assets/hooks/qoder-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/qoder-loongsuite-pilot-hook.ps1
@@ -26,7 +26,9 @@ function Test-NodeSuitable {
 function Resolve-NodeBin {
     $pinFile = Join-Path $env:USERPROFILE ".loongsuite-pilot\node-bin"
     if (Test-Path $pinFile) {
-        $pinned = (Get-Content $pinFile -ErrorAction SilentlyContinue).Trim()
+        # -Encoding UTF8 + BOM strip: the pin file can hold a non-ASCII path and 5.1
+        # defaults Get-Content to ANSI, which turns it into "??".
+        $pinned = ([string](Get-Content -LiteralPath $pinFile -Raw -Encoding UTF8 -ErrorAction SilentlyContinue)).Trim([char]0xFEFF).Trim()
         if ($pinned -and (Test-NodeSuitable $pinned)) { return $pinned }
     }
     $candidates = @()

--- a/assets/hooks/qodercn-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/qodercn-loongsuite-pilot-hook.ps1
@@ -26,7 +26,9 @@ function Test-NodeSuitable {
 function Resolve-NodeBin {
     $pinFile = Join-Path $env:USERPROFILE ".loongsuite-pilot\node-bin"
     if (Test-Path $pinFile) {
-        $pinned = (Get-Content $pinFile -ErrorAction SilentlyContinue).Trim()
+        # -Encoding UTF8 + BOM strip: the pin file can hold a non-ASCII path and 5.1
+        # defaults Get-Content to ANSI, which turns it into "??".
+        $pinned = ([string](Get-Content -LiteralPath $pinFile -Raw -Encoding UTF8 -ErrorAction SilentlyContinue)).Trim([char]0xFEFF).Trim()
         if ($pinned -and (Test-NodeSuitable $pinned)) { return $pinned }
     }
     $candidates = @()

--- a/assets/hooks/qoderworkcn-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/qoderworkcn-loongsuite-pilot-hook.ps1
@@ -26,7 +26,9 @@ function Test-NodeSuitable {
 function Resolve-NodeBin {
     $pinFile = Join-Path $env:USERPROFILE ".loongsuite-pilot\node-bin"
     if (Test-Path $pinFile) {
-        $pinned = (Get-Content $pinFile -ErrorAction SilentlyContinue).Trim()
+        # -Encoding UTF8 + BOM strip: the pin file can hold a non-ASCII path and 5.1
+        # defaults Get-Content to ANSI, which turns it into "??".
+        $pinned = ([string](Get-Content -LiteralPath $pinFile -Raw -Encoding UTF8 -ErrorAction SilentlyContinue)).Trim([char]0xFEFF).Trim()
         if ($pinned -and (Test-NodeSuitable $pinned)) { return $pinned }
     }
     $candidates = @()

--- a/assets/hooks/qwen-code-cli-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/qwen-code-cli-loongsuite-pilot-hook.ps1
@@ -64,7 +64,9 @@ function Test-NodeSuitable {
 function Resolve-NodeBin {
     $pinFile = Join-Path $env:USERPROFILE ".loongsuite-pilot\node-bin"
     if (Test-Path $pinFile) {
-        $pinned = (Get-Content $pinFile -ErrorAction SilentlyContinue).Trim()
+        # -Encoding UTF8 + BOM strip: the pin file can hold a non-ASCII path and 5.1
+        # defaults Get-Content to ANSI, which turns it into "??".
+        $pinned = ([string](Get-Content -LiteralPath $pinFile -Raw -Encoding UTF8 -ErrorAction SilentlyContinue)).Trim([char]0xFEFF).Trim()
         if ($pinned -and (Test-NodeSuitable $pinned)) { return $pinned }
     }
 

--- a/assets/hooks/shared/common.ps1
+++ b/assets/hooks/shared/common.ps1
@@ -41,7 +41,9 @@ function Resolve-NodeBin {
     }
     foreach ($pinFile in $pinFiles) {
         if (Test-Path $pinFile) {
-            $pinned = (Get-Content $pinFile -ErrorAction SilentlyContinue).Trim()
+            # -Encoding UTF8 + BOM strip: the pin file can hold a non-ASCII path and 5.1
+            # defaults Get-Content to ANSI, which turns it into "??".
+            $pinned = ([string](Get-Content -LiteralPath $pinFile -Raw -Encoding UTF8 -ErrorAction SilentlyContinue)).Trim([char]0xFEFF).Trim()
             if ($pinned -and (Test-NodeSuitable $pinned)) { return $pinned }
         }
     }

--- a/assets/hooks/workbuddy-loongsuite-pilot-hook.ps1
+++ b/assets/hooks/workbuddy-loongsuite-pilot-hook.ps1
@@ -69,8 +69,10 @@ function Resolve-NodeBin {
     }
     $pinFile = Join-Path $dataDir "node-bin"
     if (Test-Path -LiteralPath $pinFile) {
-        $pinContent = Get-Content -LiteralPath $pinFile -Raw -ErrorAction SilentlyContinue
-        $pinned = Convert-NodePath ([string]$pinContent)
+        # -Encoding UTF8 + BOM strip: the pin file can hold a non-ASCII path and 5.1
+        # defaults Get-Content to ANSI, which turns it into "??".
+        $pinContent = Get-Content -LiteralPath $pinFile -Raw -Encoding UTF8 -ErrorAction SilentlyContinue
+        $pinned = Convert-NodePath (([string]$pinContent).Trim([char]0xFEFF))
         if (Test-NodeSuitable $pinned) { return $pinned }
     }
 

--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -1075,6 +1075,10 @@ function Deploy-Package {
     $postinstallScript = Join-Path $script:PERMANENT_DIR "scripts\postinstall.js"
     $postinstallExit = 0
     $postinstallPartial = $false
+    # Empty means "nothing went wrong". The caller aborts on a non-empty value -- the policy
+    # lives at the call sites so this block stays byte-identical across the installers, same
+    # split as $script:PILOT_LAST_RESTART_ERR.
+    $script:PILOT_POSTINSTALL_ERR = ""
     if (Test-Path $postinstallScript) {
         # postinstall.js resolves its target as LOONGSUITE_PILOT_DATA_DIR, falling back to
         # $env:USERPROFILE\.loongsuite-pilot. Unset, an install started with -DataDir would
@@ -1093,7 +1097,7 @@ function Deploy-Package {
             $postinstallOut = & $script:NODE_BIN $postinstallScript 2>&1
             $postinstallExit = $LASTEXITCODE
             $postinstallOut | ForEach-Object { Write-Host $_ }
-            if (($postinstallOut | Out-String) -match "failed asset tree") { $postinstallPartial = $true }
+            if (($postinstallOut | Out-String) -match "failed asset tree|Post-install failed") { $postinstallPartial = $true }
         } finally {
             $ErrorActionPreference = $prevEAP
             if ($hadPostinstallDataDir) {
@@ -1108,18 +1112,25 @@ function Deploy-Package {
     # fs.cpSync fail-fasts with 0xC0000409 on the bundled Node, killing the script before it
     # copied anything, and this line printed "Hook scripts deployed" regardless.
     #
-    # Two distinct outcomes, and the exit code only covers the first. postinstall.js
+    # Three distinct outcomes, and the exit code only covers the first. postinstall.js
     # deliberately exits 0 after a per-tree failure -- a non-zero exit would abort the npm
-    # install fallback above -- and announces it as "N failed asset tree(s)" instead. So a
-    # non-zero code means the process died outright, while a partial failure is legible only
-    # in the output. Keying the check mark off the exit code alone printed it over an install
-    # that had just reported a tree it could not copy.
+    # install fallback above -- and announces it as "N failed asset tree(s)" instead; its
+    # top-level catch is the same story, printing "Post-install failed: <reason>" and still
+    # exiting 0. So a non-zero code means the process died outright, while the other two are
+    # legible only in the output. Keying the check mark off the exit code alone printed it over
+    # an install that had just reported a tree it could not copy.
+    #
+    # An install with no hooks/plugins is not an install: the collector finds nothing to load
+    # and every collection cycle fails on a plugin that was never written. The caller aborts
+    # (install) or rolls back (upgrade) on $script:PILOT_POSTINSTALL_ERR.
     if ($postinstallExit -ne 0) {
-        Msg "    ❌ Hook 脚本部署失败 (exit=$postinstallExit)，hooks/plugins 可能缺失" `
-            "    ❌ Hook script deployment failed (exit=$postinstallExit); hooks/plugins may be missing"
+        $script:PILOT_POSTINSTALL_ERR = "postinstall.js (exit $postinstallExit)"
+        Msg "    ❌ Hook 脚本部署失败 (exit=$postinstallExit)，hooks/plugins 缺失" `
+            "    ❌ Hook script deployment failed (exit=$postinstallExit); hooks/plugins are missing"
     } elseif ($postinstallPartial) {
-        Msg "    ❌ Hook 脚本部分部署失败（见上方 failed asset tree），hooks/plugins 可能缺失" `
-            "    ❌ Some hook asset trees failed to deploy (see 'failed asset tree' above); hooks/plugins may be missing"
+        $script:PILOT_POSTINSTALL_ERR = "postinstall.js reported a failed asset tree"
+        Msg "    ❌ Hook 脚本部分部署失败（见上方输出），hooks/plugins 缺失" `
+            "    ❌ Some hook asset trees failed to deploy (see the output above); hooks/plugins are missing"
     } else {
         Msg "    ✅ Hook 脚本已部署" "    ✅ Hook scripts deployed"
     }
@@ -2145,6 +2156,15 @@ function Cmd-Install {
         Prompt-UserId
         Confirm-ConfigOverwrite
         Deploy-Package $script:INSTALL_SRC
+        # Nothing downstream can repair this: postinstall.js is the only thing that fills
+        # $DataDir\{hooks,skills,plugins}, and a collector with no hooks collects nothing.
+        # Better to stop with the reason on screen than to finish and report success.
+        if ($script:PILOT_POSTINSTALL_ERR) {
+            Msg "❌ 安装中止：$script:PILOT_POSTINSTALL_ERR" `
+                "❌ Install aborted: $script:PILOT_POSTINSTALL_ERR"
+            Msg "   请检查上方输出后重试安装" "   Check the output above and re-run the install"
+            exit 1
+        }
         Write-Config
         Install-Command
 
@@ -2218,7 +2238,15 @@ function Cmd-Upgrade {
 
         Msg "==> 启动新版本..." "==> Starting new version..."
         $ps1Path = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot-service.ps1"
-        $started = Start-PilotAndWait -ScriptPath $ps1Path -PriorVersion $oldVer
+        # A failed postinstall is a failed upgrade: no point starting the new version, and the
+        # rollback below is what keeps `current` on a version whose assets are known complete.
+        $started = $false
+        if ($script:PILOT_POSTINSTALL_ERR) {
+            Msg "    ❌ Hook 脚本部署失败: $script:PILOT_POSTINSTALL_ERR" `
+                "    ❌ Hook script deployment failed: $script:PILOT_POSTINSTALL_ERR"
+        } else {
+            $started = Start-PilotAndWait -ScriptPath $ps1Path -PriorVersion $oldVer
+        }
         if ($started) {
             Msg "    ✅ 新版本启动成功" "    ✅ New version started successfully"
             Write-Host ""

--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -1074,6 +1074,7 @@ function Deploy-Package {
     Msg "==> 部署 hook 脚本..." "==> Deploying hook scripts..."
     $postinstallScript = Join-Path $script:PERMANENT_DIR "scripts\postinstall.js"
     $postinstallExit = 0
+    $postinstallPartial = $false
     if (Test-Path $postinstallScript) {
         # postinstall.js resolves its target as LOONGSUITE_PILOT_DATA_DIR, falling back to
         # $env:USERPROFILE\.loongsuite-pilot. Unset, an install started with -DataDir would
@@ -1087,8 +1088,12 @@ function Deploy-Package {
         $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
         try {
             $env:LOONGSUITE_PILOT_DATA_DIR = $DataDir
-            & $script:NODE_BIN $postinstallScript
+            # Captured rather than streamed because the per-tree verdict is in the output and
+            # nowhere else (see below). 2>&1 because postinstall.js reports it on stderr.
+            $postinstallOut = & $script:NODE_BIN $postinstallScript 2>&1
             $postinstallExit = $LASTEXITCODE
+            $postinstallOut | ForEach-Object { Write-Host $_ }
+            if (($postinstallOut | Out-String) -match "failed asset tree") { $postinstallPartial = $true }
         } finally {
             $ErrorActionPreference = $prevEAP
             if ($hadPostinstallDataDir) {
@@ -1098,16 +1103,23 @@ function Deploy-Package {
             }
         }
     }
-    # Never print the check mark for a postinstall that did not finish. postinstall.js
-    # reports its own per-tree failures and still exits 0 on purpose (a non-zero exit
-    # would abort the npm install fallback above), so a non-zero code here means the
-    # process died outright. That is exactly how the hooks/skills/plugins trees went
-    # missing on every Windows install without a word: fs.cpSync fail-fasts with
-    # 0xC0000409 on the bundled Node, killing the script before it copied anything,
-    # and this line printed "Hook scripts deployed" regardless.
+    # Never print the check mark for a postinstall that did not finish. That is exactly how
+    # the hooks/skills/plugins trees went missing on every Windows install without a word:
+    # fs.cpSync fail-fasts with 0xC0000409 on the bundled Node, killing the script before it
+    # copied anything, and this line printed "Hook scripts deployed" regardless.
+    #
+    # Two distinct outcomes, and the exit code only covers the first. postinstall.js
+    # deliberately exits 0 after a per-tree failure -- a non-zero exit would abort the npm
+    # install fallback above -- and announces it as "N failed asset tree(s)" instead. So a
+    # non-zero code means the process died outright, while a partial failure is legible only
+    # in the output. Keying the check mark off the exit code alone printed it over an install
+    # that had just reported a tree it could not copy.
     if ($postinstallExit -ne 0) {
         Msg "    ❌ Hook 脚本部署失败 (exit=$postinstallExit)，hooks/plugins 可能缺失" `
             "    ❌ Hook script deployment failed (exit=$postinstallExit); hooks/plugins may be missing"
+    } elseif ($postinstallPartial) {
+        Msg "    ❌ Hook 脚本部分部署失败（见上方 failed asset tree），hooks/plugins 可能缺失" `
+            "    ❌ Some hook asset trees failed to deploy (see 'failed asset tree' above); hooks/plugins may be missing"
     } else {
         Msg "    ✅ Hook 脚本已部署" "    ✅ Hook scripts deployed"
     }
@@ -1489,15 +1501,41 @@ function Print-Summary {
 # $serviceEntry is whichever entry point the caller already resolved: the .ps1 needs
 # powershell.exe -File, the .cmd wrapper is invoked directly. Branching here rather than at
 # the call sites keeps this block byte-identical across the three installers.
+#
+# Returns $true when there is nothing to displace or the displacement succeeded, $false with
+# the reason in $script:PILOT_LAST_RESTART_ERR otherwise. Native commands do not throw on a
+# nonzero exit, so $LASTEXITCODE is the only signal there is -- and discarding it put the
+# failure right back where this block came from. Cmd-RestartCollector exits 1 when the node
+# runtime cannot be resolved, when the bootstrap entry is missing, and when the service
+# manager refuses to restart a non-degraded install; in every one of those the survivor is
+# still running the OLD version dir. Callers must not print success on a $false: `status`
+# resolves `current`, which the survivor answers to exactly as well as the new collector
+# would, so "is running" cannot tell the two apart. That is the entire bug.
 function Restart-StaleCollector {
     param([string]$serviceEntry, [string]$priorVersion)
-    if (-not $priorVersion) { return }
-    if (-not $serviceEntry) { return }
-    if (-not (Test-Path $serviceEntry)) { return }
-    if ($serviceEntry -match '\.ps1$') {
-        & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $serviceEntry restart-collector 2>$null | Out-Null
-    } else {
-        & $serviceEntry restart-collector 2>$null | Out-Null
+    $script:PILOT_LAST_RESTART_ERR = ""
+    if (-not $priorVersion) { return $true }
+    if (-not $serviceEntry) { return $true }
+    if (-not (Test-Path $serviceEntry)) { return $true }
+    # Locally forced to Continue: with 2>&1 in effect a caller left on Stop turns the first
+    # stderr line into a NativeCommandError, which would report a successful restart as a
+    # failure. restart-collector writes progress to stderr on purpose.
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        if ($serviceEntry -match '\.ps1$') {
+            $restartOut = & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $serviceEntry restart-collector 2>&1
+        } else {
+            $restartOut = & $serviceEntry restart-collector 2>&1
+        }
+        if ($LASTEXITCODE -eq 0) { return $true }
+        $script:PILOT_LAST_RESTART_ERR = "restart-collector (exit $LASTEXITCODE): $(($restartOut | Out-String).Trim())"
+        return $false
+    } catch {
+        $script:PILOT_LAST_RESTART_ERR = "restart-collector failed to run: $($_.Exception.Message)"
+        return $false
+    } finally {
+        $ErrorActionPreference = $prevEAP
     }
 }
 # <<< pilot-restart-stale-collector <<<
@@ -2058,14 +2096,19 @@ function Start-PilotAndWait {
     $startOutput = & powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $ScriptPath start 2>&1
     $startExit = $LASTEXITCODE
     $startOutput | ForEach-Object { Write-Host $_ }
-    Restart-StaleCollector $ScriptPath $PriorVersion
+    $staleOk = Restart-StaleCollector $ScriptPath $PriorVersion
+    if (-not $staleOk) {
+        Write-Host "   $script:PILOT_LAST_RESTART_ERR" -ForegroundColor Yellow
+    }
 
     $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
     do {
         $statusOutput = & powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $ScriptPath status 2>$null
         if ($statusOutput -match "is running") {
             $ErrorActionPreference = $prevEAP
-            return $true
+            # Deliberately $staleOk, not $true: a collector that outlived the deploy answers
+            # "is running" from the old version dir just as convincingly as the new one.
+            return $staleOk
         }
         Start-Sleep -Seconds 2
     } while ((Get-Date) -lt $deadline)

--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -183,12 +183,21 @@ function Resolve-Node {
     $candidates = @()
 
     # Existing installations pin the exact Node binary used for deployment.
+    #
+    # The pin file holds one absolute path to node.exe, and for a managed runtime that
+    # path sits under the data dir -- i.e. under %USERPROFILE%, which can be non-ASCII.
+    # 5.1 defaults both Get-Content and Set-Content to the ANSI codepage, so an
+    # unqualified write stored "C:\Users\??.HOST\..." and every reader then failed
+    # Test-NodeSuitable and silently fell back to whatever node.exe the candidate search
+    # found first -- on a shared machine that was another account's nvm install.
+    # -Encoding UTF8 always emits a BOM on 5.1 (there is no utf8NoBOM), and U+FEFF is not
+    # whitespace, so .Trim() alone leaves it in the path: strip it explicitly first.
     foreach ($pinFile in @(
         (Join-Path $DataDir "node-bin"),
         (Join-Path $CACHE_DIR "node-bin")
     )) {
         if (-not (Test-Path -LiteralPath $pinFile)) { continue }
-        $pinned = ([string](Get-Content -LiteralPath $pinFile -Raw -ErrorAction SilentlyContinue)).Trim()
+        $pinned = ([string](Get-Content -LiteralPath $pinFile -Raw -Encoding UTF8 -ErrorAction SilentlyContinue)).Trim([char]0xFEFF).Trim()
         if ($pinned) { $candidates += $pinned }
     }
 
@@ -250,6 +259,179 @@ function Get-ManagedNodePlatform {
             return $null
         }
     }
+}
+
+# >>> pilot-ascii-temp >>>
+# Temp root guaranteed to be ASCII, for the two tar.exe staging dirs only.
+#
+# PowerShell hands native command arguments to CreateProcessW as UTF-16, but bsdtar
+# (%SystemRoot%\System32\tar.exe) enters through the ANSI CRT and converts them back
+# through the machine's ANSI codepage, so on an en-US box every character that page
+# cannot represent reaches tar as a literal "?": with $env:TEMP under a non-ASCII
+# %USERPROFILE% (e.g. C:\Users\<CJK name>\AppData\Local\Temp) both -f and -C pointed at
+# paths that do not exist and extraction failed with "Failed to open ...", which is what
+# stalled the install right after the download. Measured on that box: neither
+# [Console]::OutputEncoding = UTF8 nor `chcp 65001` changes it (they affect stdio
+# decoding, not argv conversion), and the 8.3 short name works but only where 8dot3
+# creation is still enabled, so it cannot be relied on.
+#
+# Callers keep the archive and the extraction dir inside this root and only then
+# Move-Item the result into the real (possibly non-ASCII) destination -- Move-Item is
+# pure Win32 and Unicode-safe. This root can be machine-wide (%SystemRoot%\Temp), so it
+# is for downloaded archives only: never stage credentials or config here, use $DataDir.
+#
+# The base resolution repeats Get-PilotTempRoot's fallback chain instead of calling it,
+# so this block stays byte-identical across the installers -- installer-opensource.ps1
+# has no Get-PilotTempRoot. Keep the two chains in sync. Environment variables only:
+# [System.IO.Path]::GetTempPath() is a static call on an off-list type and throws under
+# ConstrainedLanguage (WDAC / Device Guard).
+$script:PILOT_ASCII_TEMP_ROOT = ""
+function Get-PilotAsciiTempRoot {
+    if ($script:PILOT_ASCII_TEMP_ROOT) { return $script:PILOT_ASCII_TEMP_ROOT }
+    $root = "C:\Windows\Temp"
+    if ($env:TEMP) { $root = $env:TEMP }
+    elseif ($env:TMP) { $root = $env:TMP }
+    elseif ($env:SystemRoot) { $root = (Join-Path $env:SystemRoot "Temp") }
+    if ($root -notmatch '[^\x20-\x7E]') {
+        $script:PILOT_ASCII_TEMP_ROOT = $root
+        return $root
+    }
+    $candidates = @()
+    if ($env:SystemRoot) { $candidates += (Join-Path $env:SystemRoot "Temp") }
+    if ($env:SystemDrive) { $candidates += ($env:SystemDrive + "\loongsuite-pilot-tmp") }
+    $candidates += "C:\Windows\Temp"
+    foreach ($candidate in $candidates) {
+        if ($candidate -match '[^\x20-\x7E]') { continue }
+        # Probe by writing: %SystemRoot%\Temp grants Users write by default, but a
+        # hardened host may not, and Test-Path cannot tell us that.
+        try {
+            if (-not (Test-Path -LiteralPath $candidate)) {
+                New-Item -ItemType Directory -Path $candidate -Force -ErrorAction Stop | Out-Null
+            }
+            $probe = Join-Path $candidate ("pilot-w-" + $PID + ".tmp")
+            Set-Content -LiteralPath $probe -Value "1" -ErrorAction Stop
+            Remove-Item -LiteralPath $probe -Force -ErrorAction SilentlyContinue
+            $script:PILOT_ASCII_TEMP_ROOT = $candidate
+            return $candidate
+        } catch {}
+    }
+    # Nothing writable: keep the old behaviour rather than failing outright.
+    $script:PILOT_ASCII_TEMP_ROOT = $root
+    return $root
+}
+
+# Re-inherit the destination's ACL on a tree that was Move-Item'd out of the ASCII root.
+#
+# Move-Item is a rename, and a rename carries the source's ACEs along unchanged --
+# they keep their "inherited" flag but now describe a parent that no longer supplies
+# them, so the tree does not pick up the ACL of its new parent. Everything staged in
+# %SystemRoot%\Temp therefore lands in the profile with %SystemRoot%\Temp's permissions:
+# Users get (S,WD,AD,X), which is write and traverse but *not read*, and the read grant
+# comes from CREATOR OWNER. Run elevated -- an admin account, or "Run as administrator"
+# -- the owner of a new file is BUILTIN\Administrators, so CREATOR OWNER resolves to
+# Administrators and the moved tree ends up with no ACE for the user at all (measured:
+# node_modules\pino\package.json had exactly Administrators:(I)(F) and SYSTEM:(I)(F)).
+# The install then looks fine and the collector still cannot start, because the
+# scheduled task runs with a filtered token where Administrators is deny-only: node
+# cannot read the package.json it found and reports the confusing
+#   ERR_MODULE_NOT_FOUND: Cannot find package 'pino' imported from ...\dist\index.js
+# in logs\last-startup-crash.json, while the same tree reads fine from an elevated
+# shell -- which is where anyone reproducing it by hand would look first.
+#
+# Copy-Item is not affected: a copy creates new files, which do inherit normally. Only
+# the Move-Item paths out of Get-PilotAsciiTempRoot need this.
+#
+# icacls, unlike tar.exe, handles a non-ASCII path correctly (verified against a CJK
+# profile: "Successfully processed 31950 files"), so the destination goes straight
+# through. Get-Acl / Set-Acl cannot express this: re-enabling inheritance needs
+# $acl.SetAccessRuleProtection(), a method call on an off-list type that CLM blocks.
+function Reset-PilotInheritedAcl {
+    param([string]$Path)
+    $script:PILOT_LAST_ACL_ERR = ""
+    if (-not $Path -or -not (Test-Path -LiteralPath $Path)) {
+        $script:PILOT_LAST_ACL_ERR = "path not found: $Path"
+        return $false
+    }
+    # /T all descendants, /C keep going past a single failure, /Q stay quiet. Native
+    # commands do not throw on a nonzero exit, so $LASTEXITCODE is the signal; the try
+    # only covers icacls failing to launch, which $ErrorActionPreference = "Stop" would
+    # otherwise turn into a terminating error.
+    try {
+        $aclOut = & icacls $Path /reset /T /C /Q 2>&1
+        if ($LASTEXITCODE -eq 0) { return $true }
+        $script:PILOT_LAST_ACL_ERR = "icacls (exit $LASTEXITCODE): $(($aclOut | Out-String).Trim())"
+        return $false
+    } catch {
+        $script:PILOT_LAST_ACL_ERR = "icacls failed to run: $($_.Exception.Message)"
+        return $false
+    }
+}
+# <<< pilot-ascii-temp <<<
+
+# Extract a .tar.gz into $DestDir. Returns $true on success; on failure the last
+# error text is left in $script:PILOT_LAST_TAR_ERR for the caller to surface.
+#
+# Never invoke a bare `tar` on Windows. On a machine with Git for Windows
+# installed, PATH normally resolves `tar` to Git's bundled GNU tar (MSYS), and GNU
+# tar reads the colon in `-f C:\...\archive.tar.gz` as rsh host:path syntax: it
+# treats "C" as a remote host and dies with "Cannot connect to C: resolve failed"
+# (older builds hang instead). Windows' own bsdtar
+# (%SystemRoot%\System32\tar.exe, Win10 1803+ / Server 2019+) parses drive-letter
+# paths correctly, so try it first and only then fall back to PATH's tar with
+# --force-local, which is what makes GNU tar read the colon as part of a local
+# filename. Do not pass --force-local to bsdtar: it rejects the unknown flag and
+# exits immediately, which is why it is attached to the PATH candidate only.
+function Expand-PilotTarGz {
+    param([string]$ArchivePath, [string]$DestDir)
+
+    $script:PILOT_LAST_TAR_ERR = ""
+    $exes = @()
+    if ($env:SystemRoot) {
+        # Inside a 32-bit PowerShell on 64-bit Windows, System32 is redirected to
+        # SysWOW64, which ships no tar.exe; Sysnative reaches the real System32.
+        foreach ($dir in @("System32", "Sysnative")) {
+            $candidate = Join-Path $env:SystemRoot "$dir\tar.exe"
+            if (Test-Path $candidate) { $exes += $candidate }
+        }
+    }
+    # Everything from this index on is an unknown tar and needs --force-local.
+    $nativeCount = $exes.Count
+    # Require .Source: a `tar` that resolves to an alias or function has none, and
+    # only an external binary can be invoked with an argument array. -notcontains
+    # compares strings case-insensitively, so a PATH hit that is already the
+    # System32 binary under different casing is not retried.
+    $pathTar = Get-Command tar -ErrorAction SilentlyContinue
+    if ($pathTar -and $pathTar.Source -and ($exes -notcontains $pathTar.Source)) {
+        $exes += $pathTar.Source
+    }
+
+    if ($exes.Count -eq 0) {
+        $script:PILOT_LAST_TAR_ERR = "tar not found (looked in %SystemRoot%\System32, Sysnative and PATH)"
+        return $false
+    }
+
+    for ($i = 0; $i -lt $exes.Count; $i++) {
+        $exe = $exes[$i]
+        $tarArgs = @('-xzf', $ArchivePath, '-C', $DestDir)
+        if ($i -ge $nativeCount) { $tarArgs = @('--force-local') + $tarArgs }
+        # Naming the binary is the whole diagnostic: "Cannot connect to C: resolve
+        # failed" only makes sense once you can see it came from Git's tar. Msg wraps
+        # Write-Host, so this never lands in the return value.
+        Msg "    tar: $exe" "    tar: $exe"
+        # Native commands do not throw on a nonzero exit, so $LASTEXITCODE is the
+        # only signal; the try only covers a binary that fails to launch at all,
+        # which $ErrorActionPreference = "Stop" would otherwise make terminating.
+        try {
+            $tarOut = & $exe @tarArgs 2>&1
+            if ($LASTEXITCODE -eq 0) { return $true }
+            $script:PILOT_LAST_TAR_ERR = "$exe (exit $LASTEXITCODE): $(($tarOut | Out-String).Trim())"
+        } catch {
+            $script:PILOT_LAST_TAR_ERR = "$exe : $_"
+        }
+        Msg "    ⚠️  tar 解包失败: $($script:PILOT_LAST_TAR_ERR)" `
+            "    ⚠️  tar failed: $($script:PILOT_LAST_TAR_ERR)"
+    }
+    return $false
 }
 
 function Invoke-ManagedNodeDownload {
@@ -359,7 +541,10 @@ function Ensure-NodeModules {
 
     $archive = "node-modules-$($platform.Os)-$($platform.Arch).tar.gz"
     $base = $script:NODE_MODULES_BASE.TrimEnd('/') + "/$AppVersion"
-    $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("pilot-node-modules-" + [guid]::NewGuid().ToString("N"))
+    # ASCII temp root: the archive is unpacked with tar.exe, which cannot see a
+    # non-ASCII path (see Get-PilotAsciiTempRoot). Move-Item below lands it in the
+    # real, possibly non-ASCII, install dir.
+    $tmp = Join-Path (Get-PilotAsciiTempRoot) ("pilot-node-modules-" + [guid]::NewGuid().ToString("N"))
     New-Item -ItemType Directory -Path $tmp -Force | Out-Null
     try {
         Msg "==> 下载预编译 node_modules (win-x64, app v$AppVersion)..." "==> Downloading prebuilt node_modules (win-x64, app v$AppVersion)..."
@@ -369,18 +554,38 @@ function Ensure-NodeModules {
         if (-not (Invoke-ManagedNodeDownload "$base/SHASUMS256.txt" $shasumsPath)) { return $false }
         if (-not (Test-ManagedNodeChecksum $archivePath $shasumsPath $archive)) { return $false }
 
-        $tarCmd = Get-Command tar -ErrorAction SilentlyContinue
-        if (-not $tarCmd) { return $false }
         $stage = Join-Path $tmp "stage"
         New-Item -ItemType Directory -Path $stage -Force | Out-Null
-        & tar -xzf $archivePath -C $stage
-        if ($LASTEXITCODE -ne 0) { return $false }
+        # Expand-PilotTarGz already logged which tar ran and how it failed; name what
+        # that cost so the "prebuilt node_modules unavailable, falling back to npm
+        # install" notice below is not misread as "OSS has no artifact for this
+        # version". A local tar conflict and a missing archive used to look identical.
+        if (-not (Expand-PilotTarGz $archivePath $stage)) {
+            Msg "    ⚠️  预编译 node_modules 解压失败" `
+                "    ⚠️  Failed to extract prebuilt node_modules"
+            return $false
+        }
         $stagedModules = Join-Path $stage "node_modules"
-        if (-not (Test-Path $stagedModules)) { return $false }
+        if (-not (Test-Path $stagedModules)) {
+            Msg "    ⚠️  预编译包中缺少 node_modules 目录" `
+                "    ⚠️  Extracted archive contains no node_modules directory"
+            return $false
+        }
 
         Set-Content -Path (Join-Path $stagedModules ".pilot-modules-version") -Value $stamp
         if (Test-Path $modulesDir) { Remove-Item $modulesDir -Recurse -Force }
         Move-Item $stagedModules $modulesDir
+        # The move brought the ASCII root's ACL with it, which can leave the tree
+        # unreadable to the non-elevated scheduled task -- see Reset-PilotInheritedAcl.
+        # If that cannot be repaired, throw the prebuilt tree away rather than deploy
+        # dependencies the collector will not be able to read: returning $false falls
+        # back to npm install, which creates node_modules in place and inherits normally.
+        if (-not (Reset-PilotInheritedAcl $modulesDir)) {
+            Msg "    ⚠️  预编译 node_modules 权限修复失败: $script:PILOT_LAST_ACL_ERR" `
+                "    ⚠️  Could not reset permissions on prebuilt node_modules: $script:PILOT_LAST_ACL_ERR"
+            Remove-Item $modulesDir -Recurse -Force -ErrorAction SilentlyContinue
+            return $false
+        }
         return $true
     } catch {
         return $false
@@ -425,13 +630,15 @@ function Check-Deps {
         exit 1
     }
 
-    # Pin node binary path
+    # Pin node binary path. -Encoding UTF8 is required, not cosmetic: the path can sit
+    # under a non-ASCII %USERPROFILE% and the 5.1 default (ANSI) would store "??" there,
+    # see the note on Resolve-Node.
     if (-not (Test-Path $CACHE_DIR)) { New-Item -ItemType Directory -Path $CACHE_DIR -Force | Out-Null }
-    Set-Content -Path (Join-Path $CACHE_DIR "node-bin") -Value $script:NODE_BIN
+    Set-Content -LiteralPath (Join-Path $CACHE_DIR "node-bin") -Value $script:NODE_BIN -Encoding UTF8
     # Hook entrypoints can always derive DataDir from their deployed location,
     # while GUI agents do not necessarily inherit the installer's CacheDir.
     if (-not (Test-Path $DataDir)) { New-Item -ItemType Directory -Path $DataDir -Force | Out-Null }
-    Set-Content -Path (Join-Path $DataDir "node-bin") -Value $script:NODE_BIN
+    Set-Content -LiteralPath (Join-Path $DataDir "node-bin") -Value $script:NODE_BIN -Encoding UTF8
 
     # Derive npm
     $npmPath = Join-Path (Split-Path $script:NODE_BIN) "npm.cmd"
@@ -863,14 +1070,48 @@ function Deploy-Package {
     }
     Write-Host ""
 
+    # >>> pilot-postinstall-exit-check >>>
     Msg "==> 部署 hook 脚本..." "==> Deploying hook scripts..."
     $postinstallScript = Join-Path $script:PERMANENT_DIR "scripts\postinstall.js"
+    $postinstallExit = 0
     if (Test-Path $postinstallScript) {
+        # postinstall.js resolves its target as LOONGSUITE_PILOT_DATA_DIR, falling back to
+        # $env:USERPROFILE\.loongsuite-pilot. Unset, an install started with -DataDir would
+        # put hooks/skills/plugins in the default tree while its config lives elsewhere, and
+        # the collector would then find no hooks at all. Set for this child only and
+        # restored afterwards: the rest of the installer must keep seeing what it had.
+        $hadPostinstallDataDir = Test-Path Env:LOONGSUITE_PILOT_DATA_DIR
+        $priorPostinstallDataDir = if ($hadPostinstallDataDir) {
+            (Get-Item Env:LOONGSUITE_PILOT_DATA_DIR).Value
+        } else { $null }
         $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
-        & $script:NODE_BIN $postinstallScript
-        $ErrorActionPreference = $prevEAP
+        try {
+            $env:LOONGSUITE_PILOT_DATA_DIR = $DataDir
+            & $script:NODE_BIN $postinstallScript
+            $postinstallExit = $LASTEXITCODE
+        } finally {
+            $ErrorActionPreference = $prevEAP
+            if ($hadPostinstallDataDir) {
+                Set-Item Env:LOONGSUITE_PILOT_DATA_DIR -Value $priorPostinstallDataDir
+            } else {
+                Remove-Item Env:LOONGSUITE_PILOT_DATA_DIR -ErrorAction SilentlyContinue
+            }
+        }
     }
-    Msg "    ✅ Hook 脚本已部署" "    ✅ Hook scripts deployed"
+    # Never print the check mark for a postinstall that did not finish. postinstall.js
+    # reports its own per-tree failures and still exits 0 on purpose (a non-zero exit
+    # would abort the npm install fallback above), so a non-zero code here means the
+    # process died outright. That is exactly how the hooks/skills/plugins trees went
+    # missing on every Windows install without a word: fs.cpSync fail-fasts with
+    # 0xC0000409 on the bundled Node, killing the script before it copied anything,
+    # and this line printed "Hook scripts deployed" regardless.
+    if ($postinstallExit -ne 0) {
+        Msg "    ❌ Hook 脚本部署失败 (exit=$postinstallExit)，hooks/plugins 可能缺失" `
+            "    ❌ Hook script deployment failed (exit=$postinstallExit); hooks/plugins may be missing"
+    } else {
+        Msg "    ✅ Hook 脚本已部署" "    ✅ Hook scripts deployed"
+    }
+    # <<< pilot-postinstall-exit-check <<<
     Write-Host ""
 }
 
@@ -1220,6 +1461,46 @@ function Print-Summary {
         "Tip: open a NEW terminal before using the loongsuite-pilot command (a WDAC/locked-down environment may require signing out and back in)."
     Write-Host "============================================================"
 }
+
+# >>> pilot-restart-stale-collector >>>
+# Displace a collector that outlived Stop-PilotService and therefore still serves the
+# PREVIOUS version dir. `start` is deliberately a no-op when a collector is already
+# running, and on a re-install one usually is: Stop-PilotService only ends the current
+# task instance, and Task Scheduler (or the updater's own collector watchdog) relaunches
+# it within seconds -- while `current` still names the old version dir, because
+# Deploy-Package writes the new one only after Ensure-NodeModules. collector-daemon.js
+# resolves `current` exactly once at startup, so that survivor keeps running the old
+# dist forever, while `status` reads `current` and confidently reports the NEW version.
+# Nothing crashes and nothing logs: the install says "Service started" and the bytes the
+# user just installed are simply never loaded. Measured on a re-install where the
+# survivor started 30s before the new version dir even existed.
+#
+# This became silent only once re-installs stopped overwriting the live version dir (pinned
+# by tests/unit/deploy/installer-version-dir-not-overwritten.test.mjs): while Deploy-Package still
+# did Remove-Item on it, the same survivor died with ERR_MODULE_NOT_FOUND and got restarted
+# onto the new version, so the bug announced itself. Keeping the old dir is right; this is
+# the other half of it.
+#
+# restart-collector (not restart) is what the updater uses after deploying a version: it
+# stops the collector unconditionally, kills orphans, then re-registers and starts it, and
+# it leaves the updater alone. Skipped when $priorVersion is empty -- a fresh install has
+# no survivor to displace, and `start` just launched the collector from the new `current`.
+#
+# $serviceEntry is whichever entry point the caller already resolved: the .ps1 needs
+# powershell.exe -File, the .cmd wrapper is invoked directly. Branching here rather than at
+# the call sites keeps this block byte-identical across the three installers.
+function Restart-StaleCollector {
+    param([string]$serviceEntry, [string]$priorVersion)
+    if (-not $priorVersion) { return }
+    if (-not $serviceEntry) { return }
+    if (-not (Test-Path $serviceEntry)) { return }
+    if ($serviceEntry -match '\.ps1$') {
+        & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $serviceEntry restart-collector 2>$null | Out-Null
+    } else {
+        & $serviceEntry restart-collector 2>$null | Out-Null
+    }
+}
+# <<< pilot-restart-stale-collector <<<
 
 # ============================================================
 # Stop service by PID file
@@ -1766,6 +2047,7 @@ function Start-PilotAndWait {
     param(
         [Parameter(Mandatory = $true)]
         [string]$ScriptPath,
+        [string]$PriorVersion = "",
         [int]$TimeoutSeconds = 30
     )
 
@@ -1776,6 +2058,7 @@ function Start-PilotAndWait {
     $startOutput = & powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $ScriptPath start 2>&1
     $startExit = $LASTEXITCODE
     $startOutput | ForEach-Object { Write-Host $_ }
+    Restart-StaleCollector $ScriptPath $PriorVersion
 
     $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
     do {
@@ -1824,7 +2107,7 @@ function Cmd-Install {
 
         Msg "==> 启动服务..." "==> Starting service..."
         $ps1Path = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot-service.ps1"
-        $started = Start-PilotAndWait -ScriptPath $ps1Path
+        $started = Start-PilotAndWait -ScriptPath $ps1Path -PriorVersion $curVer
         if (-not $started) {
             if ($curVer -and (Test-Path (Join-Path $CACHE_DIR "previous"))) {
                 Msg "⚠️  新安装未产生运行心跳，正在恢复 previous 版本..." `
@@ -1892,7 +2175,7 @@ function Cmd-Upgrade {
 
         Msg "==> 启动新版本..." "==> Starting new version..."
         $ps1Path = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot-service.ps1"
-        $started = Start-PilotAndWait -ScriptPath $ps1Path
+        $started = Start-PilotAndWait -ScriptPath $ps1Path -PriorVersion $oldVer
         if ($started) {
             Msg "    ✅ 新版本启动成功" "    ✅ New version started successfully"
             Write-Host ""
@@ -2139,11 +2422,65 @@ function Remove-OnePilotScheduledTask {
     }
 }
 
+# >>> pilot-account-identity >>>
+# Windows account identity, DOMAIN\user, without whoami. On 5.1 a native command's
+# stdout is decoded with [Console]::OutputEncoding -- the console codepage, 437 on an
+# en-US box -- so `whoami` returns "host\??" for a non-ASCII account name: every
+# character the codepage cannot represent arrives as a literal U+003F, measured on a
+# C:\Users\<CJK name> profile. That corrupted string used to reach
+# New-ScheduledTaskPrincipal -UserId, where Task Scheduler rejected the registration
+# with "No mapping between account names and security IDs was done" (HRESULT
+# 0x80131500), so such a user never got an autostart task at all; it also collapsed
+# every non-ASCII account to the same "___" task-name tag.
+#
+# The environment variables carry the real UTF-16 string and are CLM-safe, unlike
+# [Security.Principal.WindowsIdentity]::GetCurrent() (CLM: "Method invocation is
+# supported only on core types") and unlike [Environment]::UserName. USERDOMAIN is not
+# always an account domain: under some logon providers (OpenSSH sshd among them) it is
+# the literal "WORKGROUP", which maps to no SID either, so fall back to the machine
+# name -- which is also what whoami prints for a local account, keeping the tag below
+# byte-identical for ASCII users who upgrade in place.
+function Get-PilotAccountName {
+    $user = [string]$env:USERNAME
+    if (-not $user) { return "" }
+    $domain = [string]$env:USERDOMAIN
+    if ((-not $domain) -or ($domain -eq "WORKGROUP")) { $domain = [string]$env:COMPUTERNAME }
+    if ($domain) { return ($domain + "\" + $user) }
+    return $user
+}
+
+# Task names are per-user: multiple users can run on one machine, each with their
+# own data dir under %USERPROFILE%. A global task name would collide -- the second
+# user cannot delete or overwrite the first user's task (Access is denied), so it
+# would fail with "already exists" and drop to the background fallback. The shared
+# \LoongsuitePilot folder stays cross-user writable; only the task name is scoped.
+# Tag from the full DOMAIN\user identity, not $env:USERNAME alone (bare SAM name):
+# two same-named accounts from different domains (CORP\alice vs DEV\alice) would
+# otherwise share one task name and re-introduce the cross-user "already exists"
+# collision this scoping is meant to prevent. Task names live in the file system, so
+# everything outside [A-Za-z0-9._-] becomes "_" -- which turns a non-ASCII account
+# name into a row of underscores that two such users on one machine would fight over,
+# hence the short deterministic digest appended in that case only. ASCII installs keep
+# the exact tag they already have, so their registered tasks stay upgradeable in place.
+function Get-PilotUserTag {
+    $name = (Get-PilotAccountName).ToLower()
+    $tag = $name -replace '[^A-Za-z0-9._-]', '_'
+    if ($name -match '[^\x20-\x7E]') {
+        $hash = 0
+        foreach ($ch in $name.ToCharArray()) { $hash = ($hash * 31 + [int]$ch) % 1000000007 }
+        $tag = $tag + "-" + $hash
+    }
+    return $tag
+}
+# <<< pilot-account-identity <<<
+
 function Remove-PilotScheduledTasks {
     $taskFolder = "\LoongsuitePilot"
-    $currentIdentity = (whoami).Trim()
+    # Reconstruct the task names with the same helpers that registered them -- the tag
+    # must match byte for byte or uninstall silently leaves the tasks behind.
+    $currentIdentity = Get-PilotAccountName
     $currentUser = $env:USERNAME
-    $userTag = ($currentIdentity -replace '[^A-Za-z0-9._-]', '_')
+    $userTag = Get-PilotUserTag
     $currentUserTasks = @(
         "LoongsuitePilot-$userTag",
         "LoongsuitePilotUpdater-$userTag"

--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -1509,6 +1509,17 @@ function Print-Summary {
 # it leaves the updater alone. Skipped when $priorVersion is empty -- a fresh install has
 # no survivor to displace, and `start` just launched the collector from the new `current`.
 #
+# Skipped again when `start` did not say "already running". That line (Cmd-Start, off
+# Get-CollectorRuntime or the pid file) is the only evidence a survivor was there; without
+# it `start` launched the collector itself, from the new `current`, and there is nothing
+# stale to displace. The bounce is not free either: replacing a task the running principal
+# cannot write to is denied, and because callers treat a failed displacement as a failed
+# deploy, an unnecessary one can roll back an upgrade whose collector had come up correctly.
+# Callers pass the captured start output, hence Out-String -- it arrives as lines. Passing
+# nothing would silently turn this whole block back into a no-op, so every call site has to
+# pass a variable it filled from `start`, pinned by
+# tests/unit/deploy/installer-restart-stale-collector.test.mjs.
+#
 # $serviceEntry is whichever entry point the caller already resolved: the .ps1 needs
 # powershell.exe -File, the .cmd wrapper is invoked directly. Branching here rather than at
 # the call sites keeps this block byte-identical across the three installers.
@@ -1523,11 +1534,12 @@ function Print-Summary {
 # resolves `current`, which the survivor answers to exactly as well as the new collector
 # would, so "is running" cannot tell the two apart. That is the entire bug.
 function Restart-StaleCollector {
-    param([string]$serviceEntry, [string]$priorVersion)
+    param([string]$serviceEntry, [string]$priorVersion, $startOutput = "")
     $script:PILOT_LAST_RESTART_ERR = ""
     if (-not $priorVersion) { return $true }
     if (-not $serviceEntry) { return $true }
     if (-not (Test-Path $serviceEntry)) { return $true }
+    if (($startOutput | Out-String) -notmatch "already running") { return $true }
     # Locally forced to Continue: with 2>&1 in effect a caller left on Stop turns the first
     # stderr line into a NativeCommandError, which would report a successful restart as a
     # failure. restart-collector writes progress to stderr on purpose.
@@ -2107,7 +2119,7 @@ function Start-PilotAndWait {
     $startOutput = & powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $ScriptPath start 2>&1
     $startExit = $LASTEXITCODE
     $startOutput | ForEach-Object { Write-Host $_ }
-    $staleOk = Restart-StaleCollector $ScriptPath $PriorVersion
+    $staleOk = Restart-StaleCollector $ScriptPath $PriorVersion $startOutput
     if (-not $staleOk) {
         Write-Host "   $script:PILOT_LAST_RESTART_ERR" -ForegroundColor Yellow
     }

--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -894,11 +894,28 @@ deploy_package() {
         # postinstall.js falls back to $HOME/.loongsuite-pilot when this is unset, so
         # --data-dir would otherwise put hooks/skills/plugins in the default tree while
         # the config lives elsewhere.
-        LOONGSUITE_PILOT_DATA_DIR="$DATA_DIR" \
-            "$NODE_BIN" "$PERMANENT_DIR/scripts/postinstall.js" || {
-            msg "    ❌ Hook 脚本部署失败" "    ❌ Hook script deployment failed"
+        # Captured because two of the three failure modes are only in the output: a per-tree
+        # failure and a thrown main() both exit 0 on purpose (a non-zero exit would abort the
+        # npm install fallback above), announcing themselves as "N failed asset tree(s)" and
+        # "Post-install failed: <reason>" instead. 2>&1 because both go to stderr.
+        postinstall_exit=0
+        postinstall_out="$(LOONGSUITE_PILOT_DATA_DIR="$DATA_DIR" \
+            "$NODE_BIN" "$PERMANENT_DIR/scripts/postinstall.js" 2>&1)" || postinstall_exit=$?
+        # `if`, not `[ -n ... ] && printf`: under set -e the latter aborts the function when
+        # the output is empty.
+        if [ -n "$postinstall_out" ]; then
+            printf '%s\n' "$postinstall_out"
+        fi
+        if [ "$postinstall_exit" -ne 0 ]; then
+            msg "    ❌ Hook 脚本部署失败 (exit=$postinstall_exit)，hooks/plugins 缺失" \
+                "    ❌ Hook script deployment failed (exit=$postinstall_exit); hooks/plugins are missing"
             return 1
-        }
+        fi
+        if printf '%s' "$postinstall_out" | grep -qE "failed asset tree|Post-install failed"; then
+            msg "    ❌ Hook 脚本部分部署失败（见上方输出），hooks/plugins 缺失" \
+                "    ❌ Some hook asset trees failed to deploy (see the output above); hooks/plugins are missing"
+            return 1
+        fi
         msg "    ✅ Hook 脚本已部署" "    ✅ Hook scripts deployed"
         msg "    如使用 Codex 桌面版，首次启动需在桌面端手动信任 hooks" \
             "    If using Codex desktop app, please manually trust hooks on first launch"
@@ -1856,7 +1873,13 @@ cmd_install() {
     select_agents
     prompt_user_id
     confirm_config_overwrite
-    deploy_package "$INSTALL_SRC"
+    # set -e would end the install here anyway; saying why beats an exit code on its own.
+    if ! deploy_package "$INSTALL_SRC"; then
+        echo ""
+        msg "❌ 安装中止：hook 脚本部署失败，请检查上方输出后重试" \
+            "❌ Install aborted: hook script deployment failed; check the output above and retry"
+        exit 1
+    fi
     write_config
     install_loongsuite_pilot_command
     inject_qodercli_token_intercept

--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -891,7 +891,11 @@ deploy_package() {
 
     msg "==> 部署 hook 脚本..." "==> Deploying hook scripts..."
     if [ -f "$PERMANENT_DIR/scripts/postinstall.js" ]; then
-        "$NODE_BIN" "$PERMANENT_DIR/scripts/postinstall.js" || {
+        # postinstall.js falls back to $HOME/.loongsuite-pilot when this is unset, so
+        # --data-dir would otherwise put hooks/skills/plugins in the default tree while
+        # the config lives elsewhere.
+        LOONGSUITE_PILOT_DATA_DIR="$DATA_DIR" \
+            "$NODE_BIN" "$PERMANENT_DIR/scripts/postinstall.js" || {
             msg "    ❌ Hook 脚本部署失败" "    ❌ Hook script deployment failed"
             return 1
         }

--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -58,16 +58,59 @@ $SPAN_ATTR_FILE = Join-Path $DATA_DIR "span-attributes.json"
 $NODE_PIN_FILE = Join-Path $CACHE_DIR "node-bin"
 $INIT_TYPE_FILE = Join-Path $DATA_DIR "init-type"
 
+# >>> pilot-account-identity >>>
+# Windows account identity, DOMAIN\user, without whoami. On 5.1 a native command's
+# stdout is decoded with [Console]::OutputEncoding -- the console codepage, 437 on an
+# en-US box -- so `whoami` returns "host\??" for a non-ASCII account name: every
+# character the codepage cannot represent arrives as a literal U+003F, measured on a
+# C:\Users\<CJK name> profile. That corrupted string used to reach
+# New-ScheduledTaskPrincipal -UserId, where Task Scheduler rejected the registration
+# with "No mapping between account names and security IDs was done" (HRESULT
+# 0x80131500), so such a user never got an autostart task at all; it also collapsed
+# every non-ASCII account to the same "___" task-name tag.
+#
+# The environment variables carry the real UTF-16 string and are CLM-safe, unlike
+# [Security.Principal.WindowsIdentity]::GetCurrent() (CLM: "Method invocation is
+# supported only on core types") and unlike [Environment]::UserName. USERDOMAIN is not
+# always an account domain: under some logon providers (OpenSSH sshd among them) it is
+# the literal "WORKGROUP", which maps to no SID either, so fall back to the machine
+# name -- which is also what whoami prints for a local account, keeping the tag below
+# byte-identical for ASCII users who upgrade in place.
+function Get-PilotAccountName {
+    $user = [string]$env:USERNAME
+    if (-not $user) { return "" }
+    $domain = [string]$env:USERDOMAIN
+    if ((-not $domain) -or ($domain -eq "WORKGROUP")) { $domain = [string]$env:COMPUTERNAME }
+    if ($domain) { return ($domain + "\" + $user) }
+    return $user
+}
+
 # Task names are per-user: multiple users can run on one machine, each with their
 # own data dir under %USERPROFILE%. A global task name would collide -- the second
 # user cannot delete or overwrite the first user's task (Access is denied), so it
 # would fail with "already exists" and drop to the background fallback. The shared
 # \LoongsuitePilot folder stays cross-user writable; only the task name is scoped.
-# Tag from whoami (DOMAIN\user) -- the same identity used for the task principal --
-# not $env:USERNAME (bare SAM name): two same-named accounts from different domains
-# (CORP\alice vs DEV\alice) would otherwise share one task name and re-introduce the
-# cross-user "already exists" collision this scoping is meant to prevent.
-$USER_TAG = ((whoami) -replace '[^A-Za-z0-9._-]', '_')
+# Tag from the full DOMAIN\user identity, not $env:USERNAME alone (bare SAM name):
+# two same-named accounts from different domains (CORP\alice vs DEV\alice) would
+# otherwise share one task name and re-introduce the cross-user "already exists"
+# collision this scoping is meant to prevent. Task names live in the file system, so
+# everything outside [A-Za-z0-9._-] becomes "_" -- which turns a non-ASCII account
+# name into a row of underscores that two such users on one machine would fight over,
+# hence the short deterministic digest appended in that case only. ASCII installs keep
+# the exact tag they already have, so their registered tasks stay upgradeable in place.
+function Get-PilotUserTag {
+    $name = (Get-PilotAccountName).ToLower()
+    $tag = $name -replace '[^A-Za-z0-9._-]', '_'
+    if ($name -match '[^\x20-\x7E]') {
+        $hash = 0
+        foreach ($ch in $name.ToCharArray()) { $hash = ($hash * 31 + [int]$ch) % 1000000007 }
+        $tag = $tag + "-" + $hash
+    }
+    return $tag
+}
+# <<< pilot-account-identity <<<
+
+$USER_TAG = Get-PilotUserTag
 $TASK_NAME_COLLECTOR = "LoongsuitePilot-$USER_TAG"
 $TASK_NAME_UPDATER = "LoongsuitePilotUpdater-$USER_TAG"
 $TASK_FOLDER = "\LoongsuitePilot"
@@ -97,10 +140,18 @@ function Test-NodeSuitable {
     } catch { return $false }
 }
 
+# The pin file holds one absolute path to node.exe, and for a managed runtime that path
+# sits under the data dir -- i.e. under %USERPROFILE%, which can be non-ASCII. 5.1
+# defaults both Get-Content and Set-Content to the ANSI codepage, so an unqualified
+# write stored "C:\Users\??.HOST\..." and every reader then failed Test-NodeSuitable and
+# silently fell back to whatever node.exe the fallback search found first -- on a shared
+# machine that was another account's nvm install. -Encoding UTF8 always emits a BOM on
+# 5.1 (there is no utf8NoBOM), and U+FEFF is not whitespace, so .Trim() alone leaves it
+# in the path: strip it explicitly before trimming.
 function Resolve-Node {
     # 1. Pinned file
     if (Test-Path $NODE_PIN_FILE) {
-        $pinned = (Get-Content $NODE_PIN_FILE -ErrorAction SilentlyContinue).Trim()
+        $pinned = ([string](Get-Content -LiteralPath $NODE_PIN_FILE -Raw -Encoding UTF8 -ErrorAction SilentlyContinue)).Trim([char]0xFEFF).Trim()
         if ($pinned -and (Test-NodeSuitable $pinned)) {
             return $pinned
         }
@@ -138,7 +189,7 @@ function Resolve-Node {
             # Auto-heal: update pin file
             $parentDir = Split-Path $NODE_PIN_FILE
             if (-not (Test-Path $parentDir)) { New-Item -ItemType Directory -Path $parentDir -Force | Out-Null }
-            Set-Content -Path $NODE_PIN_FILE -Value $c
+            Set-Content -LiteralPath $NODE_PIN_FILE -Value $c -Encoding UTF8
             return $c
         }
     }
@@ -400,7 +451,7 @@ function Register-PilotTask {
         $settings,
         [string]$description
     )
-    $userId = whoami
+    $userId = Get-PilotAccountName
     $lastErr = $null
     foreach ($logonType in @("Interactive", "S4U")) {
         # Clear any task a previous attempt left behind. A failed registration can
@@ -489,7 +540,7 @@ function Install-CollectorTask {
     # -User scopes the logon trigger to the current user; without it the trigger
     # fires for ALL users, which requires admin rights and fails registration with
     # "Access is denied" (0x80070005) for standard users.
-    $triggerLogon = New-ScheduledTaskTrigger -AtLogOn -User (whoami)
+    $triggerLogon = New-ScheduledTaskTrigger -AtLogOn -User (Get-PilotAccountName)
     $triggerRepeat = New-ScheduledTaskTrigger -Once -At (Get-Date) `
         -RepetitionInterval (New-TimeSpan -Minutes 5)
 
@@ -530,7 +581,7 @@ function Install-UpdaterTask {
     $action = New-HiddenTaskAction (Join-Path $BOOTSTRAP_DIR "updater-launch.vbs") $nodeBin $entry
 
     # -User scopes the trigger to the current user (all-users trigger needs admin).
-    $triggerLogon = New-ScheduledTaskTrigger -AtLogOn -User (whoami)
+    $triggerLogon = New-ScheduledTaskTrigger -AtLogOn -User (Get-PilotAccountName)
     $triggerRepeat = New-ScheduledTaskTrigger -Once -At (Get-Date) `
         -RepetitionInterval (New-TimeSpan -Minutes 5)
 
@@ -1094,7 +1145,7 @@ function Cmd-Info {
     Write-Host "versions_dir=$VERSIONS_DIR"
 
     if (Test-Path $NODE_PIN_FILE) {
-        $pinnedNode = (Get-Content $NODE_PIN_FILE -ErrorAction SilentlyContinue).Trim()
+        $pinnedNode = ([string](Get-Content -LiteralPath $NODE_PIN_FILE -Raw -Encoding UTF8 -ErrorAction SilentlyContinue)).Trim([char]0xFEFF).Trim()
         if ($pinnedNode -and (Test-Path $pinnedNode)) {
             $nodeVer = & $pinnedNode --version 2>$null
             Write-Host "node_bin=$pinnedNode"

--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -456,7 +456,18 @@ function Register-PilotTask {
     foreach ($logonType in @("Interactive", "S4U")) {
         # Clear any task a previous attempt left behind. A failed registration can
         # still create the task entry before erroring on the principal.
+        #
+        # The delete output stays suppressed: on a fresh install there is nothing to
+        # delete and schtasks exits non-zero, so its stderr is noise (and a bare stderr
+        # line can turn terminating under $ErrorActionPreference = "Stop"). A task that
+        # SURVIVES the delete is a different story and worth a line -- it means this
+        # process has no write access to the task and the registration below is about to
+        # fail with "Access is denied" or a name collision. Without this, the only
+        # symptom was the registration error, which reads like a bug in the principal.
         try { schtasks.exe /Delete /TN "$TASK_FOLDER\$taskName" /F 2>$null | Out-Null } catch {}
+        if (Get-TaskExists $taskName) {
+            Write-Host "   '$taskName' survived the delete; re-registration will likely be denied" -ForegroundColor Yellow
+        }
         try {
             # On-disk location of the task definition (absolute filesystem path).
             $diskPath = "$env:SystemRoot\System32\Tasks$TASK_FOLDER\$taskName"
@@ -838,9 +849,33 @@ function Cmd-RestartCollector {
     # Restart via Task Scheduler if registered
     $restarted = $false
     if (Get-TaskExists $TASK_NAME_COLLECTOR) {
+        # Re-register with potentially updated paths -- best-effort, and deliberately
+        # in its OWN try so a failure here can no longer skip the start below.
+        #
+        # A scheduled task grants its own principal only Read: every write ACE sits on
+        # BUILTIN\Administrators, and UAC filters that group out of the token of a
+        # -RunLevel Limited task, which is what our two daemons run as. So the updater
+        # that invokes restart-collector cannot touch its own task definition. Measured
+        # on a Medium-integrity Limited task against a task registered earlier:
+        # schtasks /Delete, Register-ScheduledTask and Register-ScheduledTask -Force all
+        # fail with "Access is denied" -- -Force is not a fix -- while
+        # Start-ScheduledTask succeeds, because starting needs no write access.
+        #
+        # Nothing is lost by skipping the re-registration: Install-CollectorTask rewrites
+        # collector-launch.vbs and reaps orphaned daemons before it reaches the
+        # registration, and the task action invokes that .vbs by a path that does not
+        # change across versions -- so the surviving registration already launches the
+        # new version. Sharing one try was the whole defect: a cosmetic re-register
+        # failure aborted before Start-ScheduledTask, and with init_type=taskscheduler
+        # the self-heal branch below is skipped, so the update ended in "Service manager
+        # failed to restart collector" + exit 1 while the collector stayed down until the
+        # task's own 5-minute watchdog trigger happened to relaunch it.
         try {
-            # Re-register with potentially updated paths
             Install-CollectorTask $nodeBin | Out-Null
+        } catch {
+            Write-Host "Task re-registration skipped (start still attempted): $($_.Exception.Message)" -ForegroundColor Yellow
+        }
+        try {
             Start-ScheduledTask -TaskName $TASK_NAME_COLLECTOR -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
             Write-Host "collector restarted (Task Scheduler)"
             $restarted = $true
@@ -934,8 +969,15 @@ function Cmd-RestartUpdater {
     # Restart via Task Scheduler
     $restarted = $false
     if (Get-TaskExists $TASK_NAME_UPDATER) {
+        # Best-effort re-registration in its own try, for the same reason as in
+        # Cmd-RestartCollector above (a -RunLevel Limited task cannot rewrite its own
+        # definition; only starting it works). See the comment there.
         try {
             Install-UpdaterTask $nodeBin | Out-Null
+        } catch {
+            Write-Host "Task re-registration skipped (start still attempted): $($_.Exception.Message)" -ForegroundColor Yellow
+        }
+        try {
             Start-ScheduledTask -TaskName $TASK_NAME_UPDATER -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
             Start-Sleep -Seconds 1
             if (Get-TaskRunning $TASK_NAME_UPDATER) {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 /**
  * Post-install script for loongsuite-pilot
- * 
+ *
  * This script runs automatically after `npm install` and:
  * 1. Copies hook scripts from assets/hooks/ to ~/.loongsuite-pilot/hooks/
- * 2. Sets permissions with least-privilege defaults
- * 
+ * 2. Copies skill docs and agent plugins into the same data dir
+ * 3. Sets permissions with least-privilege defaults
+ *
  * This mirrors the approach used by @ali/loongsuite-pilot
  */
 
@@ -50,100 +51,137 @@ function installHookFile(sourcePath, targetPath) {
 }
 
 /**
+ * Recursively copy a directory tree using only mkdir + read/write.
+ *
+ * `fs.cpSync` is deliberately NOT used here. On Windows the bundled Node kills
+ * the whole process on the very first recursive call: exit 0xC0000409
+ * (STATUS_STACK_BUFFER_OVERRUN), no JS exception, no stderr, and nothing copied
+ * -- `fs.cpSync` moved to a C++ std::filesystem implementation in Node 22.9,
+ * and that implementation fail-fasts on this platform. Reproduced with the
+ * bundled node v22.22.2 and with v22.22.3, on a two-file ASCII tree, so it is
+ * not about path length or non-ASCII paths; mkdirSync + copyFileSync copy the
+ * same tree fine, and the async `fs.cp` is unaffected.
+ *
+ * Because the process DIES rather than throwing, a try/catch around cpSync
+ * never runs. That is what made this silent for so long: the first copy killed
+ * the script, so everything after it -- skill docs, agent plugins, the legacy
+ * intercept stub, the config migration -- was skipped without a single line of
+ * output, while the installer went on to print "Hook scripts deployed". The
+ * missing plugins tree in turn failed every dsh deployment with "plugin file
+ * not found or unreadable", once per collection cycle, forever.
+ */
+function copyTree(sourceDir, targetDir) {
+  ensureDir(targetDir);
+  let count = 0;
+  for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
+    // AppleDouble sidecars ride along when the release tarball is built on a
+    // Mac. They are never runnable content and only confuse anything that
+    // enumerates these directories, so drop them at the copy boundary.
+    if (entry.name.startsWith('._') || entry.name === '.DS_Store') continue;
+    const sourcePath = path.join(sourceDir, entry.name);
+    const targetPath = path.join(targetDir, entry.name);
+    if (entry.isDirectory()) {
+      count += copyTree(sourcePath, targetPath);
+    } else {
+      installHookFile(sourcePath, targetPath);
+      count++;
+    }
+  }
+  return count;
+}
+
+/**
+ * Delete AppleDouble sidecars already sitting in a target tree.
+ *
+ * copyTree refuses to bring new ones in, but every install made before the
+ * packaging fix (COPYFILE_DISABLE around the release tar) left ~75 of them in
+ * the hooks tree, and they are not self-clearing: nothing else ever
+ * deletes a file the current package no longer ships. They matter because these
+ * directories are enumerated -- hook-manager and the plugin strategies walk them
+ * looking for runnable files.
+ *
+ * Best-effort by design: an unremovable stray is not worth failing an install.
+ */
+function pruneSidecars(targetDir) {
+  let removed = 0;
+  let entries;
+  try {
+    entries = fs.readdirSync(targetDir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  for (const entry of entries) {
+    const full = path.join(targetDir, entry.name);
+    if (entry.isDirectory()) {
+      removed += pruneSidecars(full);
+    } else if (entry.name.startsWith('._') || entry.name === '.DS_Store') {
+      try {
+        fs.unlinkSync(full);
+        removed++;
+      } catch {
+        // leave it; it is inert either way
+      }
+    }
+  }
+  return removed;
+}
+
+/**
  * Main installation logic
  */
+/**
+ * Copy one asset tree, reporting rather than throwing.
+ *
+ * Every tree gets its own guard so that one unwritable target can no longer
+ * take the remaining trees down with it -- the old shape ran hooks, skills and
+ * plugins as one straight line, so whatever failed first ended the script.
+ * Returns true when the tree is installed or genuinely absent from the package.
+ */
+function installTree(label, sourceDir, targetDir) {
+  if (!fs.existsSync(sourceDir)) {
+    console.log(`[loongsuite-pilot] No ${label} found in package, skipping.`);
+    return true;
+  }
+  try {
+    const count = copyTree(sourceDir, targetDir);
+    const pruned = pruneSidecars(targetDir);
+    const suffix = pruned > 0 ? ` (removed ${pruned} stale sidecar file(s))` : '';
+    console.log(`[loongsuite-pilot] Installed ${count} ${label} to ${targetDir}${suffix}`);
+    return true;
+  } catch (error) {
+    console.error(`[loongsuite-pilot] Failed to install ${label}:`, error.message);
+    return false;
+  }
+}
+
 function main() {
   console.log('[loongsuite-pilot] Installing hook scripts...');
 
-  // Check if source directory exists
-  if (!fs.existsSync(HOOKS_SOURCE_DIR)) {
-    console.log('[loongsuite-pilot] No hook scripts found, skipping.');
-    return;
-  }
+  let failed = 0;
 
-  // Create target directory
-  ensureDir(HOOKS_TARGET_DIR);
+  if (!installTree('hook script(s)', HOOKS_SOURCE_DIR, HOOKS_TARGET_DIR)) failed++;
 
-  // Recursively copy all hook scripts (including subdirectories: shared/, claude-code/, codex/)
-  let copySuccess = false;
-  try {
-    fs.cpSync(HOOKS_SOURCE_DIR, HOOKS_TARGET_DIR, { recursive: true });
-    copySuccess = true;
-  } catch (error) {
-    console.error('[loongsuite-pilot] Recursive copy failed, falling back to file-by-file:', error.message);
-    // Fallback: walk source dir and copy files individually
+  // Ensure .sh/.ps1 files have execute permission (belt-and-suspenders: copyTree
+  // already sets the mode at write time, but a pre-existing file keeps its own).
+  if (fs.existsSync(HOOKS_TARGET_DIR)) {
     try {
-      function copyRecursive(src, dest) {
-        ensureDir(dest);
-        for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
-          const srcPath = path.join(src, entry.name);
-          const destPath = path.join(dest, entry.name);
-          if (entry.isDirectory()) {
-            copyRecursive(srcPath, destPath);
-          } else {
-            installHookFile(srcPath, destPath);
-          }
-        }
-      }
-      copyRecursive(HOOKS_SOURCE_DIR, HOOKS_TARGET_DIR);
-      copySuccess = true;
-    } catch (fallbackError) {
-      console.error('[loongsuite-pilot] File-by-file fallback also failed:', fallbackError.message);
-    }
-  }
-
-  if (!copySuccess) {
-    console.error('[loongsuite-pilot] Hook scripts installation failed. Hooks may not work correctly.');
-    return;
-  }
-
-  // Ensure .sh files have execute permission (cpSync preserves mode on most OS, belt-and-suspenders)
-  let installedCount = 0;
-  function fixPermissions(dir) {
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-      const fullPath = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        fixPermissions(fullPath);
-      } else if (entry.name.endsWith('.sh') || entry.name.endsWith('.ps1')) {
-        try { fs.chmodSync(fullPath, 0o755); } catch {}
-        installedCount++;
-      } else if (entry.name.endsWith('.mjs') || entry.name.endsWith('.py')) {
-        installedCount++;
-      }
-    }
-  }
-  fixPermissions(HOOKS_TARGET_DIR);
-
-  console.log(`[loongsuite-pilot] Installed ${installedCount} hook script(s) to ${HOOKS_TARGET_DIR}`);
-
-  if (fs.existsSync(SKILLS_SOURCE_DIR)) {
-    try {
-      fs.cpSync(SKILLS_SOURCE_DIR, SKILLS_TARGET_DIR, { recursive: true });
-      console.log(`[loongsuite-pilot] Installed skill docs to ${SKILLS_TARGET_DIR}`);
-    } catch (error) {
-      console.error('[loongsuite-pilot] Failed to install skill docs:', error.message);
-    }
-  }
-
-  if (fs.existsSync(PLUGINS_SOURCE_DIR)) {
-    try {
-      fs.cpSync(PLUGINS_SOURCE_DIR, PLUGINS_TARGET_DIR, { recursive: true });
-      let pluginCount = 0;
-      function countPlugins(dir) {
+      const fixPermissions = (dir) => {
         for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-          if (entry.isDirectory()) {
-            countPlugins(path.join(dir, entry.name));
-          } else if (entry.name.endsWith('.mjs') || entry.name.endsWith('.js')) {
-            pluginCount++;
+          const fullPath = path.join(dir, entry.name);
+          if (entry.isDirectory()) fixPermissions(fullPath);
+          else if (entry.name.endsWith('.sh') || entry.name.endsWith('.ps1')) {
+            try { fs.chmodSync(fullPath, 0o755); } catch {}
           }
         }
-      }
-      countPlugins(PLUGINS_TARGET_DIR);
-      console.log(`[loongsuite-pilot] Installed ${pluginCount} plugin(s) to ${PLUGINS_TARGET_DIR}`);
+      };
+      fixPermissions(HOOKS_TARGET_DIR);
     } catch (error) {
-      console.error('[loongsuite-pilot] Failed to install plugins:', error.message);
+      console.error('[loongsuite-pilot] Failed to set hook permissions:', error.message);
     }
   }
+
+  if (!installTree('skill doc(s)', SKILLS_SOURCE_DIR, SKILLS_TARGET_DIR)) failed++;
+  if (!installTree('plugin(s)', PLUGINS_SOURCE_DIR, PLUGINS_TARGET_DIR)) failed++;
 
   // Place a no-op intercept.js stub at the legacy path.
   // Old otel-claude-hook versions injected NODE_OPTIONS="--require intercept.js" into shell profiles.
@@ -159,6 +197,17 @@ function main() {
       // Non-critical, don't fail
       console.error(`  ✗ Failed to create intercept.js stub:`, error.message);
     }
+  }
+
+  // Reported, not signalled through the exit code on purpose. This same script is
+  // package.json's `postinstall`, so on the installers' `npm install` fallback path
+  // a non-zero exit here surfaces as "Dependencies installation failed" and aborts
+  // the whole install (the .ps1 installers exit 1 on a non-zero npm exit). A missing
+  // skills or plugins tree is not worth failing an install over; the installers
+  // check the process exit code to catch a hard crash, and this line to explain a
+  // partial result.
+  if (failed > 0) {
+    console.error(`[loongsuite-pilot] Post-install completed with ${failed} failed asset tree(s).`);
   }
 }
 

--- a/src/deployment/deployment-manager.ts
+++ b/src/deployment/deployment-manager.ts
@@ -318,6 +318,18 @@ export class DeploymentManager {
       }
 
       this.state[def.id] = newRecord;
+    } else if (!result.skipped) {
+      // A strategy that RETURNS {success:false, error} used to vanish here: only a
+      // thrown error was logged, and deployAll just added it to the `failed` tally.
+      // So "deployAll complete {failed:1}" was the entire record of dsh failing every
+      // cycle with "plugin file not found or unreadable" -- the reason never reached
+      // the log, which is why a missing plugins/ tree took a live filesystem probe to
+      // find rather than a grep.
+      logger.error('deployment failed', {
+        agentId: def.id,
+        deployMode: def.deployMode,
+        error: result.error ?? 'strategy reported failure without an error',
+      });
     }
 
     return result;

--- a/src/updater/updater.ts
+++ b/src/updater/updater.ts
@@ -10,6 +10,11 @@ import * as os from 'node:os';
 import type { AutoUpdateConfig } from '../types/index.js';
 import { createLogger } from '../utils/logger.js';
 import { readJsonFile, writeJsonFile, resolveHome } from '../utils/fs-utils.js';
+import {
+  extractTarGz,
+  makeTarStagingDir,
+  replaceDirWith,
+} from '../utils/win-archive.js';
 import { compareVersions, computeSha256, deterministicBucket } from './version-utils.js';
 import type { UpdaterMetrics } from './updater-metrics.js';
 import { updaterRuntimePath, type UpdaterRuntimeState } from './runtime-state.js';
@@ -485,11 +490,16 @@ export class Updater {
     manifest: VersionManifest,
   ): Promise<void> {
     const { cacheDir, versionsDir } = this.paths;
-    const tmpDir = path.join(cacheDir, 'download-tmp');
+    // The tarball is unpacked with tar.exe, which cannot address a non-ASCII path
+    // (see utils/win-archive.ts), so under C:\Users\<CJK name> the download staging
+    // moves to an ASCII root. The extracted tree is copied into stagingDir below
+    // with fs.cp, which is Unicode-safe.
+    const tmpDir = await makeTarStagingDir(path.join(cacheDir, 'download-tmp'));
     const tarball = path.join(tmpDir, 'package.tar.gz');
-    const dirName = `${manifest.version}_${manifest.git_commit}`;
-    const targetDir = path.join(versionsDir, dirName);
-    const stagingDir = path.join(versionsDir, `${dirName}.candidate`);
+    const baseDirName = `${manifest.version}_${manifest.git_commit}`;
+    let dirName = baseDirName;
+    let targetDir = path.join(versionsDir, dirName);
+    const stagingDir = path.join(versionsDir, `${baseDirName}.candidate`);
     let activated = false;
     let oldCurrent: string | null = null;
     let oldPrevious: string | null = null;
@@ -529,7 +539,7 @@ export class Updater {
       }
 
       logger.info('extracting update');
-      await execFileAsync('tar', ['-xzf', tarball, '-C', tmpDir]);
+      await extractTarGz(tarball, tmpDir, ARCHIVE_EXTRACT_TIMEOUT_MS);
 
       const extractedDir = await this.findExtractedPackage(tmpDir);
       if (!extractedDir) {
@@ -576,14 +586,36 @@ export class Updater {
         timeout: 30_000,
       });
 
+      // The new package's postinstall is what (re)fills <dataDir>/{hooks,skills,plugins}.
+      // It is also how an install broken by the fs.cpSync fail-fast heals itself: the
+      // trees get rebuilt and the stale AppleDouble sidecars pruned on the next upgrade,
+      // with no reinstall. Do not drop this call -- a missing plugins tree fails every
+      // dsh deployment with "plugin file not found or unreadable", once per cycle.
       const postinstallScript = path.join(stagingDir, 'scripts', 'postinstall.js');
       if (await fs.access(postinstallScript).then(() => true).catch(() => false)) {
         try {
-          await execFileAsync(nodeBin, [postinstallScript], {
+          const { stdout, stderr } = await execFileAsync(nodeBin, [postinstallScript], {
             cwd: stagingDir,
-            env: childEnv,
+            env: {
+              ...childEnv,
+              // Pin the target explicitly instead of trusting what we inherited: the
+              // script otherwise falls back to $HOME/.loongsuite-pilot, which is the
+              // wrong tree for any install using a custom data dir.
+              LOONGSUITE_PILOT_DATA_DIR: this.paths.dataDir,
+            },
             timeout: 30_000,
           });
+          // postinstall exits 0 even when a tree failed (it is package.json's
+          // `postinstall`, and a non-zero exit there aborts the whole install), so the
+          // only signal for a partial result is its own output. Unlogged, this path
+          // reproduces the failure mode it exists to heal: hooks or plugins absent while
+          // every step reports success.
+          const output = `${stdout ?? ''}${stderr ?? ''}`.trim();
+          if (/failed asset tree/.test(output)) {
+            logger.warn('postinstall reported failed asset trees', { output });
+          } else if (output) {
+            logger.info('postinstall completed', { output });
+          }
         } catch (err) {
           logger.warn('postinstall failed, continuing', { error: String(err) });
         }
@@ -594,7 +626,18 @@ export class Updater {
       oldPrevious = await this.readPointerFile(previousFile);
 
       try {
-        await fs.rm(targetDir, { recursive: true, force: true });
+        // Never overwrite an existing version directory in place: `current` may still
+        // point at it and a collector relaunched mid-deploy would die with
+        // ERR_MODULE_NOT_FOUND (last-startup-crash.json phase=module_load), and a live
+        // collector may still hold native modules loaded out of it. Redeploying the
+        // same version/commit therefore lands in a suffixed sibling, which is what
+        // deploy/installer*.ps1 does too. Version and commit are read from VERSION, not
+        // from the directory name, so the suffix is inert.
+        if (await fs.access(targetDir).then(() => true).catch(() => false)) {
+          const suffix = `${new Date().toISOString().replace(/[^0-9]/g, '').slice(0, 14)}_${Math.floor(Math.random() * 9000) + 1000}`;
+          dirName = `${baseDirName}_${suffix}`;
+          targetDir = path.join(versionsDir, dirName);
+        }
         await fs.rename(stagingDir, targetDir);
 
         if (oldCurrent && oldCurrent !== dirName) {
@@ -769,9 +812,11 @@ export class Updater {
     let tmp = '';
 
     try {
-      // Stage inside versionsDir (same filesystem as versionDir) so the final
-      // rename can't hit EXDEV across a separate tmpfs.
-      tmp = await fs.mkdtemp(path.join(this.paths.versionsDir, '.pilot-nm-'));
+      // Stage inside versionsDir (same filesystem as versionDir) so the final rename
+      // can't hit EXDEV across a separate tmpfs. Exception: a non-ASCII versionsDir
+      // (C:\Users\<CJK name>\...) is invisible to tar.exe, so staging then moves to an
+      // ASCII root and replaceDirWith below handles the possible cross-volume move.
+      tmp = await makeTarStagingDir(path.join(this.paths.versionsDir, `.pilot-nm-${process.pid}`));
 
       logger.info('downloading prebuilt node_modules', { appVersion, os: osName, arch });
       await this.downloadFile(`${base}/${archive}`, path.join(tmp, archive));
@@ -782,17 +827,14 @@ export class Updater {
 
       const stage = path.join(tmp, 'stage');
       await fs.mkdir(stage, { recursive: true });
-      await execFileAsync('tar', ['-xzf', path.join(tmp, archive), '-C', stage], {
-        timeout: ARCHIVE_EXTRACT_TIMEOUT_MS,
-      });
+      await extractTarGz(path.join(tmp, archive), stage, ARCHIVE_EXTRACT_TIMEOUT_MS);
       const stagedModules = path.join(stage, 'node_modules');
       if (!await fs.access(stagedModules).then(() => true).catch(() => false)) {
         logger.warn('prebuilt node_modules archive has no node_modules/, falling back to npm install');
         return false;
       }
       await fs.writeFile(path.join(stagedModules, '.pilot-modules-version'), stamp + '\n');
-      await fs.rm(modulesDir, { recursive: true, force: true });
-      await fs.rename(stagedModules, modulesDir);
+      await replaceDirWith(stagedModules, modulesDir);
       logger.info('prebuilt node_modules installed', { appVersion });
       return true;
     } catch (err) {
@@ -875,7 +917,11 @@ export class Updater {
         `Expand-Archive -LiteralPath '${q(archive)}' -DestinationPath '${q(destDir)}' -Force`,
       ], { timeout: ARCHIVE_EXTRACT_TIMEOUT_MS });
     } else {
-      await execFileAsync('tar', ['-xzf', archive, '-C', destDir], { timeout: ARCHIVE_EXTRACT_TIMEOUT_MS });
+      // Windows only ever takes the zip branch above, which is why a non-ASCII
+      // destDir (<dataDir>/runtime under a CJK profile) is safe here: Expand-Archive
+      // is Unicode-safe, tar.exe would not be. extractTarGz still routes through
+      // System32\tar.exe so a Git-for-Windows GNU tar on PATH cannot capture it.
+      await extractTarGz(archive, destDir, ARCHIVE_EXTRACT_TIMEOUT_MS);
     }
   }
 

--- a/src/utils/win-archive.ts
+++ b/src/utils/win-archive.ts
@@ -1,0 +1,187 @@
+/**
+ * Windows tar.exe helpers: an ASCII staging root and a tar invocation that survives
+ * a Git-for-Windows PATH. The node side of what deploy/installer-opensource.ps1 does in
+ * the `pilot-ascii-temp` block and Expand-PilotTarGz — the .ps1 side is pinned by
+ * tests/unit/scripts/ps1-nonascii-windows-paths.test.mjs.
+ * Two distinct Windows traps, both measured on a CJK-profile box:
+ *
+ * 1) argv encoding. Node hands arguments to CreateProcessW as UTF-16 (verified:
+ *    child_process passes a path with 4 non-ASCII chars and 0 '?'), but bsdtar
+ *    (%SystemRoot%\System32\tar.exe) enters through the ANSI CRT and converts them
+ *    back through the machine's ANSI codepage. On an en-US box every character that
+ *    page cannot represent reaches tar as a literal '?', so both -f and -C point at
+ *    paths that do not exist:
+ *      tar: Error opening archive: Failed to open 'C:\Users\??.HOST\...\pkg.tar.gz'
+ *    Under C:\Users\<CJK name> that fails every auto-update (package extraction) and
+ *    every prebuilt node_modules adoption. It is not a console setting: chcp 65001 and
+ *    a UTF-8 stdio encoding change stdio decoding, not argv conversion; 8.3 short names
+ *    work only where 8dot3 creation is still enabled, so they cannot be relied on.
+ *
+ * 2) which tar. A bare `tar` resolves through PATH, and with Git for Windows installed
+ *    that is Git's bundled GNU tar (MSYS), which reads the colon in `-f C:\...` as rsh
+ *    host:path syntax and dies with "Cannot connect to C: resolve failed" (older builds
+ *    hang). Prefer System32\tar.exe, then fall back to PATH's tar with --force-local,
+ *    which is what makes GNU tar treat the colon as part of a local filename. Never
+ *    pass --force-local to bsdtar: it rejects the unknown flag and exits immediately.
+ *
+ * The staging root can be machine-wide (%SystemRoot%\Temp), so it is for downloaded
+ * archives only: never stage credentials or config there, use dataDir.
+ */
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { createLogger } from './logger.js';
+
+const execFileAsync = promisify(execFile);
+const logger = createLogger('WinArchive');
+
+/** Printable ASCII only — the same test the .ps1 blocks use (`-notmatch '[^\x20-\x7E]'`). */
+export function isAsciiPath(p: string): boolean {
+  return !/[^\x20-\x7E]/.test(p);
+}
+
+let asciiTempRoot: string | null = null;
+
+/**
+ * A temp root guaranteed to be ASCII. Returns os.tmpdir() unchanged when it is
+ * already ASCII (the overwhelmingly common case, and on every non-Windows host).
+ */
+export async function getAsciiTempRoot(): Promise<string> {
+  if (asciiTempRoot) return asciiTempRoot;
+
+  const base = os.tmpdir();
+  if (process.platform !== 'win32' || isAsciiPath(base)) {
+    asciiTempRoot = base;
+    return base;
+  }
+
+  const candidates: string[] = [];
+  if (process.env.SystemRoot) candidates.push(path.join(process.env.SystemRoot, 'Temp'));
+  if (process.env.SystemDrive) candidates.push(`${process.env.SystemDrive}\\loongsuite-pilot-tmp`);
+  candidates.push('C:\\Windows\\Temp');
+
+  for (const candidate of candidates) {
+    if (!isAsciiPath(candidate)) continue;
+    try {
+      // Probe by writing: %SystemRoot%\Temp grants Users write by default, but a
+      // hardened host may not, and an existence check cannot tell us that.
+      await fs.mkdir(candidate, { recursive: true });
+      const probe = path.join(candidate, `pilot-w-${process.pid}.tmp`);
+      await fs.writeFile(probe, '1');
+      await fs.rm(probe, { force: true });
+      asciiTempRoot = candidate;
+      return candidate;
+    } catch {
+      // try the next candidate
+    }
+  }
+
+  // Nothing writable: keep the old behaviour rather than failing outright.
+  logger.warn('no writable ASCII temp root found, tar staging may fail', { base });
+  asciiTempRoot = base;
+  return base;
+}
+
+/**
+ * Create a scratch directory that tar.exe can address. `preferred` is used as-is
+ * when it is already ASCII, so ASCII installs keep staging next to their target
+ * (same filesystem, so the caller's final rename cannot hit EXDEV).
+ */
+export async function makeTarStagingDir(preferred: string): Promise<string> {
+  if (isAsciiPath(preferred)) {
+    await fs.mkdir(preferred, { recursive: true });
+    return preferred;
+  }
+  const root = await getAsciiTempRoot();
+  const dir = path.join(
+    root,
+    `pilot-${path.basename(preferred).replace(/[^A-Za-z0-9._-]/g, '_')}-${process.pid}-${Math.floor(Math.random() * 1e6)}`,
+  );
+  await fs.rm(dir, { recursive: true, force: true });
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+/**
+ * Extract a .tar.gz. Both paths must already be ASCII on Windows — stage them with
+ * makeTarStagingDir first, then move the result into the real destination (fs.rename
+ * and fs.cp are Unicode-safe, unlike tar's arguments).
+ */
+export async function extractTarGz(
+  archive: string,
+  destDir: string,
+  timeoutMs: number,
+): Promise<void> {
+  const candidates: Array<{ bin: string; args: string[] }> = [];
+  if (process.platform === 'win32') {
+    const systemRoot = process.env.SystemRoot ?? 'C:\\Windows';
+    candidates.push({
+      bin: path.join(systemRoot, 'System32', 'tar.exe'),
+      args: ['-xzf', archive, '-C', destDir],
+    });
+    candidates.push({ bin: 'tar', args: ['-xzf', archive, '-C', destDir, '--force-local'] });
+  } else {
+    candidates.push({ bin: 'tar', args: ['-xzf', archive, '-C', destDir] });
+  }
+
+  let lastErr: unknown;
+  for (const candidate of candidates) {
+    try {
+      await execFileAsync(candidate.bin, candidate.args, { timeout: timeoutMs });
+      return;
+    } catch (err) {
+      lastErr = err;
+      logger.warn('tar extraction attempt failed', { tar: candidate.bin, error: String(err) });
+    }
+  }
+  throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+}
+
+/**
+ * Re-inherit the destination's ACL on a tree that was renamed out of the ASCII root.
+ * No-op off Windows. Mirrors Reset-PilotInheritedAcl in the installers' `pilot-ascii-temp`
+ * block, and exists for the same reason: a rename carries the source's ACEs along
+ * unchanged, so a tree staged in %SystemRoot%\Temp lands in the profile holding
+ * %SystemRoot%\Temp's permissions — Users get write and traverse but *not* read, the
+ * read grant coming from CREATOR OWNER. Whenever the owner of the staged files is not
+ * the account that has to read them (anything running elevated, where new files are
+ * owned by BUILTIN\Administrators), the moved tree ends up with no usable ACE and node
+ * reports the very misleading `ERR_MODULE_NOT_FOUND: Cannot find package 'pino'` even
+ * though the file is right there. `icacls /reset` re-inherits from the real parent and,
+ * unlike tar.exe, handles a non-ASCII path correctly.
+ */
+export async function resetInheritedAcl(dir: string): Promise<boolean> {
+  if (process.platform !== 'win32') return true;
+  const systemRoot = process.env.SystemRoot ?? 'C:\\Windows';
+  const icacls = path.join(systemRoot, 'System32', 'icacls.exe');
+  try {
+    // /T all descendants, /C keep going past a single failure, /Q stay quiet.
+    await execFileAsync(icacls, [dir, '/reset', '/T', '/C', '/Q'], { timeout: 120_000 });
+    return true;
+  } catch (err) {
+    logger.warn('could not reset inherited ACL', { dir, error: String(err) });
+    return false;
+  }
+}
+
+/**
+ * Move a staged directory onto `dest`, replacing it. Falls back to copy+remove when
+ * the staging root turned out to be on another volume (rename gives EXDEV).
+ */
+export async function replaceDirWith(staged: string, dest: string): Promise<void> {
+  await fs.rm(dest, { recursive: true, force: true });
+  let renamed = false;
+  try {
+    await fs.rename(staged, dest);
+    renamed = true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'EXDEV') throw err;
+    await fs.cp(staged, dest, { recursive: true });
+    await fs.rm(staged, { recursive: true, force: true }).catch(() => {});
+  }
+  // Only the rename needs this — fs.cp creates new files, which inherit normally.
+  if (renamed) await resetInheritedAcl(dest);
+}

--- a/src/utils/win-archive.ts
+++ b/src/utils/win-archive.ts
@@ -183,5 +183,17 @@ export async function replaceDirWith(staged: string, dest: string): Promise<void
     await fs.rm(staged, { recursive: true, force: true }).catch(() => {});
   }
   // Only the rename needs this — fs.cp creates new files, which inherit normally.
-  if (renamed) await resetInheritedAcl(dest);
+  //
+  // An unrepairable ACL is fatal on purpose. The tree is in place and looks perfectly
+  // installed, but the account that has to read it may hold no usable ACE — which is the
+  // whole reason this function exists, and what surfaces later as
+  // `ERR_MODULE_NOT_FOUND: Cannot find package 'pino'` on a directory that is plainly
+  // there. Throwing hands the caller its existing failure path: ensureNodeModules
+  // catches and returns false, which falls back to npm install, and npm creates
+  // node_modules in place so it inherits normally. Same choice as Ensure-NodeModules in
+  // deploy/installer-opensource.ps1, which drops the prebuilt tree and returns $false.
+  if (renamed && !(await resetInheritedAcl(dest))) {
+    await fs.rm(dest, { recursive: true, force: true }).catch(() => {});
+    throw new Error(`could not reset inherited ACL on ${dest}, discarded it`);
+  }
 }

--- a/tests/unit/deploy/installer-restart-stale-collector.test.mjs
+++ b/tests/unit/deploy/installer-restart-stale-collector.test.mjs
@@ -1,0 +1,101 @@
+// A re-install can leave the previous version's collector running, and nothing about it
+// looks wrong.
+//
+// `start` is a deliberate no-op when a collector is already running, and on a re-install
+// one usually is: Stop-PilotService only ends the current task instance, and Task
+// Scheduler (or the updater's collector watchdog) relaunches it within seconds -- while
+// `current` still names the OLD version dir, because Deploy-Package writes the new one
+// only after Ensure-NodeModules. collector-daemon.js resolves `current` exactly once at
+// startup, so that survivor serves the old dist forever while `status` reads `current`
+// and reports the NEW version. The install prints "Service started"; the bytes the user
+// just installed are never loaded.
+//
+// It went quiet the moment re-installs stopped overwriting the live version dir (pinned by
+// installer-version-dir-not-overwritten.test.mjs): while Deploy-Package still did Remove-Item on it,
+// the survivor died with ERR_MODULE_NOT_FOUND and got restarted onto the new version, so
+// the bug announced itself. Keeping the old dir is right -- Restart-StaleCollector is the
+// other half of it.
+//
+// Only the .ps1 installers are pinned here: the survivor is a Task Scheduler / watchdog
+// artefact, and the .sh installers have no equivalent relaunch racing the deploy.
+import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+
+const PS1_INSTALLERS = [
+  'deploy/installer.ps1',
+  'deploy/installer-inner.ps1',
+  'deploy/installer-opensource.ps1',
+];
+
+const read = (f) => readFileSync(f, 'utf-8');
+
+const blockOf = (text, tag) => {
+  const re = new RegExp(`^\\s*# >>> ${tag} >>>\\n[\\s\\S]*?^\\s*# <<< ${tag} <<<\\n`, 'm');
+  const m = text.match(re);
+  return m ? m[0] : null;
+};
+
+const codeOf = (text) => text
+  .split('\n')
+  .filter(line => !/^\s*#/.test(line))
+  .join('\n');
+
+const present = PS1_INSTALLERS.filter(existsSync);
+
+describe('installers displace a stale collector after re-installing', () => {
+  it('defines Restart-StaleCollector', () => {
+    expect(present.length).toBeGreaterThanOrEqual(1);
+    for (const file of present) {
+      const block = blockOf(read(file), 'pilot-restart-stale-collector');
+      expect(block, `${file}: pilot-restart-stale-collector block missing`).toBeTruthy();
+      expect(codeOf(block), file).toMatch(/function Restart-StaleCollector/);
+    }
+  });
+
+  it('the block is byte-identical across the .ps1 installers', () => {
+    // The three installers are near-copies maintained by hand; a block that drifts in one
+    // of them is a variant that quietly goes back to serving the old dist.
+    const blocks = present.map(f => blockOf(read(f), 'pilot-restart-stale-collector'));
+    expect(blocks.filter(b => !b)).toEqual([]);
+    expect(new Set(blocks).size).toBe(1);
+  });
+
+  it('uses restart-collector, not a bare restart', () => {
+    // `restart` would also bounce the updater. restart-collector is what the updater
+    // itself uses after deploying a version: stop unconditionally, kill orphans,
+    // re-register, start -- and leave the updater running.
+    const code = codeOf(blockOf(read(present[0]), 'pilot-restart-stale-collector'));
+    expect(code).toMatch(/restart-collector/);
+    expect(code.match(/\brestart\b(?!-collector)/), 'bare restart').toBeNull();
+  });
+
+  it('does nothing on a fresh install', () => {
+    // No prior version means no survivor to displace, and `start` already launched the
+    // collector from the new `current`. Bouncing it again would only slow the install.
+    const code = codeOf(blockOf(read(present[0]), 'pilot-restart-stale-collector'));
+    expect(code).toMatch(/if \(-not \$priorVersion\) \{ return \}/);
+  });
+
+  it('every installer calls it with the prior version, after start', () => {
+    for (const file of present) {
+      const text = read(file);
+      const lines = text.split('\n');
+      const calls = lines
+        .map((line, i) => [i + 1, line])
+        .filter(([, line]) => /^\s*Restart-StaleCollector /.test(line));
+      expect(calls.length, `${file}: never called`).toBeGreaterThanOrEqual(1);
+
+      for (const [lineNo, line] of calls) {
+        // Two arguments, both variables: the resolved service entry and the version that
+        // was current before this deploy. A literal or a missing second argument means the
+        // guard above turns the whole thing into a no-op.
+        expect(line.trim(), `${file}:${lineNo}`).toMatch(/^Restart-StaleCollector \$\S+ \$\S+$/);
+
+        // It has to run after the start attempt -- displacing a survivor before `start`
+        // just lets the watchdog put the old one back.
+        const before = lines.slice(0, lineNo - 1).join('\n');
+        expect(/-File \$\S+ start\b|& \$\S+ start\b/.test(before), `${file}:${lineNo}: no preceding start`).toBe(true);
+      }
+    }
+  });
+});

--- a/tests/unit/deploy/installer-restart-stale-collector.test.mjs
+++ b/tests/unit/deploy/installer-restart-stale-collector.test.mjs
@@ -27,6 +27,10 @@ const PS1_INSTALLERS = [
   'deploy/installer-opensource.ps1',
 ];
 
+// The script the installers deploy as loongsuite-pilot-service.ps1, and whose `start`
+// output the gate below matches against.
+const SERVICE_SCRIPT = 'scripts/loongsuite-pilot.ps1';
+
 const read = (f) => readFileSync(f, 'utf-8');
 
 const blockOf = (text, tag) => {
@@ -91,7 +95,29 @@ describe('installers displace a stale collector after re-installing', () => {
     expect(code).not.toMatch(/restart-collector[^\n]*Out-Null/);
   });
 
-  it('every installer calls it with the prior version, after start', () => {
+  it('only bounces the collector when start found one already running', () => {
+    // Displacing on every deploy costs more than it buys. Task Scheduler grants a task's own
+    // principal Read, Synchronize -- every write ACE sits on BUILTIN\Administrators, which
+    // UAC filters out of a -RunLevel Limited token -- so re-registering a task that already
+    // exists is denied outright on the machines this runs on. Callers treat a failed
+    // displacement as a failed deploy, so bouncing a collector `start` had just launched
+    // correctly turns a good upgrade into a rollback.
+    //
+    // `already running` is the one line that says a survivor was there: Cmd-Start prints it
+    // off Get-CollectorRuntime or the pid file and returns without starting anything. Any
+    // other output means `start` did the launching, from the new `current`.
+    const code = codeOf(blockOf(read(present[0]), 'pilot-restart-stale-collector'));
+    expect(code).toMatch(/if \(\(\$startOutput \| Out-String\) -notmatch "already running"\) \{ return \$true \}/);
+  });
+
+  it('the line that gate reads is still the line start prints', () => {
+    // The gate above is a string match against another script's output, so that string is
+    // load-bearing in both directions: reword Cmd-Start and every installer silently stops
+    // displacing anything, which is the original bug with no symptom.
+    expect(read(SERVICE_SCRIPT)).toMatch(/Write-Host "loongsuite-pilot is already running \(PID /);
+  });
+
+  it('every installer calls it with the prior version and the start output, after start', () => {
     for (const file of present) {
       const text = read(file);
       const lines = text.split('\n');
@@ -101,16 +127,31 @@ describe('installers displace a stale collector after re-installing', () => {
       expect(calls.length, `${file}: never called`).toBeGreaterThanOrEqual(1);
 
       for (const [lineNo, line] of calls) {
-        // Two arguments, both variables: the resolved service entry and the version that
-        // was current before this deploy. A literal or a missing second argument means the
-        // guard above turns the whole thing into a no-op. And the verdict has to be
-        // captured -- see the next test for what has to happen to it.
-        expect(line.trim(), `${file}:${lineNo}`).toMatch(/^\$\w+ = Restart-StaleCollector \$\S+ \$\S+$/);
+        // Three arguments, all variables: the resolved service entry, the version that was
+        // current before this deploy, and what `start` printed. A literal or a missing
+        // argument means one of the guards turns the whole thing into a no-op. And the
+        // verdict has to be captured -- see below for what has to happen to it.
+        const args = line.trim().match(/^\$\w+ = Restart-StaleCollector \$(\w+) \$(\w+) \$(\w+)$/);
+        expect(args, `${file}:${lineNo}: expected three variable arguments`).toBeTruthy();
 
         // It has to run after the start attempt -- displacing a survivor before `start`
         // just lets the watchdog put the old one back.
         const before = lines.slice(0, lineNo - 1).join('\n');
         expect(/-File \$\S+ start\b|& \$\S+ start\b/.test(before), `${file}:${lineNo}: no preceding start`).toBe(true);
+
+        // And the third argument has to be that attempt's own output. An unset variable
+        // never matches "already running", so a call site that forgets to capture disables
+        // the displacement everywhere without failing anything.
+        const startVar = args[3];
+        expect(
+          new RegExp(`\\$${startVar} = & [^\\n]*\\bstart\\b`).test(before),
+          `${file}:${lineNo}: $${startVar} is not filled from start`,
+        ).toBe(true);
+        // Capturing it must not hide it: the start diagnostics still go to the user.
+        expect(
+          new RegExp(`\\$${startVar} \\| ForEach-Object \\{ Write-Host \\$_ \\}`).test(text),
+          `${file}:${lineNo}: $${startVar} is captured and never shown`,
+        ).toBe(true);
       }
     }
   });

--- a/tests/unit/deploy/installer-restart-stale-collector.test.mjs
+++ b/tests/unit/deploy/installer-restart-stale-collector.test.mjs
@@ -72,8 +72,23 @@ describe('installers displace a stale collector after re-installing', () => {
   it('does nothing on a fresh install', () => {
     // No prior version means no survivor to displace, and `start` already launched the
     // collector from the new `current`. Bouncing it again would only slow the install.
+    // $true, not a bare return: nothing to do is not a failure to displace.
     const code = codeOf(blockOf(read(present[0]), 'pilot-restart-stale-collector'));
-    expect(code).toMatch(/if \(-not \$priorVersion\) \{ return \}/);
+    expect(code).toMatch(/if \(-not \$priorVersion\) \{ return \$true \}/);
+  });
+
+  it('reports a failed displacement instead of swallowing it', () => {
+    // Native commands do not throw on a nonzero exit, so $LASTEXITCODE is the only signal
+    // there is. Cmd-RestartCollector exits 1 when it cannot resolve node, when the
+    // bootstrap entry is gone, and when the service manager refuses -- in all three the
+    // survivor keeps serving the OLD version dir, and `2>$null | Out-Null` made that
+    // indistinguishable from success.
+    const code = codeOf(blockOf(read(present[0]), 'pilot-restart-stale-collector'));
+    expect(code).toMatch(/if \(\$LASTEXITCODE -eq 0\) \{ return \$true \}/);
+    expect(code).toMatch(/\$script:PILOT_LAST_RESTART_ERR = "restart-collector \(exit \$LASTEXITCODE\)/);
+    expect(code).toMatch(/return \$false/);
+    // Nothing may be discarded: no `| Out-Null` on the restart itself.
+    expect(code).not.toMatch(/restart-collector[^\n]*Out-Null/);
   });
 
   it('every installer calls it with the prior version, after start', () => {
@@ -82,19 +97,41 @@ describe('installers displace a stale collector after re-installing', () => {
       const lines = text.split('\n');
       const calls = lines
         .map((line, i) => [i + 1, line])
-        .filter(([, line]) => /^\s*Restart-StaleCollector /.test(line));
+        .filter(([, line]) => /Restart-StaleCollector \$/.test(line));
       expect(calls.length, `${file}: never called`).toBeGreaterThanOrEqual(1);
 
       for (const [lineNo, line] of calls) {
         // Two arguments, both variables: the resolved service entry and the version that
         // was current before this deploy. A literal or a missing second argument means the
-        // guard above turns the whole thing into a no-op.
-        expect(line.trim(), `${file}:${lineNo}`).toMatch(/^Restart-StaleCollector \$\S+ \$\S+$/);
+        // guard above turns the whole thing into a no-op. And the verdict has to be
+        // captured -- see the next test for what has to happen to it.
+        expect(line.trim(), `${file}:${lineNo}`).toMatch(/^\$\w+ = Restart-StaleCollector \$\S+ \$\S+$/);
 
         // It has to run after the start attempt -- displacing a survivor before `start`
         // just lets the watchdog put the old one back.
         const before = lines.slice(0, lineNo - 1).join('\n');
         expect(/-File \$\S+ start\b|& \$\S+ start\b/.test(before), `${file}:${lineNo}: no preceding start`).toBe(true);
+      }
+    }
+  });
+
+  it('no installer reports success when the displacement failed', () => {
+    // `status` resolves `current`, and the survivor answers to it exactly as well as the new
+    // collector would, so "is running" cannot tell them apart. An installer that captures
+    // the verdict and then prints its check mark anyway is back to the original bug with
+    // extra steps, so the captured variable has to reach the decision that prints it.
+    for (const file of present) {
+      const lines = read(file).split('\n');
+      const calls = lines
+        .map((line, i) => [i + 1, line])
+        .filter(([, line]) => /Restart-StaleCollector \$/.test(line));
+
+      for (const [lineNo, line] of calls) {
+        const captured = line.trim().match(/^\$(\w+) = Restart-StaleCollector /);
+        expect(captured, `${file}:${lineNo}: verdict discarded`).toBeTruthy();
+        const after = lines.slice(lineNo).join('\n');
+        const used = new RegExp(`(-and \\$${captured[1]}\\b|-not \\$${captured[1]}\\b|return \\$${captured[1]}\\b)`);
+        expect(used.test(after), `${file}:${lineNo}: $${captured[1]} never gates anything`).toBe(true);
       }
     }
   });

--- a/tests/unit/deploy/installer-version-dir-not-overwritten.test.mjs
+++ b/tests/unit/deploy/installer-version-dir-not-overwritten.test.mjs
@@ -1,0 +1,76 @@
+/**
+ * A version directory is never rewritten in place, on any install channel.
+ *
+ * Symptom this pins: re-running the installer over a live install deleted
+ * versions/<ver>_<commit>/ and re-populated it while `current` still pointed there.
+ * A collector launched in that window (the installer's own "start", or the updater
+ * task relaunching it) resolved versions/<current>/dist/index.js against a directory
+ * whose node_modules were not back yet and died with
+ *   ERR_MODULE_NOT_FOUND: Cannot find package 'pino' imported from ...\dist\index.js
+ * recorded in logs/last-startup-crash.json as phase=module_load. The install then
+ * reported "Collector task produced no runtime heartbeat" even though the box
+ * converged minutes later, once the deploy had finished.
+ *
+ * Rule: deploy into a directory nothing points at (a fresh suffixed sibling when the
+ * name is taken), install dependencies there, and only then write current/previous.
+ * Version and commit are read from the VERSION file, not from the directory name, so
+ * the suffix is inert for Get-VersionFromDir / Get-CommitFromDir / GC-OldVersions.
+ */
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+// installer-opensource.ps1 is the only one of these that exists in the open-source repo;
+// the other two arrive with the internal mirror, and the same assertions then cover them.
+const INSTALLERS = [
+  'deploy/installer.ps1',
+  'deploy/installer-inner.ps1',
+  'deploy/installer-opensource.ps1',
+].filter(rel => existsSync(join(repoRoot, rel)));
+
+/** Body of `function <name> { ... }` up to the next top-level `function` or EOF. */
+function functionBody(text, name) {
+  const start = text.indexOf(`function ${name} {`);
+  expect(start, `${name} not found`).toBeGreaterThan(-1);
+  const rest = text.slice(start);
+  const next = rest.search(/\n# =+\nfunction |\nfunction /);
+  return next === -1 ? rest : rest.slice(0, next);
+}
+
+describe('Deploy-Package never overwrites a version directory in place', () => {
+  it('finds the installers to check', () => {
+    // Guards against a silently empty sweep (renamed file, wrong cwd).
+    expect(INSTALLERS.length).toBeGreaterThanOrEqual(1);
+  });
+
+  for (const rel of INSTALLERS) {
+    describe(rel, () => {
+      const text = readFileSync(join(repoRoot, rel), 'utf8');
+      const body = functionBody(text, 'Deploy-Package');
+
+      it('picks a fresh directory name instead of removing the existing one', () => {
+        // The versioned branch must not rm -rf its own target. The legacy
+        // (no-VERSION-file) branch still overwrites $PERMANENT_DIR, which nothing
+        // points at through `current`, so it is matched narrowly by variable name.
+        expect(body).not.toMatch(/Remove-Item\s+\$target\s+-Recurse/);
+        expect(body).toMatch(/if \(Test-Path -LiteralPath \$target\)/);
+        expect(body).toMatch(/\$deployedDirName = "\$\{baseDirName\}_\$\{suffix\}"/);
+      });
+
+      it('publishes current only after dependencies are installed', () => {
+        const setCurrent = body.indexOf('Set-Content -Path $currentFile -Value $deployedDirName');
+        const installDeps = body.indexOf('Ensure-NodeModules');
+        expect(setCurrent, 'current is not published from $deployedDirName').toBeGreaterThan(-1);
+        expect(installDeps).toBeGreaterThan(-1);
+        expect(setCurrent).toBeGreaterThan(installDeps);
+      });
+
+      it('records the outgoing version as previous, without clobbering itself', () => {
+        expect(body).toMatch(/if \(\$oldDir -and \$oldDir -ne \$deployedDirName\) \{/);
+      });
+    });
+  }
+});

--- a/tests/unit/scripts/postinstall-asset-trees.test.mjs
+++ b/tests/unit/scripts/postinstall-asset-trees.test.mjs
@@ -255,19 +255,71 @@ describe('installers report what postinstall actually did', () => {
     // abort the npm install fallback. Keying the check mark off the exit code alone printed
     // "Hook scripts deployed" over an install that had just said it lost a tree -- the same
     // silent-success shape this whole file exists to prevent, one notch smaller.
+    //
+    // "Post-install failed" is the third mode and the one that hid behind both checks: a
+    // throw out of main() is caught at the bottom of postinstall.js, printed, and the process
+    // still exits 0 -- no non-zero code and no "failed asset tree" line to grep for.
     for (const file of PS1_INSTALLERS.filter(existsSync)) {
       const block = blockOf(read(file), 'pilot-postinstall-exit-check');
       const code = codeLines(block).map(([, l]) => l).join('\n');
       // Streaming the output straight to the console would leave nothing to match against;
       // 2>&1 because postinstall.js reports the count on stderr.
       expect(code, file).toMatch(/\$postinstallOut = & \$script:NODE_BIN \$postinstallScript 2>&1/);
-      expect(code, file).toMatch(/-match "failed asset tree"/);
+      expect(code, file).toMatch(/-match "failed asset tree\|Post-install failed"/);
       // The user still sees everything postinstall printed.
       expect(code, file).toMatch(/\$postinstallOut \| ForEach-Object \{ Write-Host \$_ \}/);
       // And the check mark sits behind the partial-failure branch, not in front of it.
       const partialAt = code.indexOf('elseif ($postinstallPartial)');
       expect(partialAt, `${file}: no partial-failure branch`).toBeGreaterThan(-1);
       expect(code.indexOf('Hook scripts deployed'), file).toBeGreaterThan(partialAt);
+    }
+  });
+
+  it('postinstall.js still prints the two lines the installers grep for', () => {
+    // The installers cannot see a per-tree failure or a thrown main() any other way -- both
+    // exit 0 by design. Reword either line and the abort below silently stops firing.
+    const text = read(POSTINSTALL);
+    expect(text).toMatch(/failed asset tree/);
+    expect(text).toMatch(/Post-install failed/);
+  });
+
+  it('no .ps1 installer keeps going after a failed postinstall', () => {
+    // Reporting the failure was only half of it: the install used to print the ❌ and then
+    // carry on to "Installation complete", leaving a collector with an empty
+    // $DataDir\hooks -- it loads no hook at all and every collection cycle fails on a plugin
+    // that was never written. Nothing downstream repairs that, so install aborts and upgrade
+    // rolls back.
+    //
+    // The block itself only records the reason ($script:PILOT_POSTINSTALL_ERR, empty when
+    // fine); the policy is at the call sites, which is what keeps the block byte-identical
+    // across three installers with three different failure paths. Same split as
+    // $script:PILOT_LAST_RESTART_ERR.
+    for (const file of PS1_INSTALLERS.filter(existsSync)) {
+      const text = read(file);
+      const block = blockOf(text, 'pilot-postinstall-exit-check');
+      const code = codeLines(block).map(([, l]) => l).join('\n');
+      expect(code, `${file}: the block records no reason`)
+        .toMatch(/\$script:PILOT_POSTINSTALL_ERR = "postinstall\.js/);
+      // Set in both failure branches, and left empty in the ✅ one.
+      expect(code.match(/\$script:PILOT_POSTINSTALL_ERR = "postinstall\.js/g).length, file).toBe(2);
+
+      const lines = text.split('\n');
+      const calls = lines
+        .map((line, i) => [i + 1, line])
+        .filter(([, line]) => /^\s*Deploy-Package \$script:INSTALL_SRC\s*$/.test(line));
+      // install and upgrade. A third caller that ignores the verdict is the bug coming back.
+      expect(calls.length, `${file}: expected two Deploy-Package call sites`).toBe(2);
+      for (const [lineNo] of calls) {
+        const after = lines.slice(lineNo, lineNo + 20).join('\n');
+        expect(after, `${file}:${lineNo}: the postinstall verdict is never read`)
+          .toMatch(/\$script:PILOT_POSTINSTALL_ERR/);
+      }
+      // The install path stops outright; the upgrade path falls into its existing
+      // `if (-not $started)` rollback, so it must not start the new version either.
+      expect(text, `${file}: install does not abort`)
+        .toMatch(/if \(\$script:PILOT_POSTINSTALL_ERR\) \{[\s\S]{0,400}?exit 1/);
+      expect(text, `${file}: upgrade starts the collector anyway`)
+        .toMatch(/-not \$script:PILOT_POSTINSTALL_ERR|\} else \{\n\s*\$started = Start-PilotAndWait/);
     }
   });
 
@@ -288,6 +340,26 @@ describe('installers report what postinstall actually did', () => {
       expect(run, `${file}: postinstall invocation not found`).toBeTruthy();
       // Either `|| postinstall_exit=$?` or the older `|| { ...; return 1; }` shape.
       expect(run[1], file).toMatch(/\|\|/);
+    }
+  });
+
+  it('no .sh installer keeps going after a failed postinstall either', () => {
+    for (const file of SH_INSTALLERS.filter(existsSync)) {
+      const text = read(file);
+      // Captured, not streamed: two of the three failure modes are only in the output.
+      expect(text, `${file}: postinstall output is not captured`).toMatch(/postinstall_out="\$\(/);
+      expect(text, file).toMatch(/grep -qE "failed asset tree\|Post-install failed"/);
+      // The user still sees it. `if`, not `&&`: under set -e a false `[ -n ... ]` would end
+      // deploy_package right there, turning an empty (successful) run into a failure.
+      expect(text, file).toMatch(/if \[ -n "\$postinstall_out" \]; then\n\s*printf '%s\\n' "\$postinstall_out"/);
+      // Two failure branches, each leaving deploy_package.
+      const branches = text.match(/hooks\/plugins are missing"\n\s*return 1/g) ?? [];
+      expect(branches.length, `${file}: deploy_package does not give up`).toBe(2);
+      // And both callers act on it: the install says why before exiting, the upgrade rolls the
+      // version pointer back. A bare `deploy_package "$INSTALL_SRC"` would abort under set -e
+      // without either.
+      expect(text.match(/if ! deploy_package "\$INSTALL_SRC"; then/g)?.length, `${file}: an unguarded call site`).toBe(2);
+      expect(text, `${file}: the upgrade path does not roll back`).toMatch(/rollback 2>\/dev\/null \|\| _rollback_ok=0/);
     }
   });
 

--- a/tests/unit/scripts/postinstall-asset-trees.test.mjs
+++ b/tests/unit/scripts/postinstall-asset-trees.test.mjs
@@ -249,6 +249,28 @@ describe('installers report what postinstall actually did', () => {
     }
   });
 
+  it('every .ps1 installer also catches a partial failure', () => {
+    // The exit code covers a crash, not a tree postinstall.js could not copy: it exits 0
+    // after reporting "N failed asset tree(s)" on purpose, because a non-zero exit would
+    // abort the npm install fallback. Keying the check mark off the exit code alone printed
+    // "Hook scripts deployed" over an install that had just said it lost a tree -- the same
+    // silent-success shape this whole file exists to prevent, one notch smaller.
+    for (const file of PS1_INSTALLERS.filter(existsSync)) {
+      const block = blockOf(read(file), 'pilot-postinstall-exit-check');
+      const code = codeLines(block).map(([, l]) => l).join('\n');
+      // Streaming the output straight to the console would leave nothing to match against;
+      // 2>&1 because postinstall.js reports the count on stderr.
+      expect(code, file).toMatch(/\$postinstallOut = & \$script:NODE_BIN \$postinstallScript 2>&1/);
+      expect(code, file).toMatch(/-match "failed asset tree"/);
+      // The user still sees everything postinstall printed.
+      expect(code, file).toMatch(/\$postinstallOut \| ForEach-Object \{ Write-Host \$_ \}/);
+      // And the check mark sits behind the partial-failure branch, not in front of it.
+      const partialAt = code.indexOf('elseif ($postinstallPartial)');
+      expect(partialAt, `${file}: no partial-failure branch`).toBeGreaterThan(-1);
+      expect(code.indexOf('Hook scripts deployed'), file).toBeGreaterThan(partialAt);
+    }
+  });
+
   it('the exit check is byte-identical across the .ps1 installers', () => {
     // Same reason as the other shared blocks: a copy that drifts is a variant that goes
     // back to claiming success.

--- a/tests/unit/scripts/postinstall-asset-trees.test.mjs
+++ b/tests/unit/scripts/postinstall-asset-trees.test.mjs
@@ -1,0 +1,305 @@
+// scripts/postinstall.js is the only thing that copies assets/{hooks,skills,plugins}
+// into the data dir, and on Windows it never got past the first copy.
+//
+// `fs.cpSync` moved to a C++ std::filesystem implementation in Node 22.9, and that
+// implementation fail-fasts on Windows: exit 0xC0000409 (STATUS_STACK_BUFFER_OVERRUN),
+// no JS exception, no stderr, nothing copied. Measured with the bundled node v22.22.2
+// and with v22.22.3 on a two-file ASCII tree, so it is not about path length or the
+// non-ASCII %USERPROFILE% this worktree otherwise chases. The async `fs.cp` is fine.
+//
+// Two things made it invisible for as long as it lasted:
+//   1. The process DIED rather than throwing, so postinstall's own try/catch (and its
+//      file-by-file fallback) never ran, and every step after the first copy was
+//      skipped without a word -- skill docs, agent plugins, the legacy intercept stub,
+//      the config migration.
+//   2. The installers printed "Hook scripts deployed" without looking at the exit code.
+//
+// The downstream symptom was a missing $PILOT_DATA/plugins tree, which failed the dsh
+// deployment on every collection cycle with "plugin file not found or unreadable" --
+// and DeploymentManager only tallied that failure, so the reason never reached the log.
+//
+// This file pins all three: no cpSync in shipped code, every asset tree installed
+// independently, and the installers reporting what actually happened.
+import { describe, expect, it } from 'vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const POSTINSTALL = 'scripts/postinstall.js';
+const PS1_INSTALLERS = [
+  'deploy/installer.ps1',
+  'deploy/installer-inner.ps1',
+  'deploy/installer-opensource.ps1',
+];
+const SH_INSTALLERS = [
+  'deploy/installer.sh',
+  'deploy/installer-inner.sh',
+  'deploy/installer-opensource.sh',
+];
+
+const read = (f) => readFileSync(f, 'utf-8');
+
+const codeLines = (text) => text
+  .split('\n')
+  .map((line, i) => [i + 1, line])
+  .filter(([, line]) => !/^\s*#/.test(line));
+
+const blockOf = (text, tag) => {
+  const re = new RegExp(`^\\s*# >>> ${tag} >>>\\n[\\s\\S]*?^\\s*# <<< ${tag} <<<\\n`, 'm');
+  const m = text.match(re);
+  return m ? m[0] : null;
+};
+
+const walk = (dir) => {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(full));
+    else out.push(full);
+  }
+  return out;
+};
+
+// Run postinstall.js against a throwaway data dir. HOME/USERPROFILE are redirected too:
+// the legacy intercept stub is written under $HOME/.cache, and a test has no business
+// touching the developer's real one.
+//
+// spawnSync rather than execFileSync: the exit code is the thing under test here (the
+// installers key their check mark off it), and the per-tree failures are on stderr.
+const runPostinstall = (dataDir, home) => {
+  const res = spawnSync(process.execPath, [POSTINSTALL], {
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      LOONGSUITE_PILOT_DATA_DIR: dataDir,
+    },
+  });
+  return { status: res.status, out: `${res.stdout ?? ''}${res.stderr ?? ''}` };
+};
+
+describe('postinstall installs every asset tree', () => {
+  it('no shipped script or source file calls fs.cpSync', () => {
+    // No allowlist: cpSync is unusable on the platform we ship a Node runtime for, and
+    // the async fs.cp / a mkdir+copyFile walk are exact substitutes. Tests may still use
+    // it -- they only ever run on the dev/CI machine, never on a user's Windows box.
+    const tracked = execFileSync('git', ['ls-files', 'src', 'scripts', 'assets'], { encoding: 'utf-8' })
+      .split('\n')
+      .filter(f => /\.(ts|js|mjs|cjs)$/.test(f));
+    expect(tracked.length).toBeGreaterThan(50);
+    const offenders = [];
+    for (const file of tracked) {
+      const lines = read(file).split('\n');
+      lines.forEach((line, i) => {
+        // Skip the explanatory comments that name it on purpose.
+        if (/^\s*(\*|\/\/|#)/.test(line)) return;
+        if (/\bcpSync\s*\(/.test(line)) offenders.push(`${file}:${i + 1}: ${line.trim()}`);
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('postinstall.js explains why, so nobody puts cpSync back', () => {
+    const text = read(POSTINSTALL);
+    expect(text).toMatch(/0xC0000409|STATUS_STACK_BUFFER_OVERRUN/);
+    expect(text).toMatch(/cpSync/);
+  });
+
+  it('installs hooks, skills and plugins into the data dir', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'pilot-postinstall-'));
+    try {
+      const dataDir = path.join(root, 'data');
+      const { status, out } = runPostinstall(dataDir, root);
+      expect(status, out).toBe(0);
+
+      for (const tree of ['hooks', 'skills', 'plugins']) {
+        const dir = path.join(dataDir, tree);
+        expect(existsSync(dir), `${tree} not created; postinstall said:\n${out}`).toBe(true);
+        expect(walk(dir).length, `${tree} is empty`).toBeGreaterThan(4);
+      }
+      // Floors, not exact counts: 68 hooks / 19 skills / 16 plugins at the time of
+      // writing. A tree that collapses to a handful of files is the failure mode here.
+      expect(walk(path.join(dataDir, 'hooks')).length).toBeGreaterThanOrEqual(30);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('installs the exact plugin path the dsh agent definition resolves to', () => {
+    // The two ends of this were only connected at runtime, in a log line nobody emitted:
+    // agents.d/dsh.json points at $PILOT_DATA/plugins/dsh/plugin.mjs, agent-def-loader
+    // expands $PILOT_DATA to the data dir, and postinstall is what has to put a file
+    // there. Renaming either side now fails here instead of once per collection cycle.
+    const dsh = JSON.parse(read('agents.d/dsh.json'));
+    const source = dsh.dshYamlPatch?.pluginSource ?? dsh.pluginSource;
+    expect(source).toMatch(/^\$PILOT_DATA\//);
+    const rel = source.replace(/^\$PILOT_DATA\//, '');
+    expect(existsSync(path.join('assets', rel)), `${rel} not in assets/`).toBe(true);
+
+    const root = mkdtempSync(path.join(tmpdir(), 'pilot-postinstall-dsh-'));
+    try {
+      const dataDir = path.join(root, 'data');
+      const { status, out } = runPostinstall(dataDir, root);
+      expect(status, out).toBe(0);
+      const resolved = path.join(dataDir, ...rel.split('/'));
+      expect(existsSync(resolved), `dsh plugin missing at ${resolved}`).toBe(true);
+      expect(statSync(resolved).size).toBeGreaterThan(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('one failing tree does not take the others down with it', () => {
+    // The old shape ran the three copies as one straight line, so whatever failed first
+    // ended the script. Forced here by leaving a plain FILE where the hooks directory
+    // should go: the hook copy fails with ENOTDIR, and skills and plugins must still
+    // arrive.
+    const root = mkdtempSync(path.join(tmpdir(), 'pilot-postinstall-partial-'));
+    try {
+      const dataDir = path.join(root, 'data');
+      mkdirSync(dataDir, { recursive: true });
+      writeFileSync(path.join(dataDir, 'hooks'), 'not a directory');
+
+      const { out } = runPostinstall(dataDir, root);
+
+      expect(out).toMatch(/Failed to install hook script/);
+      expect(existsSync(path.join(dataDir, 'skills')), `skills skipped:\n${out}`).toBe(true);
+      expect(existsSync(path.join(dataDir, 'plugins')), `plugins skipped:\n${out}`).toBe(true);
+      expect(walk(path.join(dataDir, 'plugins')).length).toBeGreaterThan(4);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('exits 0 on a partial failure, and says so', () => {
+    // Deliberate: this file is package.json's `postinstall`, so on the installers'
+    // `npm install` fallback a non-zero exit surfaces as "Dependencies installation
+    // failed" and aborts the install (the .ps1 installers exit 1 on a non-zero npm exit).
+    // The installers key their check mark off the exit code to catch a hard crash, and
+    // off this line to explain a partial result -- so both have to keep working.
+    const root = mkdtempSync(path.join(tmpdir(), 'pilot-postinstall-exit-'));
+    try {
+      const dataDir = path.join(root, 'data');
+      mkdirSync(dataDir, { recursive: true });
+      writeFileSync(path.join(dataDir, 'hooks'), 'not a directory');
+      const { status, out } = runPostinstall(dataDir, root);
+      expect(status, out).toBe(0);
+      expect(out).toMatch(/failed asset tree/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('clears AppleDouble sidecars an earlier install left behind', () => {
+    // Not self-clearing otherwise: nothing deletes a file the current package no longer
+    // ships, so the ~75 strays every pre-fix install put in hooks/ would sit there
+    // forever -- in a directory hook-manager and the plugin strategies enumerate.
+    const root = mkdtempSync(path.join(tmpdir(), 'pilot-postinstall-stale-'));
+    try {
+      const dataDir = path.join(root, 'data');
+      const hooks = path.join(dataDir, 'hooks', 'claude-code');
+      mkdirSync(hooks, { recursive: true });
+      writeFileSync(path.join(hooks, '._leftover.mjs'), 'stale');
+      writeFileSync(path.join(dataDir, 'hooks', '.DS_Store'), 'stale');
+
+      const { status, out } = runPostinstall(dataDir, root);
+      expect(status, out).toBe(0);
+
+      expect(existsSync(path.join(hooks, '._leftover.mjs'))).toBe(false);
+      expect(existsSync(path.join(dataDir, 'hooks', '.DS_Store'))).toBe(false);
+      expect(out).toMatch(/removed \d+ stale sidecar/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not carry AppleDouble sidecars into the data dir', () => {
+    // The release tarball is built on a Mac, so assets/ ships ._* resource forks (75 of
+    // them under assets/hooks alone). They are not runnable content and they land in
+    // directories that other code enumerates.
+    const root = mkdtempSync(path.join(tmpdir(), 'pilot-postinstall-appledouble-'));
+    try {
+      const dataDir = path.join(root, 'data');
+      const { status, out } = runPostinstall(dataDir, root);
+      expect(status, out).toBe(0);
+      const junk = walk(dataDir)
+        .map(f => path.basename(f))
+        .filter(n => n.startsWith('._') || n === '.DS_Store');
+      expect(junk).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('installers report what postinstall actually did', () => {
+  it('every .ps1 installer captures the postinstall exit code', () => {
+    for (const file of PS1_INSTALLERS.filter(existsSync)) {
+      const block = blockOf(read(file), 'pilot-postinstall-exit-check');
+      expect(block, file).toBeTruthy();
+      const code = codeLines(block).map(([, l]) => l).join('\n');
+      expect(code, file).toMatch(/\$postinstallExit = \$LASTEXITCODE/);
+      // The success message must sit behind the check, not before it.
+      expect(code, file).toMatch(/if \(\$postinstallExit -ne 0\)/);
+      const successAt = code.indexOf('Hook scripts deployed');
+      const checkAt = code.indexOf('$postinstallExit -ne 0');
+      expect(successAt, file).toBeGreaterThan(checkAt);
+    }
+  });
+
+  it('the exit check is byte-identical across the .ps1 installers', () => {
+    // Same reason as the other shared blocks: a copy that drifts is a variant that goes
+    // back to claiming success.
+    const present = PS1_INSTALLERS.filter(existsSync);
+    expect(present.length).toBeGreaterThanOrEqual(1);
+    const blocks = present.map(f => blockOf(read(f), 'pilot-postinstall-exit-check'));
+    expect(blocks.filter(b => !b)).toEqual([]);
+    expect(new Set(blocks).size).toBe(1);
+  });
+
+  it('every .sh installer checks the postinstall exit code too', () => {
+    for (const file of SH_INSTALLERS.filter(existsSync)) {
+      const text = read(file);
+      const run = text.match(/"\$NODE_BIN" "\$PERMANENT_DIR\/scripts\/postinstall\.js"(.*)/);
+      expect(run, `${file}: postinstall invocation not found`).toBeTruthy();
+      // Either `|| postinstall_exit=$?` or the older `|| { ...; return 1; }` shape.
+      expect(run[1], file).toMatch(/\|\|/);
+    }
+  });
+
+  it('every installer tells postinstall which data dir to fill', () => {
+    // postinstall.js resolves LOONGSUITE_PILOT_DATA_DIR and otherwise falls back to
+    // $HOME/.loongsuite-pilot. With -DataDir / --data-dir that fallback is the wrong
+    // tree: hooks and plugins land next to a config that lives somewhere else, and the
+    // collector finds no hooks at all -- silently, like everything else in this file.
+    for (const file of PS1_INSTALLERS.filter(existsSync)) {
+      const block = blockOf(read(file), 'pilot-postinstall-exit-check');
+      const code = codeLines(block).map(([, l]) => l).join('\n');
+      expect(code, file).toMatch(/\$env:LOONGSUITE_PILOT_DATA_DIR = \$DataDir/);
+      // Set for the child only: the surrounding installer must keep seeing what it had.
+      expect(code, file).toMatch(/Remove-Item Env:LOONGSUITE_PILOT_DATA_DIR/);
+    }
+    for (const file of SH_INSTALLERS.filter(existsSync)) {
+      const text = read(file);
+      const at = text.indexOf('"$NODE_BIN" "$PERMANENT_DIR/scripts/postinstall.js"');
+      expect(at, `${file}: postinstall invocation not found`).toBeGreaterThan(-1);
+      // The assignment sits on the line(s) directly above the command.
+      const preamble = text.slice(Math.max(0, at - 400), at);
+      expect(preamble, file).toMatch(/LOONGSUITE_PILOT_DATA_DIR="\$DATA_DIR" \\\n\s*$/);
+    }
+  });
+
+  it('the auto-upgrade path runs postinstall and reports what it said', () => {
+    // Same fix, other entry point: an auto-upgrade re-runs the new package's postinstall,
+    // which is how an already-broken install heals without a reinstall. Two ways to lose
+    // it -- delete the call (pinned behaviourally in tests/unit/updater/updater.test.ts),
+    // or keep the call and drop its output on the floor. postinstall exits 0 on a partial
+    // failure by design, so the output is the only signal there is.
+    const updater = read('src/updater/updater.ts');
+    expect(updater).toMatch(/'scripts', 'postinstall\.js'/);
+    expect(updater).toMatch(/LOONGSUITE_PILOT_DATA_DIR: this\.paths\.dataDir/);
+    expect(updater).toMatch(/failed asset tree/);
+  });
+});

--- a/tests/unit/scripts/ps1-clm-safe.test.mjs
+++ b/tests/unit/scripts/ps1-clm-safe.test.mjs
@@ -54,6 +54,12 @@ const ALLOWED_STATIC_ACCESS = new Set([
   '[Environment]::SetEnvironmentVariable',        // (c) PATH broadcast on install
   '[datetime]::MinValue',                         // (b) core type; scripts/loongsuite-pilot.ps1
   '[TimeSpan]::Zero',                             // (b) core type; scripts/loongsuite-pilot.ps1
+  // (c) UTF-8 bump for both console directions at script load, in try/catch. The catch
+  // is a no-op on purpose: the fallback is 5.1's ASCII $OutputEncoding / ANSI stdout
+  // decoding, which is why the config payloads are staged through a UTF-8 file rather
+  // than piped -- see tests/unit/scripts/ps1-json-encoding.test.mjs.
+  '[Console]::OutputEncoding',
+  '[System.Text.Encoding]::UTF8',
 ]);
 
 // Shapes that are never acceptable, whatever the file. `.PSObject` is included

--- a/tests/unit/scripts/ps1-json-encoding.test.mjs
+++ b/tests/unit/scripts/ps1-json-encoding.test.mjs
@@ -108,10 +108,20 @@ const pipedJsonToNode = (text) => {
   ));
 };
 
-// Both internal installers; the open-source variant already stages its config payload but
-// deliberately does NOT bump $OutputEncoding, because its PROBE_RESULT pipes do not strip
-// a BOM and would break if one appeared.
-const STAGED_VARIANTS = ['deploy/installer.ps1', 'deploy/installer-inner.ps1'];
+// Every installer variant stages its config payload instead of piping it, so all three are
+// checked -- the open-source one included, and it is the only one of them present in the
+// open-source tree, where the two internal entries skip and the rule would otherwise go
+// unchecked entirely. The floor differs because the internal variants run this shape twice
+// (install and reconfigure), the open-source one once.
+const STAGED_VARIANTS = [
+  ['deploy/installer.ps1', 2],
+  ['deploy/installer-inner.ps1', 2],
+  ['deploy/installer-opensource.ps1', 1],
+];
+
+// $OutputEncoding is bumped only by the internal variants. The open-source one deliberately
+// does NOT: its ad-hoc PROBE_RESULT pipes do not strip a BOM and would break if one appeared.
+const OUTPUT_ENCODING_VARIANTS = ['deploy/installer.ps1', 'deploy/installer-inner.ps1'];
 
 describe('ps1 <-> node JSON interchange is explicitly UTF-8', () => {
   it('finds interchange sites to check', () => {
@@ -198,7 +208,7 @@ describe('ps1 <-> node JSON interchange is explicitly UTF-8', () => {
     expect(pipedJsonToNode("    $other | & $script:NODE_BIN -e @'")).toEqual([]);
   });
 
-  for (const file of STAGED_VARIANTS) {
+  for (const [file, floor] of STAGED_VARIANTS) {
     it.skipIf(!existsSync(file))(`${file} stages every config payload as a UTF-8 file`, () => {
       const text = readFileSync(file, 'utf-8');
       const staged = text.match(
@@ -208,11 +218,13 @@ describe('ps1 <-> node JSON interchange is explicitly UTF-8', () => {
       const consumed = text.match(/^'@ \$cfgTmp$/gm) || [];
       const removed = text.match(
         /Remove-Item -LiteralPath \$cfgTmp -Force -ErrorAction SilentlyContinue/g) || [];
-      expect(staged.length).toBeGreaterThanOrEqual(2);
+      expect(staged.length).toBeGreaterThanOrEqual(floor);
       expect(consumed.length).toBe(staged.length);
       expect(removed.length).toBe(staged.length);
     });
+  }
 
+  for (const file of OUTPUT_ENCODING_VARIANTS) {
     it.skipIf(!existsSync(file))(`${file} bumps $OutputEncoding to UTF-8 in a try/catch`, () => {
       // Belt to the staging braces: it also covers the ad-hoc PROBE_RESULT pipes, which
       // stay on stdin. CLM makes both assignments throw, so the catch must be present

--- a/tests/unit/scripts/ps1-json-encoding.test.mjs
+++ b/tests/unit/scripts/ps1-json-encoding.test.mjs
@@ -81,6 +81,38 @@ const interchangeSites = (text) => {
 const jsonParseReads = (text) => codeLines(text)
   .filter(([, line]) => /\bJSON\.parse\b/.test(line) && /\breadFileSync\b/.test(line));
 
+// The third direction of the same boundary: JSON handed to an embedded node payload
+// through a *pipe* instead of a file. PowerShell 5.1 encodes a string piped to a native
+// command with $OutputEncoding, whose default is ASCII, so `$cfgJson | & node -e ...`
+// replaced every non-ASCII character with a literal "?" before node could parse it. With
+// a Chinese username that turned dataDir into C:\Users\???\.loongsuite-pilot and the
+// install died in writeFileSync with ENOENT. Set-Content -Encoding UTF8 staging is the
+// fix; unlike an $OutputEncoding assignment it keeps working under CLM/WDAC, where a
+// .NET static assignment throws and the try/catch degrades to a no-op.
+const convertToJsonVars = (lines) => {
+  const vars = new Set();
+  for (const [, line] of lines) {
+    const m = line.match(/\$(?:script:)?([A-Za-z_]\w*)\s*=.*\|\s*ConvertTo-Json\b/);
+    if (m) vars.add(m[1]);
+  }
+  return vars;
+};
+
+const pipedJsonToNode = (text) => {
+  const lines = codeLines(text);
+  const vars = [...convertToJsonVars(lines)];
+  if (vars.length === 0) return [];
+  return lines.filter(([, line]) => (
+    /\|\s*&\s*\$(?:script:)?NODE_BIN\b/.test(line)
+    && vars.some(v => new RegExp(`\\$(?:script:)?${v}\\s*\\|`).test(line))
+  ));
+};
+
+// Both internal installers; the open-source variant already stages its config payload but
+// deliberately does NOT bump $OutputEncoding, because its PROBE_RESULT pipes do not strip
+// a BOM and would break if one appeared.
+const STAGED_VARIANTS = ['deploy/installer.ps1', 'deploy/installer-inner.ps1'];
+
 describe('ps1 <-> node JSON interchange is explicitly UTF-8', () => {
   it('finds interchange sites to check', () => {
     // Guards against the regex silently matching nothing (renamed cmdlet, reflow).
@@ -143,6 +175,52 @@ describe('ps1 <-> node JSON interchange is explicitly UTF-8', () => {
     expect(toml[0][1]).toContain("split('\\n')");
     expect(toml[0][1]).not.toContain('uFEFF');
   });
+
+  it('no tracked .ps1 pipes a ConvertTo-Json payload into node', () => {
+    const offenders = [];
+    for (const file of tracked) {
+      for (const [n, line] of pipedJsonToNode(readFileSync(file, 'utf-8'))) {
+        offenders.push(`${file}:${n}: ${line.trim()}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('the pipe matcher still recognises the shape it bans', () => {
+    // Pins the rule rather than the current state: once every site is staged the
+    // assertion above passes vacuously, so a regressed matcher would look clean.
+    const sample = [
+      '    $cfgJson = $cfgArgs | ConvertTo-Json -Compress',
+      "    $cfgJson | & $script:NODE_BIN -e @'",
+    ].join('\n');
+    expect(pipedJsonToNode(sample)).toHaveLength(1);
+    // A pipe of something that never came from ConvertTo-Json is out of scope.
+    expect(pipedJsonToNode("    $other | & $script:NODE_BIN -e @'")).toEqual([]);
+  });
+
+  for (const file of STAGED_VARIANTS) {
+    it.skipIf(!existsSync(file))(`${file} stages every config payload as a UTF-8 file`, () => {
+      const text = readFileSync(file, 'utf-8');
+      const staged = text.match(
+        /Set-Content -LiteralPath \$cfgTmp -Value \$cfgJson -Encoding UTF8 -NoNewline/g) || [];
+      // Each staged payload must be handed to node as argv[1] and then deleted: it
+      // carries the SLS AccessKeySecret and the CMS license key.
+      const consumed = text.match(/^'@ \$cfgTmp$/gm) || [];
+      const removed = text.match(
+        /Remove-Item -LiteralPath \$cfgTmp -Force -ErrorAction SilentlyContinue/g) || [];
+      expect(staged.length).toBeGreaterThanOrEqual(2);
+      expect(consumed.length).toBe(staged.length);
+      expect(removed.length).toBe(staged.length);
+    });
+
+    it.skipIf(!existsSync(file))(`${file} bumps $OutputEncoding to UTF-8 in a try/catch`, () => {
+      // Belt to the staging braces: it also covers the ad-hoc PROBE_RESULT pipes, which
+      // stay on stdin. CLM makes both assignments throw, so the catch must be present
+      // and must not rethrow.
+      expect(readFileSync(file, 'utf-8')).toMatch(
+        /try \{\n\s*\[Console\]::OutputEncoding = \[System\.Text\.Encoding\]::UTF8\n\s*\$OutputEncoding = \[System\.Text\.Encoding\]::UTF8\n\} catch \{\}/);
+    });
+  }
 
   it('the hermes rollback path reads and writes deployed-agents.json as UTF-8', () => {
     // Named explicitly because this is the site the CR flagged: the write alone was

--- a/tests/unit/scripts/ps1-nonascii-windows-paths.test.mjs
+++ b/tests/unit/scripts/ps1-nonascii-windows-paths.test.mjs
@@ -1,0 +1,281 @@
+// A Windows account name can be non-ASCII (C:\Users\张三 is the case that broke a
+// real install), and PowerShell 5.1 loses those characters at three boundaries. Each
+// one silently produced a working-looking install that was not working:
+//
+//   1. Native command *stdout* is decoded with [Console]::OutputEncoding, i.e. the
+//      console codepage (437 on an en-US box), so `whoami` returned "host\??" with
+//      literal U+003F characters. That string reached New-ScheduledTaskPrincipal
+//      -UserId, Task Scheduler failed the registration with "No mapping between
+//      account names and security IDs was done" (0x80131500), and the user ended up
+//      with no autostart task at all. It also collapsed every non-ASCII account to
+//      the same "___" task-name tag, so two such users fought over one task name.
+//   2. Native command *arguments* survive as UTF-16 through CreateProcessW, but
+//      bsdtar (%SystemRoot%\System32\tar.exe) enters through the ANSI CRT and
+//      converts them back through the ANSI codepage, so a staging dir under a
+//      non-ASCII %TEMP% reached tar as "?" and extraction failed. Neither
+//      [Console]::OutputEncoding nor `chcp 65001` changes this (measured).
+//   3. Get-Content / Set-Content default to the ANSI codepage, so the node-bin pin
+//      file -- one absolute path, possibly under a non-ASCII %USERPROFILE% -- was
+//      written as "C:\Users\??.HOST\..." and every reader then silently fell back to
+//      some other node.exe, on a shared machine another account's nvm install.
+//
+// The reasoning above is the rule; this file is the ratchet. Directions 1 and 3
+// have exact substitutes, so they are asserted across every tracked .ps1 with no
+// allowlist. Direction 2 is asserted per function: whatever staging dir a tar call
+// sees must come from Get-PilotAsciiTempRoot.
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+
+const SERVICE = 'scripts/loongsuite-pilot.ps1';
+// Every .ps1 that names a scheduled task, and therefore needs the shared identity
+// helpers. Registration and uninstall must derive the tag the same way or uninstall
+// leaves the tasks behind.
+const TASK_FILES = [
+  SERVICE,
+  'deploy/installer.ps1',
+  'deploy/installer-inner.ps1',
+  'deploy/installer-opensource.ps1',
+];
+
+const tracked = execFileSync('git', ['ls-files', '*.ps1'], { encoding: 'utf-8' })
+  .split('\n')
+  .filter(Boolean);
+
+const read = (f) => readFileSync(f, 'utf-8');
+
+const codeLines = (text) => text
+  .split('\n')
+  .map((line, i) => [i + 1, line])
+  .filter(([, line]) => !/^\s*#/.test(line));
+
+const blockOf = (text, tag) => {
+  const re = new RegExp(`^# >>> ${tag} >>>\\n[\\s\\S]*?^# <<< ${tag} <<<\\n`, 'm');
+  const m = text.match(re);
+  return m ? m[0] : null;
+};
+
+// Lines that read or write the node-bin pin file: either the literal is right there,
+// or the path sits in a variable. Variables are tracked one alias deep (`$pinFiles`
+// -> `foreach ($pinFile in $pinFiles)`) and no further, so a sibling path derived from
+// the pin path (`Join-Path (Split-Path $pinFile) "runtime"`) is not mistaken for one.
+// Returns the following code lines too, so a read can be paired with a later strip.
+const pinSites = (text) => {
+  const lines = codeLines(text);
+  const vars = new Set();
+  const bindings = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i][1];
+    const assign = line.match(/\$(?:script:)?([A-Za-z_]\w*)\s*(?:=|\+=)\s*(.*)$/);
+    if (assign) bindings.push([assign[1], assign[2]]);
+    // The `in` list can span lines: `foreach ($pinFile in @(\n  (Join-Path ...),\n ...))`.
+    const loop = line.match(/foreach \(\$([A-Za-z_]\w*) in (.*)$/);
+    if (loop) {
+      bindings.push([loop[1], loop[2]]);
+      bindings.push([loop[1], lines.slice(i + 1, i + 5).map(([, l]) => l).join('\n')]);
+    }
+  }
+  for (const [name, rhs] of bindings) {
+    if (/node-bin/.test(rhs)) vars.add(name);
+  }
+  for (const [name, rhs] of bindings) {
+    const alias = rhs.match(/^\$(?:script:)?([A-Za-z_]\w*)\s*\)?\s*\{?\s*$/);
+    if (alias && vars.has(alias[1])) vars.add(name);
+  }
+  const names = [...vars];
+  const hit = (line) => (
+    /\b(Get-Content|Set-Content|Add-Content|Out-File)\b/.test(line)
+    && (/node-bin/.test(line)
+        || names.some(v => new RegExp(`\\$(?:script:)?${v}\\b`).test(line)))
+  );
+  return lines
+    .map(([n, line], i) => ({ n, line, after: lines.slice(i + 1, i + 6).map(([, l]) => l) }))
+    .filter(({ line }) => hit(line));
+};
+
+// Function bodies, so a tar call can be tied to the staging dir in scope.
+const functionsOf = (text) => {
+  const out = [];
+  const re = /^function ([A-Za-z][\w-]*) \{$/gm;
+  let m;
+  const starts = [];
+  while ((m = re.exec(text)) !== null) starts.push([m[1], m.index]);
+  for (let i = 0; i < starts.length; i++) {
+    const [name, start] = starts[i];
+    const end = i + 1 < starts.length ? starts[i + 1][1] : text.length;
+    out.push([name, text.slice(start, end)]);
+  }
+  return out;
+};
+
+const tarFunctions = (text) => functionsOf(text)
+  // The helper itself resolves tar.exe; its callers own the path encoding.
+  .filter(([name, body]) => name !== 'Expand-PilotTarGz' && /Expand-PilotTarGz \$/.test(body));
+
+describe('non-ASCII Windows account names survive every .ps1 boundary', () => {
+  it('finds the files to check', () => {
+    // Guards against a silently empty sweep (wrong cwd, renamed glob).
+    expect(tracked).toContain(SERVICE);
+    expect(tracked.length).toBeGreaterThan(5);
+  });
+
+  it('no tracked .ps1 derives an account identity from whoami', () => {
+    // No allowlist on purpose: $env:USERNAME / $env:USERDOMAIN / $env:COMPUTERNAME are
+    // exact substitutes, carry the real UTF-16 string, and stay CLM-safe.
+    const offenders = [];
+    for (const file of tracked) {
+      for (const [n, line] of codeLines(read(file))) {
+        if (/\bwhoami\b/.test(line)) offenders.push(`${file}:${n}: ${line.trim()}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('the identity helpers are byte-identical everywhere they appear', () => {
+    // Registration (service script) and uninstall (installers) must produce the same
+    // tag. A copy that drifts silently orphans the tasks it was supposed to remove.
+    const present = TASK_FILES.filter(existsSync);
+    expect(present).toContain(SERVICE);
+    const blocks = present.map(f => [f, blockOf(read(f), 'pilot-account-identity')]);
+    const missing = blocks.filter(([, b]) => !b).map(([f]) => f);
+    expect(missing).toEqual([]);
+    expect(new Set(blocks.map(([, b]) => b)).size).toBe(1);
+  });
+
+  it('the identity helpers use environment variables and handle WORKGROUP', () => {
+    // Pins the rule, not just the copies: [Security.Principal.WindowsIdentity]::
+    // GetCurrent() is blocked under CLM (measured), and $env:USERDOMAIN is the literal
+    // "WORKGROUP" under some logon providers (OpenSSH sshd), which maps to no SID
+    // either -- the first attempted fix failed exactly there.
+    const block = blockOf(read(SERVICE), 'pilot-account-identity');
+    expect(block).toBeTruthy();
+    const code = codeLines(block).map(([, l]) => l).join('\n');
+    expect(code).toContain('$env:USERNAME');
+    expect(code).toContain('$env:USERDOMAIN');
+    expect(code).toMatch(/\$domain -eq "WORKGROUP"/);
+    expect(code).toContain('$env:COMPUTERNAME');
+    expect(code).not.toMatch(/WindowsIdentity|\[Environment\]::UserName/);
+    // Non-ASCII names all normalise to "_", so the tag needs a discriminator; ASCII
+    // names must keep the tag they already registered with.
+    expect(code).toMatch(/\[\^\\x20-\\x7E\]/);
+    expect(code).toMatch(/\$hash = \(\$hash \* 31 \+ \[int\]\$ch\)/);
+  });
+
+  for (const file of TASK_FILES) {
+    it.skipIf(!existsSync(file))(`${file} builds task names via Get-PilotUserTag`, () => {
+      const text = read(file);
+      // Outside the shared block, which legitimately contains the one -replace. Blanked
+      // rather than removed so reported line numbers stay real.
+      const block = blockOf(text, 'pilot-account-identity') ?? '';
+      const outside = text.replace(block, '#\n'.repeat(block.split('\n').length - 1));
+      const lines = codeLines(outside);
+      const tagAssigns = lines.filter(([, l]) => /\$(?:USER_TAG|userTag)\s*=/.test(l));
+      expect(tagAssigns.length).toBeGreaterThan(0);
+      for (const [n, line] of tagAssigns) {
+        expect(line, `${file}:${n}`).toMatch(/Get-PilotUserTag/);
+      }
+      // And nobody rebuilds the tag by hand from an identity string.
+      const handRolled = lines.filter(([, l]) => /-replace '\[\^A-Za-z0-9\._-\]', '_'/.test(l));
+      expect(handRolled.map(([n, l]) => `${n}: ${l.trim()}`)).toEqual([]);
+    });
+  }
+
+  it('the scheduled-task principal and logon trigger come from Get-PilotAccountName', () => {
+    const text = read(SERVICE);
+    const identityArgs = codeLines(text)
+      .filter(([, l]) => /-UserId\b|New-ScheduledTaskTrigger .*-User\b/.test(l));
+    expect(identityArgs.length).toBeGreaterThanOrEqual(3);
+    for (const [n, line] of identityArgs) {
+      expect(line, `${SERVICE}:${n}`).toMatch(/Get-PilotAccountName|\$userId\b/);
+    }
+    expect(text).toMatch(/\$userId = Get-PilotAccountName/);
+  });
+
+  it('every node-bin pin read and write is explicitly UTF-8', () => {
+    const bare = [];
+    let total = 0;
+    for (const file of tracked) {
+      for (const { n, line } of pinSites(read(file))) {
+        total += 1;
+        if (!/-Encoding\s+UTF8\b/.test(line)) bare.push(`${file}:${n}: ${line.trim()}`);
+      }
+    }
+    // Floor: 21 here, but only 15 survive the open-source sync (8 hook wrappers +
+    // shared/common.ps1 + the service script + installer-opensource.ps1), and this
+    // file is one of the synced ones. Below that the matcher has gone blind.
+    expect(total).toBeGreaterThanOrEqual(15);
+    expect(bare).toEqual([]);
+  });
+
+  it('every node-bin pin read strips the UTF-8 BOM', () => {
+    // -Encoding UTF8 on 5.1 always writes a BOM (there is no utf8NoBOM) and U+FEFF is
+    // not whitespace in PowerShell, so .Trim() alone leaves it inside the path and
+    // Test-Path then fails on a file that exists. Two accepted shapes: strip on the
+    // read itself, or read into a variable that is stripped a few lines below.
+    const bare = [];
+    let reads = 0;
+    for (const file of tracked) {
+      for (const { n, line, after } of pinSites(read(file))) {
+        if (!/\bGet-Content\b/.test(line)) continue;
+        reads += 1;
+        const strip = /Trim\(\[char\]0xFEFF\)/;
+        if (strip.test(line)) continue;
+        const target = line.match(/\$(?:script:)?(\w+)\s*=/);
+        const stripped = target
+          && after.some(l => strip.test(l) && new RegExp(`\\$${target[1]}\\b`).test(l));
+        if (!stripped) bare.push(`${file}:${n}: ${line.trim()}`);
+      }
+    }
+    expect(reads).toBeGreaterThanOrEqual(12);  // 16 here, 12 after the open-source sync
+    expect(bare).toEqual([]);
+  });
+
+  it('tar staging dirs come from Get-PilotAsciiTempRoot', () => {
+    // Direction 2: tar.exe cannot see a non-ASCII path, so both the archive and the
+    // extraction dir must sit under an ASCII root; the result is moved into the real
+    // (possibly non-ASCII) destination afterwards, which Move-Item does natively.
+    const offenders = [];
+    let checked = 0;
+    for (const file of tracked) {
+      const text = read(file);
+      for (const [name, body] of tarFunctions(text)) {
+        checked += 1;
+        for (const [, line] of codeLines(body)) {
+          if (!/Join-Path/.test(line)) continue;
+          if (/Get-PilotTempRoot|GetTempPath|Join-Path \$env:(TEMP|TMP)\b/.test(line)) {
+            offenders.push(`${file} ${name}: ${line.trim()}`);
+          }
+        }
+      }
+    }
+    // Floor: 5 here (Ensure-NodeModules + Download-AndExtract in the two internal
+    // installers, Ensure-NodeModules in the open-source one), but only that last one
+    // survives the sync, so 1 is all this can assert. It still catches a matcher that
+    // stops recognising `function X {` or the call shape.
+    expect(checked).toBeGreaterThanOrEqual(1);
+    expect(offenders).toEqual([]);
+  });
+
+  it('the ASCII temp root is probed for writability and never used for secrets', () => {
+    const variants = ['deploy/installer.ps1', 'deploy/installer-inner.ps1',
+                      'deploy/installer-opensource.ps1'].filter(existsSync);
+    for (const file of variants) {
+      const block = blockOf(read(file), 'pilot-ascii-temp');
+      expect(block, file).toBeTruthy();
+      const code = codeLines(block).map(([, l]) => l).join('\n');
+      // Env vars only: [System.IO.Path]::GetTempPath() throws under CLM.
+      expect(code, file).not.toContain('GetTempPath');
+      // A machine-wide fallback is only safe if it is confirmed writable first.
+      expect(code, file).toMatch(/Set-Content -LiteralPath \$probe/);
+      expect(code, file).toMatch(/\[\^\\x20-\\x7E\]/);
+      // Config payloads carry the SLS AccessKeySecret and the CMS license key, so they
+      // keep going to $DataDir; this root can be C:\Windows\Temp.
+      expect(read(file)).not.toMatch(/\$cfgTmp = Join-Path \(Get-PilotAsciiTempRoot\)/);
+    }
+    if (variants.length > 0) {
+      // The block is shared verbatim, same reason as the identity helpers.
+      const blocks = variants.map(f => blockOf(read(f), 'pilot-ascii-temp'));
+      expect(new Set(blocks).size).toBe(1);
+    }
+  });
+});

--- a/tests/unit/scripts/ps1-restart-best-effort.test.mjs
+++ b/tests/unit/scripts/ps1-restart-best-effort.test.mjs
@@ -1,0 +1,94 @@
+// A -RunLevel Limited scheduled task cannot rewrite its own definition, so the
+// re-registration inside restart-collector / restart-updater must not gate the start.
+//
+// Task Scheduler gives a task's own principal only `Read, Synchronize`; every write ACE
+// sits on BUILTIN\Administrators, which UAC filters out of the token of a Limited task.
+// Both daemons run as Limited tasks, so when the updater deploys a new version and calls
+// `restart-collector`, the re-register step it does "in case paths changed" is guaranteed
+// to fail on any machine where the task already exists. Measured on a Medium-integrity
+// Limited task: `schtasks /Delete`, `Register-ScheduledTask` and `Register-ScheduledTask
+// -Force` all return "Access is denied" (so -Force is NOT the fix), while
+// `Start-ScheduledTask` succeeds -- starting needs no write access.
+//
+// While both calls shared one try block, that guaranteed failure jumped over
+// Start-ScheduledTask. With init_type=taskscheduler the self-heal branch is skipped too,
+// so every single update ended in `Service manager failed to restart collector` + exit 1
+// and left the collector down until the task's own 5-minute watchdog trigger happened to
+// relaunch it. The re-registration is genuinely unnecessary: Install-*Task rewrites the
+// launcher .vbs and reaps orphaned daemons *before* it reaches the registration, and the
+// task action invokes that .vbs by a version-independent path.
+//
+// This pins the shape, not the wording: the Install-*Task call must be closed off by its
+// own catch before Start-ScheduledTask is reached.
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const SERVICE_PS1 = 'scripts/loongsuite-pilot.ps1';
+const text = readFileSync(SERVICE_PS1, 'utf-8');
+
+// Drop comment lines so prose about try/catch cannot satisfy a structural check.
+const codeOf = (s) => s.split('\n').filter((line) => !/^\s*#/.test(line)).join('\n');
+
+// Body = from the function header to the next top-level `function` declaration. Brace
+// counting would trip over the format strings and script blocks in this file.
+const bodyOf = (name) => {
+  const start = text.indexOf(`function ${name} {`);
+  expect(start, `${name} not found in ${SERVICE_PS1}`).toBeGreaterThan(-1);
+  const rest = text.slice(start + `function ${name} {`.length);
+  const end = rest.search(/\nfunction \S+ \{/);
+  return codeOf(end === -1 ? rest : rest.slice(0, end));
+};
+
+// The "task already registered" branch, up to the `if (-not $restarted)` fallback.
+const existingTaskBranch = (body) => {
+  const start = body.search(/if \(Get-TaskExists /);
+  expect(start, 'no Get-TaskExists branch').toBeGreaterThan(-1);
+  const rest = body.slice(start);
+  const end = rest.search(/if \(-not \$restarted\)/);
+  return end === -1 ? rest : rest.slice(0, end);
+};
+
+const CASES = [
+  { fn: 'Cmd-RestartCollector', install: 'Install-CollectorTask' },
+  { fn: 'Cmd-RestartUpdater', install: 'Install-UpdaterTask' },
+];
+
+describe('restart-collector / restart-updater start the task even if re-registration is denied', () => {
+  for (const { fn, install } of CASES) {
+    it(`${fn}: ${install} cannot skip Start-ScheduledTask`, () => {
+      const branch = existingTaskBranch(bodyOf(fn));
+
+      // Count lower bounds first: an empty or mis-sliced branch must not pass vacuously.
+      const installAt = branch.indexOf(install);
+      const startAt = branch.indexOf('Start-ScheduledTask');
+      expect(installAt, `${install} missing from the existing-task branch`).toBeGreaterThan(-1);
+      expect(startAt, 'Start-ScheduledTask missing from the existing-task branch').toBeGreaterThan(-1);
+      expect(installAt).toBeLessThan(startAt);
+
+      // The re-register must be closed off by its own catch before the start is reached,
+      // i.e. they live in two separate try blocks.
+      const between = branch.slice(installAt, startAt);
+      expect(
+        /catch\s*\{[\s\S]*\btry\s*\{/.test(between),
+        `${install} and Start-ScheduledTask still share one try block in ${fn}; a denied `
+          + 're-registration would skip the start',
+      ).toBe(true);
+    });
+  }
+
+  it('Register-PilotTask reports a task that survives the pre-registration delete', () => {
+    // The delete is suppressed on purpose (nothing to delete on a fresh install, and a
+    // bare native stderr line can turn terminating under $ErrorActionPreference=Stop),
+    // so a surviving task is the only signal that write access is missing. Without it
+    // the sole symptom is the registration error, which reads like a principal bug.
+    const body = bodyOf('Register-PilotTask');
+    const deleteAt = body.indexOf('schtasks.exe /Delete');
+    const registerAt = body.indexOf('Register-ScheduledTask');
+    expect(deleteAt).toBeGreaterThan(-1);
+    expect(registerAt).toBeGreaterThan(deleteAt);
+    expect(
+      /Get-TaskExists/.test(body.slice(deleteAt, registerAt)),
+      'Register-PilotTask must check whether the task survived the delete before re-registering',
+    ).toBe(true);
+  });
+});

--- a/tests/unit/updater/updater.test.ts
+++ b/tests/unit/updater/updater.test.ts
@@ -330,6 +330,39 @@ describe('Updater', () => {
       );
     });
 
+    it('runs the staged package postinstall, pointed at this install data dir', async () => {
+      // scripts/postinstall.js is the only thing that fills <dataDir>/{hooks,skills,
+      // plugins}, so this call is also how an install broken by the Windows fs.cpSync
+      // fail-fast heals itself -- the trees get rebuilt on the next auto-upgrade with no
+      // reinstall. Nothing else covered it: the other deploy tests stub it absent, so
+      // deleting the call left every test green.
+      setupForDownload();
+      mockFsAccess.mockImplementation((p: string) => {
+        if (p.includes('package.json')) return Promise.resolve();
+        if (p.includes('dist/index.js')) return Promise.resolve();
+        if (p.includes('dist/updater/index.js')) return Promise.resolve();
+        if (p.includes('scripts/collector-daemon.js')) return Promise.resolve();
+        if (p.includes('scripts/updater-daemon.js')) return Promise.resolve();
+        if (p.includes('scripts/loongsuite-pilot.sh')) return Promise.resolve();
+        if (p.includes('postinstall.js')) return Promise.resolve();
+        return Promise.reject(new Error('ENOENT'));
+      });
+
+      const updater = new Updater(makeConfig(), tmpDir);
+      await updater.check();
+
+      const call = mockExecFile.mock.calls.find((c: unknown[]) =>
+        Array.isArray(c[1]) && (c[1] as string[]).some(a => String(a).includes('postinstall.js')));
+      expect(call, 'postinstall.js was never executed').toBeTruthy();
+      // The NEW package's copy, run out of the staging dir: the point is to install the
+      // assets that shipped with the version being activated.
+      expect(String((call![1] as string[])[0])).toContain('.candidate');
+      // And told which tree to fill. Unset, postinstall falls back to
+      // $HOME/.loongsuite-pilot, which is the wrong one for a custom data dir.
+      const env = (call![2] as { env?: Record<string, string> }).env ?? {};
+      expect(env.LOONGSUITE_PILOT_DATA_DIR).toBe(tmpDir);
+    });
+
     it('adopts the managed node runtime + prebuilt modules and pins node-bin', async () => {
       const expOs = process.platform === 'win32' ? 'win' : process.platform;
       const expArch = process.arch;

--- a/tests/unit/utils/win-archive.test.ts
+++ b/tests/unit/utils/win-archive.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Node-side counterpart of tests/unit/scripts/ps1-nonascii-windows-paths.test.mjs.
+ *
+ * tar.exe re-encodes its arguments through the machine's ANSI codepage, so a path under
+ * C:\Users\<CJK name> reaches it as C:\Users\???\... and the extraction fails. Measured
+ * from node on a CJK-profile box: child_process passed the path with 4 non-ASCII chars
+ * and 0 '?', and tar still reported "Failed to open 'C:\Users\??.HOST\...'". Every tar
+ * call in the updater must therefore stage under an ASCII root and go through
+ * extractTarGz (which also dodges Git-for-Windows' GNU tar), not through a bare
+ * execFile('tar', ...). The ratchet below pins that; the unit tests pin the helper.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { isAsciiPath, makeTarStagingDir, replaceDirWith } from '../../../src/utils/win-archive.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+
+describe('isAsciiPath', () => {
+  it('accepts printable ASCII and rejects anything else', () => {
+    expect(isAsciiPath('C:\\Users\\lee\\.loongsuite-pilot')).toBe(true);
+    expect(isAsciiPath('/tmp/pilot-node-modules')).toBe(true);
+    expect(isAsciiPath('C:\\Users\\张三\\.loongsuite-pilot')).toBe(false);
+    expect(isAsciiPath('C:\\Users\\太业.IZ1QMOR6W7C4BKZ\\versions')).toBe(false);
+    // A tab is unrepresentable in a command line the same way: not printable ASCII.
+    expect(isAsciiPath('C:\\a\tb')).toBe(false);
+  });
+});
+
+describe('makeTarStagingDir', () => {
+  it('keeps an ASCII preference as-is, so the caller can still rename within one volume', async () => {
+    const preferred = path.join(await fs.mkdtemp(path.join(os.tmpdir(), 'pilot-ascii-')), 'download-tmp');
+    try {
+      const dir = await makeTarStagingDir(preferred);
+      expect(dir).toBe(preferred);
+      expect((await fs.stat(dir)).isDirectory()).toBe(true);
+    } finally {
+      await fs.rm(path.dirname(preferred), { recursive: true, force: true });
+    }
+  });
+
+  it('redirects a non-ASCII preference to an ASCII root', async () => {
+    const base = await fs.mkdtemp(path.join(os.tmpdir(), 'pilot-cjk-'));
+    const preferred = path.join(base, '李四', 'download-tmp');
+    let dir = '';
+    try {
+      dir = await makeTarStagingDir(preferred);
+      expect(dir).not.toBe(preferred);
+      expect(isAsciiPath(dir)).toBe(true);
+      expect((await fs.stat(dir)).isDirectory()).toBe(true);
+    } finally {
+      if (dir) await fs.rm(dir, { recursive: true, force: true });
+      await fs.rm(base, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('replaceDirWith', () => {
+  it('replaces an existing destination with the staged tree', async () => {
+    const base = await fs.mkdtemp(path.join(os.tmpdir(), 'pilot-replace-'));
+    try {
+      const staged = path.join(base, 'stage', 'node_modules');
+      await fs.mkdir(staged, { recursive: true });
+      await fs.writeFile(path.join(staged, 'new.txt'), 'new');
+
+      const dest = path.join(base, 'node_modules');
+      await fs.mkdir(dest, { recursive: true });
+      await fs.writeFile(path.join(dest, 'stale.txt'), 'stale');
+
+      await replaceDirWith(staged, dest);
+
+      expect(await fs.readFile(path.join(dest, 'new.txt'), 'utf8')).toBe('new');
+      await expect(fs.access(path.join(dest, 'stale.txt'))).rejects.toThrow();
+    } finally {
+      await fs.rm(base, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('updater tar ratchet', () => {
+  it('routes every tar call through extractTarGz', async () => {
+    const src = await fs.readFile(path.join(repoRoot, 'src/updater/updater.ts'), 'utf8');
+    const code = src
+      .split('\n')
+      .filter((line) => !/^\s*(\/\/|\*|\/\*)/.test(line))
+      .join('\n');
+
+    // A bare 'tar' resolves through PATH: on Windows that can be Git's GNU tar, which
+    // reads the colon in -f C:\... as rsh host:path syntax.
+    expect(code).not.toMatch(/execFileAsync\(\s*'tar'/);
+    expect(code).not.toMatch(/spawn(?:Sync)?\(\s*'tar'/);
+
+    const uses = code.match(/extractTarGz\(/g) ?? [];
+    expect(uses.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('stages tar input under an ASCII root and never deletes a live version dir in place', async () => {
+    const src = await fs.readFile(path.join(repoRoot, 'src/updater/updater.ts'), 'utf8');
+
+    // download-tmp and the prebuilt node_modules scratch dir are the two tar inputs.
+    const staged = src.match(/makeTarStagingDir\(/g) ?? [];
+    expect(staged.length).toBeGreaterThanOrEqual(2);
+
+    // Redeploying the same version must land in a suffixed sibling instead of
+    // rm -rf'ing the directory `current` still points at (phase=module_load crashes).
+    expect(src).not.toMatch(/fs\.rm\(targetDir,[\s\S]{0,60}\)\s*;\s*\n\s*await fs\.rename\(stagingDir, targetDir\)/);
+    expect(src).toMatch(/dirName = `\$\{baseDirName\}_\$\{suffix\}`/);
+  });
+});

--- a/tests/unit/utils/win-archive.test.ts
+++ b/tests/unit/utils/win-archive.test.ts
@@ -79,6 +79,34 @@ describe('replaceDirWith', () => {
   });
 });
 
+describe('replaceDirWith ACL handling', () => {
+  it('discards the tree and throws when the inherited ACL cannot be repaired', async () => {
+    // resetInheritedAcl is a no-op off Windows, so this path is unreachable from a test
+    // host — pin the shape instead. Publishing a tree the reading account holds no usable
+    // ACE on is worse than not publishing it: it looks installed, node reports
+    // `Cannot find package 'pino'` on a directory that is plainly there, and the version
+    // stays broken because nothing downstream retries. Ensure-NodeModules in
+    // deploy/installer-opensource.ps1 makes the same call (drop it, return $false).
+    const src = await fs.readFile(path.join(repoRoot, 'src/utils/win-archive.ts'), 'utf8');
+    const guarded = src.match(/if \(renamed && !\(await resetInheritedAcl\(dest\)\)\) \{[\s\S]*?\n  \}/);
+    expect(guarded, 'replaceDirWith must act on resetInheritedAcl\'s result').toBeTruthy();
+    expect(guarded[0]).toMatch(/fs\.rm\(dest, \{ recursive: true, force: true \}\)/);
+    expect(guarded[0]).toMatch(/throw new Error\(/);
+
+    // No fire-and-forget call: the return value is the whole point of the helper.
+    expect(src).not.toMatch(/^\s*await resetInheritedAcl\(/m);
+  });
+
+  it('the only caller turns that throw into an npm install fallback', async () => {
+    const src = await fs.readFile(path.join(repoRoot, 'src/updater/updater.ts'), 'utf8');
+    const from = src.indexOf('private async ensureNodeModules');
+    expect(from).toBeGreaterThan(0);
+    const body = src.slice(from, src.indexOf('\n  private ', from + 1));
+    expect(body).toMatch(/await replaceDirWith\(/);
+    expect(body).toMatch(/catch \(err\) \{[\s\S]*?falling back to npm install[\s\S]*?return false;/);
+  });
+});
+
 describe('updater tar ratchet', () => {
   it('routes every tar call through extractTarGz', async () => {
     const src = await fs.readFile(path.join(repoRoot, 'src/updater/updater.ts'), 'utf8');


### PR DESCRIPTION
## What

Windows installs under a non-ASCII profile (`C:\Users\<CJK name>`) failed, and hooks/skills/plugins were never deployed on **any** Windows box. Both failures were silent — the installer printed "Hook scripts deployed" either way.

Measured on a CJK-profile Windows box with PowerShell 5.1 and the bundled node v22.22.2/v22.22.3.

## Three encoding boundaries (PowerShell 5.1)

- **Native stdout is decoded through the console codepage.** `whoami` came back as `host\??` on an en-US box, so anything deriving identity from it was already broken. `Get-PilotAccountName` / `Get-PilotUserTag` read the account from .NET instead of parsing a mangled string. `chcp 65001` and `[Console]::OutputEncoding = UTF8` do **not** fix this — they govern the console, not argv conversion.
- **bsdtar receives argv through the ANSI CRT.** `%SystemRoot%\System32\tar.exe` converts a UTF-16 path back through the machine's ANSI codepage, so every character that page cannot represent arrives as a literal `?` and both `-f` and `-C` point at paths that do not exist. Archives now stage under an ASCII temp root and get renamed into place. The renamed tree needs its ACL re-inherited (`icacls /reset`): a rename carries the source's ACEs along, so a tree staged in `%SystemRoot%\Temp` lands in the profile where Users get write and traverse but *not* read — and node then reports the very misleading `Cannot find package 'pino'` even though the file is right there.
- **`Get-Content`/`Set-Content` default to ANSI**, and `-Encoding UTF8` always writes a BOM on 5.1 (there is no `utf8NoBOM`). Config payloads round-trip through a UTF-8 file passed as `argv[1]`, and the reading side trims `U+FEFF` explicitly — it is not whitespace in PowerShell, so a plain `.Trim()` leaves the BOM in the path and `Test-Path` returns false for a file that exists.

## Which tar

A bare `tar` resolves through `PATH`, and with Git for Windows installed that is Git's bundled GNU tar (MSYS), which reads the colon in `-f C:\...` as rsh `host:path` syntax and dies with `Cannot connect to C: resolve failed` (older builds hang). `Expand-PilotTarGz` prefers `System32\tar.exe`, then falls back to `PATH`'s tar with `--force-local`. Never both: bsdtar rejects the unknown flag outright, which is why `--force-local` is attached to the PATH candidate only. Same logic on the node side in `src/utils/win-archive.ts`.

## The silent half: `fs.cpSync` on Windows

`fs.cpSync` moved to a C++ `std::filesystem` implementation in Node 22.9, and that implementation fail-fasts on Windows: exit `0xC0000409` (`STATUS_STACK_BUFFER_OVERRUN`), **no JS exception, no stderr, nothing copied**. Reproduced on a two-file ASCII tree, so it is not about path length or non-ASCII paths. The async `fs.cp` is unaffected.

Because the process *dies* rather than throwing, `postinstall`'s own try/catch never ran, so everything after the first copy was skipped without a word — skill docs, agent plugins, the legacy intercept stub, the config migration. Downstream, a missing `plugins/` tree failed every dsh deployment with "plugin file not found or unreadable", once per collection cycle — and `DeploymentManager` only tallied that failure, so the reason never reached the log.

Fixed by copying with `mkdir`+`copyFile`, guarding each asset tree separately so one unwritable target cannot take the others down, and having the installers key their check mark off the exit code instead of printing it unconditionally. `DeploymentManager` now logs a strategy that *returns* `{success:false}` rather than only a thrown one.

## Two install-time races, same symptom

- A re-install no longer rewrites the live version directory in place. It used to `Remove-Item` and re-populate `versions/<ver>_<commit>/` while `current` still pointed there, so a collector launched in that window resolved `dist/index.js` against a directory whose `node_modules` were not back yet and died with `ERR_MODULE_NOT_FOUND`. Deploys now go to a fresh suffixed sibling, and `current` is written only after dependencies land.
- An upgrade now displaces a collector that survived it, via `restart-collector` rather than `restart` (the latter takes the updater down with it).

## Tests

New ratchets: `ps1-nonascii-windows-paths`, `postinstall-asset-trees`, `win-archive`, `installer-version-dir-not-overwritten`, `installer-restart-stale-collector`. The `.ps1` sweeps run over `git ls-files '*.ps1'` and the installer lists are `existsSync`-guarded, so they widen automatically rather than silently passing over an absent file — each sweep also asserts a floor so a matcher that stops matching fails instead of vacuously passing.

`tsc --noEmit` is clean. The 27 suites under `tests/unit/{scripts,deploy,updater,utils}` pass (387 tests). Remaining failures in a full `vitest run` are pre-existing on `main` (hook-processor suites, parallelism-sensitive); `tests/unit/scripts/daemon-cache-dir.test.mjs` fails on `main` and passes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
