### PR TITLE
fix(workbuddy): emit user input other events

### DIFF
--- a/src/inputs/workbuddy/workbuddy-event-builder.ts
+++ b/src/inputs/workbuddy/workbuddy-event-builder.ts
@@ -10,14 +10,25 @@ import type {
 
 type Message = { role: string; parts: Array<Record<string, JsonValue>> };
 
-interface StepContext {
-  stepId: string;
-  requestId: string;
+interface TurnContext {
   turnId: string;
   traceId: string;
   provider: string;
+}
+
+interface StepContext extends TurnContext {
+  stepId: string;
+  requestId: string;
   requestModel?: string;
   responseModel?: string;
+}
+
+interface PendingUserInput {
+  source: WorkBuddyRecord;
+  message: Message;
+  timestamp?: number;
+  fallbackTimestamp?: number;
+  traceId?: string;
 }
 
 interface ToolContext {
@@ -95,6 +106,8 @@ export async function buildWorkBuddyEvents(
   let requestStartMs: number | undefined;
   let cwd: string | undefined;
   let lastResponse: AgentActivityEntry | undefined;
+  let pendingUserInput: PendingUserInput | undefined;
+  let turnStartEmitted = false;
 
   const push = async (entry: AgentActivityEntry, source: WorkBuddyRecord) => {
     if (cwd) {
@@ -103,6 +116,52 @@ export async function buildWorkBuddyEvents(
     }
     if (source.type) entry['agent.workbuddy.source_type'] = source.type;
     built.push(entry);
+  };
+
+  const rememberPendingUserContext = (source: WorkBuddyRecord) => {
+    if (!pendingUserInput) return;
+    pendingUserInput.fallbackTimestamp ??= timestampMs(source);
+    const rawTraceId = providerString(source, 'traceId');
+    if (!pendingUserInput.traceId && isValidTraceId(rawTraceId)) {
+      pendingUserInput.traceId = rawTraceId.toLowerCase();
+    }
+  };
+
+  const emitPendingUserInput = async (
+    traceId?: string,
+    fallbackTimestamp?: number,
+    useStopFallback = false,
+  ): Promise<boolean> => {
+    if (!pendingUserInput) return false;
+    const timestamp = pendingUserInput.timestamp
+      ?? fallbackTimestamp
+      ?? pendingUserInput.fallbackTimestamp
+      ?? (useStopFallback ? hookEvents.takeBoundary('Stop')?.observedAtMs : undefined);
+    if (timestamp === undefined) return false;
+
+    const context: TurnContext = {
+      turnId,
+      traceId: traceId
+        ?? pendingUserInput.traceId
+        ?? stableHex(`${opts.sessionId}:${turnId}`, 32),
+      provider: 'workbuddy',
+    };
+    const other = baseTurnEntry(
+      'other',
+      pendingUserInput.source,
+      opts.sessionId,
+      context,
+      `user-input:${turnId}`,
+      timestamp,
+    );
+    other['gen_ai.turn.start'] = true;
+    if (pendingUserInput.message.parts.length > 0) {
+      other['gen_ai.input.messages_delta'] = [pendingUserInput.message];
+    }
+    await push(other, pendingUserInput.source);
+    pendingUserInput = undefined;
+    turnStartEmitted = true;
+    return true;
   };
 
   const closeInterruptedTurn = async (boundarySource: WorkBuddyRecord): Promise<boolean> => {
@@ -177,6 +236,8 @@ export async function buildWorkBuddyEvents(
     );
     if (responseTimestamp === undefined) return;
     const requestTimestamp = requestStartMs ?? responseTimestamp;
+    rememberPendingUserContext(responseSource);
+    await emitPendingUserInput(step.traceId, requestTimestamp);
     const assistantToolParts = normalizedCalls.map(call => (
       toToolCallPart(call.record, call.callId, call.toolName)
     ));
@@ -195,7 +256,7 @@ export async function buildWorkBuddyEvents(
     );
     request['gen_ai.request.id'] = step.requestId;
     if (step.requestModel) request['gen_ai.request.model'] = step.requestModel;
-    if (firstStep) request['gen_ai.turn.start'] = true;
+    if (firstStep && !turnStartEmitted) request['gen_ai.turn.start'] = true;
     if (pendingDelta.length > 0) request['gen_ai.input.messages_delta'] = pendingDelta;
 
     const response = baseEntry(
@@ -252,14 +313,16 @@ export async function buildWorkBuddyEvents(
   for (let index = 0; index < records.length; index++) {
     const record = records[index];
     if (isInternalRecord(record)) continue;
-    if (typeof record.cwd === 'string' && record.cwd.length > 0) cwd = record.cwd;
 
     if (record.type === 'message' && record.role === 'user') {
       await closeInterruptedTurn(record);
+      await emitPendingUserInput(undefined, undefined, true);
       tools.clear();
+      if (typeof record.cwd === 'string' && record.cwd.length > 0) cwd = record.cwd;
       turnOrdinal++;
       stepOrdinal = 0;
       firstStep = true;
+      turnStartEmitted = false;
       turnId = stringValue(record.id) ?? stableId(opts.sessionId, `turn:${turnOrdinal}:${record.timestamp ?? index}`);
       lastResponse = undefined;
       const message = toMessage(record, 'user');
@@ -268,8 +331,18 @@ export async function buildWorkBuddyEvents(
       reasoningStartMs = undefined;
       requestStartMs = timestampMs(record)
         ?? hookEvents.takeBoundary('UserPromptSubmit')?.observedAtMs;
+      const rawTraceId = providerString(record, 'traceId');
+      pendingUserInput = {
+        source: record,
+        message,
+        timestamp: requestStartMs,
+        traceId: isValidTraceId(rawTraceId) ? rawTraceId.toLowerCase() : undefined,
+      };
       continue;
     }
+
+    if (typeof record.cwd === 'string' && record.cwd.length > 0) cwd = record.cwd;
+    rememberPendingUserContext(record);
 
     if (record.type === 'reasoning') {
       reasoningParts.push(...toReasoningParts(record));
@@ -354,6 +427,7 @@ export async function buildWorkBuddyEvents(
         ?? hookEvents.takeBoundary('Stop')?.observedAtMs;
       if (responseTimestamp === undefined) continue;
       const requestTimestamp = requestStartMs ?? responseTimestamp;
+      await emitPendingUserInput(step.traceId, requestTimestamp);
       const request = baseEntry(
         'llm.request',
         record,
@@ -364,7 +438,7 @@ export async function buildWorkBuddyEvents(
       );
       request['gen_ai.request.id'] = step.requestId;
       if (step.requestModel) request['gen_ai.request.model'] = step.requestModel;
-      if (firstStep) request['gen_ai.turn.start'] = true;
+      if (firstStep && !turnStartEmitted) request['gen_ai.turn.start'] = true;
       if (pendingDelta.length > 0) request['gen_ai.input.messages_delta'] = pendingDelta;
 
       const response = baseEntry(
@@ -397,6 +471,8 @@ export async function buildWorkBuddyEvents(
     }
   }
 
+  await emitPendingUserInput(undefined, undefined, true);
+
   return built;
 }
 
@@ -408,6 +484,20 @@ function baseEntry(
   eventSeed: string,
   timestamp: number,
 ): AgentActivityEntry {
+  return {
+    ...baseTurnEntry(eventName, source, sessionId, step, eventSeed, timestamp),
+    'gen_ai.step.id': step.stepId,
+  };
+}
+
+function baseTurnEntry(
+  eventName: AgentActivityEntry['event.name'],
+  source: WorkBuddyRecord,
+  sessionId: string,
+  turn: TurnContext,
+  eventSeed: string,
+  timestamp: number,
+): AgentActivityEntry {
   const time = millisecondsToNanoseconds(timestamp);
   return {
     time_unix_nano: time,
@@ -415,13 +505,12 @@ function baseEntry(
     'event.id': stableId(sessionId, eventSeed),
     'event.name': eventName,
     'user.id': '',
-    trace_id: step.traceId,
+    trace_id: turn.traceId,
     span_id: stableHex(`${sessionId}:${eventSeed}:span`, 16),
     'gen_ai.session.id': sessionId,
-    'gen_ai.turn.id': step.turnId,
-    'gen_ai.step.id': step.stepId,
+    'gen_ai.turn.id': turn.turnId,
     'gen_ai.agent.type': ClientType.WorkBuddy,
-    'gen_ai.provider.name': step.provider,
+    'gen_ai.provider.name': turn.provider,
     'agent.workbuddy.conversation_request.id': providerString(source, 'conversationRequestId'),
     'agent.workbuddy.runtime': providerString(source, 'agent'),
   };

--- a/src/normalization/turn-boundary-processor.ts
+++ b/src/normalization/turn-boundary-processor.ts
@@ -44,9 +44,9 @@ export class TurnBoundaryProcessor {
         updatedAt: now,
       };
 
-      // Inspect the complete batch before filling anything. Producers such as
-      // WorkBuddy place their existing start marker on llm.request rather than
-      // the first record; a single-pass fill would create a duplicate marker.
+      // Inspect the complete batch before filling anything. Producers may put
+      // an explicit start marker after the first record; a single-pass fill
+      // would create a duplicate marker.
       if (turnEntries.some(entry => hasOwnBoundary(entry, 'gen_ai.turn.start'))) {
         tracked.started = true;
       }

--- a/tests/e2e-remote/jsonl-validate.test.mjs
+++ b/tests/e2e-remote/jsonl-validate.test.mjs
@@ -69,9 +69,12 @@ describe('JSONL_VALIDATOR_JS (integration)', () => {
   });
 
   const validMultiToolGraph = () => [
+    graphEntry('evt-0', 'other', {
+      'gen_ai.turn.start': true,
+      'gen_ai.input.messages_delta': [{ role: 'user', parts: [{ type: 'text', content: 'SYNTHETIC_INPUT' }] }],
+    }),
     graphEntry('evt-1', 'llm.request', {
       'gen_ai.step.id': 'step-1',
-      'gen_ai.turn.start': true,
       'gen_ai.request.id': 'request-1',
       'gen_ai.request.model': 'model-synthetic',
       'gen_ai.input.messages_delta': [{ role: 'user', parts: [{ type: 'text', content: 'SYNTHETIC_INPUT' }] }],
@@ -215,37 +218,37 @@ describe('JSONL_VALIDATOR_JS (integration)', () => {
   it.each([
     {
       name: 'duplicate event IDs',
-      mutate: entries => { entries[7]['event.id'] = entries[0]['event.id']; },
+      mutate: entries => { entries[8]['event.id'] = entries[0]['event.id']; },
       category: 'duplicate_event_id=1',
     },
     {
       name: 'native JSON types and positive millisecond duration',
       mutate: entries => {
-        entries[2]['gen_ai.tool.call.arguments'] = '{"path":"/workspace/example/a.txt"}';
-        entries[4]['gen_ai.tool.call.duration'] = 0;
+        entries[3]['gen_ai.tool.call.arguments'] = '{"path":"/workspace/example/a.txt"}';
+        entries[5]['gen_ai.tool.call.duration'] = 0;
       },
       category: 'type_error=2',
     },
     {
       name: 'request/response pairing',
-      mutate: entries => { entries.splice(1, 1); },
+      mutate: entries => { entries.splice(2, 1); },
       category: 'model_pair_error=1',
     },
     {
       name: 'tool call/result pairing and name consistency',
-      mutate: entries => { entries[4]['gen_ai.tool.name'] = 'DifferentSyntheticTool'; },
+      mutate: entries => { entries[5]['gen_ai.tool.name'] = 'DifferentSyntheticTool'; },
       category: 'tool_pair_error=1',
     },
     {
       name: 'turn start/end uniqueness',
-      mutate: entries => { delete entries[7]['gen_ai.turn.end']; },
+      mutate: entries => { delete entries[8]['gen_ai.turn.end']; },
       category: 'turn_boundary_error=1',
     },
     {
       name: 'both turn boundaries missing',
       mutate: entries => {
         delete entries[0]['gen_ai.turn.start'];
-        delete entries[7]['gen_ai.turn.end'];
+        delete entries[8]['gen_ai.turn.end'];
       },
       category: 'turn_boundary_error=1',
     },
@@ -275,7 +278,7 @@ describe('JSONL_VALIDATOR_JS (integration)', () => {
 
   it('never prints prompt, tool payload, result, or user path values in validation errors', () => {
     const entries = validMultiToolGraph();
-    entries[2]['gen_ai.tool.call.arguments'] =
+    entries[3]['gen_ai.tool.call.arguments'] =
       '{"secret":"SENSITIVE_MARKER_MUST_NOT_APPEAR","path":"/Users/private/person"}';
     writeJsonl('workbuddy-2026-05-11.jsonl', entries);
     const r = runWorkBuddyValidator();

--- a/tests/unit/inputs/workbuddy-input.test.ts
+++ b/tests/unit/inputs/workbuddy-input.test.ts
@@ -87,6 +87,7 @@ describe('WorkBuddy audit-event builder', () => {
     const built = await buildWorkBuddyEvents(fixtureRecords(), { sessionId: 'session-1' });
     const entries = built;
     expect(entries.map(entry => entry['event.name'])).toEqual([
+      'other',
       'llm.request',
       'llm.response',
       'tool.call',
@@ -99,6 +100,19 @@ describe('WorkBuddy audit-event builder', () => {
 
     const requests = entries.filter(entry => entry['event.name'] === 'llm.request');
     const responses = entries.filter(entry => entry['event.name'] === 'llm.response');
+    const userInput = entries.find(entry => entry['event.name'] === 'other')!;
+    expect(userInput).toMatchObject({
+      'gen_ai.turn.id': 'turn-synthetic-1',
+      'gen_ai.turn.start': true,
+      'gen_ai.input.messages_delta': [{
+        role: 'user',
+        parts: [{ type: 'text', content: 'SYNTHETIC_PROMPT' }],
+      }],
+      trace_id: TRACE_ID,
+    });
+    expect(userInput['gen_ai.step.id']).toBeUndefined();
+    expect(requests[0]['gen_ai.turn.start']).toBeUndefined();
+    expect(entries.filter(entry => entry['gen_ai.turn.start'] === true)).toHaveLength(1);
     expect(requests.map(entry => entry['gen_ai.step.id'])).toEqual([
       'request-synthetic-1:s1',
       'request-synthetic-1:s2',
@@ -168,6 +182,7 @@ describe('WorkBuddy audit-event builder', () => {
 
     expect(entries.map(entry => entry.time_unix_nano)).toEqual([
       (BigInt(userTimestamp) * 1_000_000n).toString(),
+      (BigInt(userTimestamp) * 1_000_000n).toString(),
       (BigInt(assistantTimestamp) * 1_000_000n).toString(),
     ]);
     expect(entries.every(entry => /^\d+$/.test(entry.observed_time_unix_nano))).toBe(true);
@@ -182,6 +197,9 @@ describe('WorkBuddy audit-event builder', () => {
       expect(entry['gen_ai.tool.call.arguments']).toBeUndefined();
       expect(entry['gen_ai.tool.call.result']).toBeUndefined();
     }
+    const userInput = entries.find(entry => entry['event.name'] === 'other')!;
+    expect(userInput['gen_ai.turn.start']).toBe(true);
+    expect(userInput['gen_ai.step.id']).toBeUndefined();
   });
 
   it('replaces WorkBuddy all-zero trace IDs with a stable valid trace ID', async () => {
@@ -408,7 +426,7 @@ describe('WorkBuddy audit-event builder', () => {
     });
 
     expect(entries.map(entry => entry.time_unix_nano))
-      .toEqual(['2000000000', '2500000000']);
+      .toEqual(['2000000000', '2000000000', '2500000000']);
   });
 
   it('prefers transcript response time over an earlier Stop Hook observation', async () => {
@@ -426,7 +444,7 @@ describe('WorkBuddy audit-event builder', () => {
     });
 
     expect(entries.map(entry => entry.time_unix_nano))
-      .toEqual(['1000000000', '1500000000']);
+      .toEqual(['1000000000', '1000000000', '1500000000']);
   });
 
   it('preserves Hook fallback boundaries for later records that lack transcript timestamps', async () => {
@@ -462,7 +480,10 @@ describe('WorkBuddy audit-event builder', () => {
     });
 
     expect(entries.map(entry => entry.time_unix_nano))
-      .toEqual(['1000000000', '1500000000', '2000000000', '2500000000']);
+      .toEqual([
+        '1000000000', '1000000000', '1500000000',
+        '2000000000', '2000000000', '2500000000',
+      ]);
   });
 
   it('drops tool events when neither transcript nor Hook provides a call timestamp', async () => {
@@ -494,6 +515,14 @@ describe('WorkBuddy audit-event builder', () => {
     try {
       const conversion = await convertEventLogToReadableSpans(entries);
       expect(conversion.warnings).toEqual([]);
+
+      const agentSpan = conversion.spans
+        .find(span => span.attributes['gen_ai.span.kind'] === 'AGENT')!;
+      const agentInput = JSON.parse(String(agentSpan.attributes['gen_ai.input.messages']));
+      expect(agentInput[0]).toEqual({
+        role: 'user',
+        parts: [{ type: 'text', content: 'SYNTHETIC_PROMPT' }],
+      });
 
       const llmSpans = conversion.spans
         .filter(span => span.attributes['gen_ai.span.kind'] === 'LLM');
@@ -532,6 +561,56 @@ describe('WorkBuddy audit-event builder', () => {
         process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = previousCapture;
       }
     }
+  });
+
+  it('preserves a prompt-only turn as one stable other event', async () => {
+    const user = fixtureRecords()[0];
+    const build = () => buildWorkBuddyEvents([user], { sessionId: 'session-prompt-only' });
+    const entries = await build();
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      'event.name': 'other',
+      'gen_ai.turn.id': 'turn-synthetic-1',
+      'gen_ai.turn.start': true,
+      'gen_ai.input.messages_delta': [{
+        role: 'user',
+        parts: [{ type: 'text', content: 'SYNTHETIC_PROMPT' }],
+      }],
+    });
+    expect(entries[0]['gen_ai.step.id']).toBeUndefined();
+    expect(entries[0]['gen_ai.turn.end']).toBeUndefined();
+    expect(entries[0]['gen_ai.response.finish_reasons']).toBeUndefined();
+    expect(entries[0].trace_id).toMatch(/^[0-9a-f]{32}$/);
+    expect((await build())[0]['event.id']).toBe(entries[0]['event.id']);
+  });
+
+  it('uses an interrupted pre-step trace without fabricating a step or terminal reason', async () => {
+    const user = fixtureRecords()[0];
+    const entries = await buildWorkBuddyEvents([
+      user,
+      {
+        type: 'message',
+        role: 'assistant',
+        status: 'incomplete',
+        id: 'response-incomplete-before-step',
+        timestamp: 1_100,
+        providerData: {
+          traceId: TRACE_ID,
+          conversationRequestId: 'request-incomplete-before-step',
+        },
+      },
+    ], { sessionId: 'session-incomplete-before-step' });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      'event.name': 'other',
+      trace_id: TRACE_ID,
+      'gen_ai.turn.start': true,
+    });
+    expect(entries[0]['gen_ai.step.id']).toBeUndefined();
+    expect(entries[0]['gen_ai.turn.end']).toBeUndefined();
+    expect(entries[0]['gen_ai.response.finish_reasons']).toBeUndefined();
   });
 
   it('does not infer model finish semantics from assistant status', async () => {
@@ -717,8 +796,8 @@ describe('WorkBuddyInput checkpoints', () => {
     });
     expect(await input.collectNow()).toEqual([]);
     const entries = await input.collectNow();
-    expect(entries).toHaveLength(2);
-    expect(entries.map(entry => entry['event.name'])).toEqual(['llm.request', 'llm.response']);
+    expect(entries).toHaveLength(3);
+    expect(entries.map(entry => entry['event.name'])).toEqual(['other', 'llm.request', 'llm.response']);
     expect(entries.every(entry => entry['gen_ai.turn.id'] === 'turn-synthetic-2')).toBe(true);
     await stateStore.save();
     expect(await input.collectNow()).toEqual([]);
@@ -728,6 +807,51 @@ describe('WorkBuddyInput checkpoints', () => {
     expect(persistedState).toBeDefined();
     expect(Object.values(persistedState.extra.workbuddyTranscriptBytes))
       .toEqual([Buffer.byteLength(await readFile(transcript, 'utf8'))]);
+  });
+
+  it('checkpoints a prompt-only turn after emitting its other event once', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'workbuddy-input-prompt-only-'));
+    const projects = path.join(root, 'projects', 'safe-project');
+    const hookEventDir = path.join(root, 'pilot-events');
+    await mkdir(projects, { recursive: true });
+    await mkdir(hookEventDir, { recursive: true });
+    const transcript = path.join(projects, 'session-prompt-only.jsonl');
+    await writeFile(transcript, '');
+
+    const stateStore = new StateStore(path.join(root, 'state.json'));
+    await stateStore.load();
+    const input = new TestWorkBuddyInput({
+      stateStore,
+      workBuddyRoot: root,
+      hookEventDir,
+    });
+    expect(await input.collectNow()).toEqual([]);
+
+    const user = { ...fixtureRecords()[0], id: 'turn-prompt-only', timestamp: 2_000 };
+    await appendFile(transcript, `${JSON.stringify(user)}\n`);
+    await writeHookEvent(hookEventDir, {
+      observed_at_ms: 2_000,
+      hook_event_name: 'UserPromptSubmit',
+      session_id: 'session-prompt-only',
+      transcript_path: transcript,
+    });
+    await writeHookEvent(hookEventDir, {
+      observed_at_ms: 2_100,
+      hook_event_name: 'Stop',
+      session_id: 'session-prompt-only',
+      transcript_path: transcript,
+    });
+
+    expect(await input.collectNow()).toEqual([]);
+    const entries = await input.collectNow();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      'event.name': 'other',
+      'gen_ai.turn.id': 'turn-prompt-only',
+      'gen_ai.turn.start': true,
+    });
+    expect(entries[0]['gen_ai.turn.end']).toBeUndefined();
+    expect(await input.collectNow()).toEqual([]);
   });
 
   it('waits for Stop before processing a turn written in several chunks', async () => {
@@ -835,6 +959,7 @@ describe('WorkBuddyInput checkpoints', () => {
     expect(await input.collectNow()).toEqual([]);
     const entries = await input.collectNow();
     expect(entries.map(entry => entry['event.name'])).toEqual([
+      'other',
       'llm.request',
       'llm.response',
     ]);
@@ -989,7 +1114,7 @@ describe('WorkBuddyInput checkpoints', () => {
 
     expect(await input.collectNow()).toEqual([]);
     const recovered = await input.collectNow();
-    expect(recovered.map(entry => entry['event.name'])).toEqual(['llm.request', 'llm.response']);
+    expect(recovered.map(entry => entry['event.name'])).toEqual(['other', 'llm.request', 'llm.response']);
     expect(recovered.every(entry => entry['gen_ai.turn.id'] === 'turn-after-recovery')).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

- emit one canonical `other` event for each collected WorkBuddy user turn
- attach user input and `gen_ai.turn.start` without fabricating a step ID
- reuse the first step trace when available and use the existing stable fallback for prompt-only turns
- retain the existing LLM/tool events and preserve incomplete turns without inventing terminal semantics
- keep the legacy request-side turn-start fallback for partial transcript slices that contain no user record

## Compatibility

The implementation is shared by Windows, macOS, and Linux. No Hook wrapper, deployment, transcript checkpoint, output flusher, or public schema changes are required.

Raw JSONL/SLS output gains one `other` record per collected user turn. Existing LLM/tool event IDs, payloads, token data, and pairing remain unchanged. OTLP folds the new record into ENTRY/AGENT input rather than creating another LLM/TOOL span.

## Verification

- `npm run typecheck`
- focused WorkBuddy, JSONL, OTLP conversion, and turn-boundary tests: 103 passed
- `npm test`: 282 test files passed; 3478 tests passed; 3 files / 56 tests skipped by platform or test conditions
- `npm run build`
- `git diff --check`

Closes #326