### PR TITLE
fix(updater): prevent slow restarts from stopping collection

### DIFF
--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -388,14 +388,17 @@ function Stop-OrphanProcesses {
     # core type, so it stays CLM-safe.
     param([string]$Match = "collector-daemon|updater-daemon")
     $ownRoot = ([string]$BOOTSTRAP_DIR).ToLower()
-    Get-Process -Name "node" -ErrorAction SilentlyContinue |
+    # Query Win32_Process once. The old Get-Process pipeline issued one CIM query per
+    # node process, so a machine with many IDE/agent runtimes paid N WMI round trips on
+    # every upgrade. CommandLine and ProcessId already come from this single result set.
+    Get-CimInstance Win32_Process -Filter "Name = 'node.exe'" -ErrorAction SilentlyContinue |
         Where-Object {
             try {
-                $cmdLine = [string](Get-CimInstance Win32_Process -Filter "ProcessId = $($_.Id)" -ErrorAction SilentlyContinue).CommandLine
+                $cmdLine = [string]$_.CommandLine
                 ($cmdLine -match $Match) -and $cmdLine.ToLower().Contains($ownRoot)
             } catch { $false }
         } | ForEach-Object {
-            Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
+            Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue
         }
 }
 
@@ -579,7 +582,7 @@ sh.Run """$nodeEsc"" ""$entryEsc""", 0, True
 }
 
 function Install-CollectorTask {
-    param([string]$nodeBin)
+    param([string]$nodeBin, [switch]$SkipCleanup)
     $entry = Join-Path $BOOTSTRAP_DIR "collector-daemon.js"
     if (-not (Test-Path $entry)) {
         Write-Host "Bootstrap script missing: $entry"
@@ -612,12 +615,14 @@ function Install-CollectorTask {
     # freshly registered task's MultipleInstances=IgnoreNew only counts instances under the
     # new registration -- so without this reap the orphan keeps running alongside the new
     # instance and both write the same output (duplicate-collection incident root cause).
-    Stop-OrphanProcesses -Match "collector-daemon"
+    if (-not $SkipCleanup) {
+        Stop-OrphanProcesses -Match "collector-daemon"
 
-    # Remove existing task first (schtasks is more reliable than Unregister-ScheduledTask)
-    # Use try/catch because schtasks stderr + $ErrorActionPreference=Stop can throw
-    try { schtasks.exe /Delete /TN "$TASK_FOLDER\$TASK_NAME_COLLECTOR" /F 2>$null | Out-Null } catch {}
-    try { schtasks.exe /Delete /TN "$TASK_NAME_COLLECTOR" /F 2>$null | Out-Null } catch {}
+        # Remove existing task first (schtasks is more reliable than Unregister-ScheduledTask)
+        # Use try/catch because schtasks stderr + $ErrorActionPreference=Stop can throw
+        try { schtasks.exe /Delete /TN "$TASK_FOLDER\$TASK_NAME_COLLECTOR" /F 2>$null | Out-Null } catch {}
+        try { schtasks.exe /Delete /TN "$TASK_NAME_COLLECTOR" /F 2>$null | Out-Null } catch {}
+    }
 
     return (Register-PilotTask `
         -taskName $TASK_NAME_COLLECTOR `
@@ -857,10 +862,101 @@ function Cmd-Restart {
     Cmd-Start
 }
 
+# Start the collector without stopping it or scanning for processes. This command is
+# the updater's recovery path after restart-collector times out: the timed-out command
+# may already have completed the stop half, so running another restart would extend the
+# collection gap. If a partial upgrade deleted the scheduled task, recreate only that
+# missing task without the destructive cleanup used by normal registration.
+function Cmd-StartCollector {
+    if ((Get-CollectorRuntime) -or (Test-PidRunning $PID_FILE)) {
+        Write-Host "collector is already running"
+        return
+    }
+
+    Ensure-Dirs
+    Sync-BootstrapScripts
+    $nodeBin = Resolve-Node
+    if (-not $nodeBin) {
+        Write-Error "node runtime not found"
+        exit 1
+    }
+
+    if (Get-TaskExists $TASK_NAME_COLLECTOR) {
+        try {
+            Start-ScheduledTask -TaskName $TASK_NAME_COLLECTOR -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
+            Write-Host "collector start requested (Task Scheduler)"
+            return
+        } catch {
+            Write-Host "Task Scheduler start failed: $($_.Exception.Message)" -ForegroundColor Yellow
+            Write-Error "Service manager failed to start collector"
+            exit 1
+        }
+    }
+
+    try {
+        $ok = Install-CollectorTask $nodeBin -SkipCleanup
+        if ($ok) {
+            Start-ScheduledTask -TaskName $TASK_NAME_COLLECTOR -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
+            Set-Content -Path $INIT_TYPE_FILE -Value "taskscheduler"
+            Write-Host "collector task restored and start requested (Task Scheduler)"
+            return
+        }
+    } catch {
+        Write-Host "Collector task recovery failed: $($_.Exception.Message)" -ForegroundColor Yellow
+    }
+
+    # A missing task can be the result of an interrupted activation. Keep collection
+    # available even when task repair is denied; the updater's runtime/PID validation
+    # decides whether this detached fallback really became healthy.
+    $entry = Join-Path $BOOTSTRAP_DIR "collector-daemon.js"
+    if (-not (Test-Path $entry)) {
+        Write-Error "Bootstrap script missing"
+        exit 1
+    }
+    $errLog = Join-Path $LOG_DIR "loongsuite-pilot-service-err.log"
+    Start-Process -FilePath "powershell.exe" `
+        -ArgumentList "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:LOONGSUITE_PILOT_DATA_DIR='$DATA_DIR'; `$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$entry' >> '$LOG_FILE' 2>> '$errLog'`"" `
+        -WorkingDirectory $CACHE_DIR `
+        -WindowStyle Hidden
+    Write-Host "collector start requested (background fallback)" -ForegroundColor Yellow
+}
+
+function Schedule-UpdaterRestart {
+    Ensure-Dirs
+    $handoffScript = Join-Path $BOOTSTRAP_DIR "restart-updater-delayed.ps1"
+    $escapedBin = ([string]$LOONGSUITE_PILOT_BIN).Replace("'", "''")
+    $escapedLog = ([string]$UPDATER_LOG_FILE).Replace("'", "''")
+    @(
+        "Start-Sleep -Seconds 10",
+        "& '$escapedBin' restart-updater *>> '$escapedLog'"
+    ) | Set-Content -LiteralPath $handoffScript -Encoding Unicode
+
+    # Start-Process creates an independent process instead of a PowerShell job owned by
+    # this invocation. It therefore survives long enough to stop/relaunch the updater
+    # after the current health check and bookkeeping have completed.
+    $handoffArgs = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$handoffScript`""
+    Start-Process -FilePath "powershell.exe" `
+        -ArgumentList $handoffArgs `
+        -WorkingDirectory $CACHE_DIR `
+        -WindowStyle Hidden
+    Write-Host "updater restart scheduled"
+}
+
 # ============================================================
 # CMD: restart-collector (used by updater after deploying a new version)
 # ============================================================
 function Cmd-RestartCollector {
+    param([string[]]$Options = @())
+    $deferUpdaterRestart = $false
+    foreach ($option in $Options) {
+        if ($option -eq "--defer-updater-restart") {
+            $deferUpdaterRestart = $true
+        } else {
+            Write-Error "Unknown restart-collector option: $option"
+            exit 1
+        }
+    }
+
     # Stop collector only (leave updater running)
     $task = Get-ScheduledTask -TaskName $TASK_NAME_COLLECTOR -TaskPath "$TASK_FOLDER\" -ErrorAction SilentlyContinue
     if ($task -and $task.State -eq "Running") {
@@ -966,11 +1062,9 @@ function Cmd-RestartCollector {
         }
     }
 
-    # Schedule updater restart in background (equivalent to setsid on Linux)
-    Start-Job -ScriptBlock {
-        Start-Sleep -Seconds 10
-        & $using:LOONGSUITE_PILOT_BIN restart-updater
-    } | Out-Null
+    if (-not $deferUpdaterRestart) {
+        Schedule-UpdaterRestart
+    }
 }
 
 # ============================================================
@@ -1589,7 +1683,9 @@ switch ($Command.ToLower()) {
     "rollback"           { Cmd-Rollback }
     "worker"             { Cmd-Worker }
     "agent"              { Cmd-Agent }
-    "restart-collector"  { Cmd-RestartCollector }
+    "start-collector"    { Cmd-StartCollector }
+    "restart-collector"  { Cmd-RestartCollector -Options $SubArgs }
+    "schedule-updater-restart" { Schedule-UpdaterRestart }
     "restart-updater"    { Cmd-RestartUpdater }
     "run"                { Cmd-Run }
     "run-updater"        { Cmd-RunUpdater }

--- a/scripts/loongsuite-pilot.sh
+++ b/scripts/loongsuite-pilot.sh
@@ -26,6 +26,7 @@ UPDATER_PLIST="$HOME/Library/LaunchAgents/${UPDATER_LABEL}.plist"
 SYSTEMD_SYSTEM_UNIT_DIR="/etc/systemd/system"
 LOONGSUITE_PILOT_BIN="$HOME/.local/bin/loongsuite-pilot"
 INIT_TYPE_FILE="$DATA_DIR/init-type"
+CURRENT_USER_ID="$(id -u)"
 
 validate_current_user() {
     whoami
@@ -114,6 +115,7 @@ sync_installed_scripts_from_version() {
 process_matches_installed_entry() {
     local pid="$1"
     local kind="$2"
+    local current_user_id="${CURRENT_USER_ID:-$(id -u)}"
     local expected_entry=""
     local expected_arg=""
     local expected_process=""
@@ -141,10 +143,27 @@ process_matches_installed_entry() {
 
     [[ "$pid" =~ ^[0-9]+$ ]] || return 1
     kill -0 "$pid" 2>/dev/null || return 1
-    [ "$(ps -p "$pid" -o uid= 2>/dev/null | tr -d '[:space:]')" = "$(id -u)" ] || return 1
-
     local process_name
-    process_name=$(ps -p "$pid" -o ucomm= 2>/dev/null | tr -d '[:space:]')
+    if [ -r "/proc/$pid/status" ] && [ -r "/proc/$pid/comm" ]; then
+        # Linux procfs already contains the fields that ps reads. Read them in
+        # this shell so a large set of Node candidates does not spawn two ps
+        # processes per PID.
+        local status_key=""
+        local process_uid=""
+        while read -r status_key process_uid _; do
+            if [ "$status_key" = "Uid:" ]; then
+                break
+            fi
+            process_uid=""
+        done < "/proc/$pid/status"
+        [ "$process_uid" = "$current_user_id" ] || return 1
+        IFS= read -r process_name < "/proc/$pid/comm" || return 1
+    else
+        # macOS has no procfs. Keep the existing ps fallback, which also covers
+        # Linux installations where procfs is unavailable or restricted.
+        [ "$(ps -p "$pid" -o uid= 2>/dev/null | tr -d '[:space:]')" = "$current_user_id" ] || return 1
+        process_name=$(ps -p "$pid" -o ucomm= 2>/dev/null | tr -d '[:space:]')
+    fi
     process_name="${process_name##*/}"
     case "$expected_process:$process_name" in
         node:node|node:nodejs|shell:bash|shell:sh|shell:zsh|shell:loongsuite-pilot) ;;
@@ -197,6 +216,7 @@ process_matches_installed_entry() {
 
 find_current_user_processes() {
     local kind="$1"
+    local current_user_id="${CURRENT_USER_ID:-$(id -u)}"
     local pid=""
     local process_name=""
     while read -r pid process_name; do
@@ -206,7 +226,26 @@ find_current_user_processes() {
             *) continue ;;
         esac
         process_matches_installed_entry "$pid" "$kind" && echo "$pid"
-    done < <(ps -U "$(id -u)" -o pid= -o ucomm= 2>/dev/null || true)
+    done < <(ps -U "$current_user_id" -o pid= -o ucomm= 2>/dev/null || true)
+}
+
+# Enumerate collector daemons and their shell wrappers from one process-table
+# snapshot. The generic helper above remains useful when callers need one kind,
+# but cleanup must not scan the same large process table once per kind.
+find_current_user_collector_processes() {
+    local current_user_id="${CURRENT_USER_ID:-$(id -u)}"
+    local pid=""
+    local process_name=""
+    local kind=""
+    while read -r pid process_name; do
+        process_name="${process_name##*/}"
+        case "$process_name" in
+            node|nodejs) kind=collector ;;
+            bash|sh|zsh|loongsuite-pilot) kind=collector-wrapper ;;
+            *) continue ;;
+        esac
+        process_matches_installed_entry "$pid" "$kind" && printf '%s %s\n' "$pid" "$kind"
+    done < <(ps -U "$current_user_id" -o pid= -o ucomm= 2>/dev/null || true)
 }
 
 find_installed_collector_pid() {
@@ -251,10 +290,7 @@ stop_installed_collector_processes() {
                 matched=true
                 kill "$pid" 2>/dev/null || true
             fi
-        done < <({
-            find_current_user_processes collector-wrapper | while read -r pid; do echo "$pid collector-wrapper"; done
-            find_current_user_processes collector | while read -r pid; do echo "$pid collector"; done
-        } | sort -u)
+        done < <(find_current_user_collector_processes | sort -u)
         [ "$matched" = true ] || return 0
         sleep 0.2
     done
@@ -733,9 +769,141 @@ cmd_stop() {
     echo "✅ loongsuite-pilot stopped"
 }
 
+# Start the collector without stopping or scanning for existing processes. This
+# is intentionally separate from restart-collector so the updater can recover
+# after a timed-out restart that already stopped the managed service.
+start_collector_after_stop() {
+    local target_user
+    target_user=$(whoami)
+    local sys_unit="loongsuite-pilot-${target_user}.service"
+    local initd_script="/etc/init.d/loongsuite-pilot-${target_user}"
+    local init_type=""
+    if [ -f "$INIT_TYPE_FILE" ]; then
+        init_type=$(cat "$INIT_TYPE_FILE" 2>/dev/null | tr -d '[:space:]')
+    fi
+
+    ensure_dirs
+    sync_bootstrap_scripts
+
+    local _started=false
+    case "$(uname -s)" in
+        Darwin)
+            if launchctl list "$SERVICE_LABEL" &>/dev/null; then
+                launchctl start "$SERVICE_LABEL" 2>/dev/null || true
+                echo "✅ collector started (launchd)"
+                _started=true
+            fi
+            ;;
+        Linux)
+            case "$init_type" in
+                systemd-user)
+                    if systemctl --user is-enabled loongsuite-pilot.service &>/dev/null; then
+                        systemctl --user start loongsuite-pilot.service &>/dev/null
+                        echo "✅ collector started (systemd user-level)"
+                        _started=true
+                    fi
+                    ;;
+                systemd-system|systemd)
+                    if [ -f "$SYSTEMD_SYSTEM_UNIT_DIR/$sys_unit" ] && maybe_sudo_n systemctl is-enabled "$sys_unit" &>/dev/null; then
+                        maybe_sudo systemctl start "$sys_unit" &>/dev/null
+                        echo "✅ collector started (systemd system-level)"
+                        _started=true
+                    fi
+                    ;;
+                initd)
+                    if [ -f "$initd_script" ]; then
+                        maybe_sudo "$initd_script" start &>/dev/null
+                        echo "✅ collector started (init.d)"
+                        _started=true
+                    fi
+                    ;;
+            esac
+            ;;
+    esac
+    if [ "$_started" = true ]; then
+        sleep 1
+        if ! is_running; then
+            echo "⚠️  service manager reported success but collector process not found"
+            _started=false
+        fi
+    fi
+    if [ "$_started" = false ]; then
+        # Self-healing: try to register a proper service for degraded (nohup/unknown) installs
+        case "$init_type" in
+            nohup|unknown|"")
+                local _new_init
+                _new_init=$(detect_init_system "false")
+                if [ "$_new_init" != "none" ]; then
+                    if autostart_install_collector_only "false" 2>>"$LOG_FILE"; then
+                        sleep 1
+                        if is_running; then
+                            echo "✅ collector self-healed: registered as $_new_init"
+                            _started=true
+                        else
+                            echo "⚠️  collector self-heal registered ($_new_init) but process not found" >&2
+                        fi
+                    fi
+                fi
+                if [ "$_started" = false ]; then
+                    local entry="$BOOTSTRAP_DIR/collector-daemon.js"
+                    if [ ! -f "$entry" ]; then
+                        echo "❌ Bootstrap script missing"
+                        return 1
+                    fi
+                    local node_bin
+                    node_bin=$(resolve_node) || {
+                        echo "❌ node runtime not found" >&2
+                        return 1
+                    }
+                    export AGENT_DATA_COLLECTION_CONFIG="$CONFIG_FILE"
+                    nohup "$node_bin" "$entry" >> "$LOG_FILE" 2>&1 &
+                    echo "$!" > "$PID_FILE"
+                    echo "⚠️  collector started (nohup fallback, self-heal failed)"
+                fi
+                ;;
+            *)
+                echo "❌ Service manager failed to start collector (init_type=$init_type)" >&2
+                return 1
+                ;;
+        esac
+    fi
+
+    if ! is_running; then
+        echo "❌ collector process not found after start" >&2
+        return 1
+    fi
+}
+
+cmd_start_collector() {
+    if is_running; then
+        echo "✅ collector is already running (PID $(cat "$PID_FILE"))"
+        return 0
+    fi
+    start_collector_after_stop
+}
+
+schedule_updater_restart() {
+    # Run in a new process group so stopping the updater service cannot kill the
+    # delayed restart process along with its parent.
+    local restart_bin="$LOONGSUITE_PILOT_BIN"
+    local restart_log="$UPDATER_LOG_FILE"
+    if command -v setsid &>/dev/null; then
+        setsid bash -c 'sleep 10 && "$0" restart-updater' "$restart_bin" >> "$restart_log" 2>&1 &
+    else
+        perl -MPOSIX -e 'POSIX::setsid(); exec @ARGV' -- bash -c 'sleep 10 && "$0" restart-updater' "$restart_bin" >> "$restart_log" 2>&1 &
+    fi
+}
+
 # Restart only the collector (used by updater after deploying a new version)
 cmd_restart_collector() {
     cleanup_legacy_monitor_processes
+    local defer_updater_restart=false
+    if [ "${1:-}" = "--defer-updater-restart" ]; then
+        defer_updater_restart=true
+    elif [ -n "${1:-}" ]; then
+        echo "Unknown restart-collector option: $1" >&2
+        return 1
+    fi
     local target_user
     target_user=$(whoami)
     local sys_unit="loongsuite-pilot-${target_user}.service"
@@ -769,106 +937,10 @@ cmd_restart_collector() {
     stop_installed_collector_processes
 
     sleep 1
+    start_collector_after_stop
 
-    ensure_dirs
-    sync_bootstrap_scripts
-
-    local _restarted=false
-    case "$(uname -s)" in
-        Darwin)
-            if launchctl list "$SERVICE_LABEL" &>/dev/null; then
-                launchctl start "$SERVICE_LABEL" 2>/dev/null || true
-                echo "✅ collector restarted (launchd)"
-                _restarted=true
-            fi
-            ;;
-        Linux)
-            case "$init_type" in
-                systemd-user)
-                    if systemctl --user is-enabled loongsuite-pilot.service &>/dev/null; then
-                        systemctl --user start loongsuite-pilot.service &>/dev/null
-                        echo "✅ collector restarted (systemd user-level)"
-                        _restarted=true
-                    fi
-                    ;;
-                systemd-system|systemd)
-                    if [ -f "$SYSTEMD_SYSTEM_UNIT_DIR/$sys_unit" ] && maybe_sudo_n systemctl is-enabled "$sys_unit" &>/dev/null; then
-                        maybe_sudo systemctl start "$sys_unit" &>/dev/null
-                        echo "✅ collector restarted (systemd system-level)"
-                        _restarted=true
-                    fi
-                    ;;
-                initd)
-                    if [ -f "$initd_script" ]; then
-                        maybe_sudo "$initd_script" start &>/dev/null
-                        echo "✅ collector restarted (init.d)"
-                        _restarted=true
-                    fi
-                    ;;
-            esac
-            ;;
-    esac
-    if [ "$_restarted" = true ]; then
-        sleep 1
-        if ! is_running; then
-            echo "⚠️  service manager reported success but collector process not found"
-            _restarted=false
-        fi
-    fi
-    if [ "$_restarted" = false ]; then
-        # Self-healing: try to register a proper service for degraded (nohup/unknown) installs
-        case "$init_type" in
-            nohup|unknown|"")
-                local _new_init
-                _new_init=$(detect_init_system "false")
-                if [ "$_new_init" != "none" ]; then
-                    if autostart_install_collector_only "false" 2>>"$LOG_FILE"; then
-                        sleep 1
-                        if is_running; then
-                            echo "✅ collector self-healed: registered as $_new_init"
-                            _restarted=true
-                        else
-                            echo "⚠️  collector self-heal registered ($_new_init) but process not found" >&2
-                        fi
-                    fi
-                fi
-                if [ "$_restarted" = false ]; then
-                    local entry="$BOOTSTRAP_DIR/collector-daemon.js"
-                    if [ ! -f "$entry" ]; then
-                        echo "❌ Bootstrap script missing"
-                        exit 1
-                    fi
-                    local node_bin
-                    node_bin=$(resolve_node) || {
-                        echo "❌ node runtime not found" >&2
-                        exit 1
-                    }
-                    export AGENT_DATA_COLLECTION_CONFIG="$CONFIG_FILE"
-                    nohup "$node_bin" "$entry" >> "$LOG_FILE" 2>&1 &
-                    echo "$!" > "$PID_FILE"
-                    echo "⚠️  collector restarted (nohup fallback, self-heal failed)"
-                fi
-                ;;
-            *)
-                echo "❌ Service manager failed to restart collector (init_type=$init_type)" >&2
-                exit 1
-                ;;
-        esac
-    fi
-
-    if ! is_running; then
-        echo "❌ collector process not found after restart" >&2
-        exit 1
-    fi
-
-    # Schedule updater restart in a NEW process group so that
-    # "launchctl stop / systemctl stop" of the updater won't kill this subprocess.
-    local _restart_bin="$LOONGSUITE_PILOT_BIN"
-    local _restart_log="$UPDATER_LOG_FILE"
-    if command -v setsid &>/dev/null; then
-        setsid bash -c 'sleep 10 && "$0" restart-updater' "$_restart_bin" >> "$_restart_log" 2>&1 &
-    else
-        perl -MPOSIX -e 'POSIX::setsid(); exec @ARGV' -- bash -c 'sleep 10 && "$0" restart-updater' "$_restart_bin" >> "$_restart_log" 2>&1 &
+    if [ "$defer_updater_restart" = false ]; then
+        schedule_updater_restart
     fi
 }
 
@@ -2235,7 +2307,9 @@ case "${1:-status}" in
     worker)              shift; cmd_worker "$@" ;;
     agent)               shift; cmd_agent "$@" ;;
     rollback)            cmd_rollback ;;
-    restart-collector)   cmd_restart_collector ;;
+    start-collector)     cmd_start_collector ;;
+    restart-collector)   shift; cmd_restart_collector "$@" ;;
+    schedule-updater-restart) schedule_updater_restart ;;
     restart-updater)     cmd_restart_updater ;;
     run)                 cmd_run ;;
     run-updater)         cmd_run_updater ;;

--- a/src/updater/updater.ts
+++ b/src/updater/updater.ts
@@ -28,6 +28,9 @@ const NPM_INSTALL_TIMEOUT_MS = 2 * 60_000;
 const MAX_BACKOFF_MS = 6 * 60 * 60_000; // 6 hours
 const MAX_CONSECUTIVE_FAILURES = 10;
 const MAX_VERSION_GC_REMOVALS_PER_CHECK = 1;
+const COLLECTOR_COMMAND_TIMEOUT_MS = 30_000;
+const COLLECTOR_HEALTH_TIMEOUT_MS = 30_000;
+const COLLECTOR_HEALTH_POLL_MS = 500;
 
 // ── Managed Node.js runtime (mirrors deploy/installer-opensource.sh) ──
 // Existing installs that predate the managed runtime run the updater (and hence
@@ -98,6 +101,7 @@ export interface UpdaterPaths {
   bootstrapDir: string;
   loongsuitePilotBin: string;
   runtimeFile: string;
+  collectorRuntimeFile: string;
   // Where the CLI wrapper reads the pinned node runtime (its NODE_PIN_FILE).
   nodePinFile: string;
 }
@@ -136,6 +140,7 @@ function defaultPaths(): UpdaterPaths {
     bootstrapDir: path.join(cacheDir, 'bin'),
     loongsuitePilotBin: pilotBinPath(),
     runtimeFile: updaterRuntimePath(dataDir),
+    collectorRuntimeFile: path.join(dataDir, 'logs', 'runtime.json'),
     nodePinFile: path.join(pinDir, 'node-bin'),
   };
 }
@@ -150,6 +155,7 @@ export function buildPaths(baseDir: string): UpdaterPaths {
     bootstrapDir: path.join(baseDir, 'bin'),
     loongsuitePilotBin: pilotBinPath(),
     runtimeFile: updaterRuntimePath(baseDir),
+    collectorRuntimeFile: path.join(baseDir, 'logs', 'runtime.json'),
     nodePinFile: path.join(baseDir, 'node-bin'),
   };
 }
@@ -158,6 +164,13 @@ export interface ResolvedTarget {
   manifest: VersionManifest;
   channel: 'stable' | 'canary';
   hotfixVersion?: number;
+}
+
+interface CollectorRuntimeRecord {
+  status?: unknown;
+  packageVersion?: unknown;
+  pid?: unknown;
+  updatedAt?: unknown;
 }
 
 const DEFAULT_CONFIG_PATH = '~/.loongsuite-pilot/config.json';
@@ -280,20 +293,21 @@ export class Updater {
         latest_version: target.version,
       });
 
+      await this.restartCollector(target.version, local?.version === target.version);
+      void this.metrics?.writeEvent('collector_restarted', {
+        latest_version: target.version,
+      });
+
       if (channel === 'canary') {
         await this.persistCanaryState(hotfixVersion ?? 0);
         this.config = { ...this.config, canaryHotfixVersion: hotfixVersion ?? 0 };
       }
 
-      await this.restartCollector();
-      void this.metrics?.writeEvent('collector_restarted', {
-        latest_version: target.version,
-      });
-
       await this.gcOldVersions();
       this.consecutiveFailures = 0;
       this.nextCheckAt = 0;
       await this.writeHeartbeat();
+      await this.scheduleUpdaterRestart();
     } catch (err) {
       this.consecutiveFailures++;
       const backoffMs = Math.min(
@@ -1067,30 +1081,131 @@ export class Updater {
     }
   }
 
-  private async restartCollector(): Promise<void> {
+  private async restartCollector(targetVersion: string, requireNewPid: boolean): Promise<void> {
     logger.info('restarting collector service');
+    const previousRuntime = requireNewPid ? await this.readCollectorRuntime() : null;
+    const previousPid = typeof previousRuntime?.pid === 'number' ? previousRuntime.pid : null;
+    const restartStartedAt = Date.now();
+    let recoveryAttempted = false;
+
     try {
-      const bin = this.paths.loongsuitePilotBin;
-      let result: { stdout: string; stderr: string };
-      if (process.platform === 'win32') {
-        result = await execFileAsync('powershell.exe', [
-          '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', bin, 'restart-collector',
-        ], { timeout: 30_000 });
-      } else {
-        result = await execFileAsync(bin, ['restart-collector'], { timeout: 30_000 });
-      }
-      const output = (result.stdout || '').trim();
-      if (output) logger.info('restart-collector output', { output });
-      logger.info('collector restarted');
+      await this.runCollectorCommand('restart-collector');
     } catch (err: any) {
-      const stderr = err?.stderr?.trim?.() || '';
-      const stdout = err?.stdout?.trim?.() || '';
       logger.warn('collector restart failed', {
         error: String(err?.message || err),
-        stdout: stdout || undefined,
-        stderr: stderr || undefined,
+        stdout: err?.stdout?.trim?.() || undefined,
+        stderr: err?.stderr?.trim?.() || undefined,
       });
+      await this.startCollectorForRecovery(err);
+      recoveryAttempted = true;
     }
+
+    try {
+      await this.waitForCollectorHealth(targetVersion, restartStartedAt, previousPid);
+    } catch (healthErr) {
+      if (recoveryAttempted) throw healthErr;
+      logger.warn('collector failed post-restart health check; attempting start-only recovery', {
+        error: String(healthErr),
+      });
+      await this.startCollectorForRecovery(healthErr);
+      await this.waitForCollectorHealth(targetVersion, restartStartedAt, previousPid);
+    }
+
+    logger.info('collector restarted and healthy', { targetVersion });
+  }
+
+  private async runCollectorCommand(
+    command: 'restart-collector' | 'start-collector' | 'schedule-updater-restart',
+  ): Promise<void> {
+    const bin = this.paths.loongsuitePilotBin;
+    let result: { stdout: string; stderr: string };
+    if (process.platform === 'win32') {
+      result = await execFileAsync('powershell.exe', [
+        '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', bin, command,
+      ], { timeout: COLLECTOR_COMMAND_TIMEOUT_MS });
+    } else {
+      const args = command === 'restart-collector'
+        ? [command, '--defer-updater-restart']
+        : [command];
+      result = await execFileAsync(bin, args, { timeout: COLLECTOR_COMMAND_TIMEOUT_MS });
+    }
+    const output = (result.stdout || '').trim();
+    if (output) logger.info(`${command} output`, { output });
+  }
+
+  private async startCollectorForRecovery(cause: unknown): Promise<void> {
+    try {
+      await this.runCollectorCommand('start-collector');
+    } catch (recoveryErr) {
+      throw new Error(
+        `collector restart failed (${String(cause)}); start-only recovery also failed (${String(recoveryErr)})`,
+      );
+    }
+  }
+
+  private async scheduleUpdaterRestart(): Promise<void> {
+    // The Windows restart-collector command owns its delayed updater handoff.
+    // POSIX defers that handoff until collector health and success bookkeeping
+    // are complete, otherwise a slow startup could kill this verification.
+    if (process.platform === 'win32') return;
+    try {
+      await this.runCollectorCommand('schedule-updater-restart');
+    } catch (err) {
+      logger.warn('failed to schedule updater restart', { error: String(err) });
+    }
+  }
+
+  private async readCollectorRuntime(): Promise<CollectorRuntimeRecord | null> {
+    return readJsonFile<CollectorRuntimeRecord>(this.paths.collectorRuntimeFile);
+  }
+
+  private async waitForCollectorHealth(
+    targetVersion: string,
+    notBeforeMs: number,
+    previousPid: number | null,
+  ): Promise<void> {
+    const deadline = Date.now() + COLLECTOR_HEALTH_TIMEOUT_MS;
+    let lastFailure = 'runtime record not found';
+
+    while (true) {
+      const runtime = await this.readCollectorRuntime();
+      lastFailure = this.collectorHealthFailure(runtime, targetVersion, notBeforeMs, previousPid);
+      if (!lastFailure) return;
+      if (Date.now() >= deadline) break;
+      await new Promise<void>((resolve) => setTimeout(resolve, COLLECTOR_HEALTH_POLL_MS));
+    }
+
+    throw new Error(
+      `collector did not become healthy within ${COLLECTOR_HEALTH_TIMEOUT_MS}ms: ${lastFailure}`,
+    );
+  }
+
+  private collectorHealthFailure(
+    runtime: CollectorRuntimeRecord | null,
+    targetVersion: string,
+    notBeforeMs: number,
+    previousPid: number | null,
+  ): string {
+    if (!runtime) return 'runtime record not found';
+    if (runtime.status !== 'active') return `runtime status is ${String(runtime.status)}`;
+    if (runtime.packageVersion !== targetVersion) {
+      return `runtime version is ${String(runtime.packageVersion)}, expected ${targetVersion}`;
+    }
+
+    const updatedAtMs = typeof runtime.updatedAt === 'string' ? Date.parse(runtime.updatedAt) : NaN;
+    if (!Number.isFinite(updatedAtMs) || updatedAtMs < notBeforeMs) {
+      return 'runtime record predates restart';
+    }
+
+    const pid = runtime.pid;
+    if (!Number.isInteger(pid) || (pid as number) <= 0) return 'runtime PID is invalid';
+    if (previousPid !== null && pid === previousPid) return 'collector PID did not change';
+    try {
+      process.kill(pid as number, 0);
+    } catch {
+      return `collector PID ${String(pid)} is not alive`;
+    }
+    return '';
   }
 
   private async gcOldVersions(): Promise<void> {

--- a/src/updater/updater.ts
+++ b/src/updater/updater.ts
@@ -261,10 +261,18 @@ export class Updater {
           remote: target.version,
           channel,
         });
+        const activeVersion = local?.version || target.version;
+        const collectorRecovered = await this.recoverCurrentCollectorIfNeeded(activeVersion);
+        if (collectorRecovered) {
+          void this.metrics?.writeEvent('collector_restarted', {
+            latest_version: activeVersion,
+          });
+        }
         this.consecutiveFailures = 0;
         this.nextCheckAt = 0;
         await this.gcOldVersions();
         await this.writeHeartbeat();
+        if (collectorRecovered) await this.scheduleUpdaterRestart();
         return;
       }
 
@@ -1118,16 +1126,16 @@ export class Updater {
     command: 'restart-collector' | 'start-collector' | 'schedule-updater-restart',
   ): Promise<void> {
     const bin = this.paths.loongsuitePilotBin;
+    const commandArgs = command === 'restart-collector'
+      ? [command, '--defer-updater-restart']
+      : [command];
     let result: { stdout: string; stderr: string };
     if (process.platform === 'win32') {
       result = await execFileAsync('powershell.exe', [
-        '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', bin, command,
+        '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', bin, ...commandArgs,
       ], { timeout: COLLECTOR_COMMAND_TIMEOUT_MS });
     } else {
-      const args = command === 'restart-collector'
-        ? [command, '--defer-updater-restart']
-        : [command];
-      result = await execFileAsync(bin, args, { timeout: COLLECTOR_COMMAND_TIMEOUT_MS });
+      result = await execFileAsync(bin, commandArgs, { timeout: COLLECTOR_COMMAND_TIMEOUT_MS });
     }
     const output = (result.stdout || '').trim();
     if (output) logger.info(`${command} output`, { output });
@@ -1138,16 +1146,37 @@ export class Updater {
       await this.runCollectorCommand('start-collector');
     } catch (recoveryErr) {
       throw new Error(
-        `collector restart failed (${String(cause)}); start-only recovery also failed (${String(recoveryErr)})`,
+        `collector restart failed (${this.formatCommandFailure(cause)}); `
+          + `start-only recovery also failed (${this.formatCommandFailure(recoveryErr)})`,
       );
     }
   }
 
+  private formatCommandFailure(error: unknown): string {
+    const err = error as {
+      message?: unknown;
+      stdout?: unknown;
+      stderr?: unknown;
+      code?: unknown;
+      killed?: unknown;
+      signal?: unknown;
+    };
+    const fields = [`error=${String(err?.message ?? error)}`];
+    if (err?.stdout !== undefined && String(err.stdout).trim()) {
+      fields.push(`stdout=${JSON.stringify(String(err.stdout).trim())}`);
+    }
+    if (err?.stderr !== undefined && String(err.stderr).trim()) {
+      fields.push(`stderr=${JSON.stringify(String(err.stderr).trim())}`);
+    }
+    if (err?.code !== undefined) fields.push(`code=${String(err.code)}`);
+    if (err?.killed !== undefined) fields.push(`killed=${String(err.killed)}`);
+    if (err?.signal !== undefined) fields.push(`signal=${String(err.signal)}`);
+    return fields.join(', ');
+  }
+
   private async scheduleUpdaterRestart(): Promise<void> {
-    // The Windows restart-collector command owns its delayed updater handoff.
-    // POSIX defers that handoff until collector health and success bookkeeping
+    // Defer the updater handoff until collector health and success bookkeeping
     // are complete, otherwise a slow startup could kill this verification.
-    if (process.platform === 'win32') return;
     try {
       await this.runCollectorCommand('schedule-updater-restart');
     } catch (err) {
@@ -1157,6 +1186,22 @@ export class Updater {
 
   private async readCollectorRuntime(): Promise<CollectorRuntimeRecord | null> {
     return readJsonFile<CollectorRuntimeRecord>(this.paths.collectorRuntimeFile);
+  }
+
+  private async recoverCurrentCollectorIfNeeded(targetVersion: string): Promise<boolean> {
+    const runtime = await this.readCollectorRuntime();
+    const healthFailure = this.collectorHealthFailure(runtime, targetVersion, 0, null);
+    if (!healthFailure) return false;
+
+    logger.warn('current version is installed but collector is unhealthy; attempting start-only recovery', {
+      targetVersion,
+      error: healthFailure,
+    });
+    const recoveryStartedAt = Date.now();
+    await this.startCollectorForRecovery(new Error(healthFailure));
+    await this.waitForCollectorHealth(targetVersion, recoveryStartedAt, null);
+    logger.info('collector recovered and healthy', { targetVersion });
+    return true;
   }
 
   private async waitForCollectorHealth(

--- a/tests/integration/updater-flow.test.ts
+++ b/tests/integration/updater-flow.test.ts
@@ -115,6 +115,17 @@ describe('Updater integration (real filesystem)', () => {
     await fs.writeFile(path.join(testDir, 'current'), dirName + '\n');
   }
 
+  async function writeCollectorRuntime(version: string) {
+    const logsDir = path.join(testDir, 'logs');
+    await fs.mkdir(logsDir, { recursive: true });
+    await fs.writeFile(path.join(logsDir, 'runtime.json'), JSON.stringify({
+      status: 'active',
+      packageVersion: version,
+      pid: process.pid,
+      updatedAt: new Date().toISOString(),
+    }));
+  }
+
   async function readPointer(name: string): Promise<string | null> {
     try {
       return (await fs.readFile(path.join(testDir, name), 'utf-8')).trim();
@@ -254,6 +265,7 @@ describe('Updater integration (real filesystem)', () => {
   it('does NOT downgrade when remote version is older', async () => {
     const v2Dir = await createFakeVersion('1.0.2', 'bbb');
     await setCurrentPointer(v2Dir);
+    await writeCollectorRuntime('1.0.2');
 
     // Remote says 1.0.1 (older)
     mockFetch.mockResolvedValueOnce({
@@ -270,6 +282,34 @@ describe('Updater integration (real filesystem)', () => {
     // Should NOT have attempted download
     expect(mockFetch).toHaveBeenCalledTimes(1); // only manifest, no download
     expect(await readPointer('current')).toBe('1.0.2_bbb');
+  });
+
+  it('recovers the collector on an already-current version before clearing failure state', async () => {
+    const currentDir = await createFakeVersion('1.0.2', 'bbb');
+    await setCurrentPointer(currentDir);
+    mockFetch.mockResolvedValueOnce({
+      ok: true, status: 200,
+      json: () => Promise.resolve({
+        version: '1.0.2', git_commit: 'bbb',
+        package_url: 'https://example.com/pkg.tar.gz',
+      }),
+    });
+    mockExecFile.mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args.includes('start-collector')) await writeCollectorRuntime('1.0.2');
+      return { stdout: '', stderr: '' };
+    });
+    const updater = new Updater(makeConfig(), testDir);
+    (updater as any).consecutiveFailures = 3;
+
+    await updater.check();
+
+    const commands = mockExecFile.mock.calls
+      .map(([, args]: [string, string[]]) => args.find((arg) => [
+        'start-collector', 'schedule-updater-restart',
+      ].includes(arg)))
+      .filter(Boolean);
+    expect(commands).toEqual(['start-collector', 'schedule-updater-restart']);
+    expect((updater as any).consecutiveFailures).toBe(0);
   });
 
   // ─── GC preserves current + previous ──────────────────
@@ -357,7 +397,11 @@ describe('Updater integration (real filesystem)', () => {
 
     await (updater as any).restartCollector('1.0.2', false);
 
-    const commands = mockExecFile.mock.calls.map(([, args]: [string, string[]]) => args[0]);
+    const commands = mockExecFile.mock.calls
+      .map(([, args]: [string, string[]]) => args.find((arg) => [
+        'restart-collector', 'start-collector',
+      ].includes(arg)))
+      .filter(Boolean);
     expect(commands).toContain('restart-collector');
     expect(commands).toContain('start-collector');
   });

--- a/tests/integration/updater-flow.test.ts
+++ b/tests/integration/updater-flow.test.ts
@@ -335,4 +335,30 @@ describe('Updater integration (real filesystem)', () => {
     const local = await (updater as any).readLocalVersion();
     expect(local).toEqual({ version: '0.9.0', gitCommit: 'legacy' });
   });
+
+  it('recovers a timed-out collector restart through start-only and verifies runtime health', async () => {
+    mockExecFile.mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args.includes('restart-collector')) {
+        throw new Error('Command timed out after 30000ms');
+      }
+      if (args.includes('start-collector')) {
+        const logsDir = path.join(testDir, 'logs');
+        await fs.mkdir(logsDir, { recursive: true });
+        await fs.writeFile(path.join(logsDir, 'runtime.json'), JSON.stringify({
+          status: 'active',
+          packageVersion: '1.0.2',
+          pid: process.pid,
+          updatedAt: new Date().toISOString(),
+        }));
+      }
+      return { stdout: '', stderr: '' };
+    });
+    const updater = new Updater(makeConfig(), testDir);
+
+    await (updater as any).restartCollector('1.0.2', false);
+
+    const commands = mockExecFile.mock.calls.map(([, args]: [string, string[]]) => args[0]);
+    expect(commands).toContain('restart-collector');
+    expect(commands).toContain('start-collector');
+  });
 });

--- a/tests/unit/scripts/dashboard-lifecycle.test.mjs
+++ b/tests/unit/scripts/dashboard-lifecycle.test.mjs
@@ -77,10 +77,13 @@ describe('dashboard service lifecycle', () => {
       runtimeSh.indexOf('is_pid_file_running()'),
     );
 
+    expect(processLookup).toContain('[ -r "/proc/$pid/status" ]');
+    expect(processLookup).toContain('done < "/proc/$pid/status"');
     expect(processLookup).toContain('[ -r "/proc/$pid/cmdline" ]');
     expect(processLookup).toContain('[ "$argv_entry" = "$expected_entry" ]');
-    expect(processLookup).toContain('ps -U "$(id -u)" -o pid= -o ucomm=');
+    expect(processLookup).toContain('ps -U "$current_user_id" -o pid= -o ucomm=');
     expect(processLookup).toContain('find_current_user_processes collector');
+    expect(processLookup).toContain('find_current_user_collector_processes()');
     expect(processLookup).toContain('node:node|node:nodejs');
     expect(processLookup).toContain('[[ "$command_line" == *" $expected_suffix" ]]');
     expect(processLookup).toContain('process_matches_installed_entry "$pid" collector');
@@ -103,8 +106,9 @@ describe('dashboard service lifecycle', () => {
       runtimeSh.indexOf('cmd_restart_updater()'),
     );
 
-    expect(stopHelper).toContain('find_current_user_processes collector-wrapper');
-    expect(stopHelper).toContain('find_current_user_processes collector');
+    expect(stopHelper).toContain('find_current_user_collector_processes');
+    expect(stopHelper).not.toContain('find_current_user_processes collector-wrapper');
+    expect(stopHelper).not.toContain('find_current_user_processes collector |');
     expect(stopHelper).toContain('process_matches_installed_entry "$pid" "$kind"');
     expect(stopHelper).toContain('for attempt in 1 2 3 4 5');
     expect(stopCommand).toContain('stop_installed_collector_processes');
@@ -113,6 +117,32 @@ describe('dashboard service lifecycle', () => {
     expect(restartCommand).toContain('stop_pid_file "$PID_FILE" collector');
     expect(runtimeSh).not.toContain('pkill -f "loongsuite-pilot/bin/collector-daemon"');
     expect(runtimeSh).not.toContain('pkill -f "loongsuite-pilot/bin/updater-daemon"');
+  });
+
+  it('does not launch per-PID ps commands on the Linux procfs path', () => {
+    const matcher = runtimeSh.slice(
+      runtimeSh.indexOf('process_matches_installed_entry()'),
+      runtimeSh.indexOf('find_current_user_processes()'),
+    );
+    const procfsStart = matcher.indexOf('if [ -r "/proc/$pid/status" ]');
+    const procfsBranch = matcher.slice(procfsStart, matcher.indexOf('    else', procfsStart));
+
+    expect(procfsBranch).toContain('done < "/proc/$pid/status"');
+    expect(procfsBranch).toContain('read -r process_name < "/proc/$pid/comm"');
+    expect(procfsBranch).not.toContain('ps -p');
+  });
+
+  it('provides a start-only updater recovery path without stop or process scans', () => {
+    const startOnly = runtimeSh.slice(
+      runtimeSh.indexOf('cmd_start_collector()'),
+      runtimeSh.indexOf('# Restart only the collector'),
+    );
+    const dispatch = runtimeSh.slice(runtimeSh.indexOf('# ---- Dispatch ----'));
+
+    expect(startOnly).toContain('start_collector_after_stop');
+    expect(startOnly).not.toContain('stop_pid_file');
+    expect(startOnly).not.toContain('stop_installed_collector_processes');
+    expect(dispatch).toContain('start-collector)');
   });
 
   it('rejects a reused PID and repairs it from the real Node argv entry', async () => {

--- a/tests/unit/scripts/ps1-daemon-reap-scope.test.mjs
+++ b/tests/unit/scripts/ps1-daemon-reap-scope.test.mjs
@@ -44,12 +44,16 @@ const bodyOf = (name) => {
 const code = codeOf(text);
 
 describe('the orphan reap only kills this installation', () => {
-  it('there is exactly one place that enumerates node processes', () => {
+  it('enumerates node command lines with one bulk CIM query', () => {
     // Both inline copies are gone. A fourth copy appearing is the failure mode this
     // catches: the scope below would be correct and irrelevant.
-    const scans = code.match(/Get-Process -Name "node"/g) || [];
+    const scans = code.match(/Get-CimInstance Win32_Process/g) || [];
     expect(scans).toHaveLength(1);
-    expect(bodyOf('Stop-OrphanProcesses')).toContain('Get-Process -Name "node"');
+    const body = bodyOf('Stop-OrphanProcesses');
+    expect(body).toContain('Get-CimInstance Win32_Process');
+    expect(body).toContain('-Filter "Name = \'node.exe\'"');
+    expect(body).not.toMatch(/Get-Process -Name "node"/);
+    expect(body).not.toMatch(/ProcessId\s*=\s*\$\(\$_\./);
   });
 
   it('Stop-OrphanProcesses requires the command line to name our bootstrap dir', () => {

--- a/tests/unit/scripts/ps1-updater-handoff.test.mjs
+++ b/tests/unit/scripts/ps1-updater-handoff.test.mjs
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const SERVICE_PS1 = 'scripts/loongsuite-pilot.ps1';
+const text = readFileSync(SERVICE_PS1, 'utf-8');
+const codeOf = (source) => source
+  .split('\n')
+  .filter((line) => !/^\s*#/.test(line))
+  .join('\n');
+
+const bodyOf = (name) => {
+  const start = text.indexOf(`function ${name} {`);
+  expect(start, `${name} not found in ${SERVICE_PS1}`).toBeGreaterThan(-1);
+  const rest = text.slice(start + `function ${name} {`.length);
+  const end = rest.search(/\nfunction \S+ \{/);
+  return codeOf(end === -1 ? rest : rest.slice(0, end));
+};
+
+describe('Windows updater handoff and collector recovery commands', () => {
+  it('start-collector never stops or scans processes', () => {
+    const body = bodyOf('Cmd-StartCollector');
+    expect(body).not.toContain('Stop-PidFile');
+    expect(body).not.toContain('Stop-OrphanProcesses');
+    expect(body).not.toContain('Stop-ScheduledTask');
+    expect(body).not.toContain('Start-Job');
+    expect(body).toContain('Start-ScheduledTask');
+    expect(body).toContain('Install-CollectorTask $nodeBin -SkipCleanup');
+  });
+
+  it('missing-task repair skips destructive collector cleanup', () => {
+    const body = bodyOf('Install-CollectorTask');
+    expect(body).toContain('[switch]$SkipCleanup');
+    expect(body).toMatch(/if \(-not \$SkipCleanup\) \{[\s\S]*Stop-OrphanProcesses/);
+    expect(body).toMatch(/if \(-not \$SkipCleanup\) \{[\s\S]*schtasks\.exe \/Delete/);
+  });
+
+  it('restart-collector can defer updater restart until health validation completes', () => {
+    const body = bodyOf('Cmd-RestartCollector');
+    expect(body).toContain('--defer-updater-restart');
+    expect(body).toMatch(/if \(-not \$deferUpdaterRestart\) \{\s*Schedule-UpdaterRestart/);
+    expect(body).not.toContain('Start-Job');
+  });
+
+  it('schedules the delayed updater restart in an independent process', () => {
+    const body = bodyOf('Schedule-UpdaterRestart');
+    expect(body).toContain('Start-Sleep -Seconds 10');
+    expect(body).toContain('restart-updater');
+    expect(body).toContain('Start-Process -FilePath "powershell.exe"');
+    expect(body).not.toContain('Start-Job');
+  });
+
+  it('dispatches all three updater lifecycle commands', () => {
+    const dispatch = codeOf(text.slice(text.indexOf('switch ($Command.ToLower())')));
+    expect(dispatch).toContain('"start-collector"');
+    expect(dispatch).toContain('"restart-collector"');
+    expect(dispatch).toContain('Cmd-RestartCollector -Options $SubArgs');
+    expect(dispatch).toContain('"schedule-updater-restart"');
+  });
+});

--- a/tests/unit/updater/updater.test.ts
+++ b/tests/unit/updater/updater.test.ts
@@ -958,6 +958,79 @@ describe('Updater', () => {
       expect((updater as any).consecutiveFailures).toBe(0);
     });
 
+    it('allows a full health window after timed-out restart recovery', async () => {
+      setupForDownload();
+      const recoveryStartedAt = Date.now();
+      mockExecFile.mockImplementation((_cmd: string, args: string[]) => {
+        if (args.includes('restart-collector')) {
+          return Promise.reject(Object.assign(new Error('Command timed out'), { killed: true }));
+        }
+        return Promise.resolve({ stdout: '', stderr: '' });
+      });
+      mockReadJsonFile.mockImplementation((filePath: string) => {
+        if (!String(filePath).endsWith('/logs/runtime.json')) return Promise.resolve({});
+        if (Date.now() - recoveryStartedAt < 29_500) return Promise.resolve(null);
+        return Promise.resolve({
+          status: 'active',
+          packageVersion: '1.0.2',
+          pid: process.pid,
+          updatedAt: new Date().toISOString(),
+        });
+      });
+      const metrics = {
+        writeEvent: vi.fn().mockResolvedValue(undefined),
+        writeAlarm: vi.fn().mockResolvedValue(undefined),
+      };
+      const updater = new Updater(makeConfig(), tmpDir);
+      updater.setMetrics(metrics as any);
+
+      const checkPromise = updater.check();
+      await vi.runAllTimersAsync();
+      await checkPromise;
+
+      expect(metrics.writeEvent).toHaveBeenCalledWith('collector_restarted', {
+        latest_version: '1.0.2',
+      });
+      expect((updater as any).consecutiveFailures).toBe(0);
+    });
+
+    it('does not report success when Windows start-only returns Unknown command', async () => {
+      setupForDownload();
+      mockExecFile.mockImplementation((_cmd: string, args: string[]) => {
+        if (args.includes('restart-collector')) {
+          return Promise.reject(Object.assign(new Error('Command timed out'), { killed: true }));
+        }
+        if (args.includes('start-collector')) {
+          return Promise.reject(Object.assign(new Error('Command failed'), {
+            stdout: 'Unknown command: start-collector',
+            stderr: '',
+            code: 1,
+            killed: false,
+          }));
+        }
+        return Promise.resolve({ stdout: '', stderr: '' });
+      });
+      const metrics = {
+        writeEvent: vi.fn().mockResolvedValue(undefined),
+        writeAlarm: vi.fn().mockResolvedValue(undefined),
+      };
+      const updater = new Updater(makeConfig(), tmpDir);
+      updater.setMetrics(metrics as any);
+
+      await updater.check();
+
+      expect(metrics.writeEvent).not.toHaveBeenCalledWith(
+        'collector_restarted', expect.anything(),
+      );
+      expect(metrics.writeEvent).toHaveBeenCalledWith(
+        'update_failure',
+        expect.objectContaining({
+          error: expect.stringContaining('stdout="Unknown command: start-collector"'),
+        }),
+      );
+      expect((updater as any).consecutiveFailures).toBe(1);
+    });
+
     it('does not report restart success or run GC when collector health never appears', async () => {
       setupForDownload();
       mockReadJsonFile.mockImplementation((filePath: string) => {

--- a/tests/unit/updater/updater.test.ts
+++ b/tests/unit/updater/updater.test.ts
@@ -132,6 +132,21 @@ function makeResponseStream(status = 200): Response {
   } as unknown as Response;
 }
 
+function pilotCommandArgs(call: [string, string[]]): string[] {
+  const [cmd, args] = call;
+  if (String(cmd).toLowerCase().includes('powershell')) {
+    const fileIndex = args.indexOf('-File');
+    return fileIndex >= 0 ? args.slice(fileIndex + 2) : [];
+  }
+  return args;
+}
+
+function pilotCommands(): string[] {
+  return mockExecFile.mock.calls
+    .map((call: [string, string[]]) => pilotCommandArgs(call)[0])
+    .filter(Boolean);
+}
+
 describe('Updater', () => {
   let tmpDir: string;
 
@@ -291,6 +306,75 @@ describe('Updater', () => {
 
       // fetch called once for manifest, not for download
       expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('repairs an unhealthy collector even when the target is already current', async () => {
+      mockFetch.mockResolvedValueOnce(makeResponseJson(
+        makeManifest({ version: '1.0.2', git_commit: 'aaa' }),
+      ));
+      mockFsReadFile.mockImplementation((filePath: string) => {
+        if (filePath.endsWith('/current')) return Promise.resolve('1.0.2_aaa\n');
+        if (filePath.endsWith('/VERSION')) {
+          return Promise.resolve('version=1.0.2\ngit_commit=aaa\n');
+        }
+        return Promise.reject(new Error('ENOENT'));
+      });
+      mockFsAccess.mockResolvedValue(undefined);
+      let runtimeReads = 0;
+      mockReadJsonFile.mockImplementation((filePath: string) => {
+        if (!String(filePath).endsWith('/logs/runtime.json')) return Promise.resolve({});
+        runtimeReads++;
+        return Promise.resolve(runtimeReads === 1 ? null : {
+          status: 'active',
+          packageVersion: '1.0.2',
+          pid: process.pid,
+          updatedAt: new Date().toISOString(),
+        });
+      });
+      const metrics = {
+        writeEvent: vi.fn().mockResolvedValue(undefined),
+        writeAlarm: vi.fn().mockResolvedValue(undefined),
+      };
+      const updater = new Updater(makeConfig(), tmpDir);
+      updater.setMetrics(metrics as any);
+
+      await updater.check();
+
+      expect(pilotCommands()).toEqual(['start-collector', 'schedule-updater-restart']);
+      expect(metrics.writeEvent).toHaveBeenCalledWith('collector_restarted', {
+        latest_version: '1.0.2',
+      });
+      expect((updater as any).consecutiveFailures).toBe(0);
+    });
+
+    it('keeps failure state when already-current collector recovery never becomes healthy', async () => {
+      mockFetch.mockResolvedValueOnce(makeResponseJson(
+        makeManifest({ version: '1.0.2', git_commit: 'aaa' }),
+      ));
+      mockFsReadFile.mockImplementation((filePath: string) => {
+        if (filePath.endsWith('/current')) return Promise.resolve('1.0.2_aaa\n');
+        if (filePath.endsWith('/VERSION')) {
+          return Promise.resolve('version=1.0.2\ngit_commit=aaa\n');
+        }
+        return Promise.reject(new Error('ENOENT'));
+      });
+      mockFsAccess.mockResolvedValue(undefined);
+      mockReadJsonFile.mockImplementation((filePath: string) => (
+        String(filePath).endsWith('/logs/runtime.json')
+          ? Promise.resolve(null)
+          : Promise.resolve({})
+      ));
+      const updater = new Updater(makeConfig(), tmpDir);
+      const gc = vi.spyOn(updater as any, 'gcOldVersions');
+
+      const checkPromise = updater.check();
+      await vi.runAllTimersAsync();
+      await checkPromise;
+
+      expect(pilotCommands()).toContain('start-collector');
+      expect(pilotCommands()).not.toContain('schedule-updater-restart');
+      expect(gc).not.toHaveBeenCalled();
+      expect((updater as any).consecutiveFailures).toBe(1);
     });
   });
 
@@ -733,7 +817,7 @@ describe('Updater', () => {
         ([p]: [string]) => p.includes('/versions/1.0.0_old'),
       );
       const restartCallIndex = mockExecFile.mock.calls.findIndex(
-        ([cmd, args]: [string, string[]]) => String(cmd).includes('loongsuite-pilot') && args[0] === 'restart-collector',
+        (call: [string, string[]]) => pilotCommandArgs(call)[0] === 'restart-collector',
       );
       expect(mockFsRm.mock.invocationCallOrder[staleRmIndex]).toBeGreaterThan(
         mockExecFile.mock.invocationCallOrder[restartCallIndex],
@@ -832,16 +916,18 @@ describe('Updater', () => {
       const updater = new Updater(makeConfig(), tmpDir);
       await updater.check();
 
-      const loongsuitePilotCalls = mockExecFile.mock.calls.filter(
-        ([cmd]: [string]) => String(cmd).includes('loongsuite-pilot'),
-      );
-      expect(loongsuitePilotCalls.map(([, args]) => args)).toContainEqual([
+      const commandArgs = mockExecFile.mock.calls
+        .map((call: [string, string[]]) => pilotCommandArgs(call))
+        .filter(([command]: string[]) => [
+          'restart-collector', 'start-collector', 'schedule-updater-restart',
+        ].includes(command));
+      expect(commandArgs).toContainEqual([
         'restart-collector', '--defer-updater-restart',
       ]);
-      expect(loongsuitePilotCalls.map(([, args]) => args)).toContainEqual([
+      expect(commandArgs).toContainEqual([
         'schedule-updater-restart',
       ]);
-      expect(loongsuitePilotCalls.map(([, args]) => args).flat()).not.toContain('monitor');
+      expect(commandArgs.flat()).not.toContain('monitor');
     });
 
     it('recovers a timed-out restart with the start-only command before reporting success', async () => {
@@ -863,8 +949,7 @@ describe('Updater', () => {
 
       await updater.check();
 
-      const commands = mockExecFile.mock.calls
-        .map(([, args]: [string, string[]]) => args[0]);
+      const commands = pilotCommands();
       expect(commands).toContain('restart-collector');
       expect(commands).toContain('start-collector');
       expect(metrics.writeEvent).toHaveBeenCalledWith('collector_restarted', {
@@ -891,8 +976,7 @@ describe('Updater', () => {
       await vi.runAllTimersAsync();
       await checkPromise;
 
-      const commands = mockExecFile.mock.calls
-        .map(([, args]: [string, string[]]) => args[0]);
+      const commands = pilotCommands();
       expect(commands).toContain('restart-collector');
       expect(commands).toContain('start-collector');
       expect(metrics.writeEvent).not.toHaveBeenCalledWith(
@@ -929,6 +1013,51 @@ describe('Updater', () => {
       expect((updater as any).collectorHealthFailure(
         runtime, '1.0.2', now, null,
       )).toBe('');
+    });
+  });
+
+  describe('collector command invocation', () => {
+    it('passes Windows commands after -File and defers the updater handoff', async () => {
+      const realPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      try {
+        const updater = new Updater(makeConfig(), tmpDir);
+        await (updater as any).runCollectorCommand('restart-collector');
+        await (updater as any).runCollectorCommand('start-collector');
+        await (updater as any).runCollectorCommand('schedule-updater-restart');
+
+        expect(mockExecFile.mock.calls).toHaveLength(3);
+        expect(mockExecFile.mock.calls.map((call: [string, string[]]) => call[0]))
+          .toEqual(['powershell.exe', 'powershell.exe', 'powershell.exe']);
+        expect(mockExecFile.mock.calls.map((call: [string, string[]]) => pilotCommandArgs(call)))
+          .toEqual([
+            ['restart-collector', '--defer-updater-restart'],
+            ['start-collector'],
+            ['schedule-updater-restart'],
+          ]);
+      } finally {
+        Object.defineProperty(process, 'platform', { value: realPlatform });
+      }
+    });
+
+    it('preserves child-process diagnostics when start-only recovery fails', async () => {
+      const restartError = Object.assign(new Error('restart timed out'), {
+        stdout: 'restart output',
+        killed: true,
+        signal: 'SIGTERM',
+      });
+      const recoveryError = Object.assign(new Error('start failed'), {
+        stdout: 'start output',
+        stderr: 'permission denied',
+        code: 1,
+        killed: false,
+      });
+      mockExecFile.mockRejectedValueOnce(recoveryError);
+      const updater = new Updater(makeConfig(), tmpDir);
+
+      await expect((updater as any).startCollectorForRecovery(restartError)).rejects.toThrow(
+        /stdout="restart output".*killed=true.*signal=SIGTERM.*stdout="start output".*stderr="permission denied".*code=1.*killed=false/,
+      );
     });
   });
 

--- a/tests/unit/updater/updater.test.ts
+++ b/tests/unit/updater/updater.test.ts
@@ -158,8 +158,20 @@ describe('Updater', () => {
     mockFsAccess.mockRejectedValue(new Error('ENOENT'));
     // Default: execFile succeeds
     mockExecFile.mockResolvedValue({ stdout: '', stderr: '' });
-    // Default: readJsonFile / writeJsonFile
-    mockReadJsonFile.mockResolvedValue({});
+    // Default: config reads return an empty object; collector health reads see
+    // the freshly started target version so existing successful-upgrade tests
+    // exercise the health gate without waiting for a timer.
+    mockReadJsonFile.mockImplementation((filePath: string) => {
+      if (String(filePath).endsWith('/logs/runtime.json')) {
+        return Promise.resolve({
+          status: 'active',
+          packageVersion: '1.0.2',
+          pid: process.pid,
+          updatedAt: new Date().toISOString(),
+        });
+      }
+      return Promise.resolve({});
+    });
     mockWriteJsonFile.mockResolvedValue(undefined);
   });
 
@@ -823,8 +835,100 @@ describe('Updater', () => {
       const loongsuitePilotCalls = mockExecFile.mock.calls.filter(
         ([cmd]: [string]) => String(cmd).includes('loongsuite-pilot'),
       );
-      expect(loongsuitePilotCalls.map(([, args]) => args)).toContainEqual(['restart-collector']);
+      expect(loongsuitePilotCalls.map(([, args]) => args)).toContainEqual([
+        'restart-collector', '--defer-updater-restart',
+      ]);
+      expect(loongsuitePilotCalls.map(([, args]) => args)).toContainEqual([
+        'schedule-updater-restart',
+      ]);
       expect(loongsuitePilotCalls.map(([, args]) => args).flat()).not.toContain('monitor');
+    });
+
+    it('recovers a timed-out restart with the start-only command before reporting success', async () => {
+      setupForDownload();
+      mockExecFile.mockImplementation((_cmd: string, args: string[]) => {
+        if (args.includes('restart-collector')) {
+          const error = new Error('Command timed out');
+          (error as any).killed = true;
+          return Promise.reject(error);
+        }
+        return Promise.resolve({ stdout: '', stderr: '' });
+      });
+      const metrics = {
+        writeEvent: vi.fn().mockResolvedValue(undefined),
+        writeAlarm: vi.fn().mockResolvedValue(undefined),
+      };
+      const updater = new Updater(makeConfig(), tmpDir);
+      updater.setMetrics(metrics as any);
+
+      await updater.check();
+
+      const commands = mockExecFile.mock.calls
+        .map(([, args]: [string, string[]]) => args[0]);
+      expect(commands).toContain('restart-collector');
+      expect(commands).toContain('start-collector');
+      expect(metrics.writeEvent).toHaveBeenCalledWith('collector_restarted', {
+        latest_version: '1.0.2',
+      });
+      expect((updater as any).consecutiveFailures).toBe(0);
+    });
+
+    it('does not report restart success or run GC when collector health never appears', async () => {
+      setupForDownload();
+      mockReadJsonFile.mockImplementation((filePath: string) => {
+        if (String(filePath).endsWith('/logs/runtime.json')) return Promise.resolve(null);
+        return Promise.resolve({});
+      });
+      const metrics = {
+        writeEvent: vi.fn().mockResolvedValue(undefined),
+        writeAlarm: vi.fn().mockResolvedValue(undefined),
+      };
+      const updater = new Updater(makeConfig(), tmpDir);
+      updater.setMetrics(metrics as any);
+      const gc = vi.spyOn(updater as any, 'gcOldVersions');
+
+      const checkPromise = updater.check();
+      await vi.runAllTimersAsync();
+      await checkPromise;
+
+      const commands = mockExecFile.mock.calls
+        .map(([, args]: [string, string[]]) => args[0]);
+      expect(commands).toContain('restart-collector');
+      expect(commands).toContain('start-collector');
+      expect(metrics.writeEvent).not.toHaveBeenCalledWith(
+        'collector_restarted', expect.anything(),
+      );
+      expect(metrics.writeEvent).toHaveBeenCalledWith(
+        'update_failure', expect.objectContaining({ consecutive_failures: 1 }),
+      );
+      expect(gc).not.toHaveBeenCalled();
+      expect((updater as any).consecutiveFailures).toBe(1);
+    });
+  });
+
+  describe('collector health validation', () => {
+    it('requires the target version, a fresh heartbeat, and a new PID for rebuilds', () => {
+      const updater = new Updater(makeConfig(), tmpDir);
+      const now = Date.now();
+      const runtime = {
+        status: 'active',
+        packageVersion: '1.0.2',
+        pid: process.pid,
+        updatedAt: new Date(now).toISOString(),
+      };
+
+      expect((updater as any).collectorHealthFailure(
+        { ...runtime, packageVersion: '1.0.1' }, '1.0.2', now, null,
+      )).toContain('expected 1.0.2');
+      expect((updater as any).collectorHealthFailure(
+        { ...runtime, updatedAt: new Date(now - 1).toISOString() }, '1.0.2', now, null,
+      )).toBe('runtime record predates restart');
+      expect((updater as any).collectorHealthFailure(
+        runtime, '1.0.2', now, process.pid,
+      )).toBe('collector PID did not change');
+      expect((updater as any).collectorHealthFailure(
+        runtime, '1.0.2', now, null,
+      )).toBe('');
     });
   });
 


### PR DESCRIPTION
## Summary

- eliminate per-PID ps subprocesses on Linux by reading process identity from procfs and scanning collector candidates from one process-table snapshot
- add a start-only recovery path when restart-collector times out or fails
- require a fresh runtime heartbeat from the target version before reporting collector_restarted or running post-update cleanup
- defer the POSIX updater handoff until collector health and success bookkeeping complete

## Validation

- npm run typecheck
- npm run build
- npm test -- --run
- 282 test files passed, 3 skipped; 3480 tests passed, 56 skipped

Fixes #318