### PR TITLE
refactor(metrics): rebuild status telemetry as pilot_status + pilot_pipeline

### DIFF
--- a/src/core/input-manager.ts
+++ b/src/core/input-manager.ts
@@ -29,7 +29,14 @@ export interface InputCounter {
   outFailed: number;
   lastPollTime: string;
   startTime: string;
+  /** How this input collects (CollectionMethod) — never an agent name. */
   type: string;
+  /**
+   * The agent this input collects for, straight from the input itself. Reporting
+   * rolls ingress up by agent, and this is the only source that is right for
+   * every input, mapped or not.
+   */
+  agentType: string;
   lastActiveTime: number;
 }
 
@@ -110,6 +117,7 @@ export class InputManager extends EventEmitter {
       lastPollTime: '',
       startTime: '',
       type: input.collectionMethod,
+      agentType: input.agentType,
       lastActiveTime: 0,
     });
     input.on('entries', (entries: AgentActivityEntry[]) => {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -79,7 +79,8 @@ import { PipelineManager } from '../pipeline/pipeline-manager.js';
 import { MetricsWriter } from '../metrics/metrics-writer.js';
 import { AlarmManager } from '../metrics/alarm-manager.js';
 import { LocalWorkerActivationService } from '../local-workers/local-worker-activation-service.js';
-import type { DataflowSnapshot } from '../metrics/metrics-collector.js';
+import type { DataflowSnapshot, FlusherEndpointStats, InputStats } from '../metrics/metrics-collector.js';
+import type { OtlpEndpointCounter } from '../flushers/otlp-trace-flusher.js';
 import { RuntimeWriter, MetricsSummaryWriter, StatusBarAppManager } from '../status-bar/index.js';
 import { DashboardServer } from '../dashboard/index.js';
 import * as fs from 'node:fs';
@@ -102,6 +103,16 @@ const DEFAULT_DATA_DIR = '~/.loongsuite-pilot';
  *   6. Emit 'started'
  */
 export class Orchestrator extends EventEmitter {
+  /**
+   * Listener id → the agent it belongs to, which is also the key `config.agents`
+   * gates on. Both roles are why the values are what they are and not simply the
+   * input's own `agentType`: the four qoder listeners deliberately roll up to one
+   * `qoder` agent, and renaming a value here would silently re-point a gate.
+   *
+   * A listener missing from this map is not an error — snapshot reporting falls
+   * back to the input's `agentType`. Entries exist for listeners whose agent name
+   * differs from that, plus the ones a gate looks up.
+   */
   private static readonly LISTENER_AGENT_MAP: Record<string, string> = {
     'qoder-sqlite': 'qoder',
     'qoder-trace': 'qoder',
@@ -1600,60 +1611,112 @@ export class Orchestrator extends EventEmitter {
     const inputCounters = this.inputManager.getInputCounters();
     const activeIds = this.inputManager.getActiveInputIds();
 
-    let sendEntriesTotal = 0;
-    let receivedBytesTotal = 0;
+    // Ingress only. The instance's egress is measured where the writes actually
+    // happen — the flusher counters below — so it is not summed from the inputs.
+    let inEventsTotal = 0;
+    let inBytesTotal = 0;
     for (const counter of inputCounters.values()) {
-      sendEntriesTotal += counter.outEvents;
-      receivedBytesTotal += counter.inBytes;
+      inEventsTotal += counter.inEvents;
+      inBytesTotal += counter.inBytes;
     }
 
-    // Aggregate flusher runner stats
-    const flusherRunner = {
-      inEntries: 0, inBytes: 0, outEntries: 0, outFailed: 0,
-      totalDelayMs: 0, lastFlushTime: '', startTime: '',
-    };
+    // One entry per write destination, keyed by family plus the configured
+    // destination name — unique per flusher, and only ever a map key: the name is
+    // process-local ('user-sls', 'internal-cms'), so what identifies a row to a
+    // consumer is project + logstore, never the alias.
+    const flushers = new Map<string, FlusherEndpointStats>();
 
-    const flushers = new Map<string, { inEntries: number; inBytes: number; outEntries: number; outFailed: number; totalDelayMs: number; lastFlushTime: string; startTime: string; flusherName: string; mode: string; endpoint: string; project: string; logstore: string }>();
-
-    // Get SLS flusher counters if available
     const slsFlusher = this.getSlsFlusher();
     if (slsFlusher) {
-      for (const [epName, counter] of slsFlusher.getEndpointCounters()) {
-        flusherRunner.inEntries += counter.inEntries;
-        flusherRunner.inBytes += counter.inBytes;
-        flusherRunner.outEntries += counter.outEntries;
-        flusherRunner.outFailed += counter.outFailed;
-        flusherRunner.totalDelayMs += counter.totalDelayMs;
-        if (counter.lastFlushTime > flusherRunner.lastFlushTime) {
-          flusherRunner.lastFlushTime = counter.lastFlushTime;
-        }
-        if (!flusherRunner.startTime || counter.startTime < flusherRunner.startTime) {
-          flusherRunner.startTime = counter.startTime;
-        }
-        flushers.set(epName, {
-          ...counter,
-          flusherName: 'sls',
+      for (const [name, counter] of slsFlusher.getEndpointCounters()) {
+        flushers.set(`sls:${name}`, {
+          kind: 'sls',
+          project: counter.project,
+          logstore: counter.logstore,
+          mode: counter.mode,
+          // SLS serializes the payload here, so these are real bytes.
+          bytesBasis: 'measured',
+          inEntries: counter.inEntries,
+          inBytes: counter.inBytes,
+          outEntries: counter.outEntries,
+          outBytes: counter.outBytes,
+          outFailed: counter.outFailed,
+          totalDelayMs: counter.totalDelayMs,
+          lastFlushTime: counter.lastFlushTime,
+          startTime: counter.startTime,
         });
       }
     }
 
-    const inputs = new Map<string, { inEvents: number; inBytes: number; outEvents: number; outFailed: number; lastPollTime: string; startTime: string; type: string }>();
+    // OTLP spans: ARMS/CMS backends are their own family, everything else is
+    // plain otlp. A CMS destination resolves to a project and ARMS's fixed trace
+    // logstore, so its bytes sit on the same billing axis as an SLS row; a plain
+    // OTLP backend has no project of ours, so its row carries the family alone.
+    const otlpCounters = this.getOtlpEndpointCounters();
+    if (otlpCounters) {
+      for (const [name, counter] of otlpCounters) {
+        flushers.set(`${counter.isCms ? 'cms' : 'otlp'}:${name}`, {
+          kind: counter.isCms ? 'cms' : 'otlp',
+          project: counter.project,
+          logstore: counter.logstore,
+          mode: '',
+          // The OTLP exporter owns the encoding and reports no wire size, so these
+          // bytes are a per-span estimate — flagged, not passed off as measured.
+          bytesBasis: 'estimated',
+          inEntries: counter.inSpans,
+          inBytes: counter.inBytes,
+          outEntries: counter.outSpans,
+          outBytes: counter.outBytes,
+          outFailed: counter.outFailed,
+          totalDelayMs: counter.totalDelayMs,
+          lastFlushTime: counter.lastFlushTime,
+          startTime: counter.startTime,
+        });
+      }
+    }
+
+    const inputs = new Map<string, InputStats & { type: string; agent: string; running: boolean }>();
     const inputIdleMinutes = new Map<string, number>();
+    const runningIds = new Set(activeIds);
     for (const [id, counter] of inputCounters) {
-      inputs.set(id, { ...counter });
+      // L2 rolls ingress up by owning agent; several inputs can share one agent.
+      // The map wins where it rolls several listeners into one agent; otherwise the
+      // input's own agentType is the answer. Never counter.type — that is the
+      // collection method, and reporting 'hook-jsonl' as an agent merges every
+      // unmapped hook input into one meaningless row.
+      const agent = Orchestrator.LISTENER_AGENT_MAP[id] ?? counter.agentType ?? id;
+      // `running` is what makes the owning agent count as installed: discovery only
+      // starts an input once it has detected the agent on this host.
+      inputs.set(id, { ...counter, agent, running: runningIds.has(id) });
       inputIdleMinutes.set(id, this.inputManager.getInputIdleMinutes(id));
     }
 
     return {
-      sendEntriesTotal,
-      receivedBytesTotal,
-      inputCount: inputCounters.size,
-      activeInputCount: activeIds.length,
-      flusherRunner,
+      inEventsTotal,
+      inBytesTotal,
       inputs,
       flushers,
       inputIdleMinutes,
     };
+  }
+
+  /**
+   * Duck-typed on purpose: OtlpTraceFlusher is imported lazily so a missing
+   * OpenTelemetry dependency can't break startup, and a static `instanceof`
+   * import here would defeat that.
+   */
+  private getOtlpEndpointCounters(): Map<string, OtlpEndpointCounter> | null {
+    const candidates = this.flusher instanceof MultiFlusher
+      ? this.flusher.getFlushers()
+      : [this.flusher];
+    for (const f of candidates) {
+      if (f.name !== 'otlp-trace') continue;
+      const getter = (f as { getEndpointCounters?: unknown }).getEndpointCounters;
+      if (typeof getter === 'function') {
+        return (getter as () => Map<string, OtlpEndpointCounter>).call(f);
+      }
+    }
+    return null;
   }
 
   private getSlsFlusher(): SlsFlusher | null {

--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -27,6 +27,7 @@ import {
 } from '../normalization/global-attributes.js';
 import { createLogger } from '../utils/logger.js';
 import { appendLine, ensureDir, getTodayDateString, readInstalledVersion } from '../utils/fs-utils.js';
+import { formatTime } from '../utils/time-utils.js';
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
@@ -99,6 +100,75 @@ interface AgentExportState {
   exporters: Array<{ name: string; exporter: TraceExporterLike }>;
 }
 
+/**
+ * Per-endpoint export counters, mirroring SlsFlusher's EndpointCounter so both
+ * output legs of the agent pipeline can be reported side by side in L2.
+ * Unit is spans (the OTLP equivalent of SLS log entries).
+ */
+export interface OtlpEndpointCounter {
+  inSpans: number;
+  inBytes: number;
+  outSpans: number;
+  /**
+   * Estimated bytes actually exported to this endpoint (same estimator as
+   * inBytes). Counted per endpoint, so a span exported to two backends is
+   * counted twice — the billing view wants both writes.
+   */
+  outBytes: number;
+  outFailed: number;
+  totalDelayMs: number;
+  lastFlushTime: string;
+  startTime: string;
+  /** True when this endpoint is an ARMS/CMS backend (x-arms-* / x-cms-* headers). */
+  isCms: boolean;
+  /**
+   * SLS project this backend's spans land in, so a CMS destination is billable
+   * on the same project axis as an SLS one. ARMS derives it from the endpoint
+   * host, which config-loader has already done into `x-arms-project`; empty for
+   * a plain OTLP backend, whose storage is not ours to name.
+   */
+  project: string;
+  /** ARMS's fixed trace logstore. Empty for a plain OTLP backend. */
+  logstore: string;
+}
+
+/**
+ * Every ARMS trace endpoint writes into this one logstore inside its project —
+ * ARMS's own convention, not something the endpoint or headers tell us, so it
+ * is hardcoded here rather than derived.
+ */
+const ARMS_TRACE_LOGSTORE = 'logstore-tracing';
+
+/**
+ * A CMS/ARMS backend is an OTLP endpoint carrying the ARMS auth headers that
+ * cmsEntryToOtlpEndpoint injects. Classifying by header (not by endpoint name)
+ * keeps a plain user-configured OTLP backend from being mislabelled as CMS.
+ */
+function isCmsEndpoint(headers: Record<string, string>): boolean {
+  return Object.keys(headers).some((h) => {
+    const k = h.toLowerCase();
+    return k === 'x-cms-workspace' || k === 'x-arms-license-key' || k === 'x-arms-project';
+  });
+}
+
+/**
+ * The ARMS project for a CMS endpoint. config-loader already resolved it (from
+ * the entry's explicit project, else the endpoint host) into `x-arms-project`,
+ * so read that instead of parsing the URL a second time and risking a different
+ * answer. Falls back to the host's first label — an endpoint classified as CMS
+ * by workspace/license header alone carries no project header.
+ */
+function cmsProjectOf(headers: Record<string, string>, url: string): string {
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === 'x-arms-project' && value) return value;
+  }
+  try {
+    return new URL(url).hostname.split('.')[0] ?? '';
+  } catch {
+    return '';
+  }
+}
+
 const RESERVED_RESOURCE_KEYS = new Set([
   'service.name',
   'service.version',
@@ -166,6 +236,7 @@ export class OtlpTraceFlusher extends BaseFlusher {
   private readonly instanceId = randomUUID();
   private readonly pilotVersion: string;
   private readonly endpoints: ResolvedOtlpEndpoint[];
+  private readonly endpointCounters: Map<string, OtlpEndpointCounter> = new Map();
   private readonly exporterFactory: OtlpExporterFactory;
   private readonly debugDir: string;
   private readonly failedDir: string;
@@ -207,6 +278,16 @@ export class OtlpTraceFlusher extends BaseFlusher {
       serviceName: ep.serviceName || cfg.serviceName,
       appendAgentTypeToServiceName: cfg.appendAgentTypeToServiceName !== false,
     }));
+    for (const ep of this.endpoints) {
+      const isCms = isCmsEndpoint(ep.headers);
+      this.endpointCounters.set(ep.name, {
+        inSpans: 0, inBytes: 0, outSpans: 0, outBytes: 0, outFailed: 0,
+        totalDelayMs: 0, lastFlushTime: '', startTime: '',
+        isCms,
+        project: isCms ? cmsProjectOf(ep.headers, ep.url) : '',
+        logstore: isCms ? ARMS_TRACE_LOGSTORE : '',
+      });
+    }
     const dataDir = cfg.dataDir ?? os.homedir() + '/.loongsuite-pilot';
     this.pilotVersion = readInstalledVersion(dataDir);
     this.debugDir = path.join(dataDir, 'logs', 'otlp-debug');
@@ -680,20 +761,41 @@ export class OtlpTraceFlusher extends BaseFlusher {
     agentType: string,
     spans: ReadableSpan[],
   ): Promise<void> {
+    const counter = this.endpointCounters.get(endpointName);
+    const startMs = Date.now();
+    // Sized once and reused on the success path: in and out must measure the
+    // same thing, or the drop rate between them becomes meaningless.
+    let batchBytes = 0;
+    if (counter) {
+      counter.inSpans += spans.length;
+      for (const span of spans) batchBytes += estimateSpanSize(span);
+      counter.inBytes += batchBytes;
+      if (!counter.startTime) counter.startTime = formatTime(new Date());
+    }
     // Never rejects: a failing backend is isolated + persisted, not propagated.
     return new Promise<void>((resolve) => {
       exporter.export(spans, (result) => {
+        if (counter) counter.totalDelayMs += Date.now() - startMs;
         if (result.code !== ExportResultCode.SUCCESS) {
+          if (counter) counter.outFailed += spans.length;
           const errMsg = result.error?.message ?? 'unknown export error';
           logger.warn(`Export failed for ${agentType} → ${endpointName}: ${errMsg}`);
           this.writeFailedLog(agentType, endpointName, spans, {
             code: result.code,
             message: errMsg,
           }).catch(() => undefined);
+        } else if (counter) {
+          counter.outSpans += spans.length;
+          counter.outBytes += batchBytes;
+          counter.lastFlushTime = formatTime(new Date());
         }
         resolve();
       });
     });
+  }
+
+  getEndpointCounters(): Map<string, OtlpEndpointCounter> {
+    return this.endpointCounters;
   }
 
   private getOrCreateConvertState(

--- a/src/flushers/sls-flusher.ts
+++ b/src/flushers/sls-flusher.ts
@@ -50,14 +50,47 @@ export interface EndpointCounter {
   inEntries: number;
   inBytes: number;
   outEntries: number;
+  /**
+   * Bytes actually written out to this endpoint, i.e. what a billing view
+   * charges for. Counted per endpoint, so a log fanned out to two endpoints is
+   * counted twice — that is the point, the write happened twice.
+   */
+  outBytes: number;
+  /** Entries whose send failed after retries, i.e. persisted instead of written. */
   outFailed: number;
   totalDelayMs: number;
   lastFlushTime: string;
   startTime: string;
   mode: string;
-  endpoint: string;
   project: string;
   logstore: string;
+}
+
+/**
+ * What one endpoint's flush actually achieved. The send paths swallow their
+ * failures on purpose (persist + alarm, never propagate), so promise settlement
+ * says nothing about whether the bytes landed — the counters have to be driven
+ * by this instead, or a dead backend still reports a full out_bytes.
+ *
+ * Webtracking splits a batch into several requests, so a flush can be partly
+ * successful: the counts are per-entry, not per-batch.
+ */
+interface FlushOutcome {
+  sentEntries: number;
+  sentBytes: number;
+  failedEntries: number;
+}
+
+function sumByteSize(logs: QueuedLog[]): number {
+  return logs.reduce((sum, log) => sum + log.byteSize, 0);
+}
+
+function flushSucceeded(logs: QueuedLog[]): FlushOutcome {
+  return { sentEntries: logs.length, sentBytes: sumByteSize(logs), failedEntries: 0 };
+}
+
+function flushFailed(logs: QueuedLog[]): FlushOutcome {
+  return { sentEntries: 0, sentBytes: 0, failedEntries: logs.length };
 }
 
 const MAX_BACKOFF_MS = 60_000;
@@ -120,9 +153,9 @@ export class SlsFlusher extends BaseFlusher {
 
     for (const ep of config.endpoints) {
       this.endpointCounters.set(ep.name, {
-        inEntries: 0, inBytes: 0, outEntries: 0, outFailed: 0,
+        inEntries: 0, inBytes: 0, outEntries: 0, outBytes: 0, outFailed: 0,
         totalDelayMs: 0, lastFlushTime: '', startTime: '',
-        mode: ep.mode, endpoint: ep.endpoint, project: ep.project, logstore: ep.logstore,
+        mode: ep.mode, project: ep.project, logstore: ep.logstore,
       });
     }
   }
@@ -196,11 +229,17 @@ export class SlsFlusher extends BaseFlusher {
           const counter = this.endpointCounters.get(endpoint.name);
           const startMs = Date.now();
           const send = this.flushEndpoint(endpoint, logs);
-          return send.then(() => {
+          return send.then(outcome => {
             if (counter) {
-              counter.outEntries += logs.length;
+              // Driven by the outcome, not by the promise resolving: the send
+              // paths return normally after persisting a failed batch, so
+              // counting here on resolution alone would bill every dropped
+              // batch as written and leave failed_entries at zero.
+              counter.outEntries += outcome.sentEntries;
+              counter.outBytes += outcome.sentBytes;
+              counter.outFailed += outcome.failedEntries;
               counter.totalDelayMs += Date.now() - startMs;
-              counter.lastFlushTime = formatTime(new Date());
+              if (outcome.sentEntries > 0) counter.lastFlushTime = formatTime(new Date());
             }
           }).catch(err => {
             if (counter) {
@@ -257,7 +296,7 @@ export class SlsFlusher extends BaseFlusher {
     return tags;
   }
 
-  private flushEndpoint(endpoint: SlsEndpoint, logs: QueuedLog[]): Promise<void> {
+  private flushEndpoint(endpoint: SlsEndpoint, logs: QueuedLog[]): Promise<FlushOutcome> {
     if (endpoint.mode === 'ak') return this.flushViaAk(endpoint, logs);
     if (endpoint.mode === 'apiKey') return this.flushViaApiKey(endpoint, logs);
     return this.flushViaWebtracking(endpoint, logs);
@@ -277,7 +316,7 @@ export class SlsFlusher extends BaseFlusher {
     }
   }
 
-  private async flushViaAk(endpoint: SlsEndpoint, logs: QueuedLog[]): Promise<void> {
+  private async flushViaAk(endpoint: SlsEndpoint, logs: QueuedLog[]): Promise<FlushOutcome> {
     this.warnIfMixedAgentTypes(logs);
     const now = Math.floor(Date.now() / 1000);
     const agentType = logs[0]?.agentType;
@@ -306,7 +345,7 @@ export class SlsFlusher extends BaseFlusher {
           logstore: endpoint.logstore,
           count: logs.length,
         });
-        return;
+        return flushSucceeded(logs);
       } catch (err) {
         lastErr = err;
         if (!isRetryable(err) || attempt === this.resolvedRetryMaxAttempts - 1) break;
@@ -340,19 +379,25 @@ export class SlsFlusher extends BaseFlusher {
     await this.persistFailedLogs(
       endpoint,
       logs.length,
-      logs.reduce((sum, log) => sum + log.byteSize, 0),
+      sumByteSize(logs),
       lastErr,
     );
+    return flushFailed(logs);
   }
 
-  private async flushViaWebtracking(endpoint: SlsEndpoint, logs: QueuedLog[]): Promise<void> {
-    const chunks = this.splitForWebtracking(logs);
-    for (const chunk of chunks) {
-      await this.postWebtracking(endpoint, chunk);
+  /** One batch, several requests: sum the per-chunk outcomes so a partial send counts as partial. */
+  private async flushViaWebtracking(endpoint: SlsEndpoint, logs: QueuedLog[]): Promise<FlushOutcome> {
+    const total: FlushOutcome = { sentEntries: 0, sentBytes: 0, failedEntries: 0 };
+    for (const chunk of this.splitForWebtracking(logs)) {
+      const outcome = await this.postWebtracking(endpoint, chunk);
+      total.sentEntries += outcome.sentEntries;
+      total.sentBytes += outcome.sentBytes;
+      total.failedEntries += outcome.failedEntries;
     }
+    return total;
   }
 
-  private async flushViaApiKey(endpoint: SlsEndpoint, logs: QueuedLog[]): Promise<void> {
+  private async flushViaApiKey(endpoint: SlsEndpoint, logs: QueuedLog[]): Promise<FlushOutcome> {
     this.warnIfMixedAgentTypes(logs);
     const now = Math.floor(Date.now() / 1000);
     const agentType = logs[0]?.agentType;
@@ -387,7 +432,7 @@ export class SlsFlusher extends BaseFlusher {
           logstore: endpoint.logstore,
           count: logs.length,
         });
-        return;
+        return flushSucceeded(logs);
       } catch (err) {
         lastErr = err;
         if (!isRetryable(err) || attempt === this.resolvedRetryMaxAttempts - 1) break;
@@ -421,9 +466,10 @@ export class SlsFlusher extends BaseFlusher {
     await this.persistFailedLogs(
       endpoint,
       logs.length,
-      logs.reduce((sum, log) => sum + log.byteSize, 0),
+      sumByteSize(logs),
       lastErr,
     );
+    return flushFailed(logs);
   }
 
   private splitForWebtracking(logs: QueuedLog[]): QueuedLog[][] {
@@ -452,7 +498,7 @@ export class SlsFlusher extends BaseFlusher {
     return chunks;
   }
 
-  private async postWebtracking(endpoint: SlsEndpoint, logs: QueuedLog[]): Promise<void> {
+  private async postWebtracking(endpoint: SlsEndpoint, logs: QueuedLog[]): Promise<FlushOutcome> {
     this.warnIfMixedAgentTypes(logs);
     const agentType = logs[0]?.agentType;
     const body = {
@@ -500,7 +546,7 @@ export class SlsFlusher extends BaseFlusher {
             logstore: endpoint.logstore,
             count: logs.length,
           });
-          return;
+          return flushSucceeded(logs);
         }
       } catch (err) {
         lastErr = err;
@@ -535,6 +581,7 @@ export class SlsFlusher extends BaseFlusher {
       );
     }
     await this.persistFailedLogs(endpoint, logs.length, Buffer.byteLength(raw), lastErr);
+    return flushFailed(logs);
   }
 
   private async persistFailedLogs(

--- a/src/metrics/metrics-collector.ts
+++ b/src/metrics/metrics-collector.ts
@@ -19,6 +19,7 @@ export interface L1Metrics {
   hostname: string;
   ip: string;
   instance_id: string;
+  run_id: string;
   user_id: string;
   pid: number;
   cpu: string;
@@ -26,23 +27,44 @@ export interface L1Metrics {
   mem_heap: string;
   start_time: string;
   capture_message_disabled_agents: string;
-  project: string;
+  projects: string;
   cms_workspace: string;
   metric_json: {
-    input_count: string;
-    active_input_count: string;
+    // Agent-dimensioned, not input-dimensioned: how many agents this host has
+    // installed, and how many of those have ever produced data in this run.
+    agent_count: string;
+    active_agent_count: string;
     open_fd: string;
-    send_entries_ps: string;
-    received_bytes_ps: string;
-    send_entries_total: string;
-    received_bytes_total: string;
-  };
-  flusher_runner: {
-    in_entries_total: string;
-    in_bytes_total: string;
-    out_entries_total: string;
-    out_failed_entries_total: string;
-    last_flush_time: string;
+    /** Length of the window the flow values below cover. */
+    window_ms: string;
+    // The instance's whole-process volume, not one leg of it. This pair is what
+    // a billing view aggregates, so read the asymmetry deliberately:
+    //
+    //   in_*  = what this pilot ingested — events collected from the installed
+    //           agents, sized on the normalized entry before masking. Counted
+    //           once per event no matter how many backends it later reaches.
+    //   out_* = what this pilot actually wrote to its backends, summed over
+    //           every destination (the pilot_pipeline flusher rows carry the
+    //           per-destination split). One event fanned out to two endpoints
+    //           counts twice here, because two writes happened.
+    //
+    // So out_events > in_events is normal under fan-out, and the two sides count
+    // different units (agent events vs. SLS entries / OTLP spans). Both are
+    // per-window values, drained on every report — SUM them over a time range,
+    // never diff them.
+    //
+    // out_bytes is deliberately mixed-basis: it sums measured SLS payload bytes
+    // with estimated OTLP span bytes, because the instance total has to cover
+    // every destination. For a number that is only real bytes, sum out_bytes over
+    // the flusher rows with bytes_basis = 'measured' instead.
+    in_events: string;
+    in_bytes: string;
+    out_events: string;
+    out_bytes: string;
+    in_events_ps: string;
+    in_bytes_ps: string;
+    out_events_ps: string;
+    out_bytes_ps: string;
   };
   init_type: string;
   rollback_available: string;
@@ -54,81 +76,176 @@ export interface L1Metrics {
   __time__: number;
 }
 
-export interface AlarmMetrics {
-  category: 'alarm';
-  input_name: string;
+/**
+ * Fields every L2 row carries, whatever its type. Repeating the identity on each
+ * row is what lets the three types be queried independently — filter on `type`
+ * and group by host or agent, with no join back to another topic.
+ */
+interface L2Identity {
+  hostname: string;
+  ip: string;
   instance_id: string;
-  source_ip: string;
+  run_id: string;
   user_id: string;
-  succeed_events: string;
-  failed_events: string;
-  input_idle_minutes: string;
+  /** Length of the window every flow value in this row covers. */
+  window_ms: string;
   __time__: number;
 }
 
-export interface InputMetrics {
-  category: 'input';
-  label: {
-    input_name: string;
-    input_type: string;
-  };
-  user_id: string;
-  in_events_total: string;
-  in_size_bytes: string;
-  out_events_total: string;
-  out_failed_events_total: string;
+/**
+ * One row per agent that is installed (has a running input) or carried data this
+ * window — zeros included. Reporting the installed-but-silent ones is what makes
+ * `idle_minutes` answerable: the agent an idle alarm cares about is by definition
+ * the one with no traffic, and a traffic-gated row can never describe it. It
+ * stays cheap because discovery only starts an input once it has detected the
+ * agent on this host, so this is a handful of rows per cycle, not one per agent
+ * the build knows about.
+ *
+ * Ingress only, by design. Egress cannot be attributed to an agent — the
+ * flushers batch and fan out across all of them — so it lives on the flusher
+ * rows. How many inputs back the agent is likewise not reported: several inputs
+ * can serve one agent (qoder owns sqlite/trace/cli-hook/cli-session), which is a
+ * collection detail, not an agent-dimensioned metric.
+ */
+export interface AgentFlowMetrics extends L2Identity {
+  type: 'agent';
+  agent: string;
+  in_events: string;
+  in_bytes: string;
+  /** Events this agent produced that the dispatch to the flushers rejected. */
+  failed_events: string;
+  /** State, not a window value. -1 when the agent has never been active. */
+  idle_minutes: string;
   last_poll_time: string;
   start_time: string;
-  __time__: number;
 }
 
-export interface FlusherMetrics {
-  category: 'flusher';
-  label: {
-    flusher_name: string;
-    endpoint_name: string;
-    project: string;
-    logstore: string;
-    mode: string;
-  };
-  user_id: string;
-  in_entries_total: string;
-  in_size_bytes: string;
-  out_entries_total: string;
-  out_failed_entries_total: string;
+/**
+ * One row per destination, not per backend family: two SLS logstores are two
+ * rows, and a billing view can attribute every byte to the project and logstore
+ * it was written to. Emitted for every configured destination even at zero
+ * traffic, so "configured but silent" is visible rather than absent.
+ *
+ * The entry / byte / delay values are per-window, so average flush latency for
+ * the window is total_delay_ms / (out_entries + failed_entries) — both flushers
+ * add elapsed time on the failure path too.
+ */
+export interface FlusherFlowMetrics extends L2Identity {
+  type: 'flusher';
+  /** Backend family: sls, cms or otlp. */
+  flusher: string;
+  /**
+   * Where the bytes landed in SLS. Populated for sls and cms rows (a CMS
+   * destination resolves to an ARMS project and its fixed trace logstore), empty
+   * for a plain OTLP backend whose storage is not ours to name. `mode` is the SLS
+   * transport and stays empty for both OTLP families.
+   */
+  project: string;
+  logstore: string;
+  mode: string;
+  /** SLS log entries or OTLP spans, depending on the flusher. */
+  in_entries: string;
+  in_bytes: string;
+  out_entries: string;
+  /**
+   * Bytes actually written to this destination in the window — the billable
+   * half of the pair, and the per-destination split of L1's
+   * metric_json.out_bytes. Read it together with `bytes_basis`.
+   */
+  out_bytes: string;
+  /**
+   * How in_bytes / out_bytes were obtained: 'measured' is the serialized payload
+   * size (SLS), 'estimated' is a per-span heuristic (OTLP/CMS, where the exporter
+   * never hands back a wire size). Published so a byte comparison across rows can
+   * refuse to mix the two — an estimated row is good for trends, not for billing.
+   */
+  bytes_basis: BytesBasis;
+  failed_entries: string;
   total_delay_ms: string;
   last_flush_time: string;
   start_time: string;
-  __time__: number;
+}
+
+/**
+ * One reporting cycle's L2 output: ingress per agent, egress per destination.
+ * No instance-total row — it would be the exact sum of these rows over one
+ * window, which the query engine can do, and L1's metric_json already carries
+ * the same four axes plus agent_count for the instance.
+ */
+export interface L2Metrics {
+  agents: AgentFlowMetrics[];
+  flushers: FlusherFlowMetrics[];
 }
 
 export interface FlusherStats {
   inEntries: number;
   inBytes: number;
   outEntries: number;
+  outBytes: number;
   outFailed: number;
   totalDelayMs: number;
   lastFlushTime: string;
   startTime: string;
 }
 
+/**
+ * What the reporting needs from an input counter. The counter also tracks the
+ * dispatch handoff (outEvents / outBytes); nothing reads it here, because for a
+ * successful batch it equals the ingress byte for byte and real egress is
+ * measured at the flushers.
+ */
 export interface InputStats {
   inEvents: number;
   inBytes: number;
-  outEvents: number;
   outFailed: number;
   lastPollTime: string;
   startTime: string;
 }
 
+/** Backend family a destination belongs to. */
+export type FlusherKind = 'sls' | 'cms' | 'otlp';
+
+/**
+ * Where a destination's byte counts come from. SLS serializes the payload itself
+ * and counts real bytes ('measured'); the OTLP exporter owns the encoding and
+ * never reports a wire size, so those rows carry a per-span estimate
+ * ('estimated'). Reported per row so the two are never silently added up.
+ */
+export type BytesBasis = 'measured' | 'estimated';
+
+/**
+ * One write destination and what it has written. project / logstore are filled
+ * for sls and cms and empty for a plain OTLP backend, and `mode` is SLS-only.
+ */
+export interface FlusherEndpointStats extends FlusherStats {
+  kind: FlusherKind;
+  project: string;
+  logstore: string;
+  mode: string;
+  bytesBasis: BytesBasis;
+}
+
 export interface DataflowSnapshot {
-  sendEntriesTotal: number;
-  receivedBytesTotal: number;
-  inputCount: number;
-  activeInputCount: number;
-  flusherRunner: FlusherStats;
-  inputs: Map<string, InputStats & { type: string }>;
-  flushers: Map<string, FlusherStats & { flusherName: string; mode: string; endpoint: string; project: string; logstore: string }>;
+  /**
+   * Instance ingress, summed over the inputs. There is no matching egress total:
+   * what the instance actually wrote is the flusher side, so both levels take
+   * out_* from `flushers` and nothing has to keep two answers in sync.
+   */
+  inEventsTotal: number;
+  inBytesTotal: number;
+  /**
+   * Keyed by input id. Inputs are the collection mechanism, not a reported
+   * dimension: `agent` is the owning agent (several inputs map to one agent) and
+   * everything reported is rolled up by it. `running` means discovery detected
+   * the agent on this host and started collecting, i.e. the agent is installed.
+   */
+  inputs: Map<string, InputStats & { type: string; agent: string; running: boolean }>;
+  /**
+   * Keyed by destination id (`kind:name`), one entry per destination rather
+   * than one per family: billing attributes bytes to a project and logstore, and
+   * a merged family bucket cannot answer that.
+   */
+  flushers: Map<string, FlusherEndpointStats>;
   inputIdleMinutes: Map<string, number>;
 }
 
@@ -149,6 +266,100 @@ export interface InfraHealthSnapshot {
   updaterConsecutiveFailures: number;
 }
 
+/** Ingress axes tracked per input. */
+interface FlowTotals {
+  inEvents: number;
+  inBytes: number;
+  outFailed: number;
+}
+
+/**
+ * L1's four axes. The two halves come from opposite ends of the pipeline —
+ * ingress from the inputs, egress from the flushers — which is what makes the
+ * pair describe the instance rather than one leg of it.
+ */
+interface InstanceFlow {
+  inEvents: number;
+  inBytes: number;
+  outEvents: number;
+  outBytes: number;
+}
+
+/** Egress axes tracked per destination. */
+interface FlusherTotals {
+  inEntries: number;
+  inBytes: number;
+  outEntries: number;
+  outBytes: number;
+  outFailed: number;
+  totalDelayMs: number;
+}
+
+function zeroFlowTotals(): FlowTotals {
+  return { inEvents: 0, inBytes: 0, outFailed: 0 };
+}
+
+function zeroFlusherTotals(): FlusherTotals {
+  return { inEntries: 0, inBytes: 0, outEntries: 0, outBytes: 0, outFailed: 0, totalDelayMs: 0 };
+}
+
+/** L1's egress: every write this instance made, across all destinations. */
+function sumFlusherEgress(snapshot: DataflowSnapshot): { events: number; bytes: number } {
+  let events = 0;
+  let bytes = 0;
+  for (const stats of snapshot.flushers.values()) {
+    events += stats.outEntries;
+    bytes += stats.outBytes;
+  }
+  return { events, bytes };
+}
+
+/**
+ * Window value for one axis: current cumulative reading minus what was already
+ * reported. Clamped at 0 so a counter that somehow goes backwards (an endpoint
+ * dropping out of a merged sink bucket, say) reports no traffic instead of a
+ * negative spike.
+ */
+function delta(current: number, baseline: number): number {
+  return Math.max(0, current - baseline);
+}
+
+/**
+ * Everything is reported per agent, so every input resolves to one agent key.
+ * The snapshot already resolves `agent` (map, else the input's agentType, else
+ * its id); the id fallback here is only for a hand-built snapshot. Deliberately
+ * never `type` — that is the collection method, not an agent.
+ */
+function agentKeyOf(inputId: string, stats: { agent: string }): string {
+  return stats.agent || inputId;
+}
+
+/**
+ * The agent-dimensioned pair both levels report, computed the same way so the
+ * two topics can never disagree:
+ *
+ * - installed: agents with at least one running input. Discovery only starts an
+ *   input after it detects the agent on this host, so running == installed.
+ * - active: installed agents that have collected at least once in this run
+ *   (idle_minutes >= 0). State, not a window value — an installed agent that
+ *   simply sees no traffic this window stays active, and `active <= installed`
+ *   always holds.
+ *
+ * Inputs never surface on their own: several of them can back one agent (qoder
+ * owns sqlite/trace/cli-hook/cli-session), which is an internal detail.
+ */
+function countAgents(snapshot: DataflowSnapshot): { installed: number; active: number } {
+  const installed = new Set<string>();
+  const active = new Set<string>();
+  for (const [inputId, stats] of snapshot.inputs) {
+    if (!stats.running) continue;
+    const agent = agentKeyOf(inputId, stats);
+    installed.add(agent);
+    if ((snapshot.inputIdleMinutes.get(inputId) ?? -1) >= 0) active.add(agent);
+  }
+  return { installed: installed.size, active: active.size };
+}
+
 export class MetricsCollector {
   private readonly version: string;
   private readonly userId: string;
@@ -162,6 +373,8 @@ export class MetricsCollector {
   private readonly startTime: string;
   private readonly startTimestamp: number;
   private readonly instanceId: string;
+  private readonly runId: string;
+  private readonly hostname: string;
   private readonly localIp: string;
   private readonly initType: string;
 
@@ -169,9 +382,20 @@ export class MetricsCollector {
   private lastCpuTime = 0;
   private lastCollectTime = 0;
   private isFirstCpuSample = true;
-  // null until the first L1 sample seeds the baseline; until then rates are reported as 0
-  private prevSendEntries: number | null = null;
-  private prevReceivedBytes: number | null = null;
+  /**
+   * Reported values are per-window deltas, so every flow counter needs a
+   * "already reported up to here" baseline. The underlying input / flusher
+   * counters stay monotonic (they are the source of truth and are read by other
+   * code); subtracting a baseline here is what makes a reported row drain.
+   *
+   * L1 and L2 run on independent timers over the same snapshot, so they must
+   * keep separate baselines — a shared one would let whichever fires first
+   * swallow the other's window.
+   */
+  private l1Baseline: InstanceFlow = { inEvents: 0, inBytes: 0, outEvents: 0, outBytes: 0 };
+  private l2InputBaseline: Map<string, FlowTotals> = new Map();
+  private l2FlusherBaseline: Map<string, FlusherTotals> = new Map();
+  private l2LastCollectTime = 0;
   private l1CycleCount = 0;
   private updaterConsecutiveFailures = 0;
   private lastInfraHealth: InfraHealthSnapshot | null = null;
@@ -192,7 +416,17 @@ export class MetricsCollector {
     this.startTimestamp = Math.floor(Date.now() / 1000);
     this.startTime = formatTime(new Date());
     this.localIp = resolveLocalIp();
-    this.instanceId = `${opts.userId}_${this.localIp}_${this.startTimestamp}`;
+    this.hostname = os.hostname();
+    // Stable install identity: restart- and IP-invariant, independently derivable
+    // by any process on the host. Includes dataDir so multiple installs on one
+    // machine (e.g. several OS users, each with their own ~/.loongsuite-pilot) do
+    // not collide when hostname and configured userId coincide. dataDir is
+    // base64url-encoded (not plaintext) but remains reversible: strip the
+    // `${hostname}_${userId}_` prefix and base64url-decode to recover the path.
+    const dataDirEncoded = Buffer.from(opts.dataDir, 'utf8').toString('base64url');
+    this.instanceId = `${this.hostname}_${opts.userId}_${dataDirEncoded}`;
+    // Per-incarnation id: distinguishes runs / detects restarts.
+    this.runId = `${this.instanceId}_${this.startTimestamp}`;
     this.initType = readInitType(opts.dataDir);
   }
 
@@ -205,25 +439,37 @@ export class MetricsCollector {
     const cpuPercent = this.calcCpuPercent(now);
     const mem = process.memoryUsage();
 
-    // First sample: seed the baseline and report 0 rates rather than dividing
-    // a full cumulative count by a near-zero elapsed window.
-    let entriesPs = '0.0';
-    let bytesPs = '0.0';
-    if (this.prevSendEntries === null || this.prevReceivedBytes === null) {
-      this.prevSendEntries = snapshot.sendEntriesTotal;
-      this.prevReceivedBytes = snapshot.receivedBytesTotal;
-    } else {
-      const elapsedSec = Math.max((now - this.lastCollectTime) / 1000, 0.001);
-      const entriesDelta = snapshot.sendEntriesTotal - this.prevSendEntries;
-      const bytesDelta = snapshot.receivedBytesTotal - this.prevReceivedBytes;
-      entriesPs = (entriesDelta / elapsedSec).toFixed(1);
-      bytesPs = (bytesDelta / elapsedSec).toFixed(1);
-      this.prevSendEntries = snapshot.sendEntriesTotal;
-      this.prevReceivedBytes = snapshot.receivedBytesTotal;
-    }
+    // Drain: report what flowed since the previous L1 row, then move the
+    // baseline up. The window opens at process start for the very first row.
+    // Ingress is the input side, egress the flusher side — deliberately not the
+    // input-side dispatch count, which only says "handed to the fan-out" and is
+    // byte-identical to ingress.
+    const egress = sumFlusherEgress(snapshot);
+    const cumulative: InstanceFlow = {
+      inEvents: snapshot.inEventsTotal,
+      inBytes: snapshot.inBytesTotal,
+      outEvents: egress.events,
+      outBytes: egress.bytes,
+    };
+    const flow = {
+      inEvents: delta(cumulative.inEvents, this.l1Baseline.inEvents),
+      inBytes: delta(cumulative.inBytes, this.l1Baseline.inBytes),
+      outEvents: delta(cumulative.outEvents, this.l1Baseline.outEvents),
+      outBytes: delta(cumulative.outBytes, this.l1Baseline.outBytes),
+    };
+    this.l1Baseline = cumulative;
 
+    const hasPriorRow = this.lastCollectTime !== 0;
+    const windowMs = Math.max(0, now - (this.lastCollectTime || this.startTimestamp * 1000));
+    const elapsedSec = Math.max(windowMs / 1000, 0.001);
     this.lastCollectTime = now;
+    // The first row is emitted right at startup, so its window is a few
+    // milliseconds wide — dividing by it turns any pre-existing count into a
+    // meaningless spike. Report the values, leave the rates at 0; window_ms is
+    // published so a consumer that wants its own rate can compute one.
+    const rate = (value: number): string => (hasPriorRow ? (value / elapsedSec).toFixed(1) : '0.0');
 
+    const agents = countAgents(snapshot);
     const health = this.collectInfraHealth();
 
     return {
@@ -232,6 +478,7 @@ export class MetricsCollector {
       hostname: os.hostname(),
       ip: this.localIp,
       instance_id: this.instanceId,
+      run_id: this.runId,
       user_id: this.userId,
       pid: process.pid,
       cpu: String(cpuPercent),
@@ -239,23 +486,21 @@ export class MetricsCollector {
       mem_heap: String(Math.round(mem.heapUsed / 1024 / 1024)),
       start_time: this.startTime,
       capture_message_disabled_agents: this.buildCaptureMessageDisabledAgents(),
-      project: this.buildProject(),
+      projects: this.buildProjects(),
       cms_workspace: this.buildCmsWorkspace(),
       metric_json: {
-        input_count: String(snapshot.inputCount),
-        active_input_count: String(snapshot.activeInputCount),
+        agent_count: String(agents.installed),
+        active_agent_count: String(agents.active),
         open_fd: String(getOpenFdCount()),
-        send_entries_ps: entriesPs,
-        received_bytes_ps: bytesPs,
-        send_entries_total: String(snapshot.sendEntriesTotal),
-        received_bytes_total: String(snapshot.receivedBytesTotal),
-      },
-      flusher_runner: {
-        in_entries_total: String(snapshot.flusherRunner.inEntries),
-        in_bytes_total: String(snapshot.flusherRunner.inBytes),
-        out_entries_total: String(snapshot.flusherRunner.outEntries),
-        out_failed_entries_total: String(snapshot.flusherRunner.outFailed),
-        last_flush_time: snapshot.flusherRunner.lastFlushTime,
+        window_ms: String(windowMs),
+        in_events: String(flow.inEvents),
+        in_bytes: String(flow.inBytes),
+        out_events: String(flow.outEvents),
+        out_bytes: String(flow.outBytes),
+        in_events_ps: rate(flow.inEvents),
+        in_bytes_ps: rate(flow.inBytes),
+        out_events_ps: rate(flow.outEvents),
+        out_bytes_ps: rate(flow.outBytes),
       },
       init_type: this.initType,
       rollback_available: String(health.rollbackAvailable),
@@ -268,80 +513,149 @@ export class MetricsCollector {
     };
   }
 
-  collectL2Inputs(snapshot: DataflowSnapshot): InputMetrics[] {
-    const now = Math.floor(Date.now() / 1000);
-    const results: InputMetrics[] = [];
+  /**
+   * One cycle of L2: a row per agent that carried data, a row per write
+   * destination. Both sides are produced by a single call so they share one drain
+   * and one window — collecting them separately would let whichever ran first
+   * swallow the other's traffic, and ingress and egress would then describe
+   * different windows.
+   *
+   * Returns null when there is nothing on either side, so a freshly started
+   * instance with no agents and no destinations ships nothing at all.
+   */
+  collectL2(snapshot: DataflowSnapshot): L2Metrics | null {
+    const now = Date.now();
+    const windowMs = Math.max(0, now - (this.l2LastCollectTime || this.startTimestamp * 1000));
+    const identity = {
+      hostname: os.hostname(),
+      ip: this.localIp,
+      instance_id: this.instanceId,
+      run_id: this.runId,
+      user_id: this.userId,
+      window_ms: String(windowMs),
+      __time__: Math.floor(now / 1000),
+    };
 
-    for (const [name, stats] of snapshot.inputs) {
-      results.push({
-        category: 'input',
-        label: {
-          input_name: name,
-          input_type: stats.type,
-        },
-        user_id: this.userId,
-        in_events_total: String(stats.inEvents),
-        in_size_bytes: String(stats.inBytes),
-        out_events_total: String(stats.outEvents),
-        out_failed_events_total: String(stats.outFailed),
-        last_poll_time: stats.lastPollTime,
-        start_time: stats.startTime,
-        __time__: now,
-      });
-    }
-    return results;
+    const agentRows = this.collectAgentRows(snapshot, identity);
+    const flusherRows = this.collectFlusherRows(snapshot, identity);
+    // The row builders already drained the counters, so the window is spent
+    // whether or not there is anything to ship.
+    this.l2LastCollectTime = now;
+
+    if (agentRows.length === 0 && flusherRows.length === 0) return null;
+
+    return { agents: agentRows, flushers: flusherRows };
   }
 
-  collectL2Flushers(snapshot: DataflowSnapshot): FlusherMetrics[] {
-    const now = Math.floor(Date.now() / 1000);
-    const results: FlusherMetrics[] = [];
+  /**
+   * Several inputs belong to one agent (qoder alone owns sqlite/trace/cli-hook/
+   * cli-session), so counters are summed per agent. idle_minutes takes the
+   * freshest (smallest non-negative) of the agent's inputs: the agent is only
+   * as idle as its most recently active listener.
+   *
+   * An agent gets a row when it carried something in the window or when it is
+   * installed (at least one running input) — an all-zero row for an installed
+   * agent is the idle signal, not noise. Registered-but-never-started inputs
+   * (every build registers one per agent it knows about) stay unreported.
+   */
+  private collectAgentRows(snapshot: DataflowSnapshot, identity: L2Identity): AgentFlowMetrics[] {
+    const byAgent = new Map<string, { events: number; bytes: number; failed: number; idle: number; lastPoll: string; start: string }>();
 
-    for (const [epName, stats] of snapshot.flushers) {
-      results.push({
-        category: 'flusher',
-        label: {
-          flusher_name: stats.flusherName,
-          endpoint_name: stats.endpoint,
-          project: stats.project,
-          logstore: stats.logstore,
-          mode: stats.mode,
-        },
-        user_id: this.userId,
-        in_entries_total: String(stats.inEntries),
-        in_size_bytes: String(stats.inBytes),
-        out_entries_total: String(stats.outEntries),
-        out_failed_entries_total: String(stats.outFailed),
-        total_delay_ms: String(stats.totalDelayMs),
+    for (const [inputId, stats] of snapshot.inputs) {
+      // Drain per input, not per agent: an input registered mid-run (agent
+      // discovery) has no baseline yet and must contribute everything it holds.
+      // Drained unconditionally, before the traffic check — otherwise a stopped
+      // input's stale counts would resurface the next time it starts.
+      const base = this.l2InputBaseline.get(inputId) ?? zeroFlowTotals();
+      const flow = {
+        events: delta(stats.inEvents, base.inEvents),
+        bytes: delta(stats.inBytes, base.inBytes),
+        failed: delta(stats.outFailed, base.outFailed),
+      };
+      this.l2InputBaseline.set(inputId, {
+        inEvents: stats.inEvents,
+        inBytes: stats.inBytes,
+        outFailed: stats.outFailed,
+      });
+
+      // A running input reports every cycle, traffic or not: idle_minutes is a
+      // statement about silence, so the agent that has gone quiet — the one an
+      // idle alarm is about — must still produce a row. An input discovery
+      // stopped mid-window reports only what it collected while running, and a
+      // stopped-and-silent one drops out entirely (its agent is gone, not idle).
+      if (flow.events === 0 && flow.failed === 0 && !stats.running) continue;
+
+      const agent = agentKeyOf(inputId, stats);
+      let acc = byAgent.get(agent);
+      if (!acc) {
+        acc = { events: 0, bytes: 0, failed: 0, idle: -1, lastPoll: '', start: '' };
+        byAgent.set(agent, acc);
+      }
+      acc.events += flow.events;
+      acc.bytes += flow.bytes;
+      acc.failed += flow.failed;
+
+      // Folded from the former pilot_alarm_metric topic. -1 means never active.
+      const idle = snapshot.inputIdleMinutes.get(inputId) ?? -1;
+      if (idle >= 0 && (acc.idle < 0 || idle < acc.idle)) acc.idle = idle;
+      if (stats.lastPollTime > acc.lastPoll) acc.lastPoll = stats.lastPollTime;
+      if (!acc.start || (stats.startTime && stats.startTime < acc.start)) acc.start = stats.startTime;
+    }
+
+    const rows: AgentFlowMetrics[] = [];
+    for (const [agent, acc] of byAgent) {
+      rows.push({
+        type: 'agent',
+        ...identity,
+        agent,
+        in_events: String(acc.events),
+        in_bytes: String(acc.bytes),
+        failed_events: String(acc.failed),
+        idle_minutes: String(acc.idle),
+        last_poll_time: acc.lastPoll,
+        start_time: acc.start,
+      });
+    }
+    return rows;
+  }
+
+  /**
+   * One row per destination, drained against that destination's own baseline.
+   * Emitted whatever the traffic: destinations are configured, few, and a silent
+   * one is a finding — unlike a silent agent, whose absence is the normal case.
+   * last_flush_time / start_time stay as-is; they describe state, not the window.
+   */
+  private collectFlusherRows(snapshot: DataflowSnapshot, identity: L2Identity): FlusherFlowMetrics[] {
+    const rows: FlusherFlowMetrics[] = [];
+    for (const [id, stats] of snapshot.flushers) {
+      const base = this.l2FlusherBaseline.get(id) ?? zeroFlusherTotals();
+      rows.push({
+        type: 'flusher',
+        ...identity,
+        flusher: stats.kind,
+        project: stats.project,
+        logstore: stats.logstore,
+        mode: stats.mode,
+        bytes_basis: stats.bytesBasis,
+        in_entries: String(delta(stats.inEntries, base.inEntries)),
+        in_bytes: String(delta(stats.inBytes, base.inBytes)),
+        out_entries: String(delta(stats.outEntries, base.outEntries)),
+        out_bytes: String(delta(stats.outBytes, base.outBytes)),
+        failed_entries: String(delta(stats.outFailed, base.outFailed)),
+        total_delay_ms: String(delta(stats.totalDelayMs, base.totalDelayMs)),
         last_flush_time: stats.lastFlushTime,
         start_time: stats.startTime,
-        __time__: now,
+      });
+      this.l2FlusherBaseline.set(id, {
+        inEntries: stats.inEntries,
+        inBytes: stats.inBytes,
+        outEntries: stats.outEntries,
+        outBytes: stats.outBytes,
+        outFailed: stats.outFailed,
+        totalDelayMs: stats.totalDelayMs,
       });
     }
-    return results;
-  }
-
-  // Per-input health row. Global flusher stats (outFailed / latency) intentionally
-  // live in collectL2Flushers — emitting them here would smear a single failing
-  // endpoint across every input row and mislead downstream consumers.
-  collectL2Alarms(snapshot: DataflowSnapshot): AlarmMetrics[] {
-    const now = Math.floor(Date.now() / 1000);
-    const results: AlarmMetrics[] = [];
-
-    for (const [name, stats] of snapshot.inputs) {
-      const idleMinutes = snapshot.inputIdleMinutes.get(name) ?? -1;
-      results.push({
-        category: 'alarm',
-        input_name: name,
-        instance_id: this.instanceId,
-        source_ip: this.localIp,
-        user_id: this.userId,
-        succeed_events: String(stats.outEvents),
-        failed_events: String(stats.outFailed),
-        input_idle_minutes: String(idleMinutes),
-        __time__: now,
-      });
-    }
-    return results;
+    return rows;
   }
 
   private buildCaptureMessageDisabledAgents(): string {
@@ -353,7 +667,7 @@ export class MetricsCollector {
     return disabled.join(' ');
   }
 
-  private buildProject(): string {
+  private buildProjects(): string {
     const seen = new Set<string>();
     for (const ep of this.slsEndpoints) {
       if (ep.project) seen.add(ep.project);

--- a/src/metrics/metrics-writer.ts
+++ b/src/metrics/metrics-writer.ts
@@ -49,6 +49,7 @@ export class MetricsWriter {
   private readonly collector: MetricsCollector;
   private readonly getSnapshot: () => DataflowSnapshot;
   private readonly alarmManager: AlarmManager | null;
+  private l2WritePromise: Promise<void> | null = null;
   private l1Timer: ReturnType<typeof setInterval> | null = null;
   private l2Timer: ReturnType<typeof setInterval> | null = null;
   private alarmTimer: ReturnType<typeof setInterval> | null = null;
@@ -92,6 +93,9 @@ export class MetricsWriter {
     }
 
     await this.writeL1();
+    // Prime L2 too: without it a run shorter than L2_INTERVAL_MS reports a healthy
+    // heartbeat and no pipeline data at all.
+    void this.writeL2();
     logger.info('metrics-writer started');
   }
 
@@ -118,15 +122,18 @@ export class MetricsWriter {
     try {
       const snapshot = this.getSnapshot();
       const metrics = this.collector.collectL1(snapshot);
-      const filePath = path.join(this.logsDir, 'pilot-metrics.jsonl');
-      await appendLine(filePath, JSON.stringify(metrics));
 
       this.checkThresholds(metrics);
       this.checkUserId();
       this.checkStartupMode(metrics);
       this.checkInfraHealth();
+      // Report before the local append: collectL1 already drained its counters, so
+      // a failing disk write must not be what costs us the window.
       sendStatus('pilot_status', flattenToStrings(metrics));
       sendRunningStatus(flattenToStrings(metrics));
+
+      const filePath = path.join(this.logsDir, 'pilot-metrics.jsonl');
+      await appendLine(filePath, JSON.stringify(metrics));
     } catch (err) {
       logger.warn('L1 metrics write failed', { error: String(err) });
     }
@@ -325,40 +332,41 @@ export class MetricsWriter {
     }
   }
 
-  private async writeL2(): Promise<void> {
+  /**
+   * Collapses overlapping cycles into the in-flight one. collectL2 drains its
+   * counters, so two concurrent collects would split one window across two sets
+   * of rows — which is exactly what the priming write in start() would do
+   * against the first timer tick or the final flush in stop().
+   */
+  private writeL2(): Promise<void> {
+    if (this.l2WritePromise) return this.l2WritePromise;
+
+    this.l2WritePromise = this.collectAndWriteL2()
+      .finally(() => {
+        this.l2WritePromise = null;
+      });
+    return this.l2WritePromise;
+  }
+
+  private async collectAndWriteL2(): Promise<void> {
     try {
       const snapshot = this.getSnapshot();
 
-      const inputMetrics = this.collector.collectL2Inputs(snapshot);
-      if (inputMetrics.length > 0) {
-        const inputPath = path.join(this.logsDir, 'pilot-input-metrics.jsonl');
-        for (const m of inputMetrics) {
-          await appendLine(inputPath, JSON.stringify(m));
-        }
-        for (const m of inputMetrics) {
-          sendStatus('pilot_input_detail', flattenToStrings(m));
-        }
-      }
+      // One cycle, two row types on the same topic: a row per agent that carried
+      // data, a row per write destination. They share one window and one drain, so
+      // they must ship together — telling them apart is what `type` is for.
+      const l2 = this.collector.collectL2(snapshot);
+      if (l2) {
+        // Same as L1: the collect drained the counters, so send first and let the
+        // local mirror be the thing that can fail.
+        for (const row of l2.agents) sendStatus('pilot_pipeline', flattenToStrings(row));
+        for (const row of l2.flushers) sendStatus('pilot_pipeline', flattenToStrings(row));
 
-      const flusherMetrics = this.collector.collectL2Flushers(snapshot);
-      if (flusherMetrics.length > 0) {
-        const flusherPath = path.join(this.logsDir, 'pilot-flusher-metrics.jsonl');
-        for (const m of flusherMetrics) {
-          await appendLine(flusherPath, JSON.stringify(m));
+        for (const row of l2.agents) {
+          await appendLine(path.join(this.logsDir, 'pilot-agent-metrics.jsonl'), JSON.stringify(row));
         }
-        for (const m of flusherMetrics) {
-          sendStatus('pilot_flusher_detail', flattenToStrings(m));
-        }
-      }
-
-      const alarmMetrics = this.collector.collectL2Alarms(snapshot);
-      if (alarmMetrics.length > 0) {
-        const alarmPath = path.join(this.logsDir, 'pilot-alarm-metrics.jsonl');
-        for (const m of alarmMetrics) {
-          await appendLine(alarmPath, JSON.stringify(m));
-        }
-        for (const m of alarmMetrics) {
-          sendStatus('pilot_alarm_metric', flattenToStrings(m));
+        for (const row of l2.flushers) {
+          await appendLine(path.join(this.logsDir, 'pilot-flusher-metrics.jsonl'), JSON.stringify(row));
         }
       }
     } catch (err) {

--- a/src/updater/updater-metrics.ts
+++ b/src/updater/updater-metrics.ts
@@ -157,9 +157,10 @@ export class UpdaterMetrics {
       } catch (err) {
         logger.warn('updater event write failed', { error: String(err) });
       }
-      for (const ev of events) {
-        sendStatus('pilot_updater_event', flattenToStrings(ev));
-      }
+      // Updater events are not sent to loongsuite_status — they live only in this
+      // local JSONL. Update failures are surfaced independently via alarms below,
+      // and updater liveness/version state is covered by the collector heartbeat's
+      // infra-health fields (updater_pid_alive / current_version_valid / etc.).
     }
 
     if (alarms.length > 0) {

--- a/tests/unit/core/input-manager.test.ts
+++ b/tests/unit/core/input-manager.test.ts
@@ -519,6 +519,19 @@ describe('InputManager', () => {
     });
   });
 
+  describe('counter identity', () => {
+    it('records the collection method and the owning agent separately', () => {
+      // Reporting rolls ingress up by agent, so the counter has to carry the agent
+      // the input collects for. Without it the only label left is the collection
+      // method, and every unmapped input of one method collapses into one row.
+      manager.registerInput(new StubInput('qoder-ide') as any);
+
+      const counter = manager.getInputCounters().get('qoder-ide')!;
+      expect(counter.type).toBe(CollectionMethod.IdeSnapshotPolling);
+      expect(counter.agentType).toBe(ClientType.Qoder);
+    });
+  });
+
   describe('registerInput deduplication (T032)', () => {
     it('ignores duplicate registration for same id', () => {
       const input1 = new StubInput('dup-id');

--- a/tests/unit/flushers/otlp-trace-flusher/endpoint-counters.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/endpoint-counters.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@loongsuite/otel-util-genai', () => ({
+  convertEventLogToTrace: vi.fn(() => ({ traceIds: [], spanCount: 0, warnings: [] })),
+  ExtendedTelemetryHandler: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock('@opentelemetry/exporter-trace-otlp-proto', () => ({
+  OTLPTraceExporter: vi.fn().mockImplementation(() => ({
+    export: vi.fn((_s: unknown, cb: (r: { code: number }) => void) => cb({ code: 0 })),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+import { OtlpTraceFlusher } from '../../../../src/flushers/otlp-trace-flusher.js';
+
+const CMS_ENDPOINT =
+  'https://proj-xtrace-1d3dc285e44fcb12fa8cbcb1dd13551-cn-hongkong.cn-hongkong.log.aliyuncs.com/apm/trace/opentelemetry';
+
+function counters(endpoints: Array<{ name: string; endpoint: string; headers?: Record<string, string> }>) {
+  const flusher = new OtlpTraceFlusher({
+    enabled: true,
+    endpoints,
+    protocol: 'http/protobuf',
+    serviceName: 'test',
+  });
+  return flusher.getEndpointCounters();
+}
+
+describe('OtlpTraceFlusher - endpoint counter identity', () => {
+  it('reports an ARMS destination on the same project/logstore axis as SLS', () => {
+    // x-arms-project is what config-loader already derived from the endpoint host;
+    // the counter must reuse it rather than parse the URL a second time.
+    const counter = counters([{
+      name: 'user-cms',
+      endpoint: CMS_ENDPOINT,
+      headers: {
+        'x-arms-license-key': 'lk',
+        'x-arms-project': 'proj-xtrace-1d3dc285e44fcb12fa8cbcb1dd13551-cn-hongkong',
+      },
+    }]).get('user-cms')!;
+
+    expect(counter.isCms).toBe(true);
+    expect(counter.project).toBe('proj-xtrace-1d3dc285e44fcb12fa8cbcb1dd13551-cn-hongkong');
+    expect(counter.logstore).toBe('logstore-tracing');
+  });
+
+  it('falls back to the endpoint host when only the workspace header marks it as CMS', () => {
+    const counter = counters([{
+      name: 'inner-cms-0',
+      endpoint: CMS_ENDPOINT,
+      headers: { 'X-CMS-Workspace': 'ws-1' },
+    }]).get('inner-cms-0')!;
+
+    expect(counter.isCms).toBe(true);
+    expect(counter.project).toBe('proj-xtrace-1d3dc285e44fcb12fa8cbcb1dd13551-cn-hongkong');
+    expect(counter.logstore).toBe('logstore-tracing');
+  });
+
+  it('leaves project/logstore empty for a plain OTLP backend', () => {
+    // Not our storage to name: a generic collector has no SLS project behind it.
+    const counter = counters([{
+      name: 'user-otlp',
+      endpoint: 'https://collector.example.com/v1/traces',
+      headers: { authorization: 'Bearer t' },
+    }]).get('user-otlp')!;
+
+    expect(counter.isCms).toBe(false);
+    expect(counter.project).toBe('');
+    expect(counter.logstore).toBe('');
+  });
+});

--- a/tests/unit/flushers/sls-flusher.test.ts
+++ b/tests/unit/flushers/sls-flusher.test.ts
@@ -236,6 +236,35 @@ describe('SlsFlusher', () => {
     });
   });
 
+  describe('endpoint counters follow the flush outcome', () => {
+    it('counts a written batch as bytes out', async () => {
+      await flusher.send(buildTestEntry());
+      await flusher.send(buildTestEntry());
+      await flusher.flush();
+
+      const counter = flusher.getEndpointCounters().get('activity')!;
+      expect(counter.outEntries).toBe(2);
+      expect(counter.outBytes).toBeGreaterThan(0);
+      expect(counter.outFailed).toBe(0);
+    });
+
+    it('bills a failed batch as failed, not as bytes out', async () => {
+      // The send path persists and returns normally, so only the outcome tells the
+      // counters this batch never landed. Non-retryable, so no backoff to advance.
+      mockPostLogStoreLogs.mockRejectedValue(new Error('invalid request'));
+
+      await flusher.send(buildTestEntry());
+      await flusher.send(buildTestEntry());
+      await flusher.flush();
+
+      const counter = flusher.getEndpointCounters().get('activity')!;
+      expect(counter.outEntries).toBe(0);
+      expect(counter.outBytes).toBe(0);
+      expect(counter.outFailed).toBe(2);
+      expect(counter.lastFlushTime).toBe('');
+    });
+  });
+
   describe('shutdown (T016)', () => {
     it('stops timer and executes final flush', async () => {
       await flusher.start();

--- a/tests/unit/metrics/metrics-collector.test.ts
+++ b/tests/unit/metrics/metrics-collector.test.ts
@@ -50,16 +50,31 @@ vi.mock('node:child_process', async (importOriginal) => {
   };
 });
 
+/** Inputs are a collection detail; what the tests care about is the owning agent. */
+function inputEntry(agent: string, overrides: Record<string, any> = {}): any {
+  return {
+    inEvents: 0, inBytes: 0, outFailed: 0,
+    lastPollTime: '', startTime: '', type: 'polling', agent,
+    running: true, ...overrides,
+  };
+}
+
+/** Egress is measured where the writes happen: one entry per destination. */
+function flusherEntry(kind: string, overrides: Record<string, any> = {}): any {
+  return {
+    kind, project: '', logstore: '', mode: '',
+    // SLS counts the bytes it serializes; the OTLP families can only estimate.
+    bytesBasis: kind === 'sls' ? 'measured' : 'estimated',
+    inEntries: 0, inBytes: 0, outEntries: 0, outBytes: 0, outFailed: 0,
+    totalDelayMs: 0, lastFlushTime: '', startTime: '',
+    ...overrides,
+  };
+}
+
 function buildSnapshot(overrides: Partial<DataflowSnapshot> = {}): DataflowSnapshot {
   return {
-    sendEntriesTotal: 0,
-    receivedBytesTotal: 0,
-    inputCount: 0,
-    activeInputCount: 0,
-    flusherRunner: {
-      inEntries: 0, inBytes: 0, outEntries: 0, outFailed: 0,
-      totalDelayMs: 0, lastFlushTime: '', startTime: '',
-    },
+    inEventsTotal: 0,
+    inBytesTotal: 0,
     inputs: new Map(),
     flushers: new Map(),
     inputIdleMinutes: new Map(),
@@ -83,14 +98,23 @@ describe('MetricsCollector', () => {
   describe('collectL1', () => {
     it('returns all required fields with correct types', () => {
       const snapshot = buildSnapshot({
-        sendEntriesTotal: 100,
-        receivedBytesTotal: 5000,
-        inputCount: 3,
-        activeInputCount: 2,
-        flusherRunner: {
-          inEntries: 80, inBytes: 4000, outEntries: 75, outFailed: 5,
-          totalDelayMs: 1200, lastFlushTime: '2026-05-19 10:00:00', startTime: '2026-05-19 09:00:00',
-        },
+        inEventsTotal: 110,
+        inBytesTotal: 5000,
+        // Egress is the flusher side, summed over every destination the data was
+        // written to: 70+30 entries and 3000+1800 bytes.
+        flushers: new Map<string, any>([
+          ['sls:main', flusherEntry('sls', { outEntries: 70, outBytes: 3000 })],
+          ['cms:arms', flusherEntry('cms', { outEntries: 30, outBytes: 1800 })],
+        ]),
+        // qoder owns two inputs, cursor one, and kiro-cli is registered but never
+        // started — so the agent dimension reads 2 installed, 1 of them collecting.
+        inputs: new Map<string, any>([
+          ['qoder-sqlite', inputEntry('qoder')],
+          ['qoder-trace', inputEntry('qoder')],
+          ['cursor-hook', inputEntry('cursor')],
+          ['kiro-cli', inputEntry('kiro-cli', { running: false })],
+        ]),
+        inputIdleMinutes: new Map([['qoder-sqlite', 4]]),
       });
 
       const result = collector.collectL1(snapshot);
@@ -102,8 +126,15 @@ describe('MetricsCollector', () => {
       expect(result.os_detail).toContain(require('os').type());
       expect(result.os_detail).toContain(require('os').arch());
 
-      // instance_id format: userId_ip_timestamp
-      expect(result.instance_id).toMatch(/^test-user_.+_\d+$/);
+      // instance_id: hostname_userid_<base64url(dataDir)> (no timestamp, restart-invariant)
+      const dirEnc = Buffer.from(tmpDir, 'utf8').toString('base64url');
+      expect(result.instance_id).toBe(`${require('os').hostname()}_test-user_${dirEnc}`);
+      // dataDir is encoded, not plaintext, but reversible
+      expect(result.instance_id).not.toContain(tmpDir);
+      expect(Buffer.from(dirEnc, 'base64url').toString('utf8')).toBe(tmpDir);
+      // run_id: instance_id plus the startTimestamp incarnation suffix
+      expect(result.run_id.startsWith(result.instance_id + '_')).toBe(true);
+      expect(result.run_id).toMatch(/_\d+$/);
 
       // Numeric fields stored as strings
       expect(typeof result.cpu).toBe('string');
@@ -111,53 +142,119 @@ describe('MetricsCollector', () => {
       expect(typeof result.mem_heap).toBe('string');
       expect(Number(result.mem)).toBeGreaterThan(0);
 
-      // metric_json fields
-      expect(result.metric_json.input_count).toBe('3');
-      expect(result.metric_json.active_input_count).toBe('2');
-      expect(result.metric_json.send_entries_total).toBe('100');
-      expect(result.metric_json.received_bytes_total).toBe('5000');
+      // metric_json fields — agent-dimensioned, inputs never surface
+      expect(result.metric_json.agent_count).toBe('2');
+      expect(result.metric_json.active_agent_count).toBe('1');
+      expect((result.metric_json as Record<string, unknown>).input_count).toBeUndefined();
+      expect((result.metric_json as Record<string, unknown>).active_input_count).toBeUndefined();
+      // First row's window opens at process start, so the deltas equal the totals.
+      expect(result.metric_json.in_events).toBe('110');
+      expect(result.metric_json.in_bytes).toBe('5000');
+      // Instance egress: what was written to the backends, not what the inputs
+      // handed to the fan-out.
+      expect(result.metric_json.out_events).toBe('100');
+      expect(result.metric_json.out_bytes).toBe('4800');
+      expect(typeof result.metric_json.window_ms).toBe('string');
       expect(typeof result.metric_json.open_fd).toBe('string');
 
-      // flusher_runner
-      expect(result.flusher_runner.in_entries_total).toBe('80');
-      expect(result.flusher_runner.in_bytes_total).toBe('4000');
-      expect(result.flusher_runner.out_entries_total).toBe('75');
-      expect(result.flusher_runner.out_failed_entries_total).toBe('5');
-      expect(result.flusher_runner.last_flush_time).toBe('2026-05-19 10:00:00');
+      // flusher_runner is removed — per-flusher detail lives in pilot_pipeline now
+      expect((result as Record<string, unknown>).flusher_runner).toBeUndefined();
+
+      // updater events are NOT in status telemetry (local JSONL + alarms only)
+      expect((result as Record<string, unknown>).updater_event).toBeUndefined();
 
       // __time__ is unix timestamp
       expect(result.__time__).toBeGreaterThan(1700000000);
+    });
+
+    it('counts installed agents, and an agent stays installed while idle', () => {
+      const result = collector.collectL1(buildSnapshot({
+        inputs: new Map<string, any>([
+          ['qoder-sqlite', inputEntry('qoder')],
+          ['codex-jsonl', inputEntry('codex')],
+          // Registered for an agent this host does not have: never started.
+          ['wukong-hook', inputEntry('wukong', { running: false })],
+        ]),
+        // Only qoder has ever collected; codex is installed but has produced nothing.
+        inputIdleMinutes: new Map([['qoder-sqlite', 120], ['codex-jsonl', -1]]),
+      }));
+
+      expect(result.metric_json.agent_count).toBe('2');
+      expect(result.metric_json.active_agent_count).toBe('1');
     });
 
     it('reports zero rates on the first sample (seeds baseline)', () => {
       // Even when the first snapshot already shows nonzero totals, the
       // collector must not divide them by a near-zero elapsed window.
       const result = collector.collectL1(buildSnapshot({
-        sendEntriesTotal: 1234,
-        receivedBytesTotal: 99999,
+        inEventsTotal: 1234,
+        inBytesTotal: 99999,
+        flushers: new Map<string, any>([['sls:main', flusherEntry('sls', { outEntries: 1200, outBytes: 88888 })]]),
       }));
-      expect(result.metric_json.send_entries_ps).toBe('0.0');
-      expect(result.metric_json.received_bytes_ps).toBe('0.0');
+      expect(result.metric_json.in_events_ps).toBe('0.0');
+      expect(result.metric_json.in_bytes_ps).toBe('0.0');
+      expect(result.metric_json.out_events_ps).toBe('0.0');
+      expect(result.metric_json.out_bytes_ps).toBe('0.0');
     });
 
     it('calculates per-second rates from deltas after the first sample', async () => {
       // First call seeds baseline
-      collector.collectL1(buildSnapshot({ sendEntriesTotal: 0, receivedBytesTotal: 0 }));
+      collector.collectL1(buildSnapshot({
+        inEventsTotal: 0, inBytesTotal: 0,
+        flushers: new Map<string, any>([['sls:main', flusherEntry('sls')]]),
+      }));
 
       // Wait a tick so elapsed > 0
       await new Promise(r => setTimeout(r, 50));
 
       const result = collector.collectL1(buildSnapshot({
-        sendEntriesTotal: 60,
-        receivedBytesTotal: 3000,
+        inEventsTotal: 70,
+        inBytesTotal: 3000,
+        flushers: new Map<string, any>([['sls:main', flusherEntry('sls', { outEntries: 60, outBytes: 2800 })]]),
       }));
 
-      const entriesPs = parseFloat(result.metric_json.send_entries_ps);
-      const bytesPs = parseFloat(result.metric_json.received_bytes_ps);
+      // Rates should be positive (delta / elapsed) across all four dimensions
+      expect(parseFloat(result.metric_json.in_events_ps)).toBeGreaterThan(0);
+      expect(parseFloat(result.metric_json.in_bytes_ps)).toBeGreaterThan(0);
+      expect(parseFloat(result.metric_json.out_events_ps)).toBeGreaterThan(0);
+      expect(parseFloat(result.metric_json.out_bytes_ps)).toBeGreaterThan(0);
+    });
 
-      // Rates should be positive (delta / elapsed)
-      expect(entriesPs).toBeGreaterThan(0);
-      expect(bytesPs).toBeGreaterThan(0);
+    it('drains flow values on report, so an idle window reads zero', () => {
+      const snapshot = buildSnapshot({
+        inEventsTotal: 110, inBytesTotal: 5000,
+        flushers: new Map<string, any>([['sls:main', flusherEntry('sls', { outEntries: 100, outBytes: 4800 })]]),
+      });
+
+      const first = collector.collectL1(snapshot);
+      expect(first.metric_json.in_events).toBe('110');
+      expect(first.metric_json.out_bytes).toBe('4800');
+
+      // Same cumulative totals means nothing flowed since the previous row.
+      const second = collector.collectL1(snapshot);
+      expect(second.metric_json.in_events).toBe('0');
+      expect(second.metric_json.in_bytes).toBe('0');
+      expect(second.metric_json.out_events).toBe('0');
+      expect(second.metric_json.out_bytes).toBe('0');
+
+      // Only the increment shows up in the next row, never the running total.
+      const third = collector.collectL1(buildSnapshot({
+        inEventsTotal: 135, inBytesTotal: 5600,
+        flushers: new Map<string, any>([['sls:main', flusherEntry('sls', { outEntries: 130, outBytes: 5400 })]]),
+      }));
+      expect(third.metric_json.in_events).toBe('25');
+      expect(third.metric_json.in_bytes).toBe('600');
+      expect(third.metric_json.out_events).toBe('30');
+      expect(third.metric_json.out_bytes).toBe('600');
+    });
+
+    it('clamps at zero when a counter goes backwards', () => {
+      collector.collectL1(buildSnapshot({ inEventsTotal: 100, inBytesTotal: 4000 }));
+      // Source counters are monotonic in practice; a regression here would
+      // otherwise report a large negative window.
+      const result = collector.collectL1(buildSnapshot({ inEventsTotal: 10, inBytesTotal: 400 }));
+      expect(result.metric_json.in_events).toBe('0');
+      expect(result.metric_json.in_bytes).toBe('0');
     });
 
     it('start_time remains constant across calls', () => {
@@ -172,74 +269,258 @@ describe('MetricsCollector', () => {
     });
   });
 
-  describe('collectL2Inputs', () => {
-    it('returns one InputMetrics per input in snapshot', () => {
+  describe('collectL2', () => {
+    function pipelineSnapshot(): DataflowSnapshot {
       const inputs = new Map<string, any>();
-      inputs.set('qoder-sqlite', {
-        inEvents: 42, inBytes: 1024, outEvents: 40, outFailed: 2,
+      // Two inputs owned by the same agent — they must roll up into one entry.
+      inputs.set('qoder-sqlite', inputEntry('qoder', {
+        inEvents: 42, inBytes: 1024, outFailed: 2,
         lastPollTime: '2026-05-19 10:01:00', startTime: '2026-05-19 09:00:00',
-        type: 'polling',
-      });
-      inputs.set('cursor-hook', {
-        inEvents: 10, inBytes: 500, outEvents: 10, outFailed: 0,
+      }));
+      inputs.set('qoder-trace', inputEntry('qoder', {
+        inEvents: 8, inBytes: 256, outFailed: 0,
+        lastPollTime: '2026-05-19 10:03:00', startTime: '2026-05-19 08:30:00',
+        type: 'trace',
+      }));
+      inputs.set('cursor-hook', inputEntry('cursor', {
+        inEvents: 10, inBytes: 500, outFailed: 0,
         lastPollTime: '2026-05-19 10:02:00', startTime: '2026-05-19 09:30:00',
         type: 'hook',
-      });
+      }));
+      const inputIdleMinutes = new Map([['qoder-sqlite', 3], ['qoder-trace', 7]]);
 
-      const result = collector.collectL2Inputs(buildSnapshot({ inputs }));
-
-      expect(result).toHaveLength(2);
-
-      const qoder = result.find(r => r.label.input_name === 'qoder-sqlite')!;
-      expect(qoder.category).toBe('input');
-      expect(qoder.label.input_type).toBe('polling');
-      expect(qoder.in_events_total).toBe('42');
-      expect(qoder.in_size_bytes).toBe('1024');
-      expect(qoder.out_events_total).toBe('40');
-      expect(qoder.out_failed_events_total).toBe('2');
-      expect(qoder.last_poll_time).toBe('2026-05-19 10:01:00');
-      expect(qoder.start_time).toBe('2026-05-19 09:00:00');
-      expect(qoder.__time__).toBeGreaterThan(0);
-    });
-
-    it('returns empty array when no inputs', () => {
-      const result = collector.collectL2Inputs(buildSnapshot());
-      expect(result).toEqual([]);
-    });
-  });
-
-  describe('collectL2Flushers', () => {
-    it('returns one FlusherMetrics per endpoint in snapshot', () => {
       const flushers = new Map<string, any>();
-      flushers.set('internal-default', {
-        inEntries: 200, inBytes: 50000, outEntries: 195, outFailed: 5,
+      flushers.set('sls:main', flusherEntry('sls', {
+        project: 'proj-a', logstore: 'store-a', mode: 'sls',
+        inEntries: 200, inBytes: 50000, outEntries: 195, outBytes: 48000, outFailed: 5,
         totalDelayMs: 3500, lastFlushTime: '2026-05-19 10:05:00',
-        startTime: '2026-05-19 09:00:00', flusherName: 'sls', mode: 'webtracking',
-        endpoint: 'https://cn-heyuan.log.aliyuncs.com', project: 'my-project', logstore: 'my-logstore',
+        startTime: '2026-05-19 09:00:00',
+      }));
+      flushers.set('cms:arms', flusherEntry('cms', {
+        inEntries: 60, inBytes: 9000, outEntries: 60, outBytes: 8800,
+        totalDelayMs: 900, lastFlushTime: '2026-05-19 10:06:00',
+        startTime: '2026-05-19 09:10:00',
+      }));
+
+      return buildSnapshot({
+        inputs, inputIdleMinutes, flushers,
+        inEventsTotal: 60, inBytesTotal: 1780,
       });
+    }
 
-      const result = collector.collectL2Flushers(buildSnapshot({ flushers }));
+    function agentRow(rows: any[], agent: string): any {
+      return rows.find(r => r.agent === agent);
+    }
 
-      expect(result).toHaveLength(1);
-      const ep = result[0];
-      expect(ep.category).toBe('flusher');
-      expect(ep.label.flusher_name).toBe('sls');
-      expect(ep.label.endpoint_name).toBe('https://cn-heyuan.log.aliyuncs.com');
-      expect(ep.label.project).toBe('my-project');
-      expect(ep.label.logstore).toBe('my-logstore');
-      expect(ep.label.mode).toBe('webtracking');
-      expect(ep.in_entries_total).toBe('200');
-      expect(ep.in_size_bytes).toBe('50000');
-      expect(ep.out_entries_total).toBe('195');
-      expect(ep.out_failed_entries_total).toBe('5');
-      expect(ep.total_delay_ms).toBe('3500');
-      expect(ep.last_flush_time).toBe('2026-05-19 10:05:00');
-      expect(ep.start_time).toBe('2026-05-19 09:00:00');
+    it('emits only detail rows — no instance-total row', () => {
+      const l2 = collector.collectL2(pipelineSnapshot())!;
+
+      // The total would be the exact sum of these rows over one window, and L1
+      // already reports the same four axes plus agent_count for the instance.
+      // Emitting it a third time is three chances for the numbers to disagree.
+      expect(Object.keys(l2).sort()).toEqual(['agents', 'flushers']);
+      expect([...l2.agents, ...l2.flushers].map(r => r.type).includes('pipeline' as never)).toBe(false);
+
+      // What the dropped row said is still recoverable by summing the detail.
+      const sum = (rows: any[], field: string): number =>
+        rows.reduce((acc, r) => acc + Number(r[field]), 0);
+      expect(sum(l2.agents, 'in_events')).toBe(60);
+      expect(sum(l2.agents, 'in_bytes')).toBe(1780);
+      expect(sum(l2.flushers, 'out_entries')).toBe(255);
+      expect(sum(l2.flushers, 'out_bytes')).toBe(56800);
     });
 
-    it('returns empty array when no flushers', () => {
-      const result = collector.collectL2Flushers(buildSnapshot());
-      expect(result).toEqual([]);
+    it('repeats the full identity on every row', () => {
+      const { agents, flushers } = collector.collectL2(pipelineSnapshot())!;
+      // Same values L1 reports — the two levels must not disagree about the host.
+      const l1 = collector.collectL1(buildSnapshot());
+
+      // Identity is repeated on every row so each type can be queried on its own,
+      // with no join to another row (or to L1) needed to learn the host.
+      for (const row of [...agents, ...flushers]) {
+        expect(row.hostname).toBe(require('os').hostname());
+        expect(row.hostname).toBe(l1.hostname);
+        expect(row.ip).toBe(l1.ip);
+        expect(row.instance_id).toBe(`${require('os').hostname()}_test-user_${Buffer.from(tmpDir, 'utf8').toString('base64url')}`);
+        expect(row.run_id).toMatch(/_\d+$/);
+        expect(row.user_id).toBe(l1.user_id);
+        expect(Number(row.window_ms)).toBeGreaterThanOrEqual(0);
+        expect(row.__time__).toBeGreaterThan(0);
+      }
+      // One window per cycle: every row of the cycle must carry the same one.
+      const windows = new Set([...agents, ...flushers].map(r => r.window_ms));
+      expect(windows.size).toBe(1);
+    });
+
+    it('rolls ingress up by owning agent, one row each', () => {
+      const { agents } = collector.collectL2(pipelineSnapshot())!;
+
+      expect(agents.map(r => r.agent).sort()).toEqual(['cursor', 'qoder']);
+      expect(agents.every(r => r.type === 'agent')).toBe(true);
+
+      const qoder = agentRow(agents, 'qoder');
+      expect(qoder.in_events).toBe('50');
+      expect(qoder.in_bytes).toBe('1280');
+      // Ingress only: egress cannot be attributed to an agent, it lives per flusher.
+      expect(qoder.out_events).toBeUndefined();
+      expect(qoder.out_bytes).toBeUndefined();
+      expect(qoder.failed_events).toBe('2');
+      // Most-recent poll and earliest start win across the agent's inputs.
+      expect(qoder.last_poll_time).toBe('2026-05-19 10:03:00');
+      expect(qoder.start_time).toBe('2026-05-19 08:30:00');
+      // idle_minutes folded in from the former pilot_alarm_metric topic; smallest wins.
+      expect(qoder.idle_minutes).toBe('3');
+      // Never active: -1 rather than a misleading 0.
+      expect(agentRow(agents, 'cursor').idle_minutes).toBe('-1');
+    });
+
+    it('reports one flusher row per destination, with its own identity', () => {
+      const { flushers } = collector.collectL2(pipelineSnapshot())!;
+
+      // One row per destination, told apart by family + project/logstore. The
+      // process-local config alias ('main', 'arms') is a map key only, never a field.
+      expect(flushers.map(r => r.flusher).sort()).toEqual(['cms', 'sls']);
+      expect(flushers.every(r => !('endpoint' in r))).toBe(true);
+
+      const sls = flushers.find(r => r.flusher === 'sls')!;
+      // project / logstore ride along: billing has to attribute bytes to them.
+      expect(sls.type).toBe('flusher');
+      expect(sls.project).toBe('proj-a');
+      expect(sls.logstore).toBe('store-a');
+      expect(sls.mode).toBe('sls');
+      expect(sls.in_entries).toBe('200');
+      expect(sls.in_bytes).toBe('50000');
+      expect(sls.out_entries).toBe('195');
+      expect(sls.out_bytes).toBe('48000');
+      expect(sls.failed_entries).toBe('5');
+      expect(sls.total_delay_ms).toBe('3500');
+      expect(sls.last_flush_time).toBe('2026-05-19 10:05:00');
+      expect(sls.start_time).toBe('2026-05-19 09:00:00');
+
+      const cms = flushers.find(r => r.flusher === 'cms')!;
+      expect(cms.out_entries).toBe('60');
+      expect(cms.out_bytes).toBe('8800');
+      // Non-SLS destinations have no project/logstore to report.
+      expect(cms.project).toBe('');
+      expect(cms.logstore).toBe('');
+    });
+
+    it('keeps two logstores on one endpoint apart', () => {
+      const snapshot = pipelineSnapshot();
+      snapshot.flushers.set('sls:second', flusherEntry('sls', {
+        project: 'proj-a', logstore: 'store-b',
+        outEntries: 7, outBytes: 700,
+      }));
+
+      const { flushers } = collector.collectL2(snapshot)!;
+
+      expect(flushers.filter(r => r.flusher === 'sls').map(r => r.logstore).sort())
+        .toEqual(['store-a', 'store-b']);
+      // Every destination reports its own bytes: 195 + 60 + 7.
+      expect(flushers.reduce((acc, r) => acc + Number(r.out_entries), 0)).toBe(262);
+    });
+
+    it('drains ingress and egress on report', () => {
+      const snapshot = pipelineSnapshot();
+      collector.collectL2(snapshot);
+
+      // Second call over the same cumulative counters: nothing flowed since.
+      const second = collector.collectL2(snapshot)!;
+      // The installed agents still report — at zero flow, with idle_minutes intact.
+      // That row is the only way a consumer can see an agent has gone quiet.
+      expect(second.agents.map(r => r.agent).sort()).toEqual(['cursor', 'qoder']);
+      expect(second.agents.every(r => r.in_events === '0' && r.in_bytes === '0')).toBe(true);
+      expect(agentRow(second.agents, 'qoder').idle_minutes).toBe('3');
+      const sls = second.flushers.find(r => r.flusher === 'sls')!;
+      expect(sls.out_entries).toBe('0');
+      expect(sls.out_bytes).toBe('0');
+      expect(sls.total_delay_ms).toBe('0');
+      // Descriptors and state are not flow — they stay put.
+      expect(sls.project).toBe('proj-a');
+      expect(sls.last_flush_time).toBe('2026-05-19 10:05:00');
+    });
+
+    it('reports only the increment in the following window', () => {
+      collector.collectL2(pipelineSnapshot());
+
+      const next = pipelineSnapshot();
+      next.inputs.get('qoder-sqlite')!.inEvents = 50;
+      next.inputs.get('qoder-sqlite')!.outFailed = 3;
+      next.flushers.get('sls:main')!.outEntries = 200;
+      next.flushers.get('sls:main')!.outBytes = 49000;
+      const result = collector.collectL2(next)!;
+
+      // Only qoder moved; cursor is still installed, so it reports a zero row.
+      expect(result.agents.map(r => r.agent).sort()).toEqual(['cursor', 'qoder']);
+      expect(agentRow(result.agents, 'cursor').in_events).toBe('0');
+      expect(agentRow(result.agents, 'qoder').in_events).toBe('8');
+      expect(agentRow(result.agents, 'qoder').failed_events).toBe('1');
+      expect(result.flushers.find(r => r.flusher === 'sls')!.out_entries).toBe('5');
+      expect(result.flushers.find(r => r.flusher === 'sls')!.out_bytes).toBe('1000');
+      // A silent destination still reports, at zero.
+      expect(result.flushers.find(r => r.flusher === 'cms')!.out_entries).toBe('0');
+    });
+
+    it('counts an input registered mid-run in full, having no baseline yet', () => {
+      collector.collectL2(pipelineSnapshot());
+
+      const next = pipelineSnapshot();
+      next.inputs.set('codex-jsonl', inputEntry('codex', {
+        inEvents: 12, inBytes: 900, outFailed: 0,
+        lastPollTime: '2026-05-19 10:07:00', startTime: '2026-05-19 10:06:00',
+      }));
+      const result = collector.collectL2(next)!;
+
+      expect(agentRow(result.agents, 'codex').in_events).toBe('12');
+    });
+
+    it('keeps a silent running agent but drops one that is not installed', () => {
+      const snapshot = pipelineSnapshot();
+      // An input is registered for every agent the build knows about, but discovery
+      // only starts the ones actually found on the host. A never-started input is a
+      // missing agent, not an idle one, so it must not ship a row; a running input
+      // that carried nothing must, because that silence is what idle alarms read.
+      snapshot.inputs.set('wukong-hook', inputEntry('wukong', { running: false }));
+      snapshot.inputs.set('dsh-hook', inputEntry('dsh', { running: false }));
+      snapshot.inputs.set('idle-hook', inputEntry('idle-agent'));
+
+      const result = collector.collectL2(snapshot)!;
+
+      expect(result.agents.map(r => r.agent).sort()).toEqual(['cursor', 'idle-agent', 'qoder']);
+      const idle = agentRow(result.agents, 'idle-agent');
+      expect(idle.in_events).toBe('0');
+      expect(idle.in_bytes).toBe('0');
+      // How many are installed is L1's job, and it counts the silent-but-running one.
+      expect(collector.collectL1(snapshot).metric_json.agent_count).toBe('3');
+    });
+
+    it('keeps traffic an uninstalled agent collected before it stopped', () => {
+      const snapshot = pipelineSnapshot();
+      // Discovery stopped this input mid-window, but the events it collected while
+      // running still have to be reported or the chain totals lose them.
+      snapshot.inputs.set('kiro-cli', inputEntry('kiro-cli', {
+        inEvents: 5, inBytes: 300, running: false,
+      }));
+
+      const result = collector.collectL2(snapshot)!;
+
+      expect(agentRow(result.agents, 'kiro-cli').in_events).toBe('5');
+      expect(result.agents.reduce((acc, r) => acc + Number(r.in_events), 0)).toBe(65);
+      // It is no longer installed, so it is not counted as one.
+      expect(collector.collectL1(snapshot).metric_json.agent_count).toBe('2');
+    });
+
+    it('returns null when there are no inputs and no flushers', () => {
+      expect(collector.collectL2(buildSnapshot())).toBeNull();
+    });
+
+    it('still reports when only flushers are present', () => {
+      const flushers = new Map<string, any>([['sls:main', flusherEntry('sls', {
+        inEntries: 1, inBytes: 2, outEntries: 1, outBytes: 2, totalDelayMs: 5,
+      })]]);
+      const result = collector.collectL2(buildSnapshot({ flushers }))!;
+      expect(result.agents).toEqual([]);
+      expect(result.flushers[0].out_entries).toBe('1');
     });
   });
 
@@ -279,37 +560,6 @@ describe('MetricsCollector', () => {
 
       cpuSpy.mockRestore();
       dateSpy.mockRestore();
-    });
-  });
-
-  describe('collectL2Alarms', () => {
-    it('returns per-input alarm rows scoped to the input only', () => {
-      const inputs = new Map<string, any>();
-      inputs.set('cursor-hook', {
-        inEvents: 20, inBytes: 4096, outEvents: 18, outFailed: 2,
-        lastPollTime: '2026-05-19 10:00:00', startTime: '2026-05-19 09:00:00', type: 'hook-jsonl',
-      });
-      const inputIdleMinutes = new Map([['cursor-hook', 5]]);
-
-      const result = collector.collectL2Alarms(buildSnapshot({ inputs, inputIdleMinutes }));
-
-      expect(result).toHaveLength(1);
-      const m = result[0];
-      expect(m.category).toBe('alarm');
-      expect(m.input_name).toBe('cursor-hook');
-      expect(m.succeed_events).toBe('18');
-      expect(m.failed_events).toBe('2');
-      expect(m.input_idle_minutes).toBe('5');
-      expect(m.instance_id).toContain('test-user');
-      expect(m.__time__).toBeGreaterThan(0);
-      // Global flusher stats must NOT be smeared across per-input rows
-      // (they live in collectL2Flushers instead).
-      expect((m as Record<string, unknown>).flush_failed_total).toBeUndefined();
-      expect((m as Record<string, unknown>).flush_latency_avg_ms).toBeUndefined();
-    });
-
-    it('returns empty when no inputs', () => {
-      expect(collector.collectL2Alarms(buildSnapshot())).toEqual([]);
     });
   });
 
@@ -519,10 +769,10 @@ describe('MetricsCollector', () => {
     });
   });
 
-  describe('project', () => {
+  describe('projects', () => {
     it('returns empty string when no SLS endpoints', () => {
       const col = new MetricsCollector({ version: '1.0.0', userId: 'test-user', dataDir: tmpDir });
-      expect(col.collectL1(buildSnapshot()).project).toBe('');
+      expect(col.collectL1(buildSnapshot()).projects).toBe('');
     });
 
     it('joins unique projects with space in sorted order', () => {
@@ -536,7 +786,7 @@ describe('MetricsCollector', () => {
           { name: 'c', endpoint: 'https://x', project: 'aaa', logstore: 'l3', kind: 'agentActivity', mode: 'ak' },
         ],
       });
-      expect(col.collectL1(buildSnapshot()).project).toBe('aaa bbb');
+      expect(col.collectL1(buildSnapshot()).projects).toBe('aaa bbb');
     });
   });
 

--- a/tests/unit/metrics/metrics-writer.test.ts
+++ b/tests/unit/metrics/metrics-writer.test.ts
@@ -38,19 +38,13 @@ vi.mock('../../../src/internal/sender.js', () => ({
 
 function buildSnapshot(): DataflowSnapshot {
   return {
-    sendEntriesTotal: 10,
-    receivedBytesTotal: 2048,
-    inputCount: 2,
-    activeInputCount: 1,
-    flusherRunner: {
-      inEntries: 10, inBytes: 2048, outEntries: 9, outFailed: 1,
-      totalDelayMs: 500, lastFlushTime: '2026-05-19 10:00:00', startTime: '2026-05-19 09:00:00',
-    },
+    inEventsTotal: 12,
+    inBytesTotal: 2048,
     inputs: new Map([
-      ['test-input', { inEvents: 5, inBytes: 1024, outEvents: 5, outFailed: 0, lastPollTime: '2026-05-19 10:00:00', startTime: '2026-05-19 09:00:00', type: 'polling' }],
+      ['test-input', { inEvents: 5, inBytes: 1024, outFailed: 0, lastPollTime: '2026-05-19 10:00:00', startTime: '2026-05-19 09:00:00', type: 'polling', agent: 'test-agent', running: true }],
     ]),
     flushers: new Map([
-      ['test-ep', { inEntries: 10, inBytes: 2048, outEntries: 9, outFailed: 1, totalDelayMs: 500, lastFlushTime: '2026-05-19 10:00:00', startTime: '2026-05-19 09:00:00', flusherName: 'sls', mode: 'webtracking', endpoint: 'https://cn-heyuan.log.aliyuncs.com', project: 'test-project', logstore: 'test-logstore' }],
+      ['sls:main', { kind: 'sls' as const, project: 'proj-a', logstore: 'store-a', mode: 'sls', bytesBasis: 'measured' as const, inEntries: 10, inBytes: 2048, outEntries: 9, outBytes: 1900, outFailed: 1, totalDelayMs: 500, lastFlushTime: '2026-05-19 10:00:00', startTime: '2026-05-19 09:00:00' }],
     ]),
     inputIdleMinutes: new Map(),
   };
@@ -117,7 +111,7 @@ describe('MetricsWriter', () => {
     const entry = JSON.parse(lines[0]);
     expect(entry.version).toBe('2.0.0');
     expect(entry.user_id).toBe('u1');
-    expect(entry.metric_json.input_count).toBe('2');
+    expect(entry.metric_json.agent_count).toBe('1');
   });
 
   it('calls sendStatus with pilot_status topic on L1 write', async () => {
@@ -139,9 +133,77 @@ describe('MetricsWriter', () => {
     expect(call).toBeDefined();
     expect(call![1]).toHaveProperty('version', '2.0.0');
     expect(call![1]).not.toHaveProperty('__topic__');
+
+    // Old L2 topics must no longer be emitted (merged into pilot_pipeline)
+    const legacy = mockSendStatus.mock.calls.filter((c: unknown[]) =>
+      ['pilot_input_detail', 'pilot_flusher_detail', 'pilot_alarm_metric'].includes(c[0] as string),
+    );
+    expect(legacy).toHaveLength(0);
   });
 
-  it('writes L2 input/flusher metrics on stop (final flush)', async () => {
+  it('sends one row per agent and per destination on L2 flush', async () => {
+    writer = new MetricsWriter({
+      dataDir: tmpDir,
+      version: '2.0.0',
+      userId: 'u1',
+      getSnapshot: buildSnapshot,
+    });
+
+    vi.useRealTimers();
+    // Flush explicitly rather than leaning on start()'s priming flush: an
+    // overlapping prime coalesces into the same in-flight write, which would
+    // make a call count assertion race.
+    await (writer as any).writeL2();
+
+    // Both row types share the pilot_pipeline topic and are told apart by
+    // `type`; the snapshot has one agent with traffic and one destination.
+    const rows = mockSendStatus.mock.calls
+      .filter((c: unknown[]) => c[0] === 'pilot_pipeline')
+      .map((c: unknown[]) => c[1] as Record<string, string>);
+    expect(rows.map(r => r.type)).toEqual(['agent', 'flusher']);
+
+    const [agent, flusher] = rows;
+    // Host identity ships with every flow row, so grouping by machine needs no
+    // join back to pilot_status.
+    expect(agent.hostname).toBe(os.hostname());
+    expect(agent.ip).toBeDefined();
+    expect(flusher.hostname).toBe(os.hostname());
+
+    // Flat string fields throughout: nothing needs json_extract to be queried.
+    expect(agent.agent).toBe('test-agent');
+    expect(agent.in_events).toBe('5');
+    expect(flusher.flusher).toBe('sls');
+    expect(flusher.project).toBe('proj-a');
+    expect(flusher.logstore).toBe('store-a');
+    expect(flusher.out_entries).toBe('9');
+  });
+
+  it('drains the rows, so an unchanged snapshot reports zeros', async () => {
+    writer = new MetricsWriter({
+      dataDir: tmpDir,
+      version: '2.0.0',
+      userId: 'u1',
+      getSnapshot: buildSnapshot,
+    });
+
+    vi.useRealTimers();
+    await (writer as any).writeL2();
+    mockSendStatus.mockClear();
+    await (writer as any).writeL2();
+
+    const rows = mockSendStatus.mock.calls
+      .filter((c: unknown[]) => c[0] === 'pilot_pipeline')
+      .map((c: unknown[]) => c[1] as Record<string, string>);
+    // Both still report, at zero: the input is running, so its agent has gone
+    // quiet rather than gone away, and the destination is still configured.
+    expect(rows.map(r => r.type)).toEqual(['agent', 'flusher']);
+    expect(rows[0].in_events).toBe('0');
+    expect(rows[0].in_bytes).toBe('0');
+    expect(rows[1].out_entries).toBe('0');
+    expect(rows[1].out_bytes).toBe('0');
+  });
+
+  it('mirrors each L2 row type to its own file on stop (final flush)', async () => {
     writer = new MetricsWriter({
       dataDir: tmpDir,
       version: '2.0.0',
@@ -153,27 +215,27 @@ describe('MetricsWriter', () => {
     await writer.start();
     await writer.stop();
 
-    const inputPath = path.join(tmpDir, 'logs', 'metric_alarm', 'pilot-input-metrics.jsonl');
-    const flusherPath = path.join(tmpDir, 'logs', 'metric_alarm', 'pilot-flusher-metrics.jsonl');
+    const metricDir = path.join(tmpDir, 'logs', 'metric_alarm');
+    const firstLine = (name: string): any => JSON.parse(
+      fs.readFileSync(path.join(metricDir, name), 'utf-8').trim().split('\n')[0],
+    );
 
-    expect(fs.existsSync(inputPath)).toBe(true);
-    expect(fs.existsSync(flusherPath)).toBe(true);
+    const agent = firstLine('pilot-agent-metrics.jsonl');
+    expect(agent.type).toBe('agent');
+    expect(agent.user_id).toBe('u1');
+    expect(agent.agent).toBe('test-agent');
+    expect(agent.in_events).toBe('5');
 
-    const inputLine = JSON.parse(fs.readFileSync(inputPath, 'utf-8').trim().split('\n')[0]);
-    expect(inputLine.category).toBe('input');
-    expect(inputLine.label.input_name).toBe('test-input');
-    expect(inputLine.in_events_total).toBe('5');
-
-    const flusherLine = JSON.parse(fs.readFileSync(flusherPath, 'utf-8').trim().split('\n')[0]);
-    expect(flusherLine.category).toBe('flusher');
-    expect(flusherLine.label.endpoint_name).toBe('https://cn-heyuan.log.aliyuncs.com');
-    expect(flusherLine.out_entries_total).toBe('9');
+    const flusher = firstLine('pilot-flusher-metrics.jsonl');
+    expect(flusher.type).toBe('flusher');
+    expect(flusher.flusher).toBe('sls');
+    expect(flusher.logstore).toBe('store-a');
+    expect(flusher.out_entries).toBe('9');
   });
 
-  it('does not write L2 files when snapshot has no inputs/flushers', async () => {
+  it('does not write the L2 file when snapshot has no inputs/flushers', async () => {
     const emptySnapshot: DataflowSnapshot = {
-      sendEntriesTotal: 0, receivedBytesTotal: 0, inputCount: 0, activeInputCount: 0,
-      flusherRunner: { inEntries: 0, inBytes: 0, outEntries: 0, outFailed: 0, totalDelayMs: 0, lastFlushTime: '', startTime: '' },
+      inEventsTotal: 0, inBytesTotal: 0,
       inputs: new Map(),
       flushers: new Map(),
       inputIdleMinutes: new Map(),
@@ -190,11 +252,9 @@ describe('MetricsWriter', () => {
     await writer.start();
     await writer.stop();
 
-    const inputPath = path.join(tmpDir, 'logs', 'metric_alarm', 'pilot-input-metrics.jsonl');
-    const flusherPath = path.join(tmpDir, 'logs', 'metric_alarm', 'pilot-flusher-metrics.jsonl');
-
-    expect(fs.existsSync(inputPath)).toBe(false);
-    expect(fs.existsSync(flusherPath)).toBe(false);
+    const metricDir = path.join(tmpDir, 'logs', 'metric_alarm');
+    expect(fs.existsSync(path.join(metricDir, 'pilot-agent-metrics.jsonl'))).toBe(false);
+    expect(fs.existsSync(path.join(metricDir, 'pilot-flusher-metrics.jsonl'))).toBe(false);
   });
 
   it('includes capture_message_disabled_agents in L1 metrics', async () => {
@@ -217,27 +277,6 @@ describe('MetricsWriter', () => {
     const entry = JSON.parse(lines[0]);
 
     expect(entry.capture_message_disabled_agents).toBe('qoder');
-  });
-
-  it('includes user_id in L2 input and flusher metrics', async () => {
-    writer = new MetricsWriter({
-      dataDir: tmpDir,
-      version: '2.0.0',
-      userId: 'u1',
-      getSnapshot: buildSnapshot,
-    });
-
-    vi.useRealTimers();
-    await writer.start();
-    await writer.stop();
-
-    const inputPath = path.join(tmpDir, 'logs', 'metric_alarm', 'pilot-input-metrics.jsonl');
-    const inputLine = JSON.parse(fs.readFileSync(inputPath, 'utf-8').trim().split('\n')[0]);
-    expect(inputLine.user_id).toBe('u1');
-
-    const flusherPath = path.join(tmpDir, 'logs', 'metric_alarm', 'pilot-flusher-metrics.jsonl');
-    const flusherLine = JSON.parse(fs.readFileSync(flusherPath, 'utf-8').trim().split('\n')[0]);
-    expect(flusherLine.user_id).toBe('u1');
   });
 
   describe('process resource thresholds', () => {

--- a/tests/unit/updater/updater-metrics.test.ts
+++ b/tests/unit/updater/updater-metrics.test.ts
@@ -220,18 +220,18 @@ describe('UpdaterMetrics', () => {
   });
 
   describe('sendAlarm / sendStatus integration', () => {
-    it('calls sendStatus for queued events on flush', async () => {
+    it('does NOT send events as status rows (collector folds them into the heartbeat)', async () => {
       const m = createMetrics();
       await m.start();
       m.writeEvent('updater_started');
       await m.stop();
 
-      expect(mockSendStatus).toHaveBeenCalled();
-      const call = mockSendStatus.mock.calls.find(
+      // Events are persisted to the local JSONL only; no pilot_updater_event topic.
+      expect(appendedLines.filter(l => l.path.includes('pilot-updater-events.jsonl'))).toHaveLength(1);
+      const statusCall = mockSendStatus.mock.calls.find(
         (c: unknown[]) => c[0] === 'pilot_updater_event',
       );
-      expect(call).toBeDefined();
-      expect(call![1]).not.toHaveProperty('__topic__');
+      expect(statusCall).toBeUndefined();
     });
 
     it('calls sendAlarm for queued alarms on flush', async () => {


### PR DESCRIPTION
## Why

The five `loongsuite_status` topics overlapped in meaning, and the numbers on them did not describe what their names claimed:

- **`metric_json` mixed axes.** `send_entries_total` counted the handoff from the inputs to the fan-out — not what was written anywhere — while `received_bytes_total` counted ingress bytes, so the pair could not be read as in/out of anything. Neither had a byte counterpart on the side it measured, and both were cumulative values published next to per-second rates derived from them, which a consumer had to diff to use.
- **`instance_id` was not an install identity.** `${userId}_${ip}_${startTimestamp}` changed on every restart and every DHCP lease, so no query could follow one install over time; and two installs under different OS users on one host (each with its own `~/.loongsuite-pilot`) collided whenever hostname and configured userId coincided.
- **Egress was reported per SLS endpoint only.** The OTLP trace flusher — the entire span leg, including ARMS/CMS backends — counted nothing, so a billing-shaped question had no answer for it.
- **`pilot_input_detail` reported a row per input**, but inputs are a collection detail: qoder alone owns sqlite/trace/cli-hook/cli-session, and every build registers an input for every agent it knows about, so a cycle shipped ~19 all-zero rows whose dimension nobody queries by.

## What changed

**Two topics, split by identity vs. data**

- `pilot_status` (heartbeat) — instance identity, health, and one instance-level aggregate. `flusher_runner` is gone; its numbers were the sum of the per-destination rows, which the query engine can do. The topic name is kept so existing dashboards and stored data stay continuous; the schema is reorganized.
- `pilot_pipeline` — one row per agent that carried data, one row per write destination, told apart by `type`, keyed by `instance_id` + `run_id`. The former `pilot_alarm_metric`'s `idle_minutes` folds into the agent rows. `pilot_input_detail` / `pilot_flusher_detail` / `pilot_alarm_metric` are retired.

**Identity is derivable and stable**

- `instance_id = hostname_userId_base64url(dataDir)` — restart- and IP-invariant, independently derivable by any process on the host, unique per install. `dataDir` is encoded rather than plaintext but stays reversible: strip the `${hostname}_${userId}_` prefix and base64url-decode.
- `run_id = instance_id_startTimestamp` — one incarnation per start, so restarts are identifiable without inflating the install count.

**Flow values are symmetric and drained**

- `in_events` / `in_bytes` / `out_events` / `out_bytes` plus `_ps` rates on the heartbeat, with the per-destination split on the pipeline rows. `in_*` is what the inputs ingested; `out_*` is what was actually written, summed over every destination — so `out > in` is normal under fan-out, and the two sides count different units (agent events vs. SLS entries / OTLP spans).
- Every flow value is the delta since that level's previous report, with `window_ms` alongside it: SUM over a range, never diff. L1 and L2 keep separate baselines, since they run on independent timers over one snapshot and a shared baseline would let whichever fired first swallow the other's window.
- Both flushers count outbound bytes per endpoint, and the OTLP trace flusher gained the counters it never had (spans in/out, bytes, failures, latency). Endpoints are classified by their auth headers, so an ARMS/CMS backend reports the project it resolves to and ARMS's fixed trace logstore, while a plain user-configured OTLP backend is not mislabelled as CMS and carries no project of ours.
- Agent rows are emitted only for agents that carried something; destination rows are emitted even at zero, because a configured-but-silent destination is a finding whereas a silent agent is the normal case. How many agents are installed is what the heartbeat's `agent_count` is for.

**Updater events are no longer sent as status rows**

`pilot_updater_event` duplicated coverage that already exists — update failures go out as alarms, and updater liveness/version state is on the heartbeat's infra-health fields. The events are still written to the local JSONL and still raise alarms.

**Two smaller fixes this depends on**

- L2 is primed once at startup, so a run shorter than the L2 interval no longer reports a healthy heartbeat with no pipeline data at all.
- Overlapping L2 cycles collapse into the in-flight one: `collectL2` drains its counters, and two concurrent collects would split one window across two sets of rows.
- At both levels the status report now happens before the local JSONL append — the collect has already drained the counters, so a failing disk write must not be what costs the window.

## Scope

The agent pipeline. Wiring the file and agent_api pipelines into the same snapshot is left for a follow-up.

## Verification

- `npm run typecheck` clean.
- `tests/unit/{metrics,updater,flushers,core}`: 746 passed.
- The hooks / integration failures in a full local run reproduce unchanged on this PR's base and are unrelated to these files.
