### PR TITLE
fix(dsh, pi): emit request input message deltas

### DIFF
--- a/assets/plugins/pi-coding-agent/index.mjs
+++ b/assets/plugins/pi-coding-agent/index.mjs
@@ -311,6 +311,39 @@ function canonicalMessages(messages) {
     .filter(Boolean);
 }
 
+function sameCanonicalMessage(left, right) {
+  return safeStringify(left) === safeStringify(right);
+}
+
+/**
+ * Return the messages appended since the previous request snapshot.
+ *
+ * Pi caps the captured request context to the most recent MAX_MESSAGES, so a
+ * later snapshot may have dropped messages from the front. Matching the
+ * longest previous-suffix/current-prefix overlap handles both ordinary append
+ * growth and that rolling window. A non-overlapping replacement (for example
+ * compaction or another extension rewriting context) is not representable as
+ * an append-only delta, so leave the field absent instead of fabricating one.
+ */
+function appendedInputMessages(previous, current, hasPreviousSnapshot) {
+  if (!hasPreviousSnapshot || previous.length === 0) return current.slice();
+  if (current.length === 0) return [];
+
+  const maxOverlap = Math.min(previous.length, current.length);
+  for (let overlap = maxOverlap; overlap > 0; overlap--) {
+    const previousStart = previous.length - overlap;
+    let matches = true;
+    for (let index = 0; index < overlap; index++) {
+      if (!sameCanonicalMessage(previous[previousStart + index], current[index])) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) return current.slice(overlap);
+  }
+  return undefined;
+}
+
 function canonicalOutputMessage(message) {
   const canonical = canonicalMessage(message);
   if (!canonical) return undefined;
@@ -432,7 +465,10 @@ export function createPiTelemetryExtension(identityOptions = {}) {
     requestStartedAt: 0,
     systemPrompt: null,
     pendingUserInput: [],
+    fallbackRequestInput: [],
     userInputEmitted: false,
+    previousRequestMessages: [],
+    hasPreviousRequestSnapshot: false,
     toolStarts: new Map(),
   };
 
@@ -451,7 +487,10 @@ export function createPiTelemetryExtension(identityOptions = {}) {
     state.requestEmitted = false;
     state.requestStartedAt = 0;
     state.pendingUserInput = [];
+    state.fallbackRequestInput = [];
     state.userInputEmitted = false;
+    state.previousRequestMessages = [];
+    state.hasPreviousRequestSnapshot = false;
     state.toolStarts.clear();
   }));
 
@@ -464,8 +503,11 @@ export function createPiTelemetryExtension(identityOptions = {}) {
     state.requestEmitted = false;
     state.requestStartedAt = 0;
     state.systemPrompt = event.systemPrompt;
-    state.pendingUserInput = promptInputMessages(event);
+    state.pendingUserInput = state.captureContent ? promptInputMessages(event) : [];
+    state.fallbackRequestInput = state.pendingUserInput.slice();
     state.userInputEmitted = false;
+    state.previousRequestMessages = [];
+    state.hasPreviousRequestSnapshot = false;
     state.toolStarts.clear();
   }));
 
@@ -504,6 +546,24 @@ export function createPiTelemetryExtension(identityOptions = {}) {
     if (state.captureContent) {
       const messages = canonicalMessages(event.messages);
       if (messages.length > 0) record['gen_ai.input.messages'] = messages;
+      if (messages.length > 0) {
+        const delta = appendedInputMessages(
+          state.previousRequestMessages,
+          messages,
+          state.hasPreviousRequestSnapshot,
+        );
+        if (delta !== undefined) record['gen_ai.input.messages_delta'] = delta;
+        state.previousRequestMessages = messages;
+        state.hasPreviousRequestSnapshot = true;
+      } else if (!state.hasPreviousRequestSnapshot && state.fallbackRequestInput.length > 0) {
+        // `context` should precede every provider request, but older/custom Pi
+        // runtimes may deliver only message_end. Preserve the user input known
+        // from before_agent_start without pretending it was a full snapshot.
+        record['gen_ai.input.messages_delta'] = state.fallbackRequestInput;
+        state.previousRequestMessages = state.fallbackRequestInput.slice();
+        state.hasPreviousRequestSnapshot = true;
+      }
+      state.fallbackRequestInput = [];
       if (state.systemPrompt) {
         record['gen_ai.system_instructions'] = [
           { type: 'text', content: truncate(state.systemPrompt) },
@@ -608,6 +668,9 @@ export function createPiTelemetryExtension(identityOptions = {}) {
 
   pi.on('session_shutdown', safeHandler('session_shutdown', async () => {
     state.pendingUserInput = [];
+    state.fallbackRequestInput = [];
+    state.previousRequestMessages = [];
+    state.hasPreviousRequestSnapshot = false;
     state.toolStarts.clear();
   }));
   };

--- a/src/inputs/dsh/dsh-event-transform.ts
+++ b/src/inputs/dsh/dsh-event-transform.ts
@@ -58,6 +58,10 @@ export interface DshEventAggregatorState {
    * of a step arrives — at that point all input for the step has
    * landed (user prompt + any prior step's assistant msg + tool result). */
   inputMessages: unknown[];
+  /** Number of accumulated messages already represented by the previous
+   * llm.request. The accumulator only appends within one turn, so slicing from
+   * this position yields the exact request-level messages_delta. */
+  lastRequestInputMessageCount: number;
   /** Once true, omit input.messages instead of presenting a truncated history. */
   inputMessagesOverflowed: boolean;
 }
@@ -74,6 +78,7 @@ export function newState(): DshEventAggregatorState {
     firstOutputTimes: new Map(),
     toolNames: new Map(),
     inputMessages: [],
+    lastRequestInputMessageCount: 0,
     inputMessagesOverflowed: false,
   };
 }
@@ -88,6 +93,7 @@ function resetTurnState(state: DshEventAggregatorState): void {
   state.firstOutputTimes.clear();
   state.toolNames.clear();
   state.inputMessages = [];
+  state.lastRequestInputMessageCount = 0;
   state.inputMessagesOverflowed = false;
 }
 
@@ -349,10 +355,11 @@ export function transformDshRecord(
           if (state.emittedRequest.size >= MAX_TURN_CORRELATIONS) return null;
           state.emittedRequest.add(key);
           const inputSnapshot = state.inputMessages.slice();
+          const inputDelta = inputSnapshot.slice(state.lastRequestInputMessageCount);
           const header = state.currentTurnHeader ?? state.lastKnownHeader;
           const tools = header?.tools;
           const requestTime = state.requestStartTimes.get(key) ?? time;
-          return buildAgentActivityEntry({
+          const entry = buildAgentActivityEntry({
             ...common,
             'time_unix_nano': msToNano(requestTime),
             'event.name': 'llm.request',
@@ -365,7 +372,12 @@ export function transformDshRecord(
             'gen_ai.input.messages': !state.inputMessagesOverflowed && inputSnapshot.length > 0
               ? toJsonValue(inputSnapshot)
               : undefined,
+            'gen_ai.input.messages_delta': !state.inputMessagesOverflowed && inputSnapshot.length > 0
+              ? toJsonValue(inputDelta)
+              : undefined,
           });
+          state.lastRequestInputMessageCount = inputSnapshot.length;
+          return entry;
         }
       }
       return null;

--- a/tests/unit/hooks/pi-coding-agent-extension.test.mjs
+++ b/tests/unit/hooks/pi-coding-agent-extension.test.mjs
@@ -216,6 +216,7 @@ describe('Pi Coding Agent extension', () => {
     expect(request.resourceAttributes).toBeUndefined();
     expect(request['agent.pi-coding-agent.cwd']).toBe('/workspace/example');
     expect(request['gen_ai.input.messages'][0].parts[0].content).toBe('Inspect the repository');
+    expect(request['gen_ai.input.messages_delta']).toEqual(request['gen_ai.input.messages']);
     expect(request['gen_ai.tool.definitions'].map(tool => tool.name)).toEqual(['read', 'bash']);
 
     const response = records.find(record => record['event.name'] === 'llm.response');
@@ -444,6 +445,88 @@ describe('Pi Coding Agent extension', () => {
     expect(requests[1]['gen_ai.input.messages'][0].parts[0].content).toBe('second turn');
   });
 
+  it('emits only newly appended assistant and tool messages on later requests', async () => {
+    const runtime = await createRuntime();
+    await startTurn(runtime);
+
+    const firstContext = [{ role: 'user', content: 'Inspect the repository' }];
+    await runtime.emit('context', { messages: firstContext });
+    await runtime.emit('turn_start', { turnIndex: 1, timestamp: Date.now() });
+    await runtime.emit('context', {
+      messages: [
+        ...firstContext,
+        {
+          role: 'assistant',
+          content: [{ type: 'toolCall', id: 'call-1', name: 'read', arguments: { path: 'README.md' } }],
+        },
+        {
+          role: 'toolResult',
+          toolCallId: 'call-1',
+          toolName: 'read',
+          isError: false,
+          content: [{ type: 'text', text: '# README' }],
+        },
+      ],
+    });
+
+    const requests = readRecords().filter(record => record['event.name'] === 'llm.request');
+    expect(requests).toHaveLength(2);
+    expect(requests[0]['gen_ai.input.messages_delta']).toEqual(requests[0]['gen_ai.input.messages']);
+    expect(requests[1]['gen_ai.input.messages_delta'].map(message => message.role)).toEqual([
+      'assistant',
+      'tool',
+    ]);
+    expect([
+      ...requests[0]['gen_ai.input.messages_delta'],
+      ...requests[1]['gen_ai.input.messages_delta'],
+    ]).toEqual(requests[1]['gen_ai.input.messages']);
+  });
+
+  it('derives request deltas across the rolling 40-message capture window', async () => {
+    const runtime = await createRuntime();
+    await startTurn(runtime);
+
+    const firstContext = Array.from({ length: 40 }, (_, index) => ({
+      role: 'user',
+      content: `message-${index}`,
+    }));
+    await runtime.emit('context', { messages: firstContext });
+    await runtime.emit('turn_start', { turnIndex: 1, timestamp: Date.now() });
+    await runtime.emit('context', {
+      messages: [
+        ...firstContext.slice(2),
+        { role: 'assistant', content: 'new assistant message' },
+        {
+          role: 'toolResult',
+          toolCallId: 'call-1',
+          toolName: 'read',
+          isError: false,
+          content: 'new tool result',
+        },
+      ],
+    });
+
+    const requests = readRecords().filter(record => record['event.name'] === 'llm.request');
+    expect(requests[1]['gen_ai.input.messages']).toHaveLength(40);
+    expect(requests[1]['gen_ai.input.messages_delta'].map(message => message.role)).toEqual([
+      'assistant',
+      'tool',
+    ]);
+    expect(JSON.stringify(requests[1]['gen_ai.input.messages_delta'])).toContain('new tool result');
+  });
+
+  it('keeps the full snapshot but omits a fabricated delta after context replacement', async () => {
+    const runtime = await createRuntime();
+    await startTurn(runtime);
+    await runtime.emit('context', { messages: [{ role: 'user', content: 'before compaction' }] });
+    await runtime.emit('turn_start', { turnIndex: 1, timestamp: Date.now() });
+    await runtime.emit('context', { messages: [{ role: 'user', content: 'replacement context' }] });
+
+    const requests = readRecords().filter(record => record['event.name'] === 'llm.request');
+    expect(requests[1]['gen_ai.input.messages'][0].parts[0].content).toBe('replacement context');
+    expect(requests[1]).not.toHaveProperty('gen_ai.input.messages_delta');
+  });
+
   it('keeps an LLM response strictly later than a request in the same millisecond', async () => {
     const runtime = await createRuntime();
     await startTurn(runtime);
@@ -533,6 +616,9 @@ describe('Pi Coding Agent extension', () => {
     ]);
     const request = records.find(record => record['event.name'] === 'llm.request');
     const response = records.find(record => record['event.name'] === 'llm.response');
+    expect(request['gen_ai.input.messages_delta']).toEqual([
+      { role: 'user', parts: [{ type: 'text', content: 'Inspect the repository' }] },
+    ]);
     expect(
       BigInt(response.time_unix_nano) - BigInt(request.time_unix_nano) >= 1_000_000n,
     ).toBe(true);
@@ -812,6 +898,7 @@ describe('Pi Coding Agent extension', () => {
     const records = readRecords();
     expect(records.some(record => record['event.name'] === 'other')).toBe(false);
     expect(records[0]).not.toHaveProperty('gen_ai.input.messages');
+    expect(records[0]).not.toHaveProperty('gen_ai.input.messages_delta');
     expect(records[0]).not.toHaveProperty('gen_ai.system_instructions');
     expect(records[0]).not.toHaveProperty('gen_ai.tool.definitions');
     expect(records[1]).not.toHaveProperty('gen_ai.output.messages');

--- a/tests/unit/inputs/dsh-log/dsh-event-transform.test.ts
+++ b/tests/unit/inputs/dsh-log/dsh-event-transform.test.ts
@@ -84,6 +84,13 @@ describe('dsh-event-transform (real fixture)', () => {
       .filter(e => e['event.name'] === 'llm.request')
       .sort((a, b) => (a['gen_ai.step.id'] as string).localeCompare(b['gen_ai.step.id'] as string));
     expect(requests.length).toBe(3);
+    const accumulatedDelta: unknown[] = [];
+    for (const request of requests) {
+      const delta = request['gen_ai.input.messages_delta'] as unknown[];
+      expect(delta).toBeDefined();
+      accumulatedDelta.push(...delta);
+      expect(accumulatedDelta).toEqual(request['gen_ai.input.messages']);
+    }
     const step1 = requests[0]['gen_ai.input.messages'] as unknown[];
     expect(step1.length).toBeGreaterThanOrEqual(1);
     expect((step1[0] as { role: string }).role).toBe('user');
@@ -293,6 +300,7 @@ describe('dsh-event-transform (real fixture)', () => {
     expect(r).toBeDefined();
     expect(r!['event.name']).toBe('llm.request');
     expect(r!['gen_ai.input.messages']).toBeUndefined();
+    expect(r!['gen_ai.input.messages_delta']).toBeUndefined();
   });
 
   it('records TTFT when the first assistant chunk is already an output delta', () => {
@@ -553,6 +561,7 @@ describe('dsh-event-transform (message sources)', () => {
         data: { turn: 1, step: 1, chunk: { type: 'block-start' } },
       }, ClientType.Dsh, state);
       expect(JSON.stringify(request?.['gen_ai.input.messages'])).toContain('injected context');
+      expect(JSON.stringify(request?.['gen_ai.input.messages_delta'])).toContain('injected context');
     },
   );
 
@@ -660,6 +669,7 @@ describe('dsh-event-transform (correlation isolation)', () => {
     expect(state.currentTurnHeader).toBeUndefined();
     expect(state.lastKnownHeader).toEqual({ model: 'old-model', provider: 'old-provider' });
     expect(state.inputMessages).toEqual([]);
+    expect(state.lastRequestInputMessageCount).toBe(0);
     expect(state.toolNames.size).toBe(0);
     expect(state.requestStartTimes.size).toBe(0);
     expect(state.firstOutputTimes.size).toBe(0);

--- a/tests/unit/inputs/dsh-log/dsh-log-input.test.ts
+++ b/tests/unit/inputs/dsh-log/dsh-log-input.test.ts
@@ -126,6 +126,58 @@ describe('DshLogInput state isolation and restart recovery', () => {
 
     expect(request?.['gen_ai.provider.name']).toBe('provider-a');
     expect(JSON.stringify(request?.['gen_ai.input.messages'])).toContain('private-prompt');
+    expect(JSON.stringify(request?.['gen_ai.input.messages_delta'])).toContain('private-prompt');
+  });
+
+  it('rebuilds the request delta cursor when restarting between ReAct steps', async () => {
+    const file = path.join(tmpDir, 'dsh-session-a.jsonl');
+    await appendRecords(file, [
+      ...prefix('session-a', 'provider-a', 'private-prompt'),
+      chunk('session-a'),
+      {
+        type: 'assistant/message', sid: 'session-a', time: 11,
+        data: {
+          turn: 1,
+          step: 1,
+          message: {
+            id: 'response-1',
+            source: { provider: 'provider-a', model: 'provider-a-model' },
+            content: [{
+              type: 'tool-call', id: 'call-1', name: 'read', arguments: { path: 'README.md' },
+            }],
+          },
+        },
+      },
+      {
+        type: 'tool/result', sid: 'session-a', time: 12,
+        data: {
+          turn: 1,
+          step: 1,
+          message: {
+            source: { callId: 'call-1' },
+            content: [{ type: 'text', text: '# README' }],
+          },
+        },
+      },
+      { type: 'step/start', sid: 'session-a', time: 13, data: { turn: 1, step: 2 } },
+      { type: 'request/context', sid: 'session-a', time: 14, data: { turn: 1, step: 2 } },
+    ]);
+
+    const first = await makeInput();
+    const firstEntries = await first.input.runCollect();
+    await first.store.save();
+    const firstRequest = firstEntries.find(entry => entry['event.name'] === 'llm.request');
+    expect(JSON.stringify(firstRequest?.['gen_ai.input.messages_delta'])).toContain('private-prompt');
+
+    await appendRecords(file, [chunk('session-a', 15, 1, 2)]);
+    const second = await makeInput();
+    const entries = await second.input.runCollect();
+    const request = entries.find(entry => entry['event.name'] === 'llm.request');
+    const delta = request?.['gen_ai.input.messages_delta'] as Array<{ role: string }>;
+
+    expect(delta.map(message => message.role)).toEqual(['assistant', 'tool']);
+    expect(JSON.stringify(delta)).not.toContain('private-prompt');
+    expect(JSON.stringify(request?.['gen_ai.input.messages'])).toContain('private-prompt');
   });
 
   it('restores the last header after a completed turn and pairs a headerless next turn', async () => {


### PR DESCRIPTION
## Summary

- add request-level `gen_ai.input.messages_delta` to DSH while retaining the existing full `gen_ai.input.messages` snapshots
- rebuild the DSH delta cursor through active-turn replay so restarts between ReAct steps keep correct incremental input
- derive Pi Coding Agent request deltas from consecutive model-visible context snapshots, including the rolling 40-message window
- use the `before_agent_start` prompt as a safe fallback when a Pi response arrives without a preceding context event
- keep full snapshots authoritative and omit a delta when a non-overlapping context replacement cannot be represented without fabrication
- preserve turn-level `other` input events and content-capture privacy behavior

## Validation

- `npm run typecheck`
- `npm run build`
- focused DSH/Pi suite: 88 tests passed
- full `npm test`: 3479 passed, 56 skipped

Closes #324