### PR TITLE
fix(installer): warn on elevated upgrade, and keep node's stderr out of uninstall

### DIFF
--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -2216,8 +2216,17 @@ function Remove-OtelPlugin {
     if ((Test-Path $claudeSettings) -and $script:NODE_BIN) {
         $content = Get-Content $claudeSettings -Raw -ErrorAction SilentlyContinue
         if ($content -match "otel-claude-hook|hook-entry") {
-            $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
-            & $script:NODE_BIN -e @'
+            # Restored in finally, not on the line after the call: this function is
+            # called bare from Cmd-Uninstall, ahead of the install-directory removal and
+            # -Purge, so anything that terminates in here costs the user the credentials
+            # in config.json. The relax itself is what keeps a single stderr line from
+            # node from terminating at all (NativeCommandError under 2>, promoted by the
+            # header's EAP = Stop), and the finally keeps the rest of the uninstall from
+            # silently running at "Continue" if it ever does.
+            $prevEAP = $ErrorActionPreference
+            $ErrorActionPreference = "Continue"
+            try {
+                & $script:NODE_BIN -e @'
 const fs = require('fs');
 const f = process.argv[1];
 const isOurs = c => c.includes('otel-claude-hook') || c.includes('hook-entry.sh');
@@ -2238,7 +2247,9 @@ try {
   }
 } catch {}
 '@ $claudeSettings 2>$null
-            $ErrorActionPreference = $prevEAP
+            } finally {
+                $ErrorActionPreference = $prevEAP
+            }
             Msg "    ✅ settings.json hooks 已清理" "    ✅ settings.json hooks cleaned"
         }
     }
@@ -2381,6 +2392,11 @@ function Cmd-Upgrade {
 
     Msg "   当前版本: $oldVer" "   Current version: $oldVer"
     Write-Host ""
+
+    # After the "is anything installed" check, so the advice to re-run non-elevated is
+    # only given when there is really an upgrade to re-run; still before Check-Deps,
+    # Download-AndExtract and the start that re-registers the tasks, so Ctrl+C is cheap.
+    Warn-ElevatedInstall -Action "upgrade"
 
     Check-Deps
 
@@ -2798,11 +2814,25 @@ function Test-PilotElevated {
 }
 
 function Warn-ElevatedInstall {
+    # -Action "install" | "upgrade". Upgrade does the same damage: it starts the new
+    # version through the service script, whose start path deletes and re-registers both
+    # tasks unconditionally, so an elevated upgrade rewrites the ownership of tasks an
+    # ordinary session had installed and the next ordinary uninstall is denied again.
+    # It gets one extra line, because nothing about "upgrade" suggests the scheduled
+    # tasks are re-created from scratch.
+    param([string]$Action = "install")
     if (-not (Test-PilotElevated)) { return }
     Msg "⚠️  当前是提权(管理员)会话" "⚠️  This is an elevated (administrator) session"
-    Msg "    这样注册出来的计划任务归 BUILTIN\Administrators，本账号的普通会话之后删不掉" "    Scheduled tasks registered from it are owned by BUILTIN\Administrators, and this account's ordinary sessions cannot delete them afterwards"
-    Msg "    继续安装的话，卸载(-Uninstall)也必须在提权会话里执行" "    If you continue, uninstall (-Uninstall) will have to run elevated as well"
-    Msg "    想让普通会话自己就能卸载：Ctrl+C 退出，在非提权 PowerShell 里重新安装" "    To keep uninstall working without elevation: press Ctrl+C and re-run the install from a non-elevated PowerShell"
+    if ($Action -eq "upgrade") {
+        Msg "    升级会删除并重新注册计划任务" "    An upgrade deletes and re-registers the scheduled tasks"
+        Msg "    在这里重新注册出来的任务归 BUILTIN\Administrators，本账号的普通会话之后删不掉" "    Re-registered from this session they are owned by BUILTIN\Administrators, and this account's ordinary sessions cannot delete them afterwards"
+        Msg "    继续升级的话，卸载(-Uninstall)也必须在提权会话里执行" "    If you continue, uninstall (-Uninstall) will have to run elevated as well"
+        Msg "    想让普通会话自己就能卸载：Ctrl+C 退出，在非提权 PowerShell 里重新升级" "    To keep uninstall working without elevation: press Ctrl+C and re-run the upgrade from a non-elevated PowerShell"
+    } else {
+        Msg "    这样注册出来的计划任务归 BUILTIN\Administrators，本账号的普通会话之后删不掉" "    Scheduled tasks registered from it are owned by BUILTIN\Administrators, and this account's ordinary sessions cannot delete them afterwards"
+        Msg "    继续安装的话，卸载(-Uninstall)也必须在提权会话里执行" "    If you continue, uninstall (-Uninstall) will have to run elevated as well"
+        Msg "    想让普通会话自己就能卸载：Ctrl+C 退出，在非提权 PowerShell 里重新安装" "    To keep uninstall working without elevation: press Ctrl+C and re-run the install from a non-elevated PowerShell"
+    }
     Write-Host ""
 }
 # <<< pilot-elevation-warning <<<

--- a/tests/unit/deploy/installer-uninstall-survivability.test.mjs
+++ b/tests/unit/deploy/installer-uninstall-survivability.test.mjs
@@ -112,6 +112,38 @@ describe('uninstall continues when Node cannot be resolved', () => {
         expect(codeOf(body), `${file}: ${fn}`).toMatch(/if \(-not \$script:NODE_BIN\)/);
       }
     });
+
+    it(`${file}: nothing downstream of the guard resolves Node again`, () => {
+      // The guard above is only worth as much as its narrowest re-entry. One of these
+      // installers answered an empty $NODE_BIN by calling Resolve-Node a second time,
+      // unguarded, from a cleanup step -- so the very error Cmd-Uninstall had just
+      // swallowed came back as a terminating one, from a call site the caller does not
+      // wrap, before the install-directory removal and -Purge. A second call cannot help
+      // in any case: Cmd-Uninstall has already asked, and asking again gets the same
+      // answer or throws.
+      const src = read(file);
+      const seen = new Set(['Cmd-Uninstall']);
+      const queue = ['Cmd-Uninstall'];
+      const offenders = [];
+      while (queue.length) {
+        const body = funcOf(src, queue.shift());
+        if (!body) continue;
+        const code = codeOf(body);
+        for (const name of code.match(/\b[A-Z][a-zA-Z]+-[A-Z][a-zA-Z0-9]+\b/g) || []) {
+          if (seen.has(name) || !funcOf(src, name)) continue;
+          seen.add(name);
+          queue.push(name);
+          // The resolver itself is reached, by the one guarded call in Cmd-Uninstall, and
+          // matches its own name; every other reachable function must not ask again.
+          if (name === 'Resolve-Node') continue;
+          if (codeOf(funcOf(src, name)).includes('Resolve-Node')) offenders.push(name);
+        }
+      }
+      // Reachability, not just the offender: a rename that empties this walk would make
+      // the assertion below pass for the wrong reason.
+      expect(seen.size, `${file}: uninstall call graph came out empty`).toBeGreaterThan(5);
+      expect(offenders, `${file}: reached from Cmd-Uninstall and resolves Node again`).toEqual([]);
+    });
   }
 });
 
@@ -169,6 +201,53 @@ describe('a refusal to unpatch DSH is gated on something actually dangling', () 
   }
 });
 
+describe('a refusal to clean OpenClaw is gated the same way', () => {
+  // Nothing to check in the mirror: its Remove-OpenClawPlugin reports what it skipped and
+  // returns nothing, so it can never block -Purge. The downstream near-copies return
+  // $allClean and Cmd-Uninstall throws on a $false -- which meant that on any machine
+  // carrying an openclaw.json, "no Node" alone was enough to abort the uninstall before
+  // -Purge, exactly the blockage the DSH gate above had just been narrowed to avoid.
+  for (const file of INSTALLERS) {
+    it(`${file}: no Node only blocks the uninstall when the config still points at us`, () => {
+      const src = read(file);
+      const body = funcOf(src, 'Remove-OpenClawPlugin');
+      if (!body) return;
+      const code = codeOf(body);
+      if (!code.includes('$allClean')) return;
+
+      const start = code.indexOf('if (-not $script:NODE_BIN)');
+      expect(start, `${file}: no-Node branch not found`).toBeGreaterThan(-1);
+      const branch = code.slice(start, code.indexOf('continue', start));
+      expect(branch, `${file}: branch does not consult the probe`).toContain('Test-OpenClawStillManaged');
+      expect(branch, `${file}: branch no longer blocks at all`).toContain('$allClean = $false');
+      expect(
+        branch.indexOf('Test-OpenClawStillManaged'),
+        `${file}: blocks before asking whether anything dangles`,
+      ).toBeLessThan(branch.indexOf('$allClean = $false'));
+
+      const probe = funcOf(src, 'Test-OpenClawStillManaged');
+      expect(probe, `${file}: Test-OpenClawStillManaged missing`).toBeTruthy();
+      const probeCode = codeOf(probe);
+      // Reads a file owned by a third-party tool, on the path that would otherwise refuse:
+      // it must not be able to turn a healthy uninstall into a failing one, and when it
+      // cannot tell it has to answer "still managed" -- we cannot prove nothing dangles.
+      expect(probeCode, file).toContain('-ErrorAction SilentlyContinue');
+      expect(probeCode, file).toMatch(/catch\s*\{\s*\n\s*return \$true/);
+      // Separators are compared with both sides flattened, because the managed path is
+      // JSON-escaped inside the config (C:\\Users\\...) and may use / instead.
+      expect(probeCode, file).toMatch(/-replace '\[\\\\\/\]', ''/);
+    });
+  }
+
+  it('the block is byte-identical wherever it exists', () => {
+    const blocks = INSTALLERS
+      .map(f => blockOf(read(f), 'openclaw-unpatch-refusal'))
+      .filter(Boolean);
+    if (!blocks.length) return;
+    expect(new Set(blocks).size).toBe(1);
+  });
+});
+
 describe('the scheduled-task failure reaches the user', () => {
   for (const file of INSTALLERS) {
     it(`${file}: the schtasks call runs at "Continue" and restores in finally`, () => {
@@ -210,6 +289,29 @@ describe('the scheduled-task failure reaches the user', () => {
       expect(code, file).not.toContain('$schtasksOut | Out-String');
       expect(code, file).toContain('$schtasksLine.Exception.Message');
     });
+
+    it(`${file}: the node calls in Remove-OtelPlugin are relaxed and restored in finally`, () => {
+      // Same 5.1 trap, same uninstall path: Remove-OtelPlugin is called bare from
+      // Cmd-Uninstall ahead of the install-directory removal and -Purge, and one of these
+      // installers ran `& node ... 2>$null` there under EAP=Stop with no relax at all, so
+      // a single warning line on node's stderr would have ended the uninstall with
+      // config.json still on disk. Pinned for this function only -- the remaining inline
+      // restores elsewhere in these scripts are a separate mechanical change; the general
+      // rule lives in AGENTS.md.
+      const body = funcOf(read(file), 'Remove-OtelPlugin');
+      if (!body) return;
+      const code = codeOf(body);
+      const calls = (code.match(/& \$script:NODE_BIN/g) || []).length;
+      expect(calls, `${file}: no node invocation in Remove-OtelPlugin`).toBeGreaterThan(0);
+      expect(
+        (code.match(/\$ErrorActionPreference = "Continue"/g) || []).length,
+        `${file}: a node call runs at "Stop"`,
+      ).toBe(calls);
+      expect(
+        (code.match(/\}\s*finally\s*\{\s*\$ErrorActionPreference = \$prevEAP\s*\}/g) || []).length,
+        `${file}: a relax is not restored in finally`,
+      ).toBe(calls);
+    });
   }
 });
 
@@ -236,6 +338,26 @@ describe('an elevated install says what it costs', () => {
         install.indexOf('Warn-ElevatedInstall'),
         `${file}: warning must precede Check-Deps`,
       ).toBeLessThan(install.indexOf('Check-Deps'));
+    });
+
+    it(`${file}: upgrade warns too, and says the tasks get re-registered`, () => {
+      // Upgrade was the hole: it re-registers both tasks through the service script's
+      // start path (schtasks /Delete + Register-PilotTask, unconditional), so an elevated
+      // upgrade converts an ordinary-session install into one whose tasks that session can
+      // no longer delete -- the exact state this warning exists to prevent, reached with
+      // no warning at all. Nothing about the word "upgrade" suggests the tasks are
+      // re-created, hence the extra line rather than the install text verbatim.
+      const src = read(file);
+      const upgrade = codeOf(funcOf(src, 'Cmd-Upgrade'));
+      expect(upgrade, `${file}: Cmd-Upgrade not found`).toBeTruthy();
+      expect(upgrade, file).toContain('Warn-ElevatedInstall -Action "upgrade"');
+      expect(
+        upgrade.indexOf('Warn-ElevatedInstall'),
+        `${file}: warning must precede Check-Deps`,
+      ).toBeLessThan(upgrade.indexOf('Check-Deps'));
+      const block = codeOf(blockOf(src, 'pilot-elevation-warning'));
+      expect(block, file).toContain('param([string]$Action = "install")');
+      expect(block, file).toContain('deletes and re-registers the scheduled tasks');
     });
   }
 


### PR DESCRIPTION
#313 之后评审又发现两个洞，都在同一条「卸载被无关的东西带崩」的路上，这里一并补上。#313 已合入，所以拆成独立 PR。

## 1. `Warn-ElevatedInstall` 只接到了 `Cmd-Install`

升级同样致命，而且完全没有提示：升级会经服务脚本启动新版本，而启动路径**无条件**删掉并重新注册两个计划任务（`schtasks /Delete` + `Register-PilotTask`）。所以提权升级会把普通会话装出来的任务改成 `BUILTIN\Administrators` 所有，那个会话之后再也删不掉 —— 和提权安装一模一样的损害，只是从另一个入口进来的。

现在 `Warn-ElevatedInstall` 带 `-Action`，升级文案多一行点明「会删除并重新注册计划任务」，因为「升级」这个词本身完全看不出任务是重建的。调用点放在「有没有装过」判断之后（没装的话没有升级可重来）、`Check-Deps` / `Download-AndExtract` 之前（Ctrl+C 这时还不花钱）。

## 2. `Remove-OtelPlugin` 的 `$ErrorActionPreference` 恢复在调用后一行，不在 `finally`

这个函数被 `Cmd-Uninstall` 裸调，位置在删安装目录和 `-Purge` 之前 —— 也就是说这里终止一次，代价就是 `config.json` 连里面的上报凭据一起留在盘上。而且真抛的时候那行恢复被跳过，后面整段卸载都在 `Continue` 下跑，每一处 fail-fast 检查静默失效。改成 `try { ... } finally { $ErrorActionPreference = $prevEAP }`。

## ratchet

- 从 `Cmd-Uninstall` 走调用图，任何可达函数都不许再解析一次 node（`Cmd-Uninstall` 里那一次带 try/catch 的调用是唯一一次）；同时断言调用图非空，避免改名把检查掏空。
- `Remove-OtelPlugin` 里每个 `& $script:NODE_BIN` 调用都必须放宽且在 `finally` 恢复 —— 计数相等，不是「出现过就算」。
- `Cmd-Upgrade` 必须在 `Check-Deps` 之前告警，`pilot-elevation-warning` 块跨安装器字节一致。

另外那组 OpenClaw 断言在本仓库是**空转**的：这里的 `Remove-OpenClawPlugin` 只提示跳过、不返回值，堵不住 `-Purge`；它是给返回 `$allClean` 的近似副本准备的，那种形状下「没有可用 node」本身就足够中止卸载。断言写成先判形状再断言，所以在这里既不误报也不会因为改名而失效。

## 真机验证（Windows PowerShell 5.1，FullLanguage）

- `Parser::ParseFile` 无语法错误。
- AST 取出函数后实跑 `Warn-ElevatedInstall` 的 `install` / `upgrade` / 缺省三种文案：缺省等于 install，upgrade 与 install 不同且含「deletes and re-registers the scheduled tasks」。
- 单独复现了 5.1 的坑本身：`& cmd /c "echo boom 1>&2" 2>$null` 在 `EAP=Stop` 下确实抛 `NativeCommandError`；换成放宽 + `finally` 之后不抛，且**两条路径**（正常返回 / 函数体另抛）都把 `$ErrorActionPreference` 恢复回 `Stop`。

`tests/unit/deploy tests/unit/scripts`：39 files / 620 passed / 47 skipped。
