### PR TITLE
fix(installer): keep uninstall going when node cannot be resolved

### DIFF
--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -2798,6 +2798,27 @@ function Remove-PilotInstallationFiles {
     }
 }
 
+# >>> dsh-unpatch-refusal >>>
+# Would removing the plugin assets leave a reference behind? Only a patch file that still
+# carries our managed block would, so that is the one question worth refusing over.
+#
+# Consulted only on the paths that would otherwise refuse to continue, never on the
+# working path: this reads a file owned by a third-party tool, and an unreadable one must
+# not be able to turn a healthy uninstall into a failing one. Unreadable is answered
+# "still managed" on purpose -- we cannot prove nothing dangles, so we keep the
+# conservative answer and let the caller refuse.
+function Test-DshPatchStillManaged {
+    param([string]$PatchPath)
+    if (-not $PatchPath) { return $false }
+    if (-not (Test-Path -LiteralPath $PatchPath -ErrorAction SilentlyContinue)) { return $false }
+    try {
+        return [bool](Select-String -LiteralPath $PatchPath -SimpleMatch "# BEGIN PILOT-OBSERVABILITY-MANAGED" -Quiet)
+    } catch {
+        return $true
+    }
+}
+# <<< dsh-unpatch-refusal <<<
+
 # ============================================================
 # Remove the Pilot-owned DeepSeek Harness YAML patch before plugin assets.
 # Unix and Windows both execute assets/plugins/dsh/cleanup.mjs.
@@ -2824,14 +2845,26 @@ function Remove-DshYamlPatch {
     }
 
     if (-not (Test-Path -LiteralPath $cleanupScript)) {
-        if ((Test-Path -LiteralPath $patchPath) -and
-            (Select-String -LiteralPath $patchPath -SimpleMatch "# BEGIN PILOT-OBSERVABILITY-MANAGED" -Quiet)) {
+        if (Test-DshPatchStillManaged -PatchPath $patchPath) {
             throw "DSH cleanup helper is missing; refusing to remove plugin assets still referenced by $patchPath"
         }
         return
     }
     if (-not $script:NODE_BIN) {
-        throw "No usable Node.js; cannot safely remove the DSH YAML patch"
+        # Gated the same way as the branch above, which it was not. Resolve-Node returns
+        # $null when no candidate is suitable, so this throw has always been reachable,
+        # and uninstall now also arrives here after a failed Node probe instead of dying
+        # inside Resolve-Node itself. Refusing unconditionally aborted the entire
+        # uninstall -- Cmd-Uninstall calls this before every other cleanup step, and
+        # -Purge, the step that deletes config.json and the reporting credentials in it,
+        # is the last thing in the function -- on machines where DSH was never patched and
+        # there was nothing to protect. Refuse only when something would really dangle.
+        if (Test-DshPatchStillManaged -PatchPath $patchPath) {
+            throw "No usable Node.js; cannot safely remove the DSH YAML patch at $patchPath"
+        }
+        Msg "    ⚠️  跳过: 无可用 node,且 $patchPath 里没有 Pilot 托管块,无需 unpatch" `
+            "    ⚠️  Skipped: no usable node, and $patchPath carries no Pilot-managed block, so there is nothing to unpatch"
+        return
     }
 
     & $script:NODE_BIN $cleanupScript --patch $patchPath --plugin-dir $pluginDir
@@ -2939,8 +2972,11 @@ function Cmd-Uninstall {
         Msg "    ✅ 已删除 $DataDir" "    ✅ Removed $DataDir"
     } else {
         Msg "📁 数据目录已保留: $DataDir" "📁 Data directory preserved: $DataDir"
-        Msg "   (包含配置和日志，如需彻底删除请加 -Purge)" `
-            "   (contains config and logs, add -Purge to remove)"
+        # Names the credentials rather than saying "config": this line is the only notice
+        # a user gets that an uninstall they consider finished left an SLS AccessKeySecret
+        # readable on disk, and "contains config and logs" does not read like that.
+        Msg "   (包含配置和日志，其中 config.json 里有上报凭据；如需彻底删除请加 -Purge)" `
+            "   (contains config and logs -- config.json holds reporting credentials; add -Purge to remove)"
     }
     Write-Host ""
 

--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -201,9 +201,18 @@ function Resolve-Node {
         if ($pinned) { $candidates += $pinned }
     }
 
-    # nvm-windows
+    # nvm-windows. Both probes below must be non-fatal. NVM_HOME is often a *machine*
+    # level variable pointing into another account's profile
+    # (C:\Users\Administrator\AppData\Local\nvm was measured), and that directory's DACL
+    # grants nothing to the current user: a bare Test-Path raises a PermissionDenied
+    # UnauthorizedAccessException record, which the file header's
+    # $ErrorActionPreference = "Stop" promotes to a terminating error. Resolve-Node is
+    # called from uninstall before any cleanup runs, so one unreadable third-party node
+    # manager aborted the entire uninstall and left config.json -- credentials included --
+    # on disk even with -Purge. The Get-ChildItem calls were already guarded; these two
+    # were not. -LiteralPath as well, because a version manager path may contain [ or ].
     $nvmHome = $env:NVM_HOME
-    if ($nvmHome -and (Test-Path $nvmHome)) {
+    if ($nvmHome -and (Test-Path -LiteralPath $nvmHome -ErrorAction SilentlyContinue)) {
         $nvmDirs = Get-ChildItem $nvmHome -Directory -ErrorAction SilentlyContinue |
                    Sort-Object Name -Descending
         foreach ($d in $nvmDirs) {
@@ -211,9 +220,9 @@ function Resolve-Node {
         }
     }
 
-    # fnm
+    # fnm -- same unreadable-directory hazard as the nvm branch above.
     $fnmDir = Join-Path $env:USERPROFILE ".fnm\node-versions"
-    if (Test-Path $fnmDir) {
+    if (Test-Path -LiteralPath $fnmDir -ErrorAction SilentlyContinue) {
         $fnmDirs = Get-ChildItem $fnmDir -Directory -ErrorAction SilentlyContinue |
                    Sort-Object Name -Descending
         foreach ($d in $fnmDirs) {
@@ -1641,9 +1650,21 @@ function Remove-HookConfigs {
     foreach ($cfg in $configs) {
         if (-not (Test-Path $cfg)) { continue }
         $short = $cfg.Replace($env:USERPROFILE, "~")
+        # Same guard Remove-OpenClawPlugin and Remove-OtelPlugin already carry, and the
+        # reason uninstall may now reach this function without a Node: without it the
+        # call below runs as & "" against a hook config that then goes unreported.
+        if (-not $script:NODE_BIN) {
+            Msg "    ⚠️  跳过: $short (无 node,需手动清理)" "    ⚠️  Skipped: $short (node unavailable, manual cleanup needed)"
+            continue
+        }
 
+        # Saved and restored around the try, not inside it: a throw from the native call
+        # (an install-dir node-bin pin that no longer exists, say) used to skip the
+        # restore and leave the whole rest of uninstall running at "Continue", where the
+        # later fail-fast checks stop failing fast.
+        $prevEAP = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
         try {
-            $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
             & $script:NODE_BIN -e @'
 const fs = require('fs');
 const cfg = process.argv[1];
@@ -1674,10 +1695,11 @@ try {
   }
 } catch(e) { process.stderr.write(e.message); process.exit(1); }
 '@ $cfg $HOOK_MARKER 2>$null
-            $ErrorActionPreference = $prevEAP
             Msg "    ✅ 已清理: $short" "    ✅ Cleaned: $short"
         } catch {
             Msg "    ⚠️  跳过: $short (需手动清理)" "    ⚠️  Skipped: $short (manual cleanup needed)"
+        } finally {
+            $ErrorActionPreference = $prevEAP
         }
     }
 }
@@ -2150,6 +2172,9 @@ function Cmd-Install {
     Msg "==> 开始安装 $PACKAGE_NAME ..." "==> Installing $PACKAGE_NAME ..."
     Write-Host ""
 
+    # Before anything is downloaded or registered, so Ctrl+C is still cheap.
+    Warn-ElevatedInstall
+
     Check-Deps
     Migrate-LegacyLayout
 
@@ -2488,10 +2513,46 @@ function Remove-OnePilotScheduledTask {
     } catch {
         $unregisterError = $_.Exception.Message
         $fullTaskName = "$($TaskPath.TrimEnd('\'))\$TaskName"
-        & schtasks.exe /Delete /TN $fullTaskName /F 2>$null | Out-Null
-        $schtasksExit = $LASTEXITCODE
+        # Locally forced to Continue for the native call below. On Windows PowerShell 5.1
+        # a native command that writes stderr *while a 2> redirection is in effect*
+        # raises a NativeCommandError, and the file header's
+        # $ErrorActionPreference = "Stop" promotes that to a terminating error whose
+        # Message is nothing but the raw stderr line. schtasks.exe prints
+        # "ERROR: Access is denied." there on exactly the failure this branch exists to
+        # report, so the throw below -- the only place that tells the user why the task
+        # survived and what to do about it -- was unreachable: the user saw the bare
+        # stderr line and nothing else. Restored in finally so the rest of uninstall
+        # keeps failing fast. $schtasksExit starts at 1 so a schtasks.exe that cannot
+        # launch at all is treated as failure rather than inheriting a stale
+        # $LASTEXITCODE of 0.
+        $schtasksExit = 1
+        $schtasksOut = ""
+        $prevEAP = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
+        try {
+            $schtasksOut = & schtasks.exe /Delete /TN $fullTaskName /F 2>&1
+            $schtasksExit = $LASTEXITCODE
+        } finally {
+            $ErrorActionPreference = $prevEAP
+        }
         if ($schtasksExit -ne 0) {
-            throw "Failed to remove scheduled task $fullTaskName (Unregister-ScheduledTask: $unregisterError; schtasks exit: $schtasksExit). Run uninstall from an elevated PowerShell."
+            # Each element here is an ErrorRecord, not a string: at "Continue" the
+            # NativeCommandError still goes to the error stream and 2>&1 merges the record
+            # itself, so Out-String rendered the whole PowerShell error block -- source
+            # line, squiggle line, CategoryInfo, FullyQualifiedErrorId -- into the middle
+            # of the sentence below. Measured on a 5.1 box: schtasks.exe emits two records
+            # for one stderr line, the second one empty. .Exception.Message is a property
+            # get, so it stays CLM-safe, and it is the raw stderr text and nothing else.
+            $schtasksLines = @()
+            foreach ($schtasksLine in $schtasksOut) {
+                $lineText = ""
+                if ($schtasksLine.Exception) { $lineText = [string]$schtasksLine.Exception.Message }
+                else { $lineText = [string]$schtasksLine }
+                $lineText = $lineText.Trim()
+                if ($lineText) { $schtasksLines += $lineText }
+            }
+            $schtasksDetail = $schtasksLines -join " "
+            throw "Failed to remove scheduled task $fullTaskName (Unregister-ScheduledTask: $unregisterError; schtasks exit: $schtasksExit): $schtasksDetail. If that says access is denied, this instance's scheduled tasks are owned by BUILTIN\Administrators, which is what registering them from an elevated session produces -- uninstall itself does not need administrator rights. Re-run uninstall from an elevated PowerShell, or reinstall without elevation."
         }
     }
 
@@ -2556,6 +2617,42 @@ function Get-PilotUserTag {
     return $tag
 }
 # <<< pilot-account-identity <<<
+
+# >>> pilot-elevation-warning >>>
+# "Run as administrator" is the reflex a lot of Windows users have for an installer, and
+# here it quietly costs them the ability to uninstall. The scheduled tasks are registered
+# with -RunLevel Limited into the shared \LoongsuitePilot folder, and the only reason a
+# standard user can delete them again is that folder's inherited CREATOR OWNER :
+# FullControl ACE. Under an elevated token CREATOR OWNER resolves to
+# BUILTIN\Administrators, so the tasks come out owned by Administrators and the same
+# account's ordinary session keeps only Read, Synchronize -- schtasks /Delete answers
+# "ERROR: Access is denied." and uninstall cannot remove them. Same mechanism as the file
+# ACLs that Reset-PilotInheritedAcl already repairs with icacls /reset; the task side has
+# no equivalent yet, so for now all we can do is say so before the user commits.
+#
+# The probe is best-effort by construction: both the cast and GetCurrent() are "supported
+# only on core types" under Constrained Language Mode, so under WDAC this throws and we
+# report not-elevated. Losing the hint is acceptable; failing an install over a hint is
+# not.
+function Test-PilotElevated {
+    try {
+        $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+        $principal = [Security.Principal.WindowsPrincipal]$identity
+        return [bool]$principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    } catch {
+        return $false
+    }
+}
+
+function Warn-ElevatedInstall {
+    if (-not (Test-PilotElevated)) { return }
+    Msg "⚠️  当前是提权(管理员)会话" "⚠️  This is an elevated (administrator) session"
+    Msg "    这样注册出来的计划任务归 BUILTIN\Administrators，本账号的普通会话之后删不掉" "    Scheduled tasks registered from it are owned by BUILTIN\Administrators, and this account's ordinary sessions cannot delete them afterwards"
+    Msg "    继续安装的话，卸载(-Uninstall)也必须在提权会话里执行" "    If you continue, uninstall (-Uninstall) will have to run elevated as well"
+    Msg "    想让普通会话自己就能卸载：Ctrl+C 退出，在非提权 PowerShell 里重新安装" "    To keep uninstall working without elevation: press Ctrl+C and re-run the install from a non-elevated PowerShell"
+    Write-Host ""
+}
+# <<< pilot-elevation-warning <<<
 
 function Remove-PilotScheduledTasks {
     $taskFolder = "\LoongsuitePilot"
@@ -2761,7 +2858,26 @@ function Cmd-Uninstall {
 
     # Resolve the pinned runtime before installation files (including node-bin)
     # are removed. JSON config cleanup must also work when Node is absent from PATH.
-    $script:NODE_BIN = Resolve-Node
+    if (-not $script:NODE_BIN) {
+        try {
+            $script:NODE_BIN = Resolve-Node
+        } catch {
+            # Non-fatal on purpose. Resolve-Node probes third-party version-manager
+            # directories, and under the file header's $ErrorActionPreference = "Stop"
+            # any unexpected error record in there becomes terminating. Unguarded, that
+            # aborted Cmd-Uninstall right here -- before plugin cleanup, before the
+            # install directory was deleted, and before -Purge -- so config.json
+            # survived on disk with its credentials in it. Every step below that needs
+            # Node already checks $script:NODE_BIN and reports what it skipped.
+            $script:NODE_BIN = ""
+            Msg "    ⚠️  解析 Node 失败: $($_.Exception.Message)" `
+                "    ⚠️  Resolving Node failed: $($_.Exception.Message)"
+        }
+    }
+    if (-not $script:NODE_BIN) {
+        Msg "    ⚠️  未解析到可用的 Node;依赖 Node 的清理步骤会逐项跳过并提示,其余步骤继续" `
+            "    ⚠️  No usable Node resolved; each Node-dependent cleanup step will be skipped with a notice, the rest continues"
+    }
 
     Msg "==> 清理 DSH YAML patch..." "==> Cleaning up DSH YAML patch..."
     Remove-DshYamlPatch

--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -346,19 +346,53 @@ function Stop-PidFile {
     }
     # Force kill if still running
     try { Stop-Process -Id $pidVal -Force -ErrorAction SilentlyContinue } catch {}
-    Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
+
+    # Delete the file only while it still names the process we just killed. Up to ten
+    # seconds elapse in the wait loop above, and the collector task carries a five-minute
+    # repeating trigger, so a successor may already have started and written its own pid
+    # here -- unconditional removal then deleted a live daemon's pid file, after which
+    # status reported it as not running and the next start raced a second instance against
+    # it. Same rule the daemons themselves follow on shutdown (removeOwnPidFileSync in
+    # src/utils/pid-utils.ts). Re-read rather than trusting $pidVal: the point is what is
+    # on disk now, not what was there before Stop-Process.
+    $currentPid = ""
+    if (Test-Path -LiteralPath $pidFile) {
+        $currentPid = ([string](Get-Content -LiteralPath $pidFile -ErrorAction SilentlyContinue)).Trim()
+    }
+    if ($currentPid -eq $pidVal) {
+        Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
+    }
 }
 
 function Stop-OrphanProcesses {
     # $Match limits which daemons are terminated; the default kills both. Callers that
     # re-register a single task (Install-CollectorTask / Install-UpdaterTask) pass a
     # narrow pattern so they only reap the daemon they are about to re-launch.
+    #
+    # Both conditions below are required, and the second one is the point. The daemon
+    # names are shared by every installation on the machine: on a multi-account box each
+    # user runs their own collector and updater out of their own %USERPROFILE%, and
+    # matching on the name alone made any install / restart / stop kill all of them.
+    # Get-Process only enumerates other users' processes when the caller is elevated, so
+    # the blast radius was exactly the elevated sessions -- their victims' pid files were
+    # left pointing at dead pids, which is where the "stale single-instance lock" reports
+    # came from. $BOOTSTRAP_DIR is the directory the entry script is loaded from
+    # (New-HiddenTaskAction writes "<node>" "<$BOOTSTRAP_DIR\<name>-daemon.js>", and
+    # Cmd-Start builds the same pair), so it appears verbatim in the command line and
+    # identifies this installation and no other. It is non-empty by construction:
+    # $CACHE_DIR falls back to $DEFAULT_PILOT_DIR.
+    #
+    # .ToLower().Contains() rather than -match: the scope is a literal Windows path full
+    # of \ and possibly regex metacharacters (a user profile can contain "["), and
+    # escaping it for a regex buys nothing here. It is also a method call on [string], a
+    # core type, so it stays CLM-safe.
     param([string]$Match = "collector-daemon|updater-daemon")
+    $ownRoot = ([string]$BOOTSTRAP_DIR).ToLower()
     Get-Process -Name "node" -ErrorAction SilentlyContinue |
         Where-Object {
             try {
-                $cmdLine = (Get-CimInstance Win32_Process -Filter "ProcessId = $($_.Id)" -ErrorAction SilentlyContinue).CommandLine
-                $cmdLine -match $Match
+                $cmdLine = [string](Get-CimInstance Win32_Process -Filter "ProcessId = $($_.Id)" -ErrorAction SilentlyContinue).CommandLine
+                ($cmdLine -match $Match) -and $cmdLine.ToLower().Contains($ownRoot)
             } catch { $false }
         } | ForEach-Object {
             Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
@@ -834,16 +868,11 @@ function Cmd-RestartCollector {
     }
     Stop-PidFile $PID_FILE
 
-    # Kill orphan collector processes
-    Get-Process -Name "node" -ErrorAction SilentlyContinue |
-        Where-Object {
-            try {
-                $cmdLine = (Get-CimInstance Win32_Process -Filter "ProcessId = $($_.Id)" -ErrorAction SilentlyContinue).CommandLine
-                $cmdLine -match "collector-daemon"
-            } catch { $false }
-        } | ForEach-Object {
-            Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
-        }
+    # Kill orphan collector processes. Was an inline copy of Stop-OrphanProcesses that
+    # predated the -Match parameter; it also missed the installation scope the shared
+    # helper now applies, and restart-collector is the command the updater runs on every
+    # deploy -- i.e. the one that reached other accounts most often.
+    Stop-OrphanProcesses -Match "collector-daemon"
 
     Start-Sleep -Seconds 1
     Ensure-Dirs
@@ -955,15 +984,9 @@ function Cmd-RestartUpdater {
     }
     Stop-PidFile $UPDATER_PID_FILE
 
-    Get-Process -Name "node" -ErrorAction SilentlyContinue |
-        Where-Object {
-            try {
-                $cmdLine = (Get-CimInstance Win32_Process -Filter "ProcessId = $($_.Id)" -ErrorAction SilentlyContinue).CommandLine
-                $cmdLine -match "updater-daemon"
-            } catch { $false }
-        } | ForEach-Object {
-            Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
-        }
+    # Second inline copy, same history and same missing scope as the one in
+    # Cmd-RestartCollector.
+    Stop-OrphanProcesses -Match "updater-daemon"
 
     Start-Sleep -Seconds 1
     Ensure-Dirs

--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -160,16 +160,25 @@ function Resolve-Node {
     # 2. Fallback search
     $candidates = @()
 
-    # nvm-windows
-    if ($env:NVM_HOME -and (Test-Path $env:NVM_HOME)) {
+    # nvm-windows. Both probes below must be non-fatal. NVM_HOME is often a *machine*
+    # level variable pointing into another account's profile
+    # (C:\Users\Administrator\AppData\Local\nvm was measured), and that directory's DACL
+    # grants nothing to the current user: a bare Test-Path raises a PermissionDenied
+    # UnauthorizedAccessException record, which this file's $ErrorActionPreference = "Stop"
+    # promotes to a terminating error. Resolve-Node runs on the way into start / stop /
+    # status / restart-collector, so one unreadable third-party node manager took down
+    # every service command -- including the restart-collector the updater issues after
+    # deploying a version. The Get-ChildItem calls were already guarded; these two were
+    # not. -LiteralPath as well, because a version manager path may contain [ or ].
+    if ($env:NVM_HOME -and (Test-Path -LiteralPath $env:NVM_HOME -ErrorAction SilentlyContinue)) {
         Get-ChildItem $env:NVM_HOME -Directory -ErrorAction SilentlyContinue |
             Sort-Object Name -Descending |
             ForEach-Object { $candidates += Join-Path $_.FullName "node.exe" }
     }
 
-    # fnm
+    # fnm -- same unreadable-directory hazard as the nvm branch above.
     $fnmDir = Join-Path $env:USERPROFILE ".fnm\node-versions"
-    if (Test-Path $fnmDir) {
+    if (Test-Path -LiteralPath $fnmDir -ErrorAction SilentlyContinue) {
         Get-ChildItem $fnmDir -Directory -ErrorAction SilentlyContinue |
             Sort-Object Name -Descending |
             ForEach-Object { $candidates += Join-Path $_.FullName "installation\node.exe" }

--- a/src/core/updater-watchdog.ts
+++ b/src/core/updater-watchdog.ts
@@ -156,12 +156,28 @@ export class UpdaterWatchdog {
 
     const processState = await this.readUpdaterProcess();
     if (!processState.running) {
+      // Grace-checked like every branch below, and for the same reason. start() runs the
+      // first check immediately, and on a fresh install the collector is running before
+      // the updater task has been registered at all -- so this branch fired on
+      // essentially every install: a SERVICE_NOT_RUNNING_ALARM plus a restart-updater
+      // racing the installer's own launch of it. Being inside the startup window is
+      // exactly the situation where "the updater is not up yet" is expected rather than
+      // evidence of anything, which is what inGraceWindow means. The sleep/wake half
+      // matters just as much: after a resume the pid file can name a process that did not
+      // survive the suspend, and Task Scheduler's own repeating trigger will bring the
+      // updater back within the window without help.
+      if (this.inGraceWindow(now)) return { status: 'grace', reason: processState.reason };
       this.recordServiceAlarm(processState.reason);
       return this.restart('missing-process', processState.reason);
     }
 
     if (!processState.commandOk) {
       const reason = `updater pid ${processState.pid} command mismatch`;
+      // Same argument. Mid-install and mid-deploy the pid file legitimately still names
+      // the outgoing version's process, so a mismatch observed inside the window is a
+      // snapshot of a handover, not a broken updater. The alarm has to stay behind the
+      // check too -- an alarm raised on every install is noise that hides the real ones.
+      if (this.inGraceWindow(now)) return { status: 'grace', reason };
       this.recordFailureAlarm(reason);
       return this.restart('command-mismatch', reason);
     }

--- a/tests/unit/core/updater-watchdog.test.ts
+++ b/tests/unit/core/updater-watchdog.test.ts
@@ -149,6 +149,98 @@ describe('UpdaterWatchdog', () => {
     });
   });
 
+  it('uses startup grace before restarting for a missing updater process', async () => {
+    // The install sequence registers the collector task before the updater one, and
+    // start() runs its first check immediately, so this branch used to fire on every
+    // install: an alarm plus a restart-updater racing the installer. Nothing here is
+    // wrong yet at this point -- the process is simply not up.
+    const alarms = makeAlarmManager();
+    const wd = new UpdaterWatchdog({
+      enabled: true,
+      dataDir: tmpDir,
+      loongsuitePilotBin: '/bin/loongsuite-pilot',
+      startupGraceMs: 60_000,
+      alarmManager: alarms,
+    });
+
+    const result = await wd.runCheck();
+
+    expect(result.status).toBe('grace');
+    expect(mockExecFileAsync).not.toHaveBeenCalledWith('/bin/loongsuite-pilot', ['restart-updater'], expect.anything());
+    // The alarm has to stay behind the grace check as well, not just the restart.
+    expect(alarms.serialize()).toEqual([]);
+  });
+
+  it('uses startup grace before restarting for a command mismatch', async () => {
+    // Mid-install and mid-deploy the pid file legitimately still names the outgoing
+    // version's process; inside the window that is a handover, not a broken updater.
+    await writeHeartbeat(tmpDir);
+    const alarms = makeAlarmManager();
+    const wd = new UpdaterWatchdog({
+      enabled: true,
+      dataDir: tmpDir,
+      loongsuitePilotBin: '/bin/loongsuite-pilot',
+      startupGraceMs: 60_000,
+      alarmManager: alarms,
+      updaterLiveness: () => ({
+        running: false,
+        pid: UPDATER_PID,
+        source: 'none',
+        reason: 'pid file points to mismatched process',
+        pidFileState: 'stale',
+        pidFileProcessAlive: true,
+        pidFileCommand: 'node /tmp/other.js',
+        pidFileCommandMatched: false,
+      }),
+    });
+
+    const result = await wd.runCheck();
+
+    expect(result.status).toBe('grace');
+    expect(mockExecFileAsync).not.toHaveBeenCalledWith('/bin/loongsuite-pilot', ['restart-updater'], expect.anything());
+    expect(alarms.serialize()).toEqual([]);
+  });
+
+  it('uses sleep/wake grace before restarting for a missing updater process', async () => {
+    // A machine that suspended for longer than one interval comes back with processes
+    // that did not survive it; the repeating task trigger brings the updater back on its
+    // own, so restarting from here only adds a race and an alarm.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-16T00:00:00Z'));
+    await writePid(tmpDir);
+    await writeHeartbeat(tmpDir);
+    const alarms = makeAlarmManager();
+
+    const wd = new UpdaterWatchdog({
+      enabled: true,
+      dataDir: tmpDir,
+      loongsuitePilotBin: '/bin/loongsuite-pilot',
+      intervalMs: 1_000,
+      startupGraceMs: 0,
+      sleepWakeGraceMs: 5_000,
+      alarmManager: alarms,
+      updaterLiveness: (() => {
+        let first = true;
+        return () => {
+          if (first) {
+            first = false;
+            return { running: true, pid: UPDATER_PID, source: 'pid-file' as const, reason: 'ok' };
+          }
+          return { running: false, source: 'none' as const, reason: 'pid file is missing; no matching process found' };
+        };
+      })(),
+    });
+
+    expect((await wd.runCheck()).status).toBe('healthy');
+    vi.setSystemTime(new Date('2026-06-16T00:00:07Z'));
+
+    const result = await wd.runCheck();
+
+    expect(result.status).toBe('grace');
+    expect(mockExecFileAsync).not.toHaveBeenCalledWith('/bin/loongsuite-pilot', ['restart-updater'], expect.anything());
+    expect(alarms.serialize()).toEqual([]);
+  });
+
   it('reports healthy when updater PID changed but process identity matches heartbeat', async () => {
     await writeHeartbeat(tmpDir, { pid: 456 });
     const alarms = makeAlarmManager();

--- a/tests/unit/deploy/installer-uninstall-survivability.test.mjs
+++ b/tests/unit/deploy/installer-uninstall-survivability.test.mjs
@@ -115,6 +115,60 @@ describe('uninstall continues when Node cannot be resolved', () => {
   }
 });
 
+describe('a refusal to unpatch DSH is gated on something actually dangling', () => {
+  // Remove-DshYamlPatch is the first thing Cmd-Uninstall calls and it deliberately
+  // throws rather than delete plugin assets a DSH patch still references. Reasonable --
+  // except the no-Node branch threw unconditionally, and $pluginDir lives under
+  // $DataDir, so the throw skipped the `if ($Purge)` branch at the very bottom of
+  // Cmd-Uninstall: the same config.json this file exists to get deleted survived, on
+  // machines that had never patched DSH at all. Two refusals, one question, so both
+  // branches have to ask it.
+  for (const file of INSTALLERS) {
+    it(`${file}: both refusals check the managed block first`, () => {
+      const src = read(file);
+      const code = codeOf(funcOf(src, 'Remove-DshYamlPatch'));
+      const refusals = code.split('\n').filter(l => l.includes('throw'));
+      // Missing helper, no Node, and cleanup.mjs exiting non-zero. The third one has run
+      // the unpatch and knows it failed, so it needs no probe.
+      expect(refusals.length, `${file}: refusal count changed`).toBe(3);
+      const unguarded = refusals.filter(l => !/referenced by|DSH YAML patch at|Pilot assets were preserved/.test(l));
+      expect(unguarded, `${file}: a refusal names no reason`).toEqual([]);
+      // The probe, not an inline Select-String: an unreadable third-party file must not
+      // be able to fail the working path, which is why this moved behind a helper.
+      expect(code, file).not.toContain('Select-String');
+      const gates = code.split('\n').filter(l => l.includes('Test-DshPatchStillManaged -PatchPath'));
+      expect(gates.length, `${file}: both branches must gate`).toBe(2);
+      // And the no-Node branch must fall through to a skip, not to the unpatch call.
+      expect(code, file).toMatch(/if \(-not \$script:NODE_BIN\)[\s\S]*?Msg[\s\S]*?\n\s*return\n/);
+    });
+
+    it(`${file}: the probe answers "managed" when it cannot tell`, () => {
+      const block = blockOf(read(file), 'dsh-unpatch-refusal');
+      expect(block, `${file}: dsh-unpatch-refusal block missing`).toBeTruthy();
+      const code = codeOf(block);
+      // A missing patch file is a real "nothing dangles". A patch file we failed to read
+      // is not, and answering $false there would delete the assets anyway.
+      expect(code, file).toMatch(/Test-Path[^\n]*-ErrorAction SilentlyContinue[^\n]*\{ return \$false \}/);
+      expect(code, file).toMatch(/catch\s*\{\s*\n\s*return \$true/);
+    });
+  }
+
+  it('the block is byte-identical across the installers', () => {
+    const blocks = INSTALLERS.map(f => blockOf(read(f), 'dsh-unpatch-refusal'));
+    expect(blocks.filter(b => !b)).toEqual([]);
+    expect(new Set(blocks).size).toBe(1);
+  });
+
+  for (const file of INSTALLERS) {
+    it(`${file}: a preserved data dir says what is still in it`, () => {
+      // The counterpart to the refusals above: whenever uninstall keeps $DataDir, this is
+      // the only line telling the user an AccessKeySecret is still readable there.
+      const code = codeOf(funcOf(read(file), 'Cmd-Uninstall'));
+      expect(code, file).toContain('config.json holds reporting credentials');
+    });
+  }
+});
+
 describe('the scheduled-task failure reaches the user', () => {
   for (const file of INSTALLERS) {
     it(`${file}: the schtasks call runs at "Continue" and restores in finally`, () => {

--- a/tests/unit/deploy/installer-uninstall-survivability.test.mjs
+++ b/tests/unit/deploy/installer-uninstall-survivability.test.mjs
@@ -1,0 +1,195 @@
+// Uninstall must not be abortable by something that has nothing to do with uninstalling.
+//
+// A measured Windows box left `%USERPROFILE%\.loongsuite-pilot\config.json` -- SLS
+// AccessKeySecret and CMS license key inside it -- on disk after `-Uninstall -Purge`
+// reported nothing wrong to look at. The chain:
+//
+//   1. Resolve-Node probes third-party version managers, and NVM_HOME is commonly a
+//      *machine*-level variable pointing into another account's profile. A bare
+//      Test-Path on an unreadable directory emits a PermissionDenied
+//      UnauthorizedAccessException record, which $ErrorActionPreference = "Stop" -- set
+//      in the header of every one of these scripts -- promotes to terminating.
+//   2. Cmd-Uninstall called Resolve-Node bare, before any cleanup step. One terminating
+//      error there skipped the plugin cleanups, the install-directory removal, and the
+//      `if ($Purge)` branch that deletes the data dir. Nothing downstream repairs that:
+//      the next `-Purge` takes the same path and dies at the same line.
+//   3. The one failure mode that *is* expected -- scheduled tasks owned by
+//      BUILTIN\Administrators after an elevated install -- was reported as a bare
+//      "ERROR: Access is denied." line, because the diagnostic `throw` behind it was
+//      unreachable (see the EAP assertions below), and its text taught the workaround as
+//      if elevation were a requirement of uninstall rather than a consequence of how the
+//      install ran.
+//
+// So this file pins three separable things: the probes stay non-fatal, uninstall keeps
+// going when Node cannot be resolved at all, and the native-command diagnostic actually
+// reaches the user. It sweeps whatever .ps1 the repo tracks rather than a fixed list, so
+// the same file is meaningful in the open-source mirror (one installer) and downstream
+// (three plus the service wrapper) without editing. The prose form of the native-stderr
+// rule is pinned separately, by whichever repo's AGENTS.md carries that section.
+import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+
+const PS1 = [
+  'deploy/installer.ps1',
+  'deploy/installer-inner.ps1',
+  'deploy/installer-opensource.ps1',
+  'scripts/loongsuite-pilot.ps1',
+].filter(existsSync);
+
+const read = (f) => readFileSync(f, 'utf-8');
+
+// Top-level functions in these scripts close with `}` in column 0.
+const funcOf = (text, name) => {
+  const start = text.indexOf(`function ${name} {`);
+  if (start < 0) return null;
+  const end = text.indexOf('\n}\n', start);
+  return end < 0 ? text.slice(start) : text.slice(start, end + 3);
+};
+
+const codeOf = (text) => text
+  .split('\n')
+  .filter(line => !/^\s*#/.test(line))
+  .join('\n');
+
+const blockOf = (text, tag) => {
+  const re = new RegExp(`^\\s*# >>> ${tag} >>>\\n[\\s\\S]*?^\\s*# <<< ${tag} <<<\\n`, 'm');
+  const m = text.match(re);
+  return m ? m[0] : null;
+};
+
+describe('Resolve-Node cannot take the caller down with it', () => {
+  it('finds the scripts to check', () => {
+    // Guards against a silently empty sweep (wrong cwd, renamed files).
+    expect(PS1.length).toBeGreaterThanOrEqual(2);
+    expect(PS1).toContain('scripts/loongsuite-pilot.ps1');
+  });
+
+  for (const file of PS1) {
+    it(`${file}: the version-manager probes in Resolve-Node are non-fatal`, () => {
+      // Scoped to the third-party roots on purpose. These are the only paths here that
+      // belong to somebody else: NVM_HOME is routinely a machine-level variable pointing
+      // into another account's profile, and reading such a directory is a
+      // PermissionDenied record, not a "not found". The pin file and its parent live
+      // under the caller's own data dir, where failing fast is still the right answer.
+      const body = funcOf(read(file), 'Resolve-Node');
+      expect(body, `${file}: Resolve-Node not found`).toBeTruthy();
+      const probes = codeOf(body)
+        .split('\n')
+        .filter(l => l.includes('Test-Path'))
+        .filter(l => /NVM_HOME|\$nvmHome|\$fnmDir/.test(l))
+        .map(l => l.trim());
+      // Both roots are still probed -- a rename must not empty this check.
+      expect(probes.length, `${file}: version-manager probes not found`).toBe(2);
+      const unguarded = probes.filter(l => !l.includes('-ErrorAction SilentlyContinue'));
+      expect(unguarded, `${file}: version-manager probe at "Stop"`).toEqual([]);
+    });
+  }
+});
+
+const INSTALLERS = PS1.filter(f => f.startsWith('deploy/installer'));
+
+describe('uninstall continues when Node cannot be resolved', () => {
+  for (const file of INSTALLERS) {
+    it(`${file}: Cmd-Uninstall guards its Resolve-Node call`, () => {
+      const body = funcOf(read(file), 'Cmd-Uninstall');
+      expect(body, `${file}: Cmd-Uninstall not found`).toBeTruthy();
+      const code = codeOf(body);
+      // The assignment must sit inside a try. Matching the shape rather than just
+      // "contains try" -- Cmd-Uninstall is full of unrelated try blocks.
+      expect(code, file).toMatch(/try\s*\{\s*\n\s*\$script:NODE_BIN = Resolve-Node\s*\n\s*\}\s*catch\s*\{/);
+      // And the failure has to be visible: silently continuing with no Node would
+      // report a clean uninstall that skipped every JSON config on the machine.
+      expect(code, file).toMatch(/\$script:NODE_BIN = ""/);
+    });
+
+    it(`${file}: every Node-dependent cleanup skips explicitly without a Node`, () => {
+      // Consequence of the guard above: uninstall now reaches these with an empty
+      // $NODE_BIN. Remove-HookConfigs was the one that did not check, so it would have
+      // run `& ""` and then printed its success line for a file it never touched.
+      for (const fn of ['Remove-HookConfigs', 'Remove-OpenClawPlugin']) {
+        const body = funcOf(read(file), fn);
+        if (!body) continue;
+        expect(codeOf(body), `${file}: ${fn}`).toMatch(/if \(-not \$script:NODE_BIN\)/);
+      }
+    });
+  }
+});
+
+describe('the scheduled-task failure reaches the user', () => {
+  for (const file of INSTALLERS) {
+    it(`${file}: the schtasks call runs at "Continue" and restores in finally`, () => {
+      // On Windows PowerShell 5.1 a native command that writes stderr while a 2>
+      // redirection is in effect raises a NativeCommandError, and EAP=Stop promotes it
+      // to a terminating error whose Message is just the raw stderr line. schtasks.exe
+      // prints "ERROR: Access is denied." there on exactly the failure this branch
+      // exists to report, so the throw below it never ran.
+      const body = funcOf(read(file), 'Remove-OnePilotScheduledTask');
+      expect(body, `${file}: Remove-OnePilotScheduledTask not found`).toBeTruthy();
+      const code = codeOf(body);
+      expect(code, file).toContain('$ErrorActionPreference = "Continue"');
+      expect(code, file).toMatch(/\}\s*finally\s*\{\s*\n\s*\$ErrorActionPreference = \$prevEAP/);
+      // Exit code from the call, not from whatever ran before it.
+      expect(code, file).toContain('$schtasksExit = $LASTEXITCODE');
+      // Pre-seeded to non-zero: a schtasks.exe that cannot launch at all must not
+      // inherit a stale $LASTEXITCODE of 0 and be read as success.
+      expect(code, file).toContain('$schtasksExit = 1');
+      expect(code, file).not.toContain('catch {}');
+    });
+
+    it(`${file}: the message names the cause, not just the workaround`, () => {
+      // It used to say only "Run uninstall from an elevated PowerShell.", which reads as
+      // "uninstall needs admin". It does not. The tasks are owned by Administrators
+      // because the *install* ran elevated, and the durable fix is to install without
+      // elevation -- so both halves have to be in the text.
+      const code = codeOf(funcOf(read(file), 'Remove-OnePilotScheduledTask'));
+      expect(code, file).toContain('BUILTIN\\Administrators');
+      expect(code, file).toContain('does not need administrator');
+      expect(code, file).toContain('reinstall without elevation');
+      // The stderr that explains which of the two failures happened must be quoted.
+      expect(code, file).toContain('$schtasksDetail');
+      // And quoted as the stderr line, not as a rendered ErrorRecord. At "Continue" the
+      // NativeCommandError still goes to the error stream, so 2>&1 merges the record
+      // object; `$schtasksOut | Out-String` therefore expanded one stderr line into a
+      // six-line PowerShell error block -- source line, squiggles, CategoryInfo -- inside
+      // the sentence. Measured on a 5.1 box, where schtasks.exe produced two records for
+      // one line, the second empty.
+      expect(code, file).not.toContain('$schtasksOut | Out-String');
+      expect(code, file).toContain('$schtasksLine.Exception.Message');
+    });
+  }
+});
+
+describe('an elevated install says what it costs', () => {
+  // Cheap half of the fix. Rewriting the task security descriptor after registration so
+  // the user can delete their own tasks again is the real repair and is not attempted
+  // here; until then the install has to tell the user what it just did to them.
+  for (const file of INSTALLERS) {
+    it(`${file}: warns before doing any work`, () => {
+      const src = read(file);
+      const block = blockOf(src, 'pilot-elevation-warning');
+      expect(block, `${file}: pilot-elevation-warning block missing`).toBeTruthy();
+      const code = codeOf(block);
+      expect(code, file).toMatch(/function Test-PilotElevated/);
+      // Best-effort by construction: the cast and GetCurrent() are both CLM-forbidden,
+      // so on a WDAC box this throws and the catch has to swallow it. Losing a hint is
+      // acceptable; failing an install over a hint is not.
+      expect(code, file).toMatch(/catch\s*\{\s*\n\s*return \$false/);
+      // Called from Cmd-Install before Check-Deps / Download-AndExtract, so Ctrl+C is
+      // still free at that point.
+      const install = codeOf(funcOf(src, 'Cmd-Install'));
+      expect(install, file).toContain('Warn-ElevatedInstall');
+      expect(
+        install.indexOf('Warn-ElevatedInstall'),
+        `${file}: warning must precede Check-Deps`,
+      ).toBeLessThan(install.indexOf('Check-Deps'));
+    });
+  }
+
+  it('the block is byte-identical across the installers', () => {
+    // Three hand-maintained near-copies; a block that drifts in one of them is a
+    // variant nobody is testing.
+    const blocks = INSTALLERS.map(f => blockOf(read(f), 'pilot-elevation-warning'));
+    expect(blocks.filter(b => !b)).toEqual([]);
+    expect(new Set(blocks).size).toBe(1);
+  });
+});

--- a/tests/unit/scripts/ps1-clm-safe.test.mjs
+++ b/tests/unit/scripts/ps1-clm-safe.test.mjs
@@ -60,6 +60,12 @@ const ALLOWED_STATIC_ACCESS = new Set([
   // than piped -- see tests/unit/scripts/ps1-json-encoding.test.mjs.
   '[Console]::OutputEncoding',
   '[System.Text.Encoding]::UTF8',
+  // (c) Test-PilotElevated, in try/catch. GetCurrent() is a static *method* call and so
+  // is genuinely CLM-forbidden; the catch returns $false, which only costs the elevated
+  // install warning -- see the pilot-elevation-warning block. Administrator is an enum
+  // field read, i.e. (a) as well.
+  '[Security.Principal.WindowsIdentity]::GetCurrent',
+  '[Security.Principal.WindowsBuiltInRole]::Administrator',
 ]);
 
 // Shapes that are never acceptable, whatever the file. `.PSObject` is included

--- a/tests/unit/scripts/ps1-daemon-reap-scope.test.mjs
+++ b/tests/unit/scripts/ps1-daemon-reap-scope.test.mjs
@@ -1,0 +1,100 @@
+// Killing "node processes whose command line mentions collector-daemon" is not the same
+// thing as killing *our* daemons.
+//
+// The daemon file names are identical for every installation on the machine, and on a
+// shared Windows box each account runs its own pair out of its own %USERPROFILE%. The
+// reap in Stop-OrphanProcesses matched on the name alone, so any install, restart or stop
+// killed every account's daemons -- Get-Process only enumerates other users' processes
+// when the caller is elevated, so the damage was confined to elevated sessions, which is
+// also the sessions people are most likely to run an installer from. The victims were
+// left with a pid file naming a process that no longer existed, i.e. the "stale
+// single-instance lock" reports. The scope key is $BOOTSTRAP_DIR, which every launcher
+// puts in the command line verbatim ("<node>" "<$BOOTSTRAP_DIR\<name>-daemon.js>").
+//
+// Two more traps that only show up once you look at the whole file:
+//   * The reap existed in three places -- the helper plus a hand-inlined copy in
+//     Cmd-RestartCollector and another in Cmd-RestartUpdater, neither of which the helper's
+//     -Match parameter had ever been threaded into. Fixing the helper alone fixed nothing
+//     for restart-collector, which is the command the updater runs on every deploy.
+//   * Stop-PidFile deleted the pid file unconditionally after killing, up to ten seconds
+//     later. The collector task re-runs every five minutes, so the successor may already
+//     have written its own pid there; deleting that leaves a live daemon with no pid file.
+//
+// So this pins: one reap implementation, scoped; and a pid-file removal that checks whose
+// pid it is removing.
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const SERVICE_PS1 = 'scripts/loongsuite-pilot.ps1';
+const text = readFileSync(SERVICE_PS1, 'utf-8');
+
+// Drop comment lines so the prose explaining each rule cannot satisfy a check.
+const codeOf = (s) => s.split('\n').filter((line) => !/^\s*#/.test(line)).join('\n');
+
+// Body = from the function header to the next top-level `function` declaration. Brace
+// counting would trip over the here-strings and script blocks in this file.
+const bodyOf = (name) => {
+  const start = text.indexOf(`function ${name} {`);
+  expect(start, `${name} not found in ${SERVICE_PS1}`).toBeGreaterThan(-1);
+  const rest = text.slice(start + `function ${name} {`.length);
+  const end = rest.search(/\nfunction \S+ \{/);
+  return codeOf(end === -1 ? rest : rest.slice(0, end));
+};
+
+const code = codeOf(text);
+
+describe('the orphan reap only kills this installation', () => {
+  it('there is exactly one place that enumerates node processes', () => {
+    // Both inline copies are gone. A fourth copy appearing is the failure mode this
+    // catches: the scope below would be correct and irrelevant.
+    const scans = code.match(/Get-Process -Name "node"/g) || [];
+    expect(scans).toHaveLength(1);
+    expect(bodyOf('Stop-OrphanProcesses')).toContain('Get-Process -Name "node"');
+  });
+
+  it('Stop-OrphanProcesses requires the command line to name our bootstrap dir', () => {
+    const body = bodyOf('Stop-OrphanProcesses');
+    // Both halves, in one predicate: the daemon name *and* the install scope.
+    expect(body).toContain('$Match');
+    expect(body).toMatch(/\$ownRoot = \(\[string\]\$BOOTSTRAP_DIR\)\.ToLower\(\)/);
+    expect(body).toMatch(/\(\$cmdLine -match \$Match\) -and \$cmdLine\.ToLower\(\)\.Contains\(\$ownRoot\)/);
+    // $DATA_DIR is the wrong key even though it is usually the same directory: the entry
+    // script is loaded from $BOOTSTRAP_DIR = $CACHE_DIR\bin, and the two roots diverge
+    // whenever LOONGSUITE_PILOT_CACHE_DIR is set without LOONGSUITE_PILOT_DATA_DIR.
+    expect(body).not.toContain('$DATA_DIR');
+  });
+
+  it('restart-collector and restart-updater reap through the helper', () => {
+    // Each must reap only its own daemon -- restart-collector deliberately leaves the
+    // updater running, and vice versa -- so the -Match argument is part of the contract.
+    expect(bodyOf('Cmd-RestartCollector')).toContain('Stop-OrphanProcesses -Match "collector-daemon"');
+    expect(bodyOf('Cmd-RestartUpdater')).toContain('Stop-OrphanProcesses -Match "updater-daemon"');
+  });
+
+  it('the single-daemon callers still narrow the reap', () => {
+    // Install-CollectorTask / Install-UpdaterTask reap immediately before re-registering
+    // one task; an unnarrowed call there would take down the daemon they are not touching.
+    expect(bodyOf('Install-CollectorTask')).toContain('Stop-OrphanProcesses -Match "collector-daemon"');
+    expect(bodyOf('Install-UpdaterTask')).toContain('Stop-OrphanProcesses -Match "updater-daemon"');
+  });
+});
+
+describe('Stop-PidFile removes only the pid it killed', () => {
+  it('re-reads the file and compares before deleting', () => {
+    const body = bodyOf('Stop-PidFile');
+    // Re-read, not a reuse of the value captured before Stop-Process: the question is
+    // what is on disk now.
+    expect(body).toMatch(/\$currentPid = \(\[string\]\(Get-Content -LiteralPath \$pidFile[^\n]*\)\)\.Trim\(\)/);
+    expect(body).toMatch(/if \(\$currentPid -eq \$pidVal\) \{\s*\n\s*Remove-Item \$pidFile/);
+  });
+
+  it('the only unconditional removal is the one for a pid that is already dead', () => {
+    // The early return above it has already established the recorded process is gone, so
+    // deleting there cannot clobber a successor -- it is the stale-file cleanup.
+    const body = bodyOf('Stop-PidFile');
+    const removals = body.split('\n').filter((l) => l.includes('Remove-Item $pidFile'));
+    expect(removals).toHaveLength(2);
+    const guarded = body.slice(body.indexOf('$pidVal ='));
+    expect(guarded.split('\n').filter((l) => l.includes('Remove-Item $pidFile'))).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## The bug

A Windows box still had `%USERPROFILE%\.loongsuite-pilot\config.json` on disk — an SLS
AccessKeySecret and a license key inside it — after `-Uninstall -Purge` finished without
printing anything that looked wrong. Five defects on one path:

1. **`Resolve-Node` probes the nvm/fnm roots with a bare `Test-Path`.** `NVM_HOME` is
   routinely a *machine*-level variable pointing into another account's profile, whose DACL
   grants the current user nothing, so `Test-Path` emits a PermissionDenied record — and the
   `$ErrorActionPreference = "Stop"` in these scripts' headers promotes it to terminating.
   Both probes are non-fatal now. Only those two: the pin file lives under the caller's own
   data dir, where failing fast is still correct.

2. **`Cmd-Uninstall` called `Resolve-Node` bare, before any cleanup step**, so that one error
   skipped the plugin cleanups, the install-directory removal and the whole `if ($Purge)`
   branch — and the next `-Purge` died on the same line. The call is wrapped, `$NODE_BIN` is
   cleared, `-Purge` still runs, and the skipped steps are named at the end.
   `Remove-HookConfigs` / `Remove-OpenClawPlugin` now skip explicitly instead of printing a
   success line for a file they never touched.

3. **The one expected failure surfaced as a bare `ERROR: Access is denied.`** because the
   diagnostic behind it was unreachable: on PowerShell 5.1 a native command writing stderr
   while a `2>` redirection is in effect raises `NativeCommandError`, `EAP=Stop` makes that
   terminating, and the `if ($LASTEXITCODE -ne 0) { throw ... }` after it never runs. The
   `schtasks` call runs at `Continue` and restores the preference in `finally`, with the exit
   code pre-seeded non-zero so a `schtasks.exe` that cannot launch at all is not read as
   success through a stale `$LASTEXITCODE`.

4. **That message taught the wrong lesson.** It said only "Run uninstall from an elevated
   PowerShell", which reads as *uninstall needs admin*. It does not — the tasks are owned by
   `BUILTIN\Administrators` because the **install** ran elevated. The text now names the
   cause and the durable fix, and quotes the stderr line that says which of the two failures
   happened.

5. **An elevated install warns before doing any work.** Rewriting the task security
   descriptor after registration, so the user can delete their own tasks again, is the real
   repair and is deliberately not attempted here.

## Testing

`tests/unit/deploy/installer-uninstall-survivability.test.mjs` (new) pins all of it at the
source level, sweeping whichever `.ps1` the repo tracks so it does not need editing when the
installer set changes. `tests/unit/scripts/ps1-clm-safe.test.mjs` gains the two statics
`Test-PilotElevated` uses — both justified in place (a property get and an enum field read,
inside a try whose catch is a working fallback).

Verified on a live Windows PowerShell 5.1 box (10.0.26100), read-only:

- All touched `.ps1` parse clean under the real 5.1 parser — a bracket count locally is not
  the same check.
- The old `schtasks` shape surfaced only `ERROR: The system cannot find the file specified.`;
  the new one reached the diagnostic with `exit=1`, and `finally` restored `EAP` to `Stop`.
- `NVM_HOME` on that box is `C:\Users\Administrator\AppData\Local\nvm` at both Machine and
  User scope, and its DACL has no entry for the second account's SID — so a non-elevated
  `Test-Path` from that account does hit PermissionDenied. That is defect 1's premise, live.

Real-machine testing also caught something static review missed: at `Continue` with `2>&1`
the captured elements are `ErrorRecord` objects, not strings, so `$schtasksOut | Out-String`
expanded one stderr line into a six-line PowerShell error block — source line, squiggles,
`CategoryInfo` — inside the sentence. It reads `.Exception.Message` per record instead
(a property get, so still CLM-safe), and the ratchet pins that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
