### PR TITLE
fix(cursor): emit Windows transcript input deltas

### DIFF
--- a/assets/hooks/cursor/transcript-assembler.mjs
+++ b/assets/hooks/cursor/transcript-assembler.mjs
@@ -144,20 +144,31 @@ export function buildCursorRecordsFromTranscript(transcriptPath, journalEvents, 
     // llm.request.model from step events
     const stepModel = step.thoughtEvent?.model || step.responseEvent?.model || model;
 
+    const inputMessageDelta = [];
+    if (i === 0 && userText) {
+      inputMessageDelta.push({
+        role: 'user',
+        parts: [{ type: 'text', content: userText }],
+      });
+    }
     if (i > 0 && prevToolResults.length > 0) {
       if (previousAssistantToolMessage) {
-        cumulativeInputMessages.push(cloneMessage(previousAssistantToolMessage));
+        const assistantMessage = cloneMessage(previousAssistantToolMessage);
+        inputMessageDelta.push(assistantMessage);
+        cumulativeInputMessages.push(cloneMessage(assistantMessage));
       }
       // NOTE: tool_output from journal postToolUse may contain GB18030-garbled text.
       // Omit response content to avoid garbled data in output; structure is preserved.
-      cumulativeInputMessages.push({
+      const toolMessage = {
         role: 'tool',
         parts: prevToolResults.map(tr => ({
           type: 'tool_call_response',
           id: tr.tool_use_id || null,
           response: '',
         })),
-      });
+      };
+      inputMessageDelta.push(toolMessage);
+      cumulativeInputMessages.push(cloneMessage(toolMessage));
     }
     const inputMessages = cumulativeInputMessages.map(cloneMessage);
 
@@ -173,6 +184,9 @@ export function buildCursorRecordsFromTranscript(transcriptPath, journalEvents, 
       'gen_ai.response.id': responseId,
       'gen_ai.provider.name': inferProvider(stepModel),
       'gen_ai.request.model': stepModel,
+      'gen_ai.input.messages_delta': inputMessageDelta.length > 0
+        ? inputMessageDelta.map(cloneMessage)
+        : undefined,
       'gen_ai.input.messages': inputMessages.length > 0 ? inputMessages : undefined,
       'agent.cursor.hook_event_name': reqSource.hook_event,
       'agent.cursor.llm_request_time_source': i === 0

--- a/tests/unit/hooks/cursor-transcript-assembler.test.mjs
+++ b/tests/unit/hooks/cursor-transcript-assembler.test.mjs
@@ -230,6 +230,16 @@ describe('buildCursorRecordsFromTranscript', () => {
       expect(req['gen_ai.step.id']).toMatch(/:s1$/);
     });
 
+    it('llm.request emits the user message as both delta and full input', () => {
+      const req = records[1];
+      const expected = [
+        { role: 'user', parts: [{ type: 'text', content: '你好' }] },
+      ];
+
+      expect(req['gen_ai.input.messages_delta']).toEqual(expected);
+      expect(req['gen_ai.input.messages']).toEqual(expected);
+    });
+
     it('llm.request and llm.response share the same response.id', () => {
       const req = records[1];
       const resp = records[2];
@@ -350,6 +360,23 @@ describe('buildCursorRecordsFromTranscript', () => {
       });
     });
 
+    it('step 2 input delta contains only the new assistant call and tool result', () => {
+      const delta = records[5]['gen_ai.input.messages_delta'];
+
+      expect(delta.map(message => message.role)).toEqual(['assistant', 'tool']);
+      expect(delta[0].parts[0]).toMatchObject({
+        type: 'tool_call',
+        id: 'tool-ws-001',
+        name: 'WebSearch',
+        arguments: { query: '上海天气' },
+      });
+      expect(delta[1].parts[0]).toEqual({
+        type: 'tool_call_response',
+        id: 'tool-ws-001',
+        response: '',
+      });
+    });
+
     it('step 2 llm.response has correct final text', () => {
       const s2Resp = records[6];
       expect(s2Resp['gen_ai.step.id']).toMatch(/:s2$/);
@@ -451,6 +478,31 @@ describe('buildCursorRecordsFromTranscript', () => {
       );
       const req = records.find(r => r['event.name'] === 'llm.request' && r['gen_ai.step.id']);
       expect(req['gen_ai.request.model']).toBe('claude-3-5-sonnet');
+    });
+  });
+
+  describe('content capture policy', () => {
+    it('removes both delta and full input when message capture is disabled', () => {
+      const transcriptPath = simpleTranscript('private prompt', 'private response');
+      const records = buildCursorRecordsFromTranscript(
+        transcriptPath,
+        [
+          makePromptEvent({ prompt: 'private prompt' }),
+          makeResponseEvent({ text: 'private response' }),
+          makeStopEvent(),
+        ],
+        {
+          stopConversationId: 'conv-abc',
+          runtimeConfig: {
+            agents: { cursor: { captureMessageContent: false } },
+          },
+        },
+      );
+
+      for (const record of records) {
+        expect(record['gen_ai.input.messages_delta']).toBeUndefined();
+        expect(record['gen_ai.input.messages']).toBeUndefined();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

- emit `gen_ai.input.messages_delta` on Windows Cursor transcript-backed `llm.request` events
- align delta structure with the macOS/Linux ReAct assembler while preserving cumulative `gen_ai.input.messages`
- preserve content-capture policy behavior and add focused regression coverage

## Behavior

- Step 1 delta contains the user message.
- Later-step delta contains the preceding assistant tool-call message followed by its tool results.
- Empty deltas remain omitted.
- Existing full input history, timestamps, tokens, IDs, and OTLP conversion behavior are unchanged.
- `captureMessageContent: false` removes both full and delta input fields.

## Validation

- `npm run typecheck`
- `npm test -- --reporter=dot`
  - 282 test files passed, 3 skipped
  - 3478 tests passed, 56 skipped

Fixes #322
