### PR TITLE
fix(service): scope the daemon reap to this installation

### DIFF
--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -346,19 +346,53 @@ function Stop-PidFile {
     }
     # Force kill if still running
     try { Stop-Process -Id $pidVal -Force -ErrorAction SilentlyContinue } catch {}
-    Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
+
+    # Delete the file only while it still names the process we just killed. Up to ten
+    # seconds elapse in the wait loop above, and the collector task carries a five-minute
+    # repeating trigger, so a successor may already have started and written its own pid
+    # here -- unconditional removal then deleted a live daemon's pid file, after which
+    # status reported it as not running and the next start raced a second instance against
+    # it. Same rule the daemons themselves follow on shutdown (removeOwnPidFileSync in
+    # src/utils/pid-utils.ts). Re-read rather than trusting $pidVal: the point is what is
+    # on disk now, not what was there before Stop-Process.
+    $currentPid = ""
+    if (Test-Path -LiteralPath $pidFile) {
+        $currentPid = ([string](Get-Content -LiteralPath $pidFile -ErrorAction SilentlyContinue)).Trim()
+    }
+    if ($currentPid -eq $pidVal) {
+        Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
+    }
 }
 
 function Stop-OrphanProcesses {
     # $Match limits which daemons are terminated; the default kills both. Callers that
     # re-register a single task (Install-CollectorTask / Install-UpdaterTask) pass a
     # narrow pattern so they only reap the daemon they are about to re-launch.
+    #
+    # Both conditions below are required, and the second one is the point. The daemon
+    # names are shared by every installation on the machine: on a multi-account box each
+    # user runs their own collector and updater out of their own %USERPROFILE%, and
+    # matching on the name alone made any install / restart / stop kill all of them.
+    # Get-Process only enumerates other users' processes when the caller is elevated, so
+    # the blast radius was exactly the elevated sessions -- their victims' pid files were
+    # left pointing at dead pids, which is where the "stale single-instance lock" reports
+    # came from. $BOOTSTRAP_DIR is the directory the entry script is loaded from
+    # (New-HiddenTaskAction writes "<node>" "<$BOOTSTRAP_DIR\<name>-daemon.js>", and
+    # Cmd-Start builds the same pair), so it appears verbatim in the command line and
+    # identifies this installation and no other. It is non-empty by construction:
+    # $CACHE_DIR falls back to $DEFAULT_PILOT_DIR.
+    #
+    # .ToLower().Contains() rather than -match: the scope is a literal Windows path full
+    # of \ and possibly regex metacharacters (a user profile can contain "["), and
+    # escaping it for a regex buys nothing here. It is also a method call on [string], a
+    # core type, so it stays CLM-safe.
     param([string]$Match = "collector-daemon|updater-daemon")
+    $ownRoot = ([string]$BOOTSTRAP_DIR).ToLower()
     Get-Process -Name "node" -ErrorAction SilentlyContinue |
         Where-Object {
             try {
-                $cmdLine = (Get-CimInstance Win32_Process -Filter "ProcessId = $($_.Id)" -ErrorAction SilentlyContinue).CommandLine
-                $cmdLine -match $Match
+                $cmdLine = [string](Get-CimInstance Win32_Process -Filter "ProcessId = $($_.Id)" -ErrorAction SilentlyContinue).CommandLine
+                ($cmdLine -match $Match) -and $cmdLine.ToLower().Contains($ownRoot)
             } catch { $false }
         } | ForEach-Object {
             Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
@@ -834,16 +868,11 @@ function Cmd-RestartCollector {
     }
     Stop-PidFile $PID_FILE
 
-    # Kill orphan collector processes
-    Get-Process -Name "node" -ErrorAction SilentlyContinue |
-        Where-Object {
-            try {
-                $cmdLine = (Get-CimInstance Win32_Process -Filter "ProcessId = $($_.Id)" -ErrorAction SilentlyContinue).CommandLine
-                $cmdLine -match "collector-daemon"
-            } catch { $false }
-        } | ForEach-Object {
-            Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
-        }
+    # Kill orphan collector processes. Was an inline copy of Stop-OrphanProcesses that
+    # predated the -Match parameter; it also missed the installation scope the shared
+    # helper now applies, and restart-collector is the command the updater runs on every
+    # deploy -- i.e. the one that reached other accounts most often.
+    Stop-OrphanProcesses -Match "collector-daemon"
 
     Start-Sleep -Seconds 1
     Ensure-Dirs
@@ -955,15 +984,9 @@ function Cmd-RestartUpdater {
     }
     Stop-PidFile $UPDATER_PID_FILE
 
-    Get-Process -Name "node" -ErrorAction SilentlyContinue |
-        Where-Object {
-            try {
-                $cmdLine = (Get-CimInstance Win32_Process -Filter "ProcessId = $($_.Id)" -ErrorAction SilentlyContinue).CommandLine
-                $cmdLine -match "updater-daemon"
-            } catch { $false }
-        } | ForEach-Object {
-            Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
-        }
+    # Second inline copy, same history and same missing scope as the one in
+    # Cmd-RestartCollector.
+    Stop-OrphanProcesses -Match "updater-daemon"
 
     Start-Sleep -Seconds 1
     Ensure-Dirs

--- a/src/core/updater-watchdog.ts
+++ b/src/core/updater-watchdog.ts
@@ -156,12 +156,28 @@ export class UpdaterWatchdog {
 
     const processState = await this.readUpdaterProcess();
     if (!processState.running) {
+      // Grace-checked like every branch below, and for the same reason. start() runs the
+      // first check immediately, and on a fresh install the collector is running before
+      // the updater task has been registered at all -- so this branch fired on
+      // essentially every install: a SERVICE_NOT_RUNNING_ALARM plus a restart-updater
+      // racing the installer's own launch of it. Being inside the startup window is
+      // exactly the situation where "the updater is not up yet" is expected rather than
+      // evidence of anything, which is what inGraceWindow means. The sleep/wake half
+      // matters just as much: after a resume the pid file can name a process that did not
+      // survive the suspend, and Task Scheduler's own repeating trigger will bring the
+      // updater back within the window without help.
+      if (this.inGraceWindow(now)) return { status: 'grace', reason: processState.reason };
       this.recordServiceAlarm(processState.reason);
       return this.restart('missing-process', processState.reason);
     }
 
     if (!processState.commandOk) {
       const reason = `updater pid ${processState.pid} command mismatch`;
+      // Same argument. Mid-install and mid-deploy the pid file legitimately still names
+      // the outgoing version's process, so a mismatch observed inside the window is a
+      // snapshot of a handover, not a broken updater. The alarm has to stay behind the
+      // check too -- an alarm raised on every install is noise that hides the real ones.
+      if (this.inGraceWindow(now)) return { status: 'grace', reason };
       this.recordFailureAlarm(reason);
       return this.restart('command-mismatch', reason);
     }

--- a/tests/unit/core/updater-watchdog.test.ts
+++ b/tests/unit/core/updater-watchdog.test.ts
@@ -149,6 +149,98 @@ describe('UpdaterWatchdog', () => {
     });
   });
 
+  it('uses startup grace before restarting for a missing updater process', async () => {
+    // The install sequence registers the collector task before the updater one, and
+    // start() runs its first check immediately, so this branch used to fire on every
+    // install: an alarm plus a restart-updater racing the installer. Nothing here is
+    // wrong yet at this point -- the process is simply not up.
+    const alarms = makeAlarmManager();
+    const wd = new UpdaterWatchdog({
+      enabled: true,
+      dataDir: tmpDir,
+      loongsuitePilotBin: '/bin/loongsuite-pilot',
+      startupGraceMs: 60_000,
+      alarmManager: alarms,
+    });
+
+    const result = await wd.runCheck();
+
+    expect(result.status).toBe('grace');
+    expect(mockExecFileAsync).not.toHaveBeenCalledWith('/bin/loongsuite-pilot', ['restart-updater'], expect.anything());
+    // The alarm has to stay behind the grace check as well, not just the restart.
+    expect(alarms.serialize()).toEqual([]);
+  });
+
+  it('uses startup grace before restarting for a command mismatch', async () => {
+    // Mid-install and mid-deploy the pid file legitimately still names the outgoing
+    // version's process; inside the window that is a handover, not a broken updater.
+    await writeHeartbeat(tmpDir);
+    const alarms = makeAlarmManager();
+    const wd = new UpdaterWatchdog({
+      enabled: true,
+      dataDir: tmpDir,
+      loongsuitePilotBin: '/bin/loongsuite-pilot',
+      startupGraceMs: 60_000,
+      alarmManager: alarms,
+      updaterLiveness: () => ({
+        running: false,
+        pid: UPDATER_PID,
+        source: 'none',
+        reason: 'pid file points to mismatched process',
+        pidFileState: 'stale',
+        pidFileProcessAlive: true,
+        pidFileCommand: 'node /tmp/other.js',
+        pidFileCommandMatched: false,
+      }),
+    });
+
+    const result = await wd.runCheck();
+
+    expect(result.status).toBe('grace');
+    expect(mockExecFileAsync).not.toHaveBeenCalledWith('/bin/loongsuite-pilot', ['restart-updater'], expect.anything());
+    expect(alarms.serialize()).toEqual([]);
+  });
+
+  it('uses sleep/wake grace before restarting for a missing updater process', async () => {
+    // A machine that suspended for longer than one interval comes back with processes
+    // that did not survive it; the repeating task trigger brings the updater back on its
+    // own, so restarting from here only adds a race and an alarm.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-16T00:00:00Z'));
+    await writePid(tmpDir);
+    await writeHeartbeat(tmpDir);
+    const alarms = makeAlarmManager();
+
+    const wd = new UpdaterWatchdog({
+      enabled: true,
+      dataDir: tmpDir,
+      loongsuitePilotBin: '/bin/loongsuite-pilot',
+      intervalMs: 1_000,
+      startupGraceMs: 0,
+      sleepWakeGraceMs: 5_000,
+      alarmManager: alarms,
+      updaterLiveness: (() => {
+        let first = true;
+        return () => {
+          if (first) {
+            first = false;
+            return { running: true, pid: UPDATER_PID, source: 'pid-file' as const, reason: 'ok' };
+          }
+          return { running: false, source: 'none' as const, reason: 'pid file is missing; no matching process found' };
+        };
+      })(),
+    });
+
+    expect((await wd.runCheck()).status).toBe('healthy');
+    vi.setSystemTime(new Date('2026-06-16T00:00:07Z'));
+
+    const result = await wd.runCheck();
+
+    expect(result.status).toBe('grace');
+    expect(mockExecFileAsync).not.toHaveBeenCalledWith('/bin/loongsuite-pilot', ['restart-updater'], expect.anything());
+    expect(alarms.serialize()).toEqual([]);
+  });
+
   it('reports healthy when updater PID changed but process identity matches heartbeat', async () => {
     await writeHeartbeat(tmpDir, { pid: 456 });
     const alarms = makeAlarmManager();

--- a/tests/unit/scripts/ps1-daemon-reap-scope.test.mjs
+++ b/tests/unit/scripts/ps1-daemon-reap-scope.test.mjs
@@ -1,0 +1,100 @@
+// Killing "node processes whose command line mentions collector-daemon" is not the same
+// thing as killing *our* daemons.
+//
+// The daemon file names are identical for every installation on the machine, and on a
+// shared Windows box each account runs its own pair out of its own %USERPROFILE%. The
+// reap in Stop-OrphanProcesses matched on the name alone, so any install, restart or stop
+// killed every account's daemons -- Get-Process only enumerates other users' processes
+// when the caller is elevated, so the damage was confined to elevated sessions, which is
+// also the sessions people are most likely to run an installer from. The victims were
+// left with a pid file naming a process that no longer existed, i.e. the "stale
+// single-instance lock" reports. The scope key is $BOOTSTRAP_DIR, which every launcher
+// puts in the command line verbatim ("<node>" "<$BOOTSTRAP_DIR\<name>-daemon.js>").
+//
+// Two more traps that only show up once you look at the whole file:
+//   * The reap existed in three places -- the helper plus a hand-inlined copy in
+//     Cmd-RestartCollector and another in Cmd-RestartUpdater, neither of which the helper's
+//     -Match parameter had ever been threaded into. Fixing the helper alone fixed nothing
+//     for restart-collector, which is the command the updater runs on every deploy.
+//   * Stop-PidFile deleted the pid file unconditionally after killing, up to ten seconds
+//     later. The collector task re-runs every five minutes, so the successor may already
+//     have written its own pid there; deleting that leaves a live daemon with no pid file.
+//
+// So this pins: one reap implementation, scoped; and a pid-file removal that checks whose
+// pid it is removing.
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const SERVICE_PS1 = 'scripts/loongsuite-pilot.ps1';
+const text = readFileSync(SERVICE_PS1, 'utf-8');
+
+// Drop comment lines so the prose explaining each rule cannot satisfy a check.
+const codeOf = (s) => s.split('\n').filter((line) => !/^\s*#/.test(line)).join('\n');
+
+// Body = from the function header to the next top-level `function` declaration. Brace
+// counting would trip over the here-strings and script blocks in this file.
+const bodyOf = (name) => {
+  const start = text.indexOf(`function ${name} {`);
+  expect(start, `${name} not found in ${SERVICE_PS1}`).toBeGreaterThan(-1);
+  const rest = text.slice(start + `function ${name} {`.length);
+  const end = rest.search(/\nfunction \S+ \{/);
+  return codeOf(end === -1 ? rest : rest.slice(0, end));
+};
+
+const code = codeOf(text);
+
+describe('the orphan reap only kills this installation', () => {
+  it('there is exactly one place that enumerates node processes', () => {
+    // Both inline copies are gone. A fourth copy appearing is the failure mode this
+    // catches: the scope below would be correct and irrelevant.
+    const scans = code.match(/Get-Process -Name "node"/g) || [];
+    expect(scans).toHaveLength(1);
+    expect(bodyOf('Stop-OrphanProcesses')).toContain('Get-Process -Name "node"');
+  });
+
+  it('Stop-OrphanProcesses requires the command line to name our bootstrap dir', () => {
+    const body = bodyOf('Stop-OrphanProcesses');
+    // Both halves, in one predicate: the daemon name *and* the install scope.
+    expect(body).toContain('$Match');
+    expect(body).toMatch(/\$ownRoot = \(\[string\]\$BOOTSTRAP_DIR\)\.ToLower\(\)/);
+    expect(body).toMatch(/\(\$cmdLine -match \$Match\) -and \$cmdLine\.ToLower\(\)\.Contains\(\$ownRoot\)/);
+    // $DATA_DIR is the wrong key even though it is usually the same directory: the entry
+    // script is loaded from $BOOTSTRAP_DIR = $CACHE_DIR\bin, and the two roots diverge
+    // whenever LOONGSUITE_PILOT_CACHE_DIR is set without LOONGSUITE_PILOT_DATA_DIR.
+    expect(body).not.toContain('$DATA_DIR');
+  });
+
+  it('restart-collector and restart-updater reap through the helper', () => {
+    // Each must reap only its own daemon -- restart-collector deliberately leaves the
+    // updater running, and vice versa -- so the -Match argument is part of the contract.
+    expect(bodyOf('Cmd-RestartCollector')).toContain('Stop-OrphanProcesses -Match "collector-daemon"');
+    expect(bodyOf('Cmd-RestartUpdater')).toContain('Stop-OrphanProcesses -Match "updater-daemon"');
+  });
+
+  it('the single-daemon callers still narrow the reap', () => {
+    // Install-CollectorTask / Install-UpdaterTask reap immediately before re-registering
+    // one task; an unnarrowed call there would take down the daemon they are not touching.
+    expect(bodyOf('Install-CollectorTask')).toContain('Stop-OrphanProcesses -Match "collector-daemon"');
+    expect(bodyOf('Install-UpdaterTask')).toContain('Stop-OrphanProcesses -Match "updater-daemon"');
+  });
+});
+
+describe('Stop-PidFile removes only the pid it killed', () => {
+  it('re-reads the file and compares before deleting', () => {
+    const body = bodyOf('Stop-PidFile');
+    // Re-read, not a reuse of the value captured before Stop-Process: the question is
+    // what is on disk now.
+    expect(body).toMatch(/\$currentPid = \(\[string\]\(Get-Content -LiteralPath \$pidFile[^\n]*\)\)\.Trim\(\)/);
+    expect(body).toMatch(/if \(\$currentPid -eq \$pidVal\) \{\s*\n\s*Remove-Item \$pidFile/);
+  });
+
+  it('the only unconditional removal is the one for a pid that is already dead', () => {
+    // The early return above it has already established the recorded process is gone, so
+    // deleting there cannot clobber a successor -- it is the stale-file cleanup.
+    const body = bodyOf('Stop-PidFile');
+    const removals = body.split('\n').filter((l) => l.includes('Remove-Item $pidFile'));
+    expect(removals).toHaveLength(2);
+    const guarded = body.slice(body.indexOf('$pidVal ='));
+    expect(guarded.split('\n').filter((l) => l.includes('Remove-Item $pidFile'))).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Stacked on #313 — review that one first; this PR's base is its branch.

## Three defects, one shared blast radius: other accounts on the same machine

**1. `Stop-OrphanProcesses` was not scoped to this installation.** It killed every node
process whose command line mentioned `collector-daemon` or `updater-daemon`. Those file names
are identical for every installation on the machine, and on a shared Windows box each account
runs its own pair out of its own `%USERPROFILE%` — so any install, restart or stop reaped all
of them. `Get-Process` only enumerates other users' processes when the caller is elevated,
which is exactly where the damage landed: the victims were left with a pid file naming a
process that no longer existed, which is where the "stale single-instance lock" reports came
from.

The predicate now also requires `$BOOTSTRAP_DIR`, which every launcher writes into the
command line verbatim (`"<node>" "<$BOOTSTRAP_DIR\<name>-daemon.js>"`). `$DATA_DIR` would be
the wrong key — the two roots diverge whenever `LOONGSUITE_PILOT_CACHE_DIR` is set alone.

The reap existed in **three** places, not one: the helper plus hand-inlined copies in
`Cmd-RestartCollector` and `Cmd-RestartUpdater` that the `-Match` parameter had never been
threaded into. Fixing the helper alone would have fixed nothing for `restart-collector` —
the command the updater issues on every deploy. Both are calls now, and a new ratchet pins
that exactly one node-process scan remains.

**2. `Stop-PidFile` deleted the pid file unconditionally** after the kill, up to ten seconds
later. The collector task carries a five-minute repeating trigger, so a successor may already
have written its own pid there — and then `status` reported a live daemon as not running and
the next `start` raced a second instance against it. It re-reads the file and removes it only
while it still names the process it killed, the same rule `removeOwnPidFileSync` already
follows on the daemon side.

**3. `UpdaterWatchdog`'s `missing-process` and `command-mismatch` branches were the only ones
not behind `inGraceWindow`.** `start()` runs its first check immediately, and a fresh install
has the collector up before the updater task is registered at all — so `missing-process` fired
on essentially every install: a `SERVICE_NOT_RUNNING` alarm plus a `restart-updater` racing
the installer's own launch. Mid-deploy the pid file legitimately still names the outgoing
version's process, which is the mismatch half. Both alarms moved behind the check too — an
alarm raised on every install hides the real ones.

## Testing

`tests/unit/scripts/ps1-daemon-reap-scope.test.mjs` (new) and three new grace cases in
`tests/unit/core/updater-watchdog.test.ts`. `tsc --noEmit` clean.

Defect 1 was reproduced and the fix confirmed on a live Windows PowerShell 5.1 box, read-only
(the check only evaluated the predicate — no `Stop-Process` anywhere in it). Four node daemons
were running, owned by **two different accounts**. The old predicate matched all four; the new
one matched exactly the caller's two, run once per account. One of those profile paths is
non-ASCII, and the comparison handles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
