### PR TITLE
fix(dsh): detect process runtime during installer probe

### DIFF
--- a/src/cli-probe.ts
+++ b/src/cli-probe.ts
@@ -1,32 +1,10 @@
 import * as path from 'node:path';
 import { AgentDefLoader } from './deployment/agent-def-loader.js';
-import { detectAgent, commandExists } from './deployment/detect-utils.js';
-import { resolveHome, directoryExists, fileExists } from './utils/fs-utils.js';
+import { probeAgentDefinitions } from './deployment/cli-probe-detector.js';
+import { resolveHome } from './utils/fs-utils.js';
 
 // This file is always bundled as CJS (build.mjs), so __dirname is guaranteed.
 const __probe_dirname = __dirname;
-
-interface ProbeResult {
-  id: string;
-  displayName: string;
-  detected: boolean;
-  reason: string;
-}
-
-async function findDetectionReason(detection: { paths: string[]; commands: string[] }): Promise<string> {
-  for (const p of detection.paths) {
-    const resolved = resolveHome(p);
-    if (await directoryExists(resolved) || await fileExists(resolved)) {
-      return p;
-    }
-  }
-  for (const cmd of detection.commands) {
-    try {
-      if (await commandExists(cmd)) return `command: ${cmd}`;
-    } catch { /* ignore */ }
-  }
-  return '';
-}
 
 async function main(): Promise<void> {
   const builtinDir = path.resolve(__probe_dirname, '..', 'agents.d');
@@ -49,21 +27,7 @@ async function main(): Promise<void> {
   const listOnly = process.argv.includes('--list');
 
   const defs = await loader.load();
-  const results: ProbeResult[] = [];
-
-  for (const def of defs) {
-    if (def.detection.paths.length === 0 && def.detection.commands.length === 0) {
-      continue;
-    }
-    const detected = listOnly ? false : await detectAgent(def.detection);
-    const reason = detected ? await findDetectionReason(def.detection) : '';
-    results.push({
-      id: def.id,
-      displayName: def.displayName,
-      detected,
-      reason,
-    });
-  }
+  const results = await probeAgentDefinitions(defs, { listOnly });
 
   process.stdout.write(JSON.stringify(results));
 }

--- a/src/deployment/cli-probe-detector.ts
+++ b/src/deployment/cli-probe-detector.ts
@@ -1,0 +1,116 @@
+import type { AgentDefinition } from '../types/index.js';
+import { directoryExists, fileExists, resolveHome } from '../utils/fs-utils.js';
+import { commandExists, detectAgent } from './detect-utils.js';
+import {
+  DshRuntimeLocator,
+  type DshRuntimeTarget,
+} from './dsh-runtime-locator.js';
+
+export interface CliProbeResult {
+  id: string;
+  displayName: string;
+  detected: boolean;
+  reason: string;
+}
+
+interface DshRuntimeLocatorLike {
+  locate(def: AgentDefinition): Promise<DshRuntimeTarget | null>;
+}
+
+export interface CliProbeOptions {
+  listOnly?: boolean;
+  /** Injectable for deterministic procfs tests. */
+  dshRuntimeLocator?: DshRuntimeLocatorLike;
+}
+
+async function findDetectionReason(def: AgentDefinition): Promise<string> {
+  for (const configuredPath of def.detection.paths) {
+    const resolved = resolveHome(configuredPath);
+    if (await directoryExists(resolved) || await fileExists(resolved)) {
+      return configuredPath;
+    }
+  }
+  for (const command of def.detection.commands) {
+    try {
+      if (await commandExists(command)) return `command: ${command}`;
+    } catch {
+      // Detection is best effort. A failed PATH lookup is an ordinary miss.
+    }
+  }
+  return '';
+}
+
+function describeDshTarget(target: DshRuntimeTarget): string {
+  switch (target.source) {
+    case 'running-process':
+      return `running process: DSH_HOME=${target.home}${target.pid === undefined ? '' : ` (pid ${target.pid})`}`;
+    case 'pilot-env':
+      return `DSH_HOME=${target.home}`;
+    case 'configured-patch':
+      return `configured patch: ${target.patchPath}`;
+    case 'persisted':
+      return `persisted patch: ${target.patchPath}`;
+    case 'standard-detection':
+      return '';
+  }
+}
+
+/**
+ * Probe one installer-selectable Agent.
+ *
+ * DSH is intentionally the only special case: its runtime home may exist only
+ * in a running Node process environment, so the generic path/PATH boolean is
+ * insufficient. All failures remain local to this Agent so one transient or
+ * ambiguous procfs result cannot erase the complete installer menu.
+ */
+export async function probeAgentDefinition(
+  def: AgentDefinition,
+  options: CliProbeOptions = {},
+): Promise<CliProbeResult> {
+  const result: CliProbeResult = {
+    id: def.id,
+    displayName: def.displayName,
+    detected: false,
+    reason: '',
+  };
+
+  if (options.listOnly) return result;
+
+  try {
+    if (def.deployMode === 'dsh-yaml-patch') {
+      const locator = options.dshRuntimeLocator ?? new DshRuntimeLocator();
+      const target = await locator.locate(def);
+      if (!target) return result;
+      return {
+        ...result,
+        detected: true,
+        reason: target.source === 'standard-detection'
+          ? await findDetectionReason(def)
+          : describeDshTarget(target),
+      };
+    }
+
+    const detected = await detectAgent(def.detection);
+    return {
+      ...result,
+      detected,
+      reason: detected ? await findDetectionReason(def) : '',
+    };
+  } catch {
+    return result;
+  }
+}
+
+export async function probeAgentDefinitions(
+  definitions: AgentDefinition[],
+  options: CliProbeOptions = {},
+): Promise<CliProbeResult[]> {
+  const results: CliProbeResult[] = [];
+  for (const def of definitions) {
+    if (def.detection.paths.length === 0 && def.detection.commands.length === 0) {
+      continue;
+    }
+    results.push(await probeAgentDefinition(def, options));
+  }
+  return results;
+}

--- a/src/deployment/cli-probe-detector.ts
+++ b/src/deployment/cli-probe-detector.ts
@@ -60,8 +60,9 @@ function describeDshTarget(target: DshRuntimeTarget): string {
  *
  * DSH is intentionally the only special case: its runtime home may exist only
  * in a running Node process environment, so the generic path/PATH boolean is
- * insufficient. All failures remain local to this Agent so one transient or
- * ambiguous procfs result cannot erase the complete installer menu.
+ * insufficient. DSH discovery failures remain local to DSH so one transient
+ * or ambiguous procfs result cannot erase the complete installer menu. Other
+ * Agents retain the generic detector's existing error behavior.
  */
 export async function probeAgentDefinition(
   def: AgentDefinition,
@@ -76,8 +77,8 @@ export async function probeAgentDefinition(
 
   if (options.listOnly) return result;
 
-  try {
-    if (def.deployMode === 'dsh-yaml-patch') {
+  if (def.deployMode === 'dsh-yaml-patch') {
+    try {
       const locator = options.dshRuntimeLocator ?? new DshRuntimeLocator();
       const target = await locator.locate(def);
       if (!target) return result;
@@ -88,17 +89,17 @@ export async function probeAgentDefinition(
           ? await findDetectionReason(def)
           : describeDshTarget(target),
       };
+    } catch {
+      return result;
     }
-
-    const detected = await detectAgent(def.detection);
-    return {
-      ...result,
-      detected,
-      reason: detected ? await findDetectionReason(def) : '',
-    };
-  } catch {
-    return result;
   }
+
+  const detected = await detectAgent(def.detection);
+  return {
+    ...result,
+    detected,
+    reason: detected ? await findDetectionReason(def) : '',
+  };
 }
 
 export async function probeAgentDefinitions(

--- a/tests/unit/deployment/cli-probe-detector.test.ts
+++ b/tests/unit/deployment/cli-probe-detector.test.ts
@@ -136,6 +136,13 @@ describe('CLI probe detector', () => {
     ]);
   });
 
+  it('preserves generic Agent detection errors', async () => {
+    const failure = new Error('generic detector failed');
+    vi.mocked(detectAgent).mockRejectedValueOnce(failure);
+
+    await expect(probeAgentDefinition(genericDef())).rejects.toBe(failure);
+  });
+
   it('preserves list-only behavior without consulting runtime discovery', async () => {
     const locate = vi.fn();
 

--- a/tests/unit/deployment/cli-probe-detector.test.ts
+++ b/tests/unit/deployment/cli-probe-detector.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { AgentDefinition } from '../../../src/types/index.js';
+
+vi.mock('../../../src/deployment/detect-utils.js', () => ({
+  detectAgent: vi.fn(),
+  commandExists: vi.fn(),
+}));
+
+import { commandExists, detectAgent } from '../../../src/deployment/detect-utils.js';
+import {
+  probeAgentDefinition,
+  probeAgentDefinitions,
+} from '../../../src/deployment/cli-probe-detector.js';
+import { DshRuntimeLocator } from '../../../src/deployment/dsh-runtime-locator.js';
+
+describe('CLI probe detector', () => {
+  let tmpDir: string;
+  let procRoot: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cli-probe-detector-'));
+    procRoot = path.join(tmpDir, 'proc');
+    await fs.mkdir(procRoot);
+    vi.mocked(detectAgent).mockResolvedValue(false);
+    vi.mocked(commandExists).mockResolvedValue(false);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  function dshDef(): AgentDefinition {
+    return {
+      id: 'dsh',
+      displayName: 'DeepSeek Harness',
+      deployMode: 'dsh-yaml-patch',
+      detection: { paths: ['~/.dsh'], commands: ['dsh'] },
+      dshYamlPatch: {
+        pluginSource: '/pilot/plugins/dsh/plugin.mjs',
+        entryId: 'loongsuite-pilot-observability',
+        marker: 'PILOT-OBSERVABILITY-MANAGED',
+      },
+    };
+  }
+
+  function genericDef(): AgentDefinition {
+    return {
+      id: 'generic-cli',
+      displayName: 'Generic CLI',
+      deployMode: 'detection-only',
+      detection: { paths: [], commands: ['generic-cli'] },
+    };
+  }
+
+  function locator(): DshRuntimeLocator {
+    return new DshRuntimeLocator({
+      procRoot,
+      platform: 'linux',
+      env: {},
+      cwd: () => tmpDir,
+      uid: process.getuid?.(),
+    });
+  }
+
+  async function writeDshProcess(pid: number, home: string): Promise<void> {
+    const processDir = path.join(procRoot, String(pid));
+    await fs.mkdir(processDir);
+    await fs.writeFile(
+      path.join(processDir, 'cmdline'),
+      Buffer.from(['node', '/code/node_modules/@deepseek-ai/dsh/lib/bin.js', 'web', ''].join('\0')),
+    );
+    await fs.writeFile(
+      path.join(processDir, 'environ'),
+      Buffer.from([
+        'PATH=/usr/bin',
+        `DSH_HOME=${home}`,
+        'DEEPSEEK_API_KEY=must-not-appear-in-the-probe-result',
+        '',
+      ].join('\0')),
+    );
+  }
+
+  it('detects a Node-launched DSH from procfs when the installer environment misses it', async () => {
+    const home = path.join(tmpDir, 'runtime-home');
+    await writeDshProcess(321, home);
+
+    const result = await probeAgentDefinition(dshDef(), { dshRuntimeLocator: locator() });
+
+    expect(result).toEqual({
+      id: 'dsh',
+      displayName: 'DeepSeek Harness',
+      detected: true,
+      reason: `running process: DSH_HOME=${home} (pid 321)`,
+    });
+    expect(JSON.stringify(result)).not.toContain('DEEPSEEK_API_KEY');
+    expect(detectAgent).not.toHaveBeenCalled();
+  });
+
+  it('returns a normal miss when no DSH runtime is discoverable', async () => {
+    await expect(probeAgentDefinition(dshDef(), { dshRuntimeLocator: locator() })).resolves.toEqual({
+      id: 'dsh',
+      displayName: 'DeepSeek Harness',
+      detected: false,
+      reason: '',
+    });
+  });
+
+  it('contains an ambiguous DSH failure and preserves other Agent results', async () => {
+    await writeDshProcess(401, path.join(tmpDir, 'home-a'));
+    await writeDshProcess(402, path.join(tmpDir, 'home-b'));
+    vi.mocked(detectAgent).mockImplementation(async detection => detection.commands.includes('generic-cli'));
+    vi.mocked(commandExists).mockImplementation(async command => command === 'generic-cli');
+
+    const results = await probeAgentDefinitions(
+      [dshDef(), genericDef()],
+      { dshRuntimeLocator: locator() },
+    );
+
+    expect(results).toEqual([
+      {
+        id: 'dsh',
+        displayName: 'DeepSeek Harness',
+        detected: false,
+        reason: '',
+      },
+      {
+        id: 'generic-cli',
+        displayName: 'Generic CLI',
+        detected: true,
+        reason: 'command: generic-cli',
+      },
+    ]);
+  });
+
+  it('preserves list-only behavior without consulting runtime discovery', async () => {
+    const locate = vi.fn();
+
+    const result = await probeAgentDefinition(dshDef(), {
+      listOnly: true,
+      dshRuntimeLocator: { locate },
+    });
+
+    expect(result.detected).toBe(false);
+    expect(result.reason).toBe('');
+    expect(locate).not.toHaveBeenCalled();
+    expect(detectAgent).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- reuse `DshRuntimeLocator` for DSH during the installer CLI probe, including process-discovered non-standard `DSH_HOME`
- keep the generic Agent detector, its existing error behavior, and `--list` behavior unchanged
- contain only DSH process-discovery failures to the DSH result so the installer menu remains usable
- add unit coverage for Node-launched DSH, normal misses, ambiguous runtime homes, generic error compatibility, and list-only probing

## Verification

- `npm test -- tests/unit/deployment/cli-probe-detector.test.ts tests/unit/deployment/dsh-runtime-locator.test.ts` (20 passed)
- `npm run typecheck`
- `npm run build`
- `env -u LOONGSUITE_PILOT_UPSTREAM_LINK npm test` (3353 passed, 56 skipped)
- `node dist/cli-probe.cjs --list`

Fixes #311

Follow-up to #298.