### PR TITLE
fix(qoder-work): align step timing and message history

### DIFF
--- a/assets/hooks/qoderwork-hook-processor.mjs
+++ b/assets/hooks/qoderwork-hook-processor.mjs
@@ -255,12 +255,15 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
         .map(tc => ({ tc, result: toolResultsByUseId.get(tc.id) }))
         .filter(item => item.result);
       if (completedToolCalls.length > 0) {
+        const completedToolCallIds = new Set(completedToolCalls.map(({ tc }) => tc.id));
         inputDelta = [
           {
             role: 'assistant',
             // The next model receives the complete previous assistant message,
-            // including reasoning/text that preceded its tool calls.
-            parts: prevAssistantOutputParts,
+            // including reasoning/text that preceded its tool calls. Filter only
+            // incomplete tool calls so every retained call has one tool response.
+            parts: prevAssistantOutputParts.filter(part =>
+              part.type !== 'tool_call' || completedToolCallIds.has(part.id)),
           },
           ...completedToolCalls.map(({ tc, result }) => {
             const content = result.block?.content;

--- a/assets/hooks/qoderwork-hook-processor.mjs
+++ b/assets/hooks/qoderwork-hook-processor.mjs
@@ -35,6 +35,8 @@ import {
   getStringValue,
 } from './agent-event-normalizer.mjs';
 
+const MAX_INPUT_MESSAGES_BYTES = 1024 * 1024;
+
 async function main() {
   const { agentId, logPrefix } = parseArgs();
   const payload = await parseStdinPayload(agentId);
@@ -234,7 +236,13 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
   const userText = userRow ? extractText(userRow) : '';
   const userTs = userRow ? timestampToUnixNanos(userRow.timestamp) : undefined;
   let prevToolCalls = []; // tool calls from previous step, for building assistant + tool_result delta
+  let prevAssistantOutputParts = []; // exact assistant output from previous step
   let prevStepLastToolResultTs = undefined; // 上一个 step 最后一个 tool_result 的 nano ts，用于本 step llm.request 时间
+  // Mirror Codex's message-context model: emit both the per-step delta and the
+  // complete context while it remains reasonably sized. Keeping the explicit
+  // context makes the assistant/tool role boundary independent of converter
+  // batching or restart state.
+  let fullInputMessages = [];
 
   let stepCounter = 0;
   for (const group of llmGroups) {
@@ -248,28 +256,47 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
     if (stepCounter === 1 && userText) {
       inputDelta = [{ role: 'user', parts: [{ type: 'text', content: userText }] }];
     } else if (prevToolCalls.length > 0) {
-      const toolParts = [];
-      for (const tc of prevToolCalls) {
-        const matchingResult = toolResultsByUseId.get(tc.id);
-        if (matchingResult) {
-          const resultBlock = matchingResult.block;
-          const resultText = typeof resultBlock?.content === 'string' ? resultBlock.content : JSON.stringify(resultBlock?.content);
-          toolParts.push({ type: 'tool_call_response', id: tc.id, response: resultText });
-        }
-      }
-      if (toolParts.length > 0) {
+      // As in Codex, only completed calls enter the next model input. Use the
+      // same set for both messages so every assistant tool_call has exactly one
+      // matching tool response.
+      const completedToolCalls = prevToolCalls
+        .map(tc => ({ tc, result: toolResultsByUseId.get(tc.id) }))
+        .filter(item => item.result);
+      if (completedToolCalls.length > 0) {
         inputDelta = [
           {
             role: 'assistant',
-            parts: prevToolCalls.map(tc => ({
-              type: 'tool_call',
-              id: tc.id,
-              name: tc.name,
-              arguments: tc.input,
-            })),
+            // The next model receives the complete previous assistant message,
+            // including reasoning/text that preceded its tool calls.
+            parts: prevAssistantOutputParts,
           },
-          { role: 'tool', parts: toolParts },
+          ...completedToolCalls.map(({ tc, result }) => {
+            const content = result.block?.content;
+            return {
+              role: 'tool',
+              // Keep one tool response per message. This preserves the 1:1
+              // call/result boundary for parallel tool calls in OTLP input messages.
+              parts: [{
+                type: 'tool_call_response',
+                id: tc.id,
+                response: typeof content === 'string' ? content : JSON.stringify(content),
+              }],
+            };
+          }),
         ];
+      }
+    }
+
+    let inputMessages;
+    if (inputDelta && fullInputMessages !== undefined) {
+      const candidate = [...fullInputMessages, ...inputDelta];
+      if (Buffer.byteLength(JSON.stringify(candidate), 'utf8') <= MAX_INPUT_MESSAGES_BYTES) {
+        fullInputMessages = candidate;
+        inputMessages = candidate;
+      } else {
+        // Continue emitting deltas, but stop duplicating an oversized complete
+        // context into every subsequent request event.
+        fullInputMessages = undefined;
       }
     }
 
@@ -279,25 +306,20 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
     // 否则用 assistant 行写盘时间会导致 LLM span 退化为 0ms（thinking/tool_use 同毫秒批量 flush）
     const llmRequestTs = stepCounter === 1 ? userTs : prevStepLastToolResultTs;
 
-    const stepRecords = buildStepEvents(group, toolResultsByUseId, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, agentId, stepCounter === llmGroups.length, inputDelta, cwd, llmRequestTs, turnMetadata);
+    const assistantOutput = extractAssistantOutput(group);
+    const stepRecords = buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, agentId, inputDelta, inputMessages, cwd, llmRequestTs, turnMetadata);
     records.push(...stepRecords);
 
     // Collect this step's tool_calls for next step's input delta
-    prevToolCalls = [];
+    prevToolCalls = assistantOutput.toolCalls;
+    prevAssistantOutputParts = assistantOutput.outputParts;
     let lastToolResultTsInStep = undefined;
-    for (const row of group) {
-      const msg = row.message || {};
-      const content = Array.isArray(msg.content) ? msg.content : [];
-      for (const b of content) {
-        if (b.type === 'tool_use') {
-          prevToolCalls.push({ id: b.id, name: b.name, input: b.input });
-          // 找到本 step 该 tool_use 对应的 tool_result 行，记录 ts；多 tool 场景保留最后一个
-          const matchingResult = toolResultsByUseId.get(b.id);
-          if (matchingResult?.row.timestamp) {
-            const nano = timestampToUnixNanos(matchingResult.row.timestamp);
-            if (nano) lastToolResultTsInStep = nano;
-          }
-        }
+    for (const toolCall of prevToolCalls) {
+      // 找到本 step 该 tool_use 对应的 tool_result 行，记录 ts；多 tool 场景保留最后一个
+      const matchingResult = toolResultsByUseId.get(toolCall.id);
+      if (matchingResult?.row.timestamp) {
+        const nano = timestampToUnixNanos(matchingResult.row.timestamp);
+        if (nano) lastToolResultTsInStep = nano;
       }
     }
     if (lastToolResultTsInStep) {
@@ -364,25 +386,7 @@ function groupAssistantRowsByToolResults(turnRows) {
   return groups;
 }
 
-function buildStepEvents(group, toolResultsByUseId, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, agentId, isLastStep, inputDelta, cwd, llmRequestTs, turnMetadata = {}) {
-  const records = [];
-  const firstRow = group[0];
-  const lastRow = group[group.length - 1];
-
-  // thinking 行的 ts 用作 llm.response 时间（模型完成输出的真实时刻）；
-  // 没有 thinking 时回退到 lastRow.timestamp（与现有行为一致）
-  const thinkingRow = group.find(r => {
-    const content = Array.isArray(r.message?.content) ? r.message.content : [];
-    const firstType = content[0]?.type;
-    return firstType === 'thinking' || r.content_type === 'thinking';
-  });
-  const llmResponseTs = timestampToUnixNanos(thinkingRow ? thinkingRow.timestamp : lastRow.timestamp);
-
-  // Prefer message.id (chatcmpl-xxx, matches qoderwork-intercept.jsonl) for direct token matching.
-  // Fall back to parentUuid for backward compat with older QoderWork versions.
-  const responseId = firstRow.message?.id || firstRow.parentUuid || firstRow.uuid;
-
-  // Build merged output parts
+function extractAssistantOutput(group) {
   const outputParts = [];
   const toolCalls = [];
 
@@ -408,18 +412,43 @@ function buildStepEvents(group, toolResultsByUseId, stepId, turnId, sessionId, u
     }
   }
 
-  const finishReason = toolCalls.length > 0 ? 'tool_calls' : (isLastStep ? 'end_turn' : 'stop');
+  return { outputParts, toolCalls };
+}
+
+function buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, agentId, inputDelta, inputMessages, cwd, llmRequestTs, turnMetadata = {}) {
+  const records = [];
+  const firstRow = group[0];
+  const lastRow = group[group.length - 1];
+
+  // thinking 行的 ts 用作 llm.response 时间（模型完成输出的真实时刻）；
+  // 没有 thinking 时回退到 lastRow.timestamp（与现有行为一致）
+  const thinkingRow = group.find(r => {
+    const content = Array.isArray(r.message?.content) ? r.message.content : [];
+    const firstType = content[0]?.type;
+    return firstType === 'thinking' || r.content_type === 'thinking';
+  });
+  const llmResponseTs = timestampToUnixNanos(thinkingRow ? thinkingRow.timestamp : lastRow.timestamp);
+
+  // Prefer message.id (chatcmpl-xxx, matches qoderwork-intercept.jsonl) for direct token matching.
+  // Fall back to parentUuid for backward compat with older QoderWork versions.
+  const responseId = firstRow.message?.id || firstRow.parentUuid || firstRow.uuid;
+
+  const { outputParts, toolCalls } = assistantOutput;
+
+  // QoderWork uses the provider-specific `end_turn` sentinel in its raw
+  // transcript. Emit the standard finish reason expected by downstream GenAI
+  // consumers while keeping tool-producing responses distinguishable.
+  const finishReason = toolCalls.length > 0 ? 'tool_calls' : 'stop';
 
   // llm.request for this step.
-  //
-  // Field choice: gen_ai.input.messages_delta (incremental, NOT full).
   //
   // Each step's delta contains only the NEW content since the previous step:
   //   - Step 1: user prompt
   //   - Step N>1: previous assistant tool_calls followed by tool_results
-  // The converter (@loongsuite/otel-util-genai) accumulates deltas across
-  // steps to reconstruct the full context window for each LLM span, which
-  // is the correct behaviour.
+  // We also emit the complete input context (up to 1 MiB), following Codex's
+  // approach. This preserves the assistant/tool split even when conversion
+  // starts from a partial batch; the delta remains available for incremental
+  // consumers.
   const llmRequestFields = {
     ...turnMetadata,
     'event.name': 'llm.request',
@@ -436,6 +465,9 @@ function buildStepEvents(group, toolResultsByUseId, stepId, turnId, sessionId, u
   };
   if (inputDelta) {
     llmRequestFields['gen_ai.input.messages_delta'] = inputDelta;
+  }
+  if (inputMessages) {
+    llmRequestFields['gen_ai.input.messages'] = inputMessages;
   }
   records.push(buildRecord(llmRequestFields, firstRow, runtimeConfig, cwd));
 
@@ -585,6 +617,6 @@ function resolveQoderWorkProjectDir(sandboxCwd, agentId) {
   return sandboxCwd;
 }
 
-export { extractText, getTurnIdForRows, isSystemInjection, isToolResult, splitIntoTurns };
+export { extractText, getTurnIdForRows, isSystemInjection, isToolResult, processTranscript, splitIntoTurns };
 
 main().catch(() => { /* fail-open */ });

--- a/assets/hooks/qoderwork-hook-processor.mjs
+++ b/assets/hooks/qoderwork-hook-processor.mjs
@@ -35,8 +35,6 @@ import {
   getStringValue,
 } from './agent-event-normalizer.mjs';
 
-const MAX_INPUT_MESSAGES_BYTES = 1024 * 1024;
-
 async function main() {
   const { agentId, logPrefix } = parseArgs();
   const payload = await parseStdinPayload(agentId);
@@ -238,12 +236,6 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
   let prevToolCalls = []; // tool calls from previous step, for building assistant + tool_result delta
   let prevAssistantOutputParts = []; // exact assistant output from previous step
   let prevStepLastToolResultTs = undefined; // 上一个 step 最后一个 tool_result 的 nano ts，用于本 step llm.request 时间
-  // Mirror Codex's message-context model: emit both the per-step delta and the
-  // complete context while it remains reasonably sized. Keeping the explicit
-  // context makes the assistant/tool role boundary independent of converter
-  // batching or restart state.
-  let fullInputMessages = [];
-
   let stepCounter = 0;
   for (const group of llmGroups) {
     stepCounter++;
@@ -287,19 +279,6 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
       }
     }
 
-    let inputMessages;
-    if (inputDelta && fullInputMessages !== undefined) {
-      const candidate = [...fullInputMessages, ...inputDelta];
-      if (Buffer.byteLength(JSON.stringify(candidate), 'utf8') <= MAX_INPUT_MESSAGES_BYTES) {
-        fullInputMessages = candidate;
-        inputMessages = candidate;
-      } else {
-        // Continue emitting deltas, but stop duplicating an oversized complete
-        // context into every subsequent request event.
-        fullInputMessages = undefined;
-      }
-    }
-
     // llm.request time:
     //   step 1 = user input ts (user message arrival, a reasonable proxy for LLM start)
     //   step N>1 = 上一个 step 最后一个 tool_result ts (工具返回后模型立刻开始处理)
@@ -307,7 +286,7 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
     const llmRequestTs = stepCounter === 1 ? userTs : prevStepLastToolResultTs;
 
     const assistantOutput = extractAssistantOutput(group);
-    const stepRecords = buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, agentId, inputDelta, inputMessages, cwd, llmRequestTs, turnMetadata);
+    const stepRecords = buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, agentId, inputDelta, cwd, llmRequestTs, turnMetadata);
     records.push(...stepRecords);
 
     // Collect this step's tool_calls for next step's input delta
@@ -415,7 +394,7 @@ function extractAssistantOutput(group) {
   return { outputParts, toolCalls };
 }
 
-function buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, agentId, inputDelta, inputMessages, cwd, llmRequestTs, turnMetadata = {}) {
+function buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, agentId, inputDelta, cwd, llmRequestTs, turnMetadata = {}) {
   const records = [];
   const firstRow = group[0];
   const lastRow = group[group.length - 1];
@@ -445,10 +424,9 @@ function buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, tur
   // Each step's delta contains only the NEW content since the previous step:
   //   - Step 1: user prompt
   //   - Step N>1: previous assistant tool_calls followed by tool_results
-  // We also emit the complete input context (up to 1 MiB), following Codex's
-  // approach. This preserves the assistant/tool split even when conversion
-  // starts from a partial batch; the delta remains available for incremental
-  // consumers.
+  // The converter accumulates these deltas into the full input context carried
+  // by each OTLP LLM span. Keep the Hook event incremental so existing event-log
+  // consumers do not receive a second, duplicated representation of history.
   const llmRequestFields = {
     ...turnMetadata,
     'event.name': 'llm.request',
@@ -465,9 +443,6 @@ function buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, tur
   };
   if (inputDelta) {
     llmRequestFields['gen_ai.input.messages_delta'] = inputDelta;
-  }
-  if (inputMessages) {
-    llmRequestFields['gen_ai.input.messages'] = inputMessages;
   }
   records.push(buildRecord(llmRequestFields, firstRow, runtimeConfig, cwd));
 

--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -156,6 +156,81 @@ function estimateSpanSize(span: ReadableSpan): number {
   return size;
 }
 
+/**
+ * Apply QoderWork's explicit loop.iteration boundaries to STEP spans without
+ * changing the enclosed LLM timestamps. The converter otherwise derives STEP
+ * start/end from child records, which loses the small but real orchestration
+ * window around each model/tool wave.
+ */
+export function applyQoderWorkStepTiming(
+  records: AgentActivityEntry[],
+  spans: ReadableSpan[],
+): void {
+  // OtlpTraceFlusher invokes the converter once per turn, so session + round
+  // uniquely identifies a STEP even though the converter does not carry the
+  // event-log turn id onto STEP spans.
+  const boundaries = new Map<string, { startNano?: string; endNano?: string }>();
+  for (const record of records) {
+    const sessionId = record['gen_ai.session.id'];
+    const stepId = record['gen_ai.step.id'];
+    if (typeof sessionId !== 'string' || typeof stepId !== 'string') continue;
+    const startNano = record['agent.qoderwork.step.start_time_unix_nano'];
+    const endNano = record['agent.qoderwork.step.end_time_unix_nano'];
+    if (typeof startNano !== 'string' && typeof endNano !== 'string') continue;
+    const round = stepRound(stepId);
+    if (round === undefined) continue;
+    boundaries.set(`${sessionId}\0${round}`, {
+      ...(typeof startNano === 'string' ? { startNano } : {}),
+      ...(typeof endNano === 'string' ? { endNano } : {}),
+    });
+  }
+  if (boundaries.size === 0) return;
+
+  for (const span of spans) {
+    if (span.attributes['gen_ai.span.kind'] !== 'STEP') continue;
+    const sessionId = span.attributes['gen_ai.session.id'];
+    const round = span.attributes['gen_ai.react.round'];
+    if (typeof sessionId !== 'string' || typeof round !== 'number') continue;
+    const boundary = boundaries.get(`${sessionId}\0${round}`);
+    if (!boundary) continue;
+
+    const currentStartNano = hrTimeToNano(span.startTime);
+    const currentEndNano = currentStartNano + hrTimeToNano(span.duration);
+    const desiredStartNano = parseNano(boundary.startNano) ?? currentStartNano;
+    const desiredEndNano = parseNano(boundary.endNano) ?? currentEndNano;
+    if (desiredEndNano < desiredStartNano) continue;
+
+    // ReadableSpan declares these values readonly and SDK Span exposes duration
+    // through a getter. Define per-instance values so this stays independent of
+    // the SDK Span's private backing fields.
+    Object.defineProperties(span, {
+      startTime: { value: nanoToHrTime(desiredStartNano), configurable: true },
+      endTime: { value: nanoToHrTime(desiredEndNano), configurable: true },
+      duration: { value: nanoToHrTime(desiredEndNano - desiredStartNano), configurable: true },
+    });
+  }
+}
+
+function stepRound(stepId: string): number | undefined {
+  const match = stepId.match(/(?:^|[_:s])(\d+)$/);
+  if (!match) return undefined;
+  const value = Number(match[1]);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+function parseNano(value: string | undefined): bigint | undefined {
+  if (!value) return undefined;
+  try { return BigInt(value); } catch { return undefined; }
+}
+
+function hrTimeToNano(value: readonly [number, number]): bigint {
+  return BigInt(value[0]) * 1_000_000_000n + BigInt(value[1]);
+}
+
+function nanoToHrTime(value: bigint): [number, number] {
+  return [Number(value / 1_000_000_000n), Number(value % 1_000_000_000n)];
+}
+
 export class OtlpTraceFlusher extends BaseFlusher {
   readonly name = 'otlp-trace';
 
@@ -606,6 +681,7 @@ export class OtlpTraceFlusher extends BaseFlusher {
       inMem.reset();
 
       if (spans.length === 0) return;
+      applyQoderWorkStepTiming(records, spans);
       this.enrichToolSkillAttributes(records, spans);
       if (agentType === 'openclaw') {
         this.enrichOpenClawToolAttributes(records, spans);

--- a/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
+++ b/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
@@ -52,11 +52,15 @@ export class QoderWorkTraceInput extends BaseInput {
   private readonly segmentPairs: Map<string, SegmentLlmPair[]> = new Map();
   // Per-session tool timing from segments, keyed by tool_call_id.
   private readonly segmentToolTimings: Map<string, Map<string, SegmentToolTiming>> = new Map();
+  // Logical LLM iterations keyed by loop_id. QoderWork may change request_id
+  // after an internal retry without emitting another model.request.started, so
+  // request_id is intentionally not the pairing key for current segment logs.
+  private readonly segmentIterations: Map<string, Map<string, SegmentIterationLlmState>> = new Map();
   // Per-session set of turn_ids known to be subagent. We only filter LLM calls
   // whose turn_id is in this set. A turn_id absent from the set is treated as
   // main (covers the rare case where turn.started is split across files).
   private readonly subagentTurns: Map<string, Map<string, number>> = new Map();
-  // Per-session in-flight LLM pairs (request seen, response not yet seen).
+  // Legacy request-id pairing for old segment writers that do not emit loop_id.
   private readonly inFlightPairs: Map<string, Map<string, InFlightPair>> = new Map();
   // Legacy SDK fallback is token-only. It must never change timing or model.
   private readonly sdkTokenPairs: Map<string, SdkTokenPair[]> = new Map();
@@ -240,6 +244,7 @@ export class QoderWorkTraceInput extends BaseInput {
     for (const filePath of files) {
       await this.readSegmentsFile(sessionId, filePath);
     }
+    this.materializeCompletedSegmentIterations(sessionId);
   }
 
   private async resolveSegmentsDir(sessionId: string, cwd: string): Promise<string | undefined> {
@@ -340,15 +345,26 @@ export class QoderWorkTraceInput extends BaseInput {
         return;
       }
       case 'model.request.started': {
-        if (!event.turn_id || !event.request_id || !event.ts) return;
+        if (!event.turn_id || !event.ts) return;
         // Skip subagent LLM calls — hook transcript only carries main agent.
         if (this.shouldSkipSegmentTurn(sessionId, event.turn_id)) return;
         const startNano = isoToNano(event.ts);
         if (!startNano) return;
+        if (event.loop_id) {
+          const state = this.getOrCreateSegmentIteration(sessionId, event, seenAtMs);
+          if (!state) return;
+          state.requestStartNano = earlierNano(state.requestStartNano, startNano);
+          state.model ||= event.data?.model || '';
+          state.seenAtMs = seenAtMs;
+          return;
+        }
+        if (!event.request_id) return;
         let m = this.inFlightPairs.get(sessionId);
         if (!m) { m = new Map(); this.inFlightPairs.set(sessionId, m); }
         m.set(event.request_id, {
           turnId: event.turn_id,
+          loopId: event.loop_id,
+          requestIndex: positiveNumber(event.data?.request_index),
           startNano,
           model: event.data?.model || '',
           seenAtMs,
@@ -356,17 +372,34 @@ export class QoderWorkTraceInput extends BaseInput {
         return;
       }
       case 'model.response.completed': {
-        if (!event.turn_id || !event.request_id || !event.ts) return;
+        if (!event.turn_id || !event.ts) return;
         if (this.shouldSkipSegmentTurn(sessionId, event.turn_id)) return;
+        const endNano = isoToNano(event.ts);
+        if (!endNano) return;
+        if (event.loop_id) {
+          const state = this.getOrCreateSegmentIteration(sessionId, event, seenAtMs);
+          if (!state) return;
+          // A future writer may emit several completed attempts for one logical
+          // iteration. The final completion owns end/model/usage/stop reason.
+          if (!state.responseEndNano || BigInt(endNano) >= BigInt(state.responseEndNano)) {
+            state.responseEndNano = endNano;
+            state.model = event.data?.model || state.model || '';
+            state.usage = extractSegmentUsage(event.data);
+            state.stopReason = getSegmentString(event.data?.stop_reason);
+          }
+          state.seenAtMs = seenAtMs;
+          return;
+        }
+        if (!event.request_id) return;
         const inFlightForSession = this.inFlightPairs.get(sessionId);
         const inFlight = inFlightForSession?.get(event.request_id);
         if (!inFlight) return; // orphan response (e.g. resumed mid-stream)
         inFlightForSession!.delete(event.request_id);
-        const endNano = isoToNano(event.ts);
-        if (!endNano) return;
         const list = this.segmentPairs.get(sessionId) ?? [];
         list.push({
           turnId: inFlight.turnId,
+          loopId: inFlight.loopId || event.loop_id,
+          requestIndex: inFlight.requestIndex ?? positiveNumber(event.data?.request_index),
           startNano: inFlight.startNano,
           endNano,
           model: event.data?.model || inFlight.model || '',
@@ -376,6 +409,26 @@ export class QoderWorkTraceInput extends BaseInput {
         this.segmentPairs.set(sessionId, list);
         return;
       }
+      case 'loop.iteration.started':
+      case 'loop.iteration.finished': {
+        if (!event.turn_id || !event.loop_id || !event.ts) return;
+        if (this.shouldSkipSegmentTurn(sessionId, event.turn_id)) return;
+        const nano = isoToNano(event.ts);
+        if (!nano) return;
+        const state = this.getOrCreateSegmentIteration(sessionId, event, seenAtMs);
+        if (!state) return;
+        if (event.type === 'loop.iteration.started') {
+          state.iterationStartNano = earlierNano(state.iterationStartNano, nano);
+        } else {
+          state.iterationEndNano = laterNano(state.iterationEndNano, nano);
+        }
+        state.seenAtMs = seenAtMs;
+        return;
+      }
+      case 'model.request.attempt_failed':
+        // Attempt failure does not close the logical loop. A later completed
+        // event may use a different request_id but the same loop_id.
+        return;
       case 'tool.requested':
       case 'tool.execution.finished': {
         if (!event.turn_id || !event.tool_call_id || !event.ts) return;
@@ -392,6 +445,30 @@ export class QoderWorkTraceInput extends BaseInput {
         } else {
           existing.finishedNano = nano;
         }
+        timings.set(event.tool_call_id, existing);
+        this.segmentToolTimings.set(sessionId, timings);
+        return;
+      }
+      case 'hook.started': {
+        if (!event.tool_call_id || !event.ts) return;
+        const hookEventName = getSegmentString(event.data?.hook_event_name);
+        const isPre = hookEventName === 'PreToolUse';
+        const isPost = hookEventName === 'PostToolUse' || hookEventName === 'PostToolUseFailure';
+        if (!isPre && !isPost) return;
+        const nano = isoToNano(event.ts);
+        if (!nano) return;
+        const timings = this.segmentToolTimings.get(sessionId) ?? new Map<string, SegmentToolTiming>();
+        const existing = timings.get(event.tool_call_id) ?? {
+          turnId: event.turn_id || '',
+          seenAtMs,
+        };
+        existing.seenAtMs = seenAtMs;
+        const candidate: SegmentHookTiming = {
+          nano,
+          source: getSegmentString(event.data?.source),
+        };
+        if (isPre) (existing.preHookTimings ??= []).push(candidate);
+        else (existing.postHookTimings ??= []).push(candidate);
         timings.set(event.tool_call_id, existing);
         this.segmentToolTimings.set(sessionId, timings);
         return;
@@ -432,7 +509,13 @@ export class QoderWorkTraceInput extends BaseInput {
           const pair = this.takeSegmentPair(sessionId, turnId, request, response);
           if (pair) {
             (request as Record<string, unknown>)['time_unix_nano'] = pair.startNano;
+            if (pair.iterationStartNano) {
+              (request as Record<string, unknown>)['agent.qoderwork.step.start_time_unix_nano'] = pair.iterationStartNano;
+            }
             (response as Record<string, unknown>)['time_unix_nano'] = pair.endNano;
+            if (pair.iterationEndNano) {
+              (request as Record<string, unknown>)['agent.qoderwork.step.end_time_unix_nano'] = pair.iterationEndNano;
+            }
 
             if (pair.model) {
               for (const e of stepEntries) {
@@ -489,7 +572,10 @@ export class QoderWorkTraceInput extends BaseInput {
 
       const nextRequest = nextStepEntries.find(e => e['event.name'] === 'llm.request');
       if (!nextRequest) continue;
-      const nextStartNano = nextRequest['time_unix_nano'] as string | undefined;
+      const nextStartNano = (
+        nextRequest['agent.qoderwork.step.start_time_unix_nano']
+        ?? nextRequest['time_unix_nano']
+      ) as string | undefined;
       if (!nextStartNano) continue;
       const nextStartBig = BigInt(nextStartNano);
       const capNano = String(nextStartBig - 1_000_000n); // 减 1ms
@@ -717,6 +803,7 @@ export class QoderWorkTraceInput extends BaseInput {
     const cutoff = Date.now() - SEGMENT_STATE_TTL_MS;
     evictMapValues(this.segmentPairs, pair => pair.seenAtMs >= cutoff);
     evictNestedMapValues(this.segmentToolTimings, timing => timing.seenAtMs >= cutoff);
+    evictNestedMapValues(this.segmentIterations, timing => timing.seenAtMs >= cutoff);
     evictNestedMapValues(this.subagentTurns, seenAtMs => seenAtMs >= cutoff);
     evictNestedMapValues(this.inFlightPairs, pair => pair.seenAtMs >= cutoff);
     evictMapValues(this.sdkTokenPairs, pair => pair.seenAtMs >= cutoff);
@@ -725,6 +812,60 @@ export class QoderWorkTraceInput extends BaseInput {
     }
     for (const [sessionId, cachedDir] of this.segmentDirBySession) {
       if (cachedDir.seenAtMs < cutoff) this.segmentDirBySession.delete(sessionId);
+    }
+  }
+
+  private getOrCreateSegmentIteration(
+    sessionId: string,
+    event: SegmentEvent,
+    seenAtMs: number,
+  ): SegmentIterationLlmState | undefined {
+    if (!event.turn_id || !event.loop_id) return undefined;
+    const states = this.segmentIterations.get(sessionId) ?? new Map<string, SegmentIterationLlmState>();
+    const state = states.get(event.loop_id) ?? {
+      turnId: event.turn_id,
+      loopId: event.loop_id,
+      requestIndex: positiveNumber(event.data?.request_index) ?? loopIterationIndex(event.loop_id),
+      model: '',
+      usage: {},
+      seenAtMs,
+    };
+    state.turnId = event.turn_id;
+    state.requestIndex ??= positiveNumber(event.data?.request_index) ?? loopIterationIndex(event.loop_id);
+    state.seenAtMs = seenAtMs;
+    states.set(event.loop_id, state);
+    this.segmentIterations.set(sessionId, states);
+    return state;
+  }
+
+  private materializeCompletedSegmentIterations(sessionId: string): void {
+    const states = this.segmentIterations.get(sessionId);
+    if (!states?.size) return;
+
+    const pairs = this.segmentPairs.get(sessionId) ?? [];
+    for (const [loopId, state] of states) {
+      if (!state.responseEndNano) continue;
+      const startNano = state.requestStartNano ?? state.iterationStartNano;
+      if (!startNano) continue;
+      pairs.push({
+        turnId: state.turnId,
+        loopId,
+        requestIndex: state.requestIndex,
+        startNano,
+        endNano: state.responseEndNano,
+        iterationStartNano: state.iterationStartNano,
+        iterationEndNano: state.iterationEndNano,
+        model: state.model,
+        usage: state.usage,
+        stopReason: state.stopReason,
+        seenAtMs: state.seenAtMs,
+      });
+      states.delete(loopId);
+    }
+    if (states.size === 0) this.segmentIterations.delete(sessionId);
+    if (pairs.length > 0) {
+      pairs.sort(compareSegmentPairs);
+      this.segmentPairs.set(sessionId, pairs);
     }
   }
 
@@ -737,7 +878,18 @@ export class QoderWorkTraceInput extends BaseInput {
     const buffer = this.segmentPairs.get(sessionId);
     if (!buffer?.length) return undefined;
 
-    let idx = turnId ? buffer.findIndex(pair => pair.turnId === turnId) : -1;
+    let idx = -1;
+    const stepIndex = stepIterationIndex(request['gen_ai.step.id']);
+    if (turnId && stepIndex !== undefined) {
+      idx = buffer.findIndex(pair => pair.turnId === turnId && pair.requestIndex === stepIndex);
+      // Once a writer provides iteration indexes, a missing pair is a real gap
+      // (for example an interrupted loop). Do not shift the following pair into
+      // this transcript step.
+      if (idx < 0 && buffer.some(pair => pair.turnId === turnId && pair.requestIndex !== undefined)) {
+        return undefined;
+      }
+    }
+    if (idx < 0 && turnId) idx = buffer.findIndex(pair => pair.turnId === turnId);
     if (idx < 0) {
       idx = buffer.findIndex(pair => this.isSegmentPairCompatible(pair, request, response));
     }
@@ -762,26 +914,37 @@ export class QoderWorkTraceInput extends BaseInput {
 
   private applySegmentToolTiming(sessionId: string, stepEntries: AgentActivityEntry[]): void {
     const timings = this.segmentToolTimings.get(sessionId);
-    if (!timings?.size) return;
 
     const usedCallIds = new Set<string>();
+    const modelResponseNano = stepEntries.find(entry => entry['event.name'] === 'llm.response')
+      ?.time_unix_nano as string | undefined;
     for (const entry of stepEntries) {
       const eventName = entry['event.name'];
       if (eventName !== 'tool.call' && eventName !== 'tool.result') continue;
       const callId = entry['gen_ai.tool.call.id'] as string | undefined;
       if (!callId) continue;
-      const timing = timings.get(callId);
-      if (!timing) continue;
+      const timing = timings?.get(callId);
 
-      if (eventName === 'tool.call' && timing.requestedNano) {
-        (entry as Record<string, unknown>)['time_unix_nano'] = timing.requestedNano;
+      if (eventName === 'tool.call') {
+        // Prefer timestamps emitted closest to QoderWork's own runtime:
+        // runtime > user settings > plugins. If no PreToolUse exists, the
+        // owning model response completion is the safest start fallback.
+        const startNano = selectPreferredHookNano(timing?.preHookTimings)
+          ?? modelResponseNano
+          ?? timing?.requestedNano;
+        if (!startNano) continue;
+        (entry as Record<string, unknown>)['time_unix_nano'] = startNano;
         usedCallIds.add(callId);
-      } else if (eventName === 'tool.result' && timing.finishedNano) {
-        (entry as Record<string, unknown>)['time_unix_nano'] = timing.finishedNano;
+      } else if (eventName === 'tool.result') {
+        const endNano = selectPreferredHookNano(timing?.postHookTimings)
+          ?? timing?.finishedNano;
+        if (!endNano) continue;
+        (entry as Record<string, unknown>)['time_unix_nano'] = endNano;
         usedCallIds.add(callId);
       }
     }
 
+    if (!timings) return;
     for (const callId of usedCallIds) {
       const timing = timings.get(callId);
       const hasCallEntry = stepEntries.some(entry =>
@@ -790,7 +953,12 @@ export class QoderWorkTraceInput extends BaseInput {
       const hasResultEntry = stepEntries.some(entry =>
         entry['event.name'] === 'tool.result' && entry['gen_ai.tool.call.id'] === callId
       );
-      if (hasCallEntry && hasResultEntry && timing?.requestedNano && timing.finishedNano) {
+      const hasStartTiming = !!selectPreferredHookNano(timing?.preHookTimings)
+        || !!timing?.requestedNano
+        || !!modelResponseNano;
+      const hasEndTiming = !!selectPreferredHookNano(timing?.postHookTimings)
+        || !!timing?.finishedNano;
+      if (hasCallEntry && hasResultEntry && hasStartTiming && hasEndTiming) {
         timings.delete(callId);
       }
     }
@@ -845,6 +1013,7 @@ interface SegmentEvent {
   turn_id?: string;
   request_id?: string;
   tool_call_id?: string;
+  loop_id?: string;
   data?: {
     model?: string;
     is_subagent?: boolean;
@@ -855,6 +1024,8 @@ interface SegmentEvent {
 
 interface InFlightPair {
   turnId: string;
+  loopId?: string;
+  requestIndex?: number;
   startNano: string;
   model: string;
   seenAtMs: number;
@@ -862,10 +1033,15 @@ interface InFlightPair {
 
 interface SegmentLlmPair {
   turnId: string;
+  loopId?: string;
+  requestIndex?: number;
   startNano: string;
   endNano: string;
+  iterationStartNano?: string;
+  iterationEndNano?: string;
   model: string;
   usage: TokenUsage;
+  stopReason?: string;
   seenAtMs: number;
 }
 
@@ -874,6 +1050,27 @@ interface SegmentToolTiming {
   toolName?: string;
   requestedNano?: string;
   finishedNano?: string;
+  preHookTimings?: SegmentHookTiming[];
+  postHookTimings?: SegmentHookTiming[];
+  seenAtMs: number;
+}
+
+interface SegmentHookTiming {
+  nano: string;
+  source: string;
+}
+
+interface SegmentIterationLlmState {
+  turnId: string;
+  loopId: string;
+  requestIndex?: number;
+  iterationStartNano?: string;
+  iterationEndNano?: string;
+  requestStartNano?: string;
+  responseEndNano?: string;
+  model: string;
+  usage: TokenUsage;
+  stopReason?: string;
   seenAtMs: number;
 }
 
@@ -897,6 +1094,58 @@ interface SdkInFlightMessage {
 interface CachedSegmentDir {
   path: string;
   seenAtMs: number;
+}
+
+const HOOK_SOURCE_PRIORITY: Record<string, number> = {
+  runtime: 0,
+  user: 1,
+  plugins: 2,
+};
+
+function selectPreferredHookNano(candidates: SegmentHookTiming[] | undefined): string | undefined {
+  if (!candidates?.length) return undefined;
+  return [...candidates]
+    .sort((left, right) => {
+      const priorityDelta = (HOOK_SOURCE_PRIORITY[left.source] ?? 3)
+        - (HOOK_SOURCE_PRIORITY[right.source] ?? 3);
+      if (priorityDelta !== 0) return priorityDelta;
+      return BigInt(left.nano) < BigInt(right.nano) ? -1 : BigInt(left.nano) > BigInt(right.nano) ? 1 : 0;
+    })[0]?.nano;
+}
+
+function getSegmentString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function earlierNano(current: string | undefined, candidate: string): string {
+  return !current || BigInt(candidate) < BigInt(current) ? candidate : current;
+}
+
+function laterNano(current: string | undefined, candidate: string): string {
+  return !current || BigInt(candidate) > BigInt(current) ? candidate : current;
+}
+
+function loopIterationIndex(loopId: string): number | undefined {
+  const match = loopId.match(/:(\d+)$/);
+  return match ? positiveNumber(Number(match[1])) : undefined;
+}
+
+function stepIterationIndex(stepId: unknown): number | undefined {
+  if (typeof stepId !== 'string') return undefined;
+  const match = stepId.match(/:s(\d+)$/);
+  return match ? positiveNumber(Number(match[1])) : undefined;
+}
+
+function compareSegmentPairs(left: SegmentLlmPair, right: SegmentLlmPair): number {
+  if (left.requestIndex !== undefined && right.requestIndex !== undefined
+    && left.requestIndex !== right.requestIndex) {
+    return left.requestIndex - right.requestIndex;
+  }
+  if (left.requestIndex !== undefined) return -1;
+  if (right.requestIndex !== undefined) return 1;
+  const leftStart = left.iterationStartNano ?? left.startNano;
+  const rightStart = right.iterationStartNano ?? right.startNano;
+  return BigInt(leftStart) < BigInt(rightStart) ? -1 : BigInt(leftStart) > BigInt(rightStart) ? 1 : 0;
 }
 
 function isoToNano(iso: string): string | undefined {

--- a/tests/unit/hooks/qoderwork-hook-processor.test.mjs
+++ b/tests/unit/hooks/qoderwork-hook-processor.test.mjs
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
+import { convertEventLogToReadableSpans } from '@loongsuite/otel-util-genai';
 import {
   extractText,
   getTurnIdForRows,
   isSystemInjection,
   isToolResult,
+  processTranscript,
   splitIntoTurns,
 } from '../../../assets/hooks/qoderwork-hook-processor.mjs';
 
@@ -143,5 +145,272 @@ describe('splitIntoTurns', () => {
     expect(turns).toHaveLength(2);
     expect(turns[0]).toHaveLength(4);
     expect(turns[1]).toHaveLength(2);
+  });
+});
+
+describe('QoderWork OTLP message semantics', () => {
+  it('uses stop for the final response and keeps tool call/result in assistant/tool messages', async () => {
+    const rows = [
+      {
+        type: 'user',
+        uuid: 'user-1',
+        promptId: 'turn-1',
+        timestamp: '2026-08-25T01:00:00.000Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'inspect a file' }] },
+      },
+      {
+        type: 'assistant',
+        uuid: 'assistant-tool-1',
+        parentUuid: 'user-1',
+        timestamp: '2026-08-25T01:00:01.000Z',
+        message: {
+          role: 'assistant',
+          id: 'response-1',
+          content: [{ type: 'tool_use', id: 'call-1', name: 'Read', input: { file_path: 'a.txt' } }],
+        },
+      },
+      {
+        type: 'user',
+        uuid: 'tool-result-1',
+        parentUuid: 'assistant-tool-1',
+        timestamp: '2026-08-25T01:00:02.000Z',
+        message: {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'call-1', content: 'file contents' }],
+        },
+      },
+      {
+        type: 'assistant',
+        uuid: 'assistant-final-1',
+        parentUuid: 'tool-result-1',
+        timestamp: '2026-08-25T01:00:03.000Z',
+        message: {
+          role: 'assistant',
+          id: 'response-2',
+          stop_reason: 'end_turn',
+          content: [{ type: 'text', text: 'done' }],
+        },
+      },
+    ];
+
+    const events = processTranscript(
+      rows,
+      'session-1',
+      'qoder-work',
+      { userId: 'user-1' },
+      '/workspace',
+      { rangeReason: 'incremental' },
+    );
+
+    const responses = events.filter(event => event['event.name'] === 'llm.response');
+    expect(responses.map(event => event['gen_ai.response.finish_reasons'])).toEqual([
+      ['tool_calls'],
+      ['stop'],
+    ]);
+    expect(responses[1]['gen_ai.output.messages'][0].finish_reason).toBe('stop');
+
+    const secondRequest = events.find(event =>
+      event['event.name'] === 'llm.request' && event['gen_ai.step.id'] === 'turn-1:s2');
+    const firstRequest = events.find(event =>
+      event['event.name'] === 'llm.request' && event['gen_ai.step.id'] === 'turn-1:s1');
+    expect(firstRequest['gen_ai.input.messages']).toEqual([
+      { role: 'user', parts: [{ type: 'text', content: 'inspect a file' }] },
+    ]);
+    expect(secondRequest['gen_ai.input.messages_delta']).toEqual([
+      {
+        role: 'assistant',
+        parts: [{
+          type: 'tool_call',
+          id: 'call-1',
+          name: 'Read',
+          arguments: { file_path: 'a.txt' },
+        }],
+      },
+      {
+        role: 'tool',
+        parts: [{ type: 'tool_call_response', id: 'call-1', response: 'file contents' }],
+      },
+    ]);
+    expect(secondRequest['gen_ai.input.messages']).toEqual([
+      { role: 'user', parts: [{ type: 'text', content: 'inspect a file' }] },
+      {
+        role: 'assistant',
+        parts: [{
+          type: 'tool_call',
+          id: 'call-1',
+          name: 'Read',
+          arguments: { file_path: 'a.txt' },
+        }],
+      },
+      {
+        role: 'tool',
+        parts: [{ type: 'tool_call_response', id: 'call-1', response: 'file contents' }],
+      },
+    ]);
+
+    const previousStability = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+    const previousCapture = process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+    process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'gen_ai_latest_experimental';
+    process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = 'SPAN_ONLY';
+    try {
+      const conversion = await convertEventLogToReadableSpans(events);
+      expect(conversion.warnings).toEqual([]);
+      const llmSpans = conversion.spans
+        .filter(span => span.attributes['gen_ai.span.kind'] === 'LLM')
+        .sort((left, right) => left.startTime[0] - right.startTime[0]
+          || left.startTime[1] - right.startTime[1]);
+      expect(llmSpans).toHaveLength(2);
+
+      const convertedInput = JSON.parse(llmSpans[1].attributes['gen_ai.input.messages']);
+      expect(convertedInput.map(message => message.role)).toEqual(['user', 'assistant', 'tool']);
+      expect(convertedInput[1].parts.map(part => part.type)).toEqual(['tool_call']);
+      expect(convertedInput[2].parts.map(part => part.type)).toEqual(['tool_call_response']);
+      expect(convertedInput[1].parts[0].id).toBe('call-1');
+      expect(convertedInput[2].parts[0].id).toBe('call-1');
+    } finally {
+      if (previousStability === undefined) delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+      else process.env.OTEL_SEMCONV_STABILITY_OPT_IN = previousStability;
+      if (previousCapture === undefined) delete process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+      else process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = previousCapture;
+    }
+  });
+
+  it('carries the complete previous assistant output and keeps parallel tool results separate', async () => {
+    const rows = [
+      {
+        type: 'user',
+        uuid: 'user-1',
+        promptId: 'turn-1',
+        timestamp: '2026-08-25T01:00:00.000Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'run both tools' }] },
+      },
+      {
+        type: 'assistant',
+        uuid: 'assistant-thinking-1',
+        parentUuid: 'user-1',
+        timestamp: '2026-08-25T01:00:01.000Z',
+        message: {
+          role: 'assistant',
+          id: 'response-1',
+          content: [{ type: 'thinking', thinking: 'I need both results.' }],
+        },
+      },
+      {
+        type: 'assistant',
+        uuid: 'assistant-tool-1',
+        parentUuid: 'user-1',
+        timestamp: '2026-08-25T01:00:01.100Z',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 'call-1', name: 'Read', input: { file_path: 'a.txt' } }],
+        },
+      },
+      {
+        type: 'assistant',
+        uuid: 'assistant-tool-2',
+        parentUuid: 'user-1',
+        timestamp: '2026-08-25T01:00:01.200Z',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 'call-2', name: 'Read', input: { file_path: 'b.txt' } }],
+        },
+      },
+      {
+        type: 'user',
+        uuid: 'tool-result-1',
+        timestamp: '2026-08-25T01:00:02.000Z',
+        message: {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'call-1', content: 'a contents' }],
+        },
+      },
+      {
+        type: 'user',
+        uuid: 'tool-result-2',
+        timestamp: '2026-08-25T01:00:02.100Z',
+        message: {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'call-2', content: 'b contents' }],
+        },
+      },
+      {
+        type: 'assistant',
+        uuid: 'assistant-final-1',
+        timestamp: '2026-08-25T01:00:03.000Z',
+        message: {
+          role: 'assistant',
+          id: 'response-2',
+          content: [{ type: 'text', text: 'done' }],
+        },
+      },
+    ];
+
+    const events = processTranscript(
+      rows,
+      'session-1',
+      'qoder-work',
+      { userId: 'user-1' },
+      '/workspace',
+      { rangeReason: 'incremental' },
+    );
+    const firstResponse = events.find(event =>
+      event['event.name'] === 'llm.response' && event['gen_ai.step.id'] === 'turn-1:s1');
+    const secondRequest = events.find(event =>
+      event['event.name'] === 'llm.request' && event['gen_ai.step.id'] === 'turn-1:s2');
+
+    expect(firstResponse['gen_ai.output.messages']).toEqual([{
+      role: 'assistant',
+      parts: [
+        { type: 'reasoning', content: 'I need both results.' },
+        { type: 'tool_call', id: 'call-1', name: 'Read', arguments: { file_path: 'a.txt' } },
+        { type: 'tool_call', id: 'call-2', name: 'Read', arguments: { file_path: 'b.txt' } },
+      ],
+      finish_reason: 'tool_calls',
+    }]);
+    expect(secondRequest['gen_ai.input.messages_delta']).toEqual([
+      {
+        role: 'assistant',
+        parts: firstResponse['gen_ai.output.messages'][0].parts,
+      },
+      {
+        role: 'tool',
+        parts: [{ type: 'tool_call_response', id: 'call-1', response: 'a contents' }],
+      },
+      {
+        role: 'tool',
+        parts: [{ type: 'tool_call_response', id: 'call-2', response: 'b contents' }],
+      },
+    ]);
+    expect(secondRequest['gen_ai.input.messages'].map(message => message.role)).toEqual([
+      'user', 'assistant', 'tool', 'tool',
+    ]);
+
+    const previousStability = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+    const previousCapture = process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+    process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'gen_ai_latest_experimental';
+    process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = 'SPAN_ONLY';
+    try {
+      const conversion = await convertEventLogToReadableSpans(events);
+      expect(conversion.warnings).toEqual([]);
+      const llmSpans = conversion.spans
+        .filter(span => span.attributes['gen_ai.span.kind'] === 'LLM')
+        .sort((left, right) => left.startTime[0] - right.startTime[0]
+          || left.startTime[1] - right.startTime[1]);
+      const convertedInput = JSON.parse(llmSpans[1].attributes['gen_ai.input.messages']);
+      expect(convertedInput.map(message => message.role)).toEqual([
+        'user', 'assistant', 'tool', 'tool',
+      ]);
+      expect(convertedInput[1].parts.map(part => part.type)).toEqual([
+        'reasoning', 'tool_call', 'tool_call',
+      ]);
+      expect(convertedInput.slice(2).map(message => message.parts[0].id)).toEqual([
+        'call-1', 'call-2',
+      ]);
+    } finally {
+      if (previousStability === undefined) delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+      else process.env.OTEL_SEMCONV_STABILITY_OPT_IN = previousStability;
+      if (previousCapture === undefined) delete process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+      else process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = previousCapture;
+    }
   });
 });

--- a/tests/unit/hooks/qoderwork-hook-processor.test.mjs
+++ b/tests/unit/hooks/qoderwork-hook-processor.test.mjs
@@ -394,4 +394,122 @@ describe('QoderWork OTLP message semantics', () => {
       else process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = previousCapture;
     }
   });
+
+  it('keeps assistant content but excludes parallel tool calls without results', async () => {
+    const rows = [
+      {
+        type: 'user',
+        uuid: 'user-1',
+        promptId: 'turn-1',
+        timestamp: '2026-08-25T01:00:00.000Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'run available tools' }] },
+      },
+      {
+        type: 'assistant',
+        uuid: 'assistant-thinking-1',
+        timestamp: '2026-08-25T01:00:01.000Z',
+        message: {
+          role: 'assistant',
+          id: 'response-1',
+          content: [{ type: 'thinking', thinking: 'I will inspect both files.' }],
+        },
+      },
+      {
+        type: 'assistant',
+        uuid: 'assistant-text-1',
+        timestamp: '2026-08-25T01:00:01.050Z',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Reading both files.' }],
+        },
+      },
+      {
+        type: 'assistant',
+        uuid: 'assistant-tool-1',
+        timestamp: '2026-08-25T01:00:01.100Z',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 'call-1', name: 'Read', input: { file_path: 'a.txt' } }],
+        },
+      },
+      {
+        type: 'assistant',
+        uuid: 'assistant-tool-2',
+        timestamp: '2026-08-25T01:00:01.200Z',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 'call-2', name: 'Read', input: { file_path: 'b.txt' } }],
+        },
+      },
+      {
+        type: 'user',
+        uuid: 'tool-result-1',
+        timestamp: '2026-08-25T01:00:02.000Z',
+        message: {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'call-1', content: 'a contents' }],
+        },
+      },
+      {
+        type: 'assistant',
+        uuid: 'assistant-final-1',
+        timestamp: '2026-08-25T01:00:03.000Z',
+        message: {
+          role: 'assistant',
+          id: 'response-2',
+          content: [{ type: 'text', text: 'Only one result was available.' }],
+        },
+      },
+    ];
+
+    const events = processTranscript(
+      rows,
+      'session-1',
+      'qoder-work',
+      { userId: 'user-1' },
+      '/workspace',
+      { rangeReason: 'incremental' },
+    );
+    const secondRequest = events.find(event =>
+      event['event.name'] === 'llm.request' && event['gen_ai.step.id'] === 'turn-1:s2');
+
+    expect(secondRequest['gen_ai.input.messages_delta']).toEqual([
+      {
+        role: 'assistant',
+        parts: [
+          { type: 'reasoning', content: 'I will inspect both files.' },
+          { type: 'text', content: 'Reading both files.' },
+          { type: 'tool_call', id: 'call-1', name: 'Read', arguments: { file_path: 'a.txt' } },
+        ],
+      },
+      {
+        role: 'tool',
+        parts: [{ type: 'tool_call_response', id: 'call-1', response: 'a contents' }],
+      },
+    ]);
+
+    const previousStability = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+    const previousCapture = process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+    process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'gen_ai_latest_experimental';
+    process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = 'SPAN_ONLY';
+    try {
+      const conversion = await convertEventLogToReadableSpans(events);
+      expect(conversion.warnings).toEqual([
+        'Orphan tool.call (tool.call.id=call-2): no matching tool.result in step',
+      ]);
+      const llmSpans = conversion.spans
+        .filter(span => span.attributes['gen_ai.span.kind'] === 'LLM')
+        .sort((left, right) => left.startTime[0] - right.startTime[0]
+          || left.startTime[1] - right.startTime[1]);
+      const convertedInput = JSON.parse(llmSpans[1].attributes['gen_ai.input.messages']);
+      expect(convertedInput.map(message => message.role)).toEqual(['user', 'assistant', 'tool']);
+      expect(convertedInput[1].parts).toEqual(secondRequest['gen_ai.input.messages_delta'][0].parts);
+      expect(convertedInput[2].parts[0].id).toBe('call-1');
+    } finally {
+      if (previousStability === undefined) delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+      else process.env.OTEL_SEMCONV_STABILITY_OPT_IN = previousStability;
+      if (previousCapture === undefined) delete process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
+      else process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = previousCapture;
+    }
+  });
 });

--- a/tests/unit/hooks/qoderwork-hook-processor.test.mjs
+++ b/tests/unit/hooks/qoderwork-hook-processor.test.mjs
@@ -213,9 +213,7 @@ describe('QoderWork OTLP message semantics', () => {
       event['event.name'] === 'llm.request' && event['gen_ai.step.id'] === 'turn-1:s2');
     const firstRequest = events.find(event =>
       event['event.name'] === 'llm.request' && event['gen_ai.step.id'] === 'turn-1:s1');
-    expect(firstRequest['gen_ai.input.messages']).toEqual([
-      { role: 'user', parts: [{ type: 'text', content: 'inspect a file' }] },
-    ]);
+    expect(firstRequest['gen_ai.input.messages']).toBeUndefined();
     expect(secondRequest['gen_ai.input.messages_delta']).toEqual([
       {
         role: 'assistant',
@@ -231,22 +229,7 @@ describe('QoderWork OTLP message semantics', () => {
         parts: [{ type: 'tool_call_response', id: 'call-1', response: 'file contents' }],
       },
     ]);
-    expect(secondRequest['gen_ai.input.messages']).toEqual([
-      { role: 'user', parts: [{ type: 'text', content: 'inspect a file' }] },
-      {
-        role: 'assistant',
-        parts: [{
-          type: 'tool_call',
-          id: 'call-1',
-          name: 'Read',
-          arguments: { file_path: 'a.txt' },
-        }],
-      },
-      {
-        role: 'tool',
-        parts: [{ type: 'tool_call_response', id: 'call-1', response: 'file contents' }],
-      },
-    ]);
+    expect(secondRequest['gen_ai.input.messages']).toBeUndefined();
 
     const previousStability = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
     const previousCapture = process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
@@ -381,9 +364,7 @@ describe('QoderWork OTLP message semantics', () => {
         parts: [{ type: 'tool_call_response', id: 'call-2', response: 'b contents' }],
       },
     ]);
-    expect(secondRequest['gen_ai.input.messages'].map(message => message.role)).toEqual([
-      'user', 'assistant', 'tool', 'tool',
-    ]);
+    expect(secondRequest['gen_ai.input.messages']).toBeUndefined();
 
     const previousStability = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
     const previousCapture = process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;

--- a/tests/unit/inputs/qoder-work-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-work-trace-input.test.ts
@@ -5,7 +5,9 @@ import * as os from 'node:os';
 import { CollectionMethod, ClientType } from '../../../src/types/index.js';
 import type { AgentActivityEntry } from '../../../src/types/index.js';
 import { QoderWorkTraceInput } from '../../../src/inputs/qoder-work-trace/qoder-work-trace-input.js';
+import { applyQoderWorkStepTiming } from '../../../src/flushers/otlp-trace-flusher.js';
 import { MockStateStore } from '../../helpers/mock-state-store.js';
+import { convertEventLogToReadableSpans } from '@loongsuite/otel-util-genai';
 
 describe('QoderWorkTraceInput', () => {
   let tmpRoot: string;
@@ -70,8 +72,8 @@ describe('QoderWorkTraceInput', () => {
   function segTurnStarted(turnId: string, isSubagent = false, ts = '2026-06-16T10:00:00.000Z') {
     return { ts, type: 'turn.started', turn_id: turnId, data: { is_subagent: isSubagent } };
   }
-  function segModelStart(turnId: string, requestId: string, ts: string, model = 'qwork-ultimate') {
-    return { ts, type: 'model.request.started', turn_id: turnId, request_id: requestId, data: { model } };
+  function segModelStart(turnId: string, requestId: string, ts: string, model = 'qwork-ultimate', loopId?: string) {
+    return { ts, type: 'model.request.started', turn_id: turnId, request_id: requestId, loop_id: loopId, data: { model } };
   }
   function segModelEnd(
     turnId: string,
@@ -79,8 +81,19 @@ describe('QoderWorkTraceInput', () => {
     ts: string,
     model = 'qwork-ultimate',
     usage: Record<string, number> = {},
+    loopId?: string,
   ) {
-    return { ts, type: 'model.response.completed', turn_id: turnId, request_id: requestId, data: { model, ...usage } };
+    return { ts, type: 'model.response.completed', turn_id: turnId, request_id: requestId, loop_id: loopId, data: { model, ...usage } };
+  }
+  function segModelAttemptFailed(turnId: string, requestId: string, ts: string, loopId: string) {
+    return {
+      ts,
+      type: 'model.request.attempt_failed',
+      turn_id: turnId,
+      request_id: requestId,
+      loop_id: loopId,
+      data: { attempt_had_payload: false, stream_event_count: 0 },
+    };
   }
   function segToolRequested(turnId: string, toolCallId: string, ts: string, toolName = 'TodoWrite') {
     return { ts, type: 'tool.requested', turn_id: turnId, tool_call_id: toolCallId, data: { tool_name: toolName, args: {} } };
@@ -88,8 +101,30 @@ describe('QoderWorkTraceInput', () => {
   function segToolFinished(turnId: string, toolCallId: string, ts: string, toolName = 'TodoWrite') {
     return { ts, type: 'tool.execution.finished', turn_id: turnId, tool_call_id: toolCallId, data: { tool_name: toolName, status: 'success' } };
   }
+  function segIteration(turnId: string, loopId: string, requestIndex: number, type: 'started' | 'finished', ts: string) {
+    return { ts, type: `loop.iteration.${type}`, turn_id: turnId, loop_id: loopId, data: { request_index: requestIndex } };
+  }
+  function segToolHook(
+    sessionId: string,
+    toolCallId: string,
+    hookEventName: 'PreToolUse' | 'PostToolUse' | 'PostToolUseFailure',
+    source: 'runtime' | 'user' | 'plugins',
+    ts: string,
+  ) {
+    return {
+      ts,
+      type: 'hook.started',
+      turn_id: sessionId,
+      tool_call_id: toolCallId,
+      data: { hook_event_name: hookEventName, source },
+    };
+  }
   function nano(iso: string) {
     return String(BigInt(Date.parse(iso)) * 1_000_000n);
+  }
+
+  function toNano(hrTime: [number, number]) {
+    return String(BigInt(hrTime[0]) * 1_000_000_000n + BigInt(hrTime[1]));
   }
 
   function sdkMessageStart(sessionId: string, messageId: string, iso: string) {
@@ -665,6 +700,249 @@ describe('QoderWorkTraceInput', () => {
     expect(s3Resp.time_unix_nano).toBe(String(BigInt(Date.parse('2026-06-16T10:00:05.000Z')) * 1_000_000n));
   });
 
+  it('pairs a retried logical LLM by loop_id when request_id changes', async () => {
+    const sessionId = 'sess-retry-loop';
+    const turnId = 'turn-retry-loop';
+    const loopId = `${turnId}:1`;
+    const hookFile = path.join(hookLogDir, todayFileName());
+    await fs.writeFile(hookFile, [
+      buildHookEntry({
+        'event.id': 'retry-req',
+        'event.name': 'llm.request' as any,
+        'gen_ai.session.id': sessionId,
+        'gen_ai.turn.id': turnId,
+        'gen_ai.step.id': `${turnId}:s1`,
+      }),
+      buildHookEntry({
+        'event.id': 'retry-resp',
+        'gen_ai.session.id': sessionId,
+        'gen_ai.turn.id': turnId,
+        'gen_ai.step.id': `${turnId}:s1`,
+      }),
+    ].map(entry => JSON.stringify(entry)).join('\n') + '\n');
+    await writeSegments(sessionId, 'retry.jsonl', [
+      segIteration(turnId, loopId, 1, 'started', '2026-08-25T11:33:40.419+08:00'),
+      segModelStart(turnId, 'request-a', '2026-08-25T11:33:40.421+08:00', 'initial-model', loopId),
+      segModelAttemptFailed(turnId, 'request-a', '2026-08-25T11:33:41.722+08:00', loopId),
+      segModelEnd(turnId, 'request-b', '2026-08-25T11:33:57.690+08:00', 'final-model', {
+        input_tokens: 123,
+        output_tokens: 45,
+      }, loopId),
+      segIteration(turnId, loopId, 1, 'finished', '2026-08-25T11:34:01.320+08:00'),
+    ]);
+
+    const input = makeInput();
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    const request = entries.find(entry => entry['event.id'] === 'retry-req')!;
+    const response = entries.find(entry => entry['event.id'] === 'retry-resp')!;
+    expect(request.time_unix_nano).toBe(nano('2026-08-25T11:33:40.421+08:00'));
+    expect(request['agent.qoderwork.step.start_time_unix_nano']).toBe(nano('2026-08-25T11:33:40.419+08:00'));
+    expect(request['agent.qoderwork.step.end_time_unix_nano']).toBe(nano('2026-08-25T11:34:01.320+08:00'));
+    expect(response.time_unix_nano).toBe(nano('2026-08-25T11:33:57.690+08:00'));
+    expect(response['gen_ai.response.model']).toBe('final-model');
+    expect(response['gen_ai.usage.input_tokens']).toBe(123);
+    expect(response['gen_ai.usage.output_tokens']).toBe(45);
+  });
+
+  it('keeps ten transcript steps aligned when iterations 1 and 3 change request_id', async () => {
+    const sessionId = 'sess-ten-retry-loops';
+    const turnId = 'turn-ten-retry-loops';
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const hookEntries: AgentActivityEntry[] = [];
+    const segmentEvents: object[] = [];
+    const baseMs = Date.parse('2026-08-25T10:00:00.000Z');
+
+    for (let i = 1; i <= 10; i++) {
+      hookEntries.push(
+        buildHookEntry({
+          'event.id': `ten-s${i}-req`,
+          'event.name': 'llm.request' as any,
+          'gen_ai.session.id': sessionId,
+          'gen_ai.turn.id': turnId,
+          'gen_ai.step.id': `${turnId}:s${i}`,
+        }),
+        buildHookEntry({
+          'event.id': `ten-s${i}-resp`,
+          'gen_ai.session.id': sessionId,
+          'gen_ai.turn.id': turnId,
+          'gen_ai.step.id': `${turnId}:s${i}`,
+        }),
+      );
+      const loopId = `${turnId}:${i}`;
+      const start = new Date(baseMs + i * 10_000).toISOString();
+      const end = new Date(baseMs + i * 10_000 + 5_000).toISOString();
+      segmentEvents.push(
+        segIteration(turnId, loopId, i, 'started', new Date(baseMs + i * 10_000 - 1).toISOString()),
+        segModelStart(turnId, `request-${i}-a`, start, `model-${i}`, loopId),
+      );
+      if (i === 1 || i === 3) {
+        segmentEvents.push(segModelAttemptFailed(
+          turnId,
+          `request-${i}-a`,
+          new Date(baseMs + i * 10_000 + 1_000).toISOString(),
+          loopId,
+        ));
+      }
+      segmentEvents.push(
+        segModelEnd(
+          turnId,
+          i === 1 || i === 3 ? `request-${i}-b` : `request-${i}-a`,
+          end,
+          `model-${i}`,
+          {},
+          loopId,
+        ),
+        segIteration(turnId, loopId, i, 'finished', new Date(baseMs + i * 10_000 + 5_001).toISOString()),
+      );
+    }
+    await fs.writeFile(hookFile, hookEntries.map(entry => JSON.stringify(entry)).join('\n') + '\n');
+    // Write complete iterations in reverse order to prove requestIndex ordering
+    // and direct sN ↔ :N matching do not depend on file event order.
+    // Iterations without a retry have four records, so use an explicit grouping.
+    const byLoop = new Map<string, object[]>();
+    for (const event of segmentEvents as Array<{ loop_id?: string }>) {
+      const group = byLoop.get(event.loop_id!) ?? [];
+      group.push(event);
+      byLoop.set(event.loop_id!, group);
+    }
+    await writeSegments(sessionId, 'ten.jsonl', [...byLoop.values()].reverse().flat());
+
+    const input = makeInput();
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    for (let i = 1; i <= 10; i++) {
+      expect(entries.find(entry => entry['event.id'] === `ten-s${i}-req`)!.time_unix_nano)
+        .toBe(String(BigInt(baseMs + i * 10_000) * 1_000_000n));
+      expect(entries.find(entry => entry['event.id'] === `ten-s${i}-resp`)!.time_unix_nano)
+        .toBe(String(BigInt(baseMs + i * 10_000 + 5_000) * 1_000_000n));
+    }
+  });
+
+  it('does not shift a later indexed pair into an interrupted transcript step', async () => {
+    const sessionId = 'sess-interrupted-loop';
+    const turnId = 'turn-interrupted-loop';
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const hookEntries: AgentActivityEntry[] = [];
+    for (let i = 1; i <= 2; i++) {
+      hookEntries.push(
+        buildHookEntry({
+          'event.id': `interrupted-s${i}-req`,
+          'event.name': 'llm.request' as any,
+          'gen_ai.session.id': sessionId,
+          'gen_ai.turn.id': turnId,
+          'gen_ai.step.id': `${turnId}:s${i}`,
+          time_unix_nano: String(1_000_000_000_000_000_000n + BigInt(i)),
+        }),
+        buildHookEntry({
+          'event.id': `interrupted-s${i}-resp`,
+          'gen_ai.session.id': sessionId,
+          'gen_ai.turn.id': turnId,
+          'gen_ai.step.id': `${turnId}:s${i}`,
+          time_unix_nano: String(1_000_000_000_100_000_000n + BigInt(i)),
+        }),
+      );
+    }
+    await fs.writeFile(hookFile, hookEntries.map(entry => JSON.stringify(entry)).join('\n') + '\n');
+    await writeSegments(sessionId, 'interrupted.jsonl', [
+      segIteration(turnId, `${turnId}:1`, 1, 'started', '2026-06-16T10:00:00.000Z'),
+      segModelStart(turnId, 'interrupted-request', '2026-06-16T10:00:00.001Z', 'model-1', `${turnId}:1`),
+      segIteration(turnId, `${turnId}:2`, 2, 'started', '2026-06-16T10:00:10.000Z'),
+      segModelStart(turnId, 'complete-request', '2026-06-16T10:00:10.001Z', 'model-2', `${turnId}:2`),
+      segModelEnd(turnId, 'complete-request', '2026-06-16T10:00:15.000Z', 'model-2', {}, `${turnId}:2`),
+      segIteration(turnId, `${turnId}:2`, 2, 'finished', '2026-06-16T10:00:15.001Z'),
+    ]);
+
+    const input = makeInput();
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    expect(entries.find(entry => entry['event.id'] === 'interrupted-s1-req')!.time_unix_nano)
+      .toBe('1000000000000000001');
+    expect(entries.find(entry => entry['event.id'] === 'interrupted-s2-req')!.time_unix_nano)
+      .toBe(nano('2026-06-16T10:00:10.001Z'));
+    expect(entries.find(entry => entry['event.id'] === 'interrupted-s2-resp')!.time_unix_nano)
+      .toBe(nano('2026-06-16T10:00:15.000Z'));
+  });
+
+  it('pairs model start and completion across segment files by loop_id', async () => {
+    const sessionId = 'sess-cross-file-loop';
+    const turnId = 'turn-cross-file-loop';
+    const loopId = `${turnId}:1`;
+    const hookFile = path.join(hookLogDir, todayFileName());
+    await fs.writeFile(hookFile, [
+      buildHookEntry({
+        'event.id': 'cross-file-req',
+        'event.name': 'llm.request' as any,
+        'gen_ai.session.id': sessionId,
+        'gen_ai.turn.id': turnId,
+        'gen_ai.step.id': `${turnId}:s1`,
+      }),
+      buildHookEntry({
+        'event.id': 'cross-file-resp',
+        'gen_ai.session.id': sessionId,
+        'gen_ai.turn.id': turnId,
+        'gen_ai.step.id': `${turnId}:s1`,
+      }),
+    ].map(entry => JSON.stringify(entry)).join('\n') + '\n');
+    await writeSegments(sessionId, '001.jsonl', [
+      segIteration(turnId, loopId, 1, 'started', '2026-06-16T10:00:00.000Z'),
+      segModelStart(turnId, 'cross-file-a', '2026-06-16T10:00:00.010Z', 'first-model', loopId),
+      segModelAttemptFailed(turnId, 'cross-file-a', '2026-06-16T10:00:01.000Z', loopId),
+    ]);
+    await writeSegments(sessionId, '002.jsonl', [
+      segModelEnd(turnId, 'cross-file-b', '2026-06-16T10:00:05.000Z', 'final-model', {}, loopId),
+      segIteration(turnId, loopId, 1, 'finished', '2026-06-16T10:00:05.010Z'),
+    ]);
+
+    const input = makeInput();
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    expect(entries.find(entry => entry['event.id'] === 'cross-file-req')!.time_unix_nano)
+      .toBe(nano('2026-06-16T10:00:00.010Z'));
+    expect(entries.find(entry => entry['event.id'] === 'cross-file-resp')!['gen_ai.response.model'])
+      .toBe('final-model');
+  });
+
+  it('uses iteration start when a completed loop has no model.request.started', async () => {
+    const sessionId = 'sess-missing-model-start';
+    const turnId = 'turn-missing-model-start';
+    const loopId = `${turnId}:1`;
+    const hookFile = path.join(hookLogDir, todayFileName());
+    await fs.writeFile(hookFile, [
+      buildHookEntry({
+        'event.id': 'missing-start-req',
+        'event.name': 'llm.request' as any,
+        'gen_ai.session.id': sessionId,
+        'gen_ai.turn.id': turnId,
+        'gen_ai.step.id': `${turnId}:s1`,
+      }),
+      buildHookEntry({
+        'event.id': 'missing-start-resp',
+        'gen_ai.session.id': sessionId,
+        'gen_ai.turn.id': turnId,
+        'gen_ai.step.id': `${turnId}:s1`,
+      }),
+    ].map(entry => JSON.stringify(entry)).join('\n') + '\n');
+    await writeSegments(sessionId, 'missing-start.jsonl', [
+      segIteration(turnId, loopId, 1, 'started', '2026-06-16T10:00:00.000Z'),
+      segModelEnd(turnId, 'completed-only', '2026-06-16T10:00:05.000Z', 'fallback-model', {}, loopId),
+      segIteration(turnId, loopId, 1, 'finished', '2026-06-16T10:00:05.010Z'),
+    ]);
+
+    const input = makeInput();
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    expect(entries.find(entry => entry['event.id'] === 'missing-start-req')!.time_unix_nano)
+      .toBe(nano('2026-06-16T10:00:00.000Z'));
+    expect(entries.find(entry => entry['event.id'] === 'missing-start-resp')!.time_unix_nano)
+      .toBe(nano('2026-06-16T10:00:05.000Z'));
+  });
+
   it('matches segment timing by turn id and uses segment tool timing without consuming background pairs', async () => {
     const sessionId = 'sess-background-pair';
     const turnId = 'prompt-real-turn';
@@ -740,12 +1018,23 @@ describe('QoderWorkTraceInput', () => {
     await writeSegments(sessionId, 'run1.jsonl', [
       segModelStart('qoderwork-memory-sink-fork-qoderwork-memory-sink', 'memory-1', '2026-06-18T09:39:42.866+08:00'),
       segModelEnd('qoderwork-memory-sink-fork-qoderwork-memory-sink', 'memory-1', '2026-06-18T09:39:50.736+08:00'),
-      segModelStart(turnId, 'real-1', '2026-06-18T10:37:43.032+08:00'),
+      segIteration(turnId, `${turnId}:1`, 1, 'started', '2026-06-18T10:37:43.000+08:00'),
+      segModelStart(turnId, 'real-1', '2026-06-18T10:37:43.032+08:00', 'qwork-ultimate', `${turnId}:1`),
       segToolRequested(turnId, toolCallId, '2026-06-18T10:38:05.093+08:00'),
-      segModelEnd(turnId, 'real-1', '2026-06-18T10:38:05.168+08:00'),
+      segModelEnd(turnId, 'real-1', '2026-06-18T10:38:05.168+08:00', 'qwork-ultimate', {}, `${turnId}:1`),
+      // The earlier user/plugin timestamps must not beat the runtime source.
+      segToolHook(sessionId, toolCallId, 'PreToolUse', 'user', '2026-06-18T10:38:05.180+08:00'),
+      segToolHook(sessionId, toolCallId, 'PreToolUse', 'plugins', '2026-06-18T10:38:05.190+08:00'),
+      segToolHook(sessionId, toolCallId, 'PreToolUse', 'runtime', '2026-06-18T10:38:05.200+08:00'),
+      // Without runtime PostToolUse, prefer user over an earlier plugin hook.
+      segToolHook(sessionId, toolCallId, 'PostToolUse', 'plugins', '2026-06-18T10:38:06.400+08:00'),
+      segToolHook(sessionId, toolCallId, 'PostToolUse', 'user', '2026-06-18T10:38:06.500+08:00'),
       segToolFinished(turnId, toolCallId, '2026-06-18T10:38:06.616+08:00'),
-      segModelStart(turnId, 'real-2', '2026-06-18T10:38:06.840+08:00'),
-      segModelEnd(turnId, 'real-2', '2026-06-18T10:38:11.107+08:00'),
+      segIteration(turnId, `${turnId}:1`, 1, 'finished', '2026-06-18T10:38:06.700+08:00'),
+      segIteration(turnId, `${turnId}:2`, 2, 'started', '2026-06-18T10:38:06.800+08:00'),
+      segModelStart(turnId, 'real-2', '2026-06-18T10:38:06.840+08:00', 'qwork-ultimate', `${turnId}:2`),
+      segModelEnd(turnId, 'real-2', '2026-06-18T10:38:11.107+08:00', 'qwork-ultimate', {}, `${turnId}:2`),
+      segIteration(turnId, `${turnId}:2`, 2, 'finished', '2026-06-18T10:38:11.200+08:00'),
     ]);
 
     const input = makeInput();
@@ -753,11 +1042,34 @@ describe('QoderWorkTraceInput', () => {
     await input.stop();
 
     expect(entries.find(e => e['event.id'] === 's1-req')!.time_unix_nano).toBe(nano('2026-06-18T10:37:43.032+08:00'));
+    expect(entries.find(e => e['event.id'] === 's1-req')!['agent.qoderwork.step.start_time_unix_nano'])
+      .toBe(nano('2026-06-18T10:37:43.000+08:00'));
+    expect(entries.find(e => e['event.id'] === 's1-req')!['agent.qoderwork.step.end_time_unix_nano'])
+      .toBe(nano('2026-06-18T10:38:06.700+08:00'));
     expect(entries.find(e => e['event.id'] === 's1-resp')!.time_unix_nano).toBe(nano('2026-06-18T10:38:05.168+08:00'));
-    expect(entries.find(e => e['event.id'] === 's1-tool-call')!.time_unix_nano).toBe(nano('2026-06-18T10:38:05.093+08:00'));
-    expect(entries.find(e => e['event.id'] === 's1-tool-result')!.time_unix_nano).toBe(nano('2026-06-18T10:38:06.616+08:00'));
+    expect(entries.find(e => e['event.id'] === 's1-tool-call')!.time_unix_nano).toBe(nano('2026-06-18T10:38:05.200+08:00'));
+    expect(entries.find(e => e['event.id'] === 's1-tool-result')!.time_unix_nano).toBe(nano('2026-06-18T10:38:06.500+08:00'));
     expect(entries.find(e => e['event.id'] === 's2-req')!.time_unix_nano).toBe(nano('2026-06-18T10:38:06.840+08:00'));
     expect(entries.find(e => e['event.id'] === 's2-resp')!.time_unix_nano).toBe(nano('2026-06-18T10:38:11.107+08:00'));
+
+    const previousStability = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+    process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'gen_ai_latest_experimental';
+    try {
+      const converted = await convertEventLogToReadableSpans(entries as any[]);
+      applyQoderWorkStepTiming(entries, converted.spans as any[]);
+      const steps = converted.spans
+        .filter(span => span.attributes['gen_ai.span.kind'] === 'STEP')
+        .sort((left, right) => left.startTime[0] - right.startTime[0]
+          || left.startTime[1] - right.startTime[1]);
+      expect(steps).toHaveLength(2);
+      expect(toNano(steps[0].startTime)).toBe(nano('2026-06-18T10:37:43.000+08:00'));
+      expect(toNano(steps[0].endTime)).toBe(nano('2026-06-18T10:38:06.700+08:00'));
+      expect(toNano(steps[1].startTime)).toBe(nano('2026-06-18T10:38:06.800+08:00'));
+      expect(toNano(steps[1].endTime)).toBe(nano('2026-06-18T10:38:11.200+08:00'));
+    } finally {
+      if (previousStability === undefined) delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+      else process.env.OTEL_SEMCONV_STABILITY_OPT_IN = previousStability;
+    }
   });
 
   it('retains segment tool timing when tool.call and tool.result arrive in separate batches', async () => {
@@ -811,7 +1123,9 @@ describe('QoderWorkTraceInput', () => {
 
     const input = makeInput();
     const firstBatch = await startAndCollect(input);
-    expect(firstBatch.find(e => e['event.id'] === 'tool-call')!.time_unix_nano).toBe(nano('2026-06-18T10:00:05.050+08:00'));
+    // No PreToolUse event: tool start falls back to model.response.completed,
+    // not the earlier tool.requested notification.
+    expect(firstBatch.find(e => e['event.id'] === 'tool-call')!.time_unix_nano).toBe(nano('2026-06-18T10:00:05.200+08:00'));
 
     await fs.appendFile(hookFile, JSON.stringify(toolResult) + '\n');
     const secondBatch = await triggerCycle(input);
@@ -851,7 +1165,7 @@ describe('QoderWorkTraceInput', () => {
     expect(respOut.time_unix_nano).toBe('1700001000000000000');
   });
 
-  it('keeps hook tool.call timestamp when segments have no tool.requested event', async () => {
+  it('uses model.response.completed when segments have no PreToolUse event', async () => {
     const sessionId = 'sess-tc';
     const hookFile = path.join(hookLogDir, todayFileName());
 
@@ -877,6 +1191,7 @@ describe('QoderWorkTraceInput', () => {
       'gen_ai.session.id': sessionId,
       'gen_ai.turn.id': 'turn-tc',
       'gen_ai.step.id': 'turn-tc:s1',
+      'gen_ai.tool.call.id': 'tool-no-pre',
       time_unix_nano: '999999999999000000',
     });
     await fs.writeFile(hookFile, [JSON.stringify(req), JSON.stringify(resp), JSON.stringify(toolCall)].join('\n') + '\n');
@@ -892,7 +1207,7 @@ describe('QoderWorkTraceInput', () => {
     await input.stop();
 
     const tcOut = entries.find(e => e['event.id'] === 'tc')!;
-    expect(tcOut.time_unix_nano).toBe('999999999999000000');
+    expect(tcOut.time_unix_nano).toBe(nano('2026-06-16T10:00:05.000Z'));
   });
 
   // fixture 来源: qoderwork-runtime-wrapper.mjs 写出的 qoderwork-intercept.jsonl


### PR DESCRIPTION
## Summary

- normalize the final QoderWork LLM finish reason to `stop`
- carry the complete previous assistant output into the next LLM input and emit one tool response message per tool call
- aggregate retried segment requests by `loop_id` so each logical loop maps to exactly one transcript step
- apply explicit loop iteration boundaries to STEP spans and source-aware tool timing to tool spans

## Validation

- `npx vitest run tests/unit/hooks/qoderwork-hook-processor.test.mjs tests/unit/inputs/qoder-work-trace-input.test.ts tests/unit/flushers/otlp-trace-flusher`
  - 12 test files, 134 tests passed
- `npm run typecheck`
- live QoderWork trace verification: previous assistant reasoning and parallel tool calls are preserved in the next LLM input; tool responses remain one message per call; no tool span starts before its LLM span

## Notes

Token collection behavior is unchanged. When QoderWork segment usage reports zero and no runtime intercept record is available, OTLP usage fields remain absent.