### PR TITLE
fix(hooks): repair three failure modes in the Windows ANSI code page correction

### DIFF
--- a/assets/hooks/shared/decode-payload.mjs
+++ b/assets/hooks/shared/decode-payload.mjs
@@ -3,11 +3,12 @@
 
 /**
  * decode-payload.mjs — 把 hook stdin 的原始字节解码为字符串,并修复
- * Cursor/Qoder 在中文 Windows 上的 UTF-8→GBK 双重编码。
+ * Cursor/Qoder 在 Windows 上的 UTF-8→ANSI 代码页双重编码。
  *
- * 背景:中文 Windows 上部分 host agent(Cursor/Qoder)会先把 UTF-8 的 hook 负载按系统代码页
- * (GBK/CP936)解码成字符串,再以 UTF-8 重新编码后经 stdin 传入,导致中文乱码(ASCII/JSON 结构不受影响)。
- * 还原:对收到的字节做 gbkEncode(utf8Decode(bytes)),若结果是严格合法的 UTF-8 则采用,否则保留原始 UTF-8。
+ * 背景:Windows 上部分 host agent(Cursor/Qoder)会先把 UTF-8 的 hook 负载按**系统 ANSI 代码页(ACP)**
+ * 解码成字符串,再以 UTF-8 重新编码后经 stdin 传入,导致非 ASCII 乱码(ASCII/JSON 结构不受影响)。
+ * ACP 取决于系统区域:中文 Windows 是 CP936(GBK),en-US 等西文 Windows 是 CP1252 —— 两者都在线上实测到,
+ * 故依次尝试两张表。还原:对收到的字节做 cpEncode(utf8Decode(bytes)),若结果通过下面两道判据则采用。
  *
  * 该纠偏原先在 PowerShell hook wrapper 里用 .NET 完成,但 WDAC 受限语言模式(CLM)禁止
  * .NET 静态调用,故整体移入 node —— node 不受 CLM 约束,PS 侧从此无需触碰字节。
@@ -16,34 +17,77 @@
  * 即便限定 win32,严格 UTF-8 校验仍不足以排除干净单 CJK 的误纠(如「业」的 GBK 字节 D2 B5 恰是合法
  * UTF-8 的 U+04B5),故再加一道"膨胀判据":真正的双重编码必然使收到的中间串 code point 数 > 还原串
  * (UTF-8 的 CJK 占 3 字节,被误当 GBK 每字符 2 字节解码后字符数变多),仅当膨胀时才采纳,消除假阳性。
+ *
+ * 部分丢字节的情况:CP936 解码遇到非法/未定义的字节组合会吐出一个 U+FFFD,源字节就此永久丢失
+ * (最常见:奇数个 CJK 之后紧跟 '"' ',' 等 < 0x40 的 ASCII 字节,末字节被当成首字节而报错)。
+ * 实测这类负载在中文 Windows 上占比接近一半,若因此放弃整条负载,等于纠偏对中文 Windows 基本无效。
+ * 故按 U+FFFD 把乱码切段、逐段还原,再用 U+FFFD 重新拼接:丢掉的那一个字符仍标记为 U+FFFD,
+ * 其余内容全部恢复可读。切口两侧允许存在被吃掉的不完整 UTF-8 序列(丢的字节必然落在某个字符内部),
+ * 段内部仍走严格 UTF-8 校验,不做任何字节猜测(不伪造内容)。
  */
 
-// char code point -> [lead, trail],首次使用时用内置 TextDecoder('gbk') 运行时反建,模块级缓存。
-let GBK_ENCODE_MAP = null;
+// 待尝试的代码页。顺序有讲究:CP936 乱码里几乎全是 CJK 字符,CP1252 编不出来会立刻抛错、安全回退;
+// 反之 CP936 每个非 ASCII 字符输出 2 字节,对 CP1252 乱码存在极小概率凑出合法 UTF-8 并通过膨胀判据,
+// 故先试单字节的 CP1252,再试 CP936。
+const CODE_PAGES = [
+  { label: 'windows-1252', multiByte: false },
+  { label: 'gbk', multiByte: true },
+];
 
-function buildGbkEncodeMap() {
+// label -> (char code point -> bytes[]);首次使用时用内置 TextDecoder 运行时反建,模块级缓存
+// (不可用的代码页缓存 null,避免每条负载重复构建再抛错)。
+const ENCODE_MAPS = new Map();
+
+function buildEncodeMap(label, multiByte) {
   const map = new Map();
-  // fatal:false → 无法映射的字节对解码为 U+FFFD,据此跳过。
-  // 若当前 node 为 small-ICU 构建、不支持 'gbk',TextDecoder 构造会抛错 → 上层放弃纠偏。
-  const dec = new TextDecoder('gbk', { fatal: false });
-  const pair = new Uint8Array(2);
-  for (let lead = 0x81; lead <= 0xfe; lead++) {
-    for (let trail = 0x40; trail <= 0xfe; trail++) {
-      if (trail === 0x7f) continue; // 0x7F 不是合法 GBK 尾字节
-      pair[0] = lead;
-      pair[1] = trail;
-      const ch = dec.decode(pair);
-      if (ch.length !== 1 || ch.charCodeAt(0) === 0xfffd) continue; // 未映射
-      const cp = ch.charCodeAt(0);
-      if (!map.has(cp)) map.set(cp, [lead, trail]);
+  // fatal:false → 无法映射的字节(对)解码为 U+FFFD,据此跳过。
+  // 若当前 node 为 small-ICU 构建、不支持该 label,TextDecoder 构造会抛错 → 该代码页记为不可用。
+  const dec = new TextDecoder(label, { fatal: false });
+  const single = new Uint8Array(1);
+  // 先建单字节映射,使其优先于双字节项。CP936 的 0x80 是**单字节**的 '€'(U+20AC):
+  // 只要源负载里出现字节 0x80(码位为 64 的倍数的 UTF-8 字符,如「一」「什」「最」的末字节),
+  // 旧版只枚举双字节对的编码表就查不到 '€' 而抛错,导致整条负载放弃纠偏。
+  for (let b = 0x80; b <= 0xff; b++) {
+    single[0] = b;
+    const ch = dec.decode(single);
+    if (ch.length !== 1 || ch.charCodeAt(0) === 0xfffd) continue; // 未映射(如 GBK 的首字节)
+    map.set(ch.charCodeAt(0), [b]);
+  }
+  if (multiByte) {
+    const pair = new Uint8Array(2);
+    for (let lead = 0x81; lead <= 0xfe; lead++) {
+      for (let trail = 0x40; trail <= 0xfe; trail++) {
+        if (trail === 0x7f) continue; // 0x7F 不是合法 GBK 尾字节
+        pair[0] = lead;
+        pair[1] = trail;
+        const ch = dec.decode(pair);
+        if (ch.length !== 1 || ch.charCodeAt(0) === 0xfffd) continue; // 未映射
+        const cp = ch.charCodeAt(0);
+        if (!map.has(cp)) map.set(cp, [lead, trail]);
+      }
     }
   }
   return map;
 }
 
-// 把字符串编码为 GBK 字节;遇到无法映射的非 ASCII 字符则抛错(上层据此放弃纠偏)。
-function gbkEncode(str) {
-  if (!GBK_ENCODE_MAP) GBK_ENCODE_MAP = buildGbkEncodeMap();
+function getEncodeMap(label, multiByte) {
+  if (!ENCODE_MAPS.has(label)) {
+    let map = null;
+    try {
+      map = buildEncodeMap(label, multiByte);
+    } catch {
+      map = null; // 该 node 构建不支持此代码页
+    }
+    ENCODE_MAPS.set(label, map);
+  }
+  const map = ENCODE_MAPS.get(label);
+  if (!map) throw new Error('code page unavailable: ' + label);
+  return map;
+}
+
+// 按指定代码页把字符串编码回字节;遇到无法映射的非 ASCII 字符则抛错(上层据此换表/放弃纠偏)。
+function encodeToCodePage(str, label, multiByte) {
+  const map = getEncodeMap(label, multiByte);
   const out = [];
   for (const ch of str) {
     const cp = ch.codePointAt(0);
@@ -51,15 +95,61 @@ function gbkEncode(str) {
       out.push(cp);
       continue;
     }
-    const pair = GBK_ENCODE_MAP.get(cp);
-    if (!pair) throw new Error('char not mappable to GBK: U+' + cp.toString(16));
-    out.push(pair[0], pair[1]);
+    const bytes = map.get(cp);
+    if (!bytes) throw new Error('char not mappable to ' + label + ': U+' + cp.toString(16));
+    for (const b of bytes) out.push(b);
   }
   return Buffer.from(out);
 }
 
+// host agent 解码失败处留下的替换字符 —— 既是切段依据,也是还原结果里"此处字节已丢失"的标记。
+// 用转义而非字面量:这个字符本身就是编码事故的产物,写成字面量在任何一次文件转码里都可能被再次破坏。
+const LOST = '\uFFFD';
+
+// 严格解码一段还原出的字节。trimHead/trimTail 表示该段紧邻一个丢字节的切口:
+// 丢掉的字节必然落在某个 UTF-8 字符内部,故切口一侧会残留不完整序列,允许丢弃(只丢那一个字符,
+// 由调用方补回 U+FFFD 标记);段内部一律走严格校验,任何真实的非法字节都会抛错、放弃纠偏。
+function decodeSegment(bytes, trimHead, trimTail) {
+  let start = 0;
+  let end = bytes.length;
+  // 段首残留的续字节(10xxxxxx):它们所属字符的首字节被吃掉了。
+  if (trimHead) {
+    while (start < end && (bytes[start] & 0xc0) === 0x80) start++;
+  }
+  // 段尾不完整的序列:回退到最后一个首字节,若其续字节不足则整体丢弃。
+  if (trimTail) {
+    let i = end - 1;
+    let cont = 0;
+    while (i >= start && (bytes[i] & 0xc0) === 0x80) {
+      cont++;
+      i--;
+    }
+    if (i < start) {
+      end = start;
+    } else {
+      const lead = bytes[i];
+      const need = lead < 0x80 ? 0 : lead < 0xe0 ? 1 : lead < 0xf0 ? 2 : 3;
+      if (lead >= 0x80 && cont < need) end = i;
+    }
+  }
+  return new TextDecoder('utf-8', { fatal: true }).decode(bytes.subarray(start, end));
+}
+
+// 用一个代码页尝试还原整条负载。无 U+FFFD 时就是"整体回编码 + 严格校验";
+// 有 U+FFFD 时按切口分段处理。任一段无法映射或非法都会抛错,由调用方换表/放弃。
+function recoverWithCodePage(utf8, label, multiByte) {
+  const segments = utf8.split(LOST);
+  const last = segments.length - 1;
+  const out = [];
+  for (let i = 0; i <= last; i++) {
+    const bytes = encodeToCodePage(segments[i], label, multiByte);
+    out.push(decodeSegment(bytes, i > 0, i < last));
+  }
+  return out.join(LOST);
+}
+
 /**
- * 把 hook stdin 原始字节解码为字符串:去 UTF-8 BOM + 修复 GBK 双重编码。
+ * 把 hook stdin 原始字节解码为字符串:去 UTF-8 BOM + 修复 ANSI 代码页双重编码。
  * @param {Buffer} buf 原始 stdin 字节
  * @returns {string}
  */
@@ -70,24 +160,28 @@ export function decodePayload(buf) {
     buf = buf.subarray(3);
   }
   const utf8 = buf.toString('utf-8');
-  // GBK 双重编码纠偏仅在 Windows 上进行。该乱码只源于中文 Windows 上的 host agent(Cursor/Qoder)
-  // 先按系统代码页(CP936)解码 UTF-8 负载再重新编码;原 PowerShell 版本本就是 .ps1、只在 Windows 运行。
+  // 双重编码纠偏仅在 Windows 上进行。该乱码只源于 Windows 上的 host agent(Cursor/Qoder)
+  // 先按系统 ANSI 代码页解码 UTF-8 负载再重新编码;原 PowerShell 版本本就是 .ps1、只在 Windows 运行。
   // 移入 node 后若不加平台判断,会在 macOS/Linux 上对本就合法的 UTF-8(如孤立中文字符)误纠而损坏遥测——
   // 因为孤立 CJK 字符的 GBK 编码字节本身也可能是合法 UTF-8,严格校验无法排除这种误纠。
-  // 额外要求负载含非 ASCII 字节:纯 ASCII 不可能是该乱码,借此跳过绝大多数负载,也避免无谓构建 GBK 编码表。
+  // 额外要求负载含非 ASCII 字节:纯 ASCII 不可能是该乱码,借此跳过绝大多数负载,也避免无谓构建编码表。
   if (process.platform === 'win32' && buf.length > 2 && /[^\x00-\x7f]/.test(utf8)) {
-    try {
-      const recovered = gbkEncode(utf8);
-      // 严格 UTF-8 校验:还原结果必须是合法 UTF-8(排除大部分正确输入被误纠)。
-      const recoveredStr = new TextDecoder('utf-8', { fatal: true }).decode(recovered);
-      // 膨胀判据:真正的 UTF-8→GBK 双重编码必然使收到的中间串 code point 数 > 还原串
-      // ——UTF-8 的 CJK 占 3 字节,被误当 GBK(每字符 2 字节)解码后字符数变多。反之干净单 CJK
-      // (如「业」→ GBK D2 B5 恰是合法 UTF-8 U+04B5「ҵ」)长度不变,严格校验放行却是误纠。仅当膨胀时才采纳。
-      if ([...utf8].length > [...recoveredStr].length) {
+    for (const { label, multiByte } of CODE_PAGES) {
+      try {
+        // 段内严格 UTF-8 校验在 recoverWithCodePage 里完成(排除大部分正确输入被误纠)。
+        const recoveredStr = recoverWithCodePage(utf8, label, multiByte);
+        // 膨胀判据:真正的 UTF-8→ANSI 双重编码必然使收到的中间串 code point 数 > 还原串
+        // ——UTF-8 的 CJK 占 3 字节,被误当 CP936(每字符 2 字节)/CP1252(每字符 1 字节)解码后字符数变多。
+        // 反之干净单 CJK(如「业」→ GBK D2 B5 恰是合法 UTF-8 U+04B5「ҵ」)长度不变,严格校验放行却是误纠。
+        if ([...utf8].length <= [...recoveredStr].length) continue;
+        // 还原结果里除 U+FFFD 标记外必须仍有非 ASCII 字符。分段还原会丢弃切口处不完整的序列,
+        // 若结果只剩标记,说明我们只是把非 ASCII 内容删掉了而非还原了它(该字符本就已被 host agent
+        // 破坏,无从恢复),此时宁可保留原始乱码,也顺带堵住"干净负载恰好含 U+FFFD"被误纠的可能。
+        if (!/[^\x00-\x7f\uFFFD]/.test(recoveredStr)) continue;
         return recoveredStr;
+      } catch {
+        // 该代码页不匹配(或此 node 构建不支持)——换下一张表
       }
-    } catch {
-      // 非双重编码(或 gbk 不可用)——保留原始 UTF-8
     }
   }
   return utf8;

--- a/tests/unit/hooks/shared/decode-payload.test.mjs
+++ b/tests/unit/hooks/shared/decode-payload.test.mjs
@@ -9,12 +9,17 @@ function setPlatform(platform) {
   Object.defineProperty(process, 'platform', { value: platform, configurable: true });
 }
 
-// Simulate a host that mis-decoded UTF-8 bytes as GBK (CP936) and re-encoded them as UTF-8 —
-// the exact double-encoding decodePayload is meant to repair on Chinese Windows.
-function doubleEncode(text) {
+// Simulate a host that mis-decoded UTF-8 bytes with the system ANSI code page and re-encoded them
+// as UTF-8 — the exact double-encoding decodePayload is meant to repair on Windows. The ACP is
+// CP936 on Chinese Windows and CP1252 on en-US Windows; both were observed in production.
+function doubleEncodeAs(text, codePage) {
   const utf8Bytes = Buffer.from(text, 'utf-8');
-  const asGbk = new TextDecoder('gbk').decode(utf8Bytes);
-  return Buffer.from(asGbk, 'utf-8');
+  const asCodePage = new TextDecoder(codePage).decode(utf8Bytes);
+  return Buffer.from(asCodePage, 'utf-8');
+}
+
+function doubleEncode(text) {
+  return doubleEncodeAs(text, 'gbk');
 }
 
 describe('decodePayload', () => {
@@ -108,6 +113,99 @@ describe('decodePayload', () => {
     setPlatform('win32');
     for (const text of ['中文', '测试日志', '中文abc123']) {
       expect(decodePayload(doubleEncode(text))).toBe(text);
+    }
+  });
+
+  // --- Regression: CP936 single-byte mappings (the '€' abort) --------------------------------
+  // The encode map only enumerated 2-byte GBK pairs, but 0x80 is a SINGLE-byte CP936 mapping to
+  // '€' (U+20AC). Any source char whose code point is a multiple of 64 ends its UTF-8 encoding
+  // with 0x80 — 一 (U+4E00), 什 (U+4EC0), 最 (U+6700), 327 such chars in the CJK block alone —
+  // so the mojibake contained '€', the map lookup threw, and the ENTIRE payload stayed garbled.
+  // The prior fixtures ('中文', '测试日志') never produce 0x80, which is why CI stayed green.
+  it('repairs CP936 mojibake containing € (single-byte 0x80 mapping)', () => {
+    setPlatform('win32');
+    for (const text of ['{"c":"一"}', '{"c":"什"}', '{"c":"最"}', '{"c":"稀"}', '{"c":"耀"}']) {
+      const mojibake = doubleEncode(text);
+      expect(mojibake.toString('utf-8')).toContain('€'); // fixture really hits the trigger
+      expect(decodePayload(mojibake)).toBe(text);
+    }
+  });
+
+  // --- New: CP1252 (en-US Windows) ------------------------------------------------------------
+  // The ACP is not always CP936. On en-US Windows the host agent decodes with CP1252, producing
+  // 'å¤ªä¸š'-style mojibake; gbkEncode threw on 'ä' (U+00E4) so nothing was ever repaired there.
+  // CP1252 is a lossless 256-byte table, so these payloads recover exactly — no byte is ever lost.
+  it('repairs CP1252 double-encoded payloads on Windows', () => {
+    setPlatform('win32');
+    const cases = [
+      '{"c":"中文"}',
+      '{"c":"一下"}',
+      '{"c":"帮我看一下这个问题"}',
+      '{"workspace":{"path":"C:/Users/太业/项目"}}',
+      '{"status":"完成","summary":"已修复三个缺陷"}',
+    ];
+    for (const text of cases) {
+      expect(decodePayload(doubleEncodeAs(text, 'windows-1252'))).toBe(text);
+    }
+  });
+
+  it('does not run the CP1252 repair off Windows', () => {
+    const mojibake = doubleEncodeAs('{"c":"中文"}', 'windows-1252');
+    for (const platform of ['darwin', 'linux']) {
+      setPlatform(platform);
+      expect(decodePayload(mojibake)).toBe(mojibake.toString('utf-8'));
+    }
+  });
+
+  // --- New: partial repair around bytes the host agent destroyed ------------------------------
+  // CP936 decoding emits U+FFFD for illegal byte combinations and the source byte is gone for
+  // good (an odd number of CJK chars followed by an ASCII byte < 0x40 such as '"' or ',' — close
+  // to half of real Chinese-Windows payloads). Aborting the whole payload over one lost byte left
+  // the correction effectively useless there, so each U+FFFD-delimited run is repaired on its own
+  // and only the destroyed character stays marked as U+FFFD.
+  it('repairs around a destroyed byte, keeping one U+FFFD marker (CP936)', () => {
+    setPlatform('win32');
+    const cases = [
+      ['{"c":"一下"}', '{"c":"一\ufffd"}'],
+      ['{"c":"什么"}', '{"c":"什\ufffd"}'],
+      ['{"c":"帮我看一下这个问题"}', '{"c":"帮我看一下这个问\ufffd"}'],
+      ['{"status":"完成","summary":"已修复三个缺陷"}', '{"status":"完成","summary":"已修复三个缺\ufffd"}'],
+    ];
+    for (const [text, expected] of cases) {
+      const mojibake = doubleEncode(text);
+      expect(mojibake.toString('utf-8')).toContain('\ufffd'); // fixture really loses a byte
+      expect(decodePayload(mojibake)).toBe(expected);
+    }
+  });
+
+  // Nothing is ever guessed: if the destroyed character was the payload's ONLY non-ASCII content,
+  // the "repair" would just delete it, so the original mojibake is kept instead. This also closes
+  // the false-positive door for a clean payload that happens to carry a literal U+FFFD.
+  it('keeps the original when the only non-ASCII char was destroyed', () => {
+    setPlatform('win32');
+    const mojibake = doubleEncode('{"c":"上"}');
+    expect(decodePayload(mojibake)).toBe(mojibake.toString('utf-8'));
+  });
+
+  it('preserves clean payloads containing € or a literal U+FFFD on Windows', () => {
+    setPlatform('win32');
+    for (const text of ['{"c":"€100"}', '{"c":"一下"}', '{"c":"坏\ufffd字"}', '{"c":"café"}']) {
+      expect(decodePayload(Buffer.from(text, 'utf-8'))).toBe(text);
+    }
+  });
+
+  // Bulk sweep: no clean CJK payload may ever be rewritten, on any of the code pages tried.
+  it('never corrupts clean CJK payloads (bulk sweep)', () => {
+    setPlatform('win32');
+    let seed = 12345;
+    const rnd = () => ((seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff);
+    for (let i = 0; i < 500; i++) {
+      let s = '';
+      for (let j = 0, n = 1 + Math.floor(rnd() * 12); j < n; j++) {
+        s += String.fromCodePoint(0x4e00 + Math.floor(rnd() * 0x51a6));
+      }
+      const text = JSON.stringify({ content: s, n: 42 });
+      expect(decodePayload(Buffer.from(text, 'utf-8'))).toBe(text);
     }
   });
 });


### PR DESCRIPTION
## Summary

- add the missing CP936 single-byte mappings so a `0x80` byte (decoded as `€`) no longer aborts the whole payload
- add a CP1252 table and try the code pages in sequence, so en-US Windows payloads are repaired at all
- repair each `U+FFFD`-delimited run independently instead of discarding the entire payload when the host agent destroyed one byte
- add a third false-correction guard, and fixtures covering the three shapes the old tests could not reach

## Symptom

Cursor telemetry collected on Windows arrives mojibaked in production: `workspace.path` shows up as `C:\Users\澶笟\宸ヤ綔绌洪棿` and `content` as `甯垜鐪嬩竴涓�`. The cause is a host agent (Cursor/Qoder) decoding the UTF-8 hook payload with the **system ANSI code page (ACP)** and re-encoding it as UTF-8 before writing it to stdin. `assets/hooks/shared/decode-payload.mjs` exists precisely to undo this, but all three production shapes failed, so in practice the correction never ran.

That file is the single chokepoint for the cursor / codex / workbuddy / qoder hooks and runs **before** `JSON.parse` ([`stdin-reader.mjs:35`](assets/hooks/shared/stdin-reader.mjs#L35), [`cursor-hook-processor.mjs:74`](assets/hooks/cursor-hook-processor.mjs#L74)), so it covers both message content and `cwd` / `workspace_roots`. The latter become `workspace.path` in [`enrich-git-context.ts:25`](src/normalization/enrich-git-context.ts#L25) and are used as the git probe directory, so a mojibaked path also silently lost `git.repo` / `git.branch` — fixed as a side effect.

## Root cause

**1. Missing CP936 single-byte mappings (the `€` abort).** The encode map only enumerated two-byte GBK pairs, but `0x80` is a **single-byte** CP936 mapping to `€` (U+20AC). Any character whose code point is a multiple of 64 ends its UTF-8 encoding with `0x80` — `一` U+4E00, `什` U+4EC0, `最` U+6700, 327 such characters in the CJK block alone — so the mojibake contained `€`, the map lookup threw, and the **entire payload** was abandoned. Single-byte mappings for `0x80`–`0xFF` are now built first so they take precedence over two-byte entries.

**2. Only one code page.** The ACP is not always 936: en-US Windows uses CP1252, producing `å¤ªä¸š`-style mojibake, and `gbkEncode` threw on `ä` (U+00E4), so those payloads were never repaired. A CP1252 table is added and the code pages are tried in sequence. **Order matters**: the single-byte CP1252 is tried first, because CP936 mojibake is almost entirely CJK and CP1252 cannot encode it (immediate throw, safe fallback), whereas CP936 emits two bytes per character and could — with small probability — assemble valid UTF-8 out of CP1252 mojibake and pass the inflation test.

**3. One destroyed byte discarded the whole payload.** CP936 decoding emits a `U+FFFD` for illegal byte combinations and the source byte is gone for good (most commonly an odd number of CJK characters followed by an ASCII byte `< 0x40` such as `"` or `,`, where the trailing byte is taken as a lead byte and errors). Close to half of real Chinese-Windows payloads hit this, so aborting over a single byte left the correction effectively useless there. Each `U+FFFD`-delimited run is now repaired on its own and rejoined: only the destroyed character stays marked as `U+FFFD`, everything else becomes readable. Segmenting is safe because the lost byte always falls inside a multi-byte character (the byte after it is ASCII), so incomplete sequences adjacent to a cut may be dropped; strict UTF-8 validation still applies within each segment.

## Guarding against false corrections

Both existing guards are unchanged: strict per-segment UTF-8 validation, and the code-point inflation criterion (genuine double-encoding always leaves the received string with more code points than the recovered one — this is what rejects clean input such as `业`, whose GBK bytes `D2 B5` happen to be valid UTF-8 `U+04B5`).

A **third guard** is added: the recovered string must still contain non-ASCII beyond `U+FFFD` markers. Segmented recovery drops incomplete sequences at the cuts, so if nothing but markers remains, the "repair" merely deleted the non-ASCII content rather than restoring it — the original mojibake is kept instead. This also closes the new false-positive door for a clean payload that happens to carry a literal `U+FFFD` next to a `€`. No byte is ever guessed and nothing is fabricated.

## Validation

Identical corpora, before → after. Short payloads, 4000 records (1–12 characters):

| ACP | exact | readable (incl. loss markers) |
|---|---|---|
| CP936 | 1774 → 1930 | 1774 → 3658 (44% → 91.5%) |
| CP1252 | 0 → 4000 | 0% → 100% |

Realistic long payloads, 500 records (cwd + 3–7 conversation turns, 75k CJK characters). Long payloads almost always contain `0x80` or lose a byte, so the old code recovered **nothing at all** on real traffic; byte-exactness is also a meaningless metric there (7000 characters with 3 lost still scores zero), so character-level recovery is the honest comparison:

| ACP | character-level | structurally readable | chars lost |
|---|---|---|---|
| CP936 | 0% → **97.61%** | 500/500 | 3.59 per payload |
| CP1252 | 0% → **100%** | 500/500 (byte-exact) | 0 |

Clean payloads are never rewritten (4000 short records plus a 500-record random-CJK sweep in the unit test). End to end, `C:\Users\澶笟\宸ヤ綔绌洪棿\鏀粯缃戝叧` recovers to `C:\Users\太业\工作空间\支付网关` under both code pages, and `宸ヤ綔` → `工作` matches the production records exactly.

`tests/unit/hooks/shared/decode-payload.test.mjs`: 16 passed. `tsc --noEmit`: clean.

CI stayed green before because the fixtures used only `中文` and `测试日志` — neither produces `0x80`, and both are even-aligned so they never trigger byte loss. **All three defects were invisible to the test suite.** Seven cases now pin them down: CP936 mojibake containing `€` (`一/什/最/稀/耀`), CP1252 double-encoding, CP1252 repair not running off Windows, byte-loss payloads keeping exactly one `U+FFFD`, keeping the original when the only non-ASCII character was destroyed, clean payloads containing `€` or a literal `U+FFFD` being left alone, and the random-CJK no-corruption sweep.

## Why not 100%

The destroyed byte **cannot** be recovered — an information-theoretic limit, not an implementation gap. The lost byte is always the final byte of a three-byte CJK sequence whose first two bytes survive, narrowing the candidates to 63; but all 63 produce **byte-identical** mojibake. Measured: for the template `{"c":"一X"}`, 20902 CJK characters collapse into only 654 distinct mojibake byte strings, largest collision group 63 (`丁 丂 七 丄 丅 丆 万 丈 三 上 下 …`). Narrowing further would require dictionary or language-model guessing — fabricating telemetry, which is worse than an honest `U+FFFD` marker.

Genuine 100% requires bypassing the lossy channel, which is out of scope here: read Cursor's on-disk `transcript_path` (clean UTF-8, never passes through the ACP), set the endpoint ACP to 65001 so the mis-decode becomes an identity transform, or fix the root cause upstream in Cursor. Related finding: the Windows transcript fallback at [`react-assembler.mjs:37-57`](assets/hooks/cursor/react-assembler.mjs#L37-L57) could **never be entered** on Chinese Windows, because `transcript_path` was itself mojibaked and `fs.existsSync` returned false. This PR makes it reachable for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
