### PR TITLE
feat(k8s): core runtime hardening for containerized agents

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -38,6 +38,31 @@ await build({
   minify: true,
   treeShaking: true,
   packages: 'external',
+  // The guard must run BEFORE this bundle's module graph loads: the graph
+  // imports sqlite3 at top level (orchestrator.ts → qoder-*-sqlite inputs), so
+  // on a libc that cannot load the addon the bundle dies mid-import, before any
+  // logging exists, and the spawners used to drop that stderr. A static import
+  // in the banner is evaluated first by Node, so the guard's check — and its
+  // readable FATAL diagnostic — precede the crash it replaces. See
+  // src/native-deps-guard.ts.
+  banner: { js: "import './native-deps-guard.cjs';" },
+  define: commonDefine,
+  plugins: commonPlugins,
+});
+
+// Loaded by the banner above, before the daemon graph. Must keep
+// `packages: 'external'`: its require('sqlite3') has to resolve against the
+// payload's node_modules at runtime — bundling it would try to inline a native
+// addon and defeat the check.
+await build({
+  entryPoints: ['src/native-deps-guard.ts'],
+  outfile: 'dist/native-deps-guard.cjs',
+  platform: 'node',
+  target: 'es2022',
+  format: 'cjs',
+  bundle: true,
+  packages: 'external',
+  minifySyntax: true,
   define: commonDefine,
   plugins: commonPlugins,
 });
@@ -49,6 +74,32 @@ await build({
   target: 'es2022',
   format: 'cjs',
   bundle: true,
+  banner: { js: "process.env.LOG_LEVEL = 'silent';" },
+  minifySyntax: true,
+  define: commonDefine,
+  plugins: commonPlugins,
+});
+
+// Self-contained CJS, like cli-probe above: no `packages: 'external'`, so it
+// needs no node_modules at runtime. That is the point — the K8s preload blocks
+// the business process on this while it runs, so it must start at bare-node
+// cost rather than dragging in the daemon's dependency graph.
+await build({
+  entryPoints: ['src/inject-hooks.ts'],
+  outfile: 'dist/inject-hooks.cjs',
+  platform: 'node',
+  target: 'es2022',
+  format: 'cjs',
+  bundle: true,
+  // Prefer each package's ESM build over its `main`. Needed for real
+  // self-containment: jsonc-parser's `main` is a UMD file whose deps are
+  // fetched with a runtime require('./impl/format'), which esbuild cannot
+  // follow — the bundle then builds fine and throws MODULE_NOT_FOUND on first
+  // run without node_modules. Its `module` entry uses static imports that
+  // bundle cleanly. Verified by running the artifact with node_modules absent.
+  mainFields: ['module', 'main'],
+  // Keeps pilot's own logging off the agent's stdout/stderr; this process runs
+  // attached to a business workload, and some agents parse their own output.
   banner: { js: "process.env.LOG_LEVEL = 'silent';" },
   minifySyntax: true,
   define: commonDefine,

--- a/src/core/config-loader.ts
+++ b/src/core/config-loader.ts
@@ -34,12 +34,11 @@ import {
   SUPPORTED_MASK_TYPES,
 } from '../types/index.js';
 import { readJsonFile, resolveHome } from '../utils/fs-utils.js';
+import { configJsonPath, pickDataDir } from '../utils/data-dir.js';
 import { createLogger } from '../utils/logger.js';
 import { parseKeyValueAttributes, sanitizeAttributes } from '../normalization/global-attributes.js';
 
 const logger = createLogger('ConfigLoader');
-
-const DEFAULT_CONFIG_PATH = '~/.loongsuite-pilot/config.json';
 
 export interface SlsEndpointEntry {
   name?: string;
@@ -254,7 +253,7 @@ function envInt(key: string, fallback: number): number {
  * Env vars override config file values. Config file overrides defaults.
  */
 export async function loadConfig(): Promise<AnalyticsConfig> {
-  const configPath = resolveHome(env('AGENT_DATA_COLLECTION_CONFIG') ?? DEFAULT_CONFIG_PATH);
+  const configPath = configJsonPath();
   const file = await readJsonFile<ConfigFile>(configPath);
 
   if (file) {
@@ -263,7 +262,7 @@ export async function loadConfig(): Promise<AnalyticsConfig> {
     logger.debug('no config file found, using env + defaults', { path: configPath });
   }
 
-  const dataDir = env('LOONGSUITE_PILOT_DATA_DIR') ?? file?.dataDir ?? '~/.loongsuite-pilot';
+  const dataDir = pickDataDir(env('LOONGSUITE_PILOT_DATA_DIR'), file?.dataDir);
 
   const innerDataConfigPath = resolveHome(`${dataDir}/configs/inner/data_config.json`);
   const innerDataConfig = await readJsonFile<InnerDataConfig>(innerDataConfigPath);

--- a/src/deployment/detect-utils.ts
+++ b/src/deployment/detect-utils.ts
@@ -29,11 +29,28 @@ export async function detectAgent(detection: AgentDetectionConfig): Promise<bool
   return false;
 }
 
+// Per-process memoisation of `which`/`where.exe` results. Detection sweeps every
+// eager-safe definition (and the daemon re-detects on each deployAll), so the same
+// lookups repeat; PATH does not change inside a process, so caching is safe and
+// turns N serial subprocess spawns into one per command per process.
+const commandExistsCache = new Map<string, boolean>();
+
+// `which`/`where.exe` is on the startup critical path (eager injection runs it
+// synchronously before the workload's first module). A hung lookup — a stale NFS
+// mount or dead disk on PATH — must not block the business process indefinitely,
+// so bound it and treat a timeout as "not installed". The child is killed on
+// timeout rather than left to linger.
+const COMMAND_EXISTS_TIMEOUT_MS = 2000;
+
 export function commandExists(command: string): Promise<boolean> {
+  const cached = commandExistsCache.get(command);
+  if (cached !== undefined) return Promise.resolve(cached);
   const bin = process.platform === 'win32' ? 'where.exe' : 'which';
   return new Promise(resolve => {
-    execFile(bin, [command], err => {
-      resolve(!err);
+    execFile(bin, [command], { timeout: COMMAND_EXISTS_TIMEOUT_MS, killSignal: 'SIGKILL' }, err => {
+      const exists = !err;
+      commandExistsCache.set(command, exists);
+      resolve(exists);
     });
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,6 +143,16 @@ async function main(): Promise<void> {
     flushLogsSync();
     lock.release();
     if (pidFile) removeOwnPidFileSync(pidFile);
+    // Release the spawn lock the same way the pid file is released: only when it
+    // still carries THIS daemon's pid, so a successor that already took over (or a
+    // pid-reused process) is never disturbed. Leaving a dead pid behind is exactly
+    // the hazard the prestop contract guards against — prestop.sh would SIGTERM a
+    // recycled pid. See the daemon.spawn.lock contract in prestop.sh.
+    try {
+      if (fs.readFileSync(spawnLockPath, 'utf8').trim() === String(process.pid)) {
+        fs.unlinkSync(spawnLockPath);
+      }
+    } catch { /* lock never written, or already gone — nothing to clean */ }
   });
 
   const orchestrator = new Orchestrator(config);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import * as path from 'path';
+import * as fs from 'fs';
 import { Orchestrator } from './core/orchestrator.js';
 import { loadConfig } from './core/config-loader.js';
 import { createLogger, initFileLogging, flushLogsSync } from './utils/logger.js';
@@ -100,6 +101,27 @@ async function main(): Promise<void> {
   }
   logger.info('single-instance lock acquired', { pid: process.pid, lockPath });
 
+  // PID-write authority lives HERE, not in the spawners (k8s-preload.cjs /
+  // start.sh). Two spawners that each recorded the pid they spawned could leave
+  // the lock pointing at a daemon that lost THIS collector.lock race and exited —
+  // so prestop.sh would signal a dead pid while the real daemon died in the
+  // SIGKILL with buffers unflushed. The daemon that actually holds collector.lock
+  // is the only one prestop.sh should ever signal, so it is the only one allowed
+  // to publish a pid. See the daemon.spawn.lock contract in prestop.sh.
+  //
+  // Only written on the K8s path (or when a spawner already created the file),
+  // so a bare local `npm start` does not grow a stray lock file in the data dir.
+  const spawnLockPath = path.join(dataDir, 'daemon.spawn.lock');
+  if (process.env.KUBERNETES_SERVICE_HOST || fs.existsSync(spawnLockPath)) {
+    try {
+      fs.writeFileSync(spawnLockPath, String(process.pid), 'utf8');
+    } catch (err) {
+      // Non-fatal: worst case prestop.sh finds a stale/empty lock and lets the
+      // grace period run its course — the same as before this write existed.
+      logger.warn('cannot record daemon pid in spawn lock', { spawnLockPath, error: String(err) });
+    }
+  }
+
   // On Windows the launcher cannot record the daemon's real pid: there is no exec(2),
   // so wscript/PowerShell run node as a *child* and would only ever capture the wrapper
   // pid (or, on the Task Scheduler path, nothing at all). Unix keeps writing the pid file
@@ -150,11 +172,38 @@ async function main(): Promise<void> {
   // must match the daemon writer and the updater reader (env-or-default), not config.dataDir.
   clearStartupCrash(resolveBreadcrumbDataDir());
 
+  const enabledFlushers = Object.entries(config.flushers)
+    .filter(([, v]) => v?.enabled)
+    .map(([k]) => k);
+
+  // LOONGSUITE_SLS_* alone does not switch SLS on: buildSlsConfig only consults
+  // those vars when the config file carries an `sls` section. Under K8s nothing
+  // writes that section except k8s-preload.cjs, so a failed unlock write leaves a
+  // destination fully configured in the env and no exporter to use it. The sole
+  // symptom used to be `sls` missing from the list logged below — readable only
+  // by someone who already knew it belonged there, which cost hours to diagnose
+  // once. Where the intent is this unambiguous, say so rather than stay quiet.
+  if (
+    !enabledFlushers.includes('sls')
+    && process.env.LOONGSUITE_SLS_PROJECT
+    && process.env.LOONGSUITE_SLS_LOGSTORE
+  ) {
+    logger.warn(
+      'an SLS destination is set in the environment but the SLS flusher is NOT enabled — '
+      + 'events will be collected locally and never uploaded. Those env vars are only read '
+      + 'when the config file carries an "sls" section; check that the file exists and is readable.',
+      {
+        project: process.env.LOONGSUITE_SLS_PROJECT,
+        logstore: process.env.LOONGSUITE_SLS_LOGSTORE,
+        expectedConfigPath: process.env.AGENT_DATA_COLLECTION_CONFIG ?? '~/.loongsuite-pilot/config.json',
+        enabledFlushers,
+      },
+    );
+  }
+
   logger.info('AI Agent Input is running', {
     dataDir: config.dataDir,
-    flushers: Object.entries(config.flushers)
-      .filter(([, v]) => v?.enabled)
-      .map(([k]) => k),
+    flushers: enabledFlushers,
   });
 }
 

--- a/src/inject-hooks.ts
+++ b/src/inject-hooks.ts
@@ -27,9 +27,9 @@ import { AgentDefLoader } from './deployment/agent-def-loader.js';
 import { HookManager } from './hooks/hook-manager.js';
 import { HookStrategy } from './deployment/hook-strategy.js';
 import { PluginInjectStrategy } from './deployment/plugin-inject-strategy.js';
-import { resolveHome } from './utils/fs-utils.js';
-import { resolveDataDir } from './utils/data-dir.js';
-import type { AgentDefinition } from './types/deployment.js';
+import { readJsonFile, writeJsonFile, resolveHome } from './utils/fs-utils.js';
+import { readConfigAgentsGate, resolveDataDir } from './utils/data-dir.js';
+import type { AgentDefinition, DeployedAgentsState } from './types/deployment.js';
 
 // This file is always bundled as CJS (build.mjs), so __dirname is guaranteed.
 const __inject_dirname = __dirname;
@@ -157,6 +157,24 @@ function warn(msg: string): void {
 }
 
 /**
+ * The same decision deploy-command.isAgentGatedEnabled() makes for the daemon:
+ * no gate (or an empty one) means everything is enabled; otherwise an agent is
+ * enabled unless it is explicitly `enabled: false`. Re-decided here instead of
+ * imported because this entry must stay a self-contained bundle, and pinned by
+ * the inject-hooks gate-parity test so the two cannot drift. Without it a
+ * disabled agent would be eagerly instrumented and keep firing until the
+ * daemon's next undeployDisabledAgent pass — admission control silently off for
+ * short-lived Jobs that never live long enough for that pass.
+ */
+export function isGateEnabled(
+  gate: Record<string, { enabled?: boolean } | undefined> | undefined,
+  agentId: string,
+): boolean {
+  if (!gate || Object.keys(gate).length === 0) return true;
+  return gate[agentId]?.enabled !== false;
+}
+
+/**
  * Resolve the data dir exactly as loadConfig() does, including the config
  * file's `dataDir`. The chain lives in utils/data-dir.ts — the single home of
  * that precedence — because the hookCommand written into the agent's settings
@@ -196,11 +214,21 @@ async function main(): Promise<number> {
   const plan = planEagerDeploys(defs, args.agents);
   const byId = new Map(defs.map(def => [def.id, def]));
 
+  // The same enabled/disabled gate the daemon applies (deployAll(enabled) →
+  // isAgentGatedEnabled). Read once, not per agent.
+  const gate = readConfigAgentsGate();
+
   // Names of the agents actually written to, not of the agents considered. Under
   // sweep the plan holds every eager-safe definition while typically one is
   // installed, so reporting the plan would name 19 agents alongside "injected 1".
   const injected: string[] = [];
   let failed = 0;
+
+  // Records for agents we successfully deploy, written to deployed-agents.json
+  // after the loop. Without them the daemon's undeployDisabledAgent() sees no
+  // state record for an eagerly-installed hook and no-ops, so a later-disabled
+  // agent's hook would fire forever (see DeploymentManager.undeployDisabledAgent).
+  const newRecords: DeployedAgentsState = {};
 
   for (const entry of plan) {
     if (entry.action === 'unknown-id') {
@@ -215,6 +243,16 @@ async function main(): Promise<number> {
     }
 
     const def = byId.get(entry.agentId)!;
+
+    // Respect the enabled gate: an agent turned off in config.agents must not be
+    // eagerly instrumented. Silent under sweep for the same reason "not detected"
+    // is — the caller did not name it, so one line per disabled agent would be
+    // noise in every Pod.
+    if (!isGateEnabled(gate, def.id)) {
+      if (!sweep) warn(`${def.id} is disabled via config.agents — skipping eager injection`);
+      continue;
+    }
+
     const strategy = def.deployMode === 'hook' ? hookStrategy : pluginInjectStrategy;
     try {
       if (!await strategy.detect(def)) {
@@ -234,6 +272,9 @@ async function main(): Promise<number> {
       const result = await strategy.deploy(def);
       if (result.success) {
         injected.push(def.id);
+        // Same record shape the daemon writes (DeploymentManager.deployAgent),
+        // so the state file stays a single consistent schema.
+        newRecords[def.id] = { deployMode: def.deployMode, deployedAt: new Date().toISOString() };
       } else {
         failed++;
         warn(`failed to inject ${def.id}: ${result.error ?? 'unknown error'}`);
@@ -241,6 +282,20 @@ async function main(): Promise<number> {
     } catch (err) {
       failed++;
       warn(`failed to inject ${def.id}: ${(err as Error).message}`);
+    }
+  }
+
+  // Merge into (not clobber) any existing state, then persist. Runs before the
+  // daemon spawns, so there is no concurrent writer; the atomic write guards a
+  // crash mid-write. Best-effort — the hooks are already installed, and failing
+  // to record only delays disabled-agent cleanup until the daemon reconciles.
+  if (Object.keys(newRecords).length > 0) {
+    const stateFile = path.join(dataDir, 'deployed-agents.json');
+    try {
+      const existing = (await readJsonFile<DeployedAgentsState>(stateFile)) ?? {};
+      await writeJsonFile(stateFile, { ...existing, ...newRecords });
+    } catch (err) {
+      warn(`could not record deployment state: ${(err as Error).message}`);
     }
   }
 

--- a/src/inject-hooks.ts
+++ b/src/inject-hooks.ts
@@ -1,0 +1,282 @@
+// inject-hooks — deploy the agents present in this container synchronously,
+// ahead of the daemon. `--agents` narrows the candidate set; without it every
+// eager-safe definition is detected, exactly as the daemon would.
+//
+// Why this exists as its own entry point rather than a daemon subcommand:
+// under the K8s auto-inject flow the business container is started with
+// NODE_OPTIONS="--require .../k8s-preload.cjs", and that preload can only
+// *spawn* the daemon, not wait for it — a `--require` hook is synchronous and
+// cannot await. The daemon then needs 1-3s of cold start (bundle load, native
+// modules, flusher setup) before deployAll() writes hooks into the agent's
+// settings. An agent that reads its settings inside that window runs
+// uninstrumented, and nothing reports an error: the telemetry is simply absent.
+// Short-lived Jobs (`claude -p "..."`) can lose their entire run that way.
+//
+// So the preload spawnSync()s this entry *before* it spawns the daemon. This is
+// a separate, self-contained CJS bundle (build.mjs) so that starting it costs a
+// bare node startup instead of the daemon's full module graph.
+//
+// It deliberately reuses HookStrategy/PluginInjectStrategy verbatim instead of
+// reimplementing injection synchronously. The hookCommand string those produce
+// must match the daemon's byte for byte, because the daemon's later pass asks
+// `isHookInstalled` — a one-character divergence reads as "not installed" and
+// appends a SECOND hook entry, making every event fire twice. Sharing the code
+// makes that impossible by construction rather than by review.
+import * as path from 'node:path';
+import { AgentDefLoader } from './deployment/agent-def-loader.js';
+import { HookManager } from './hooks/hook-manager.js';
+import { HookStrategy } from './deployment/hook-strategy.js';
+import { PluginInjectStrategy } from './deployment/plugin-inject-strategy.js';
+import { resolveHome } from './utils/fs-utils.js';
+import { resolveDataDir } from './utils/data-dir.js';
+import type { AgentDefinition } from './types/deployment.js';
+
+// This file is always bundled as CJS (build.mjs), so __dirname is guaranteed.
+const __inject_dirname = __dirname;
+
+/**
+ * Modes safe to deploy eagerly, on the agent's startup critical path.
+ *
+ * `plugin-probe` is excluded on purpose: its deploy() stops the running worker,
+ * runs the previous package's uninstall.sh and re-extracts a tarball
+ * (plugin-probe-strategy.ts), and its needsDeploy() can do network I/O. None of
+ * that belongs in front of a business process. The four agentteams-* defs that
+ * use it also carry empty detection blocks, so they never deploy through this
+ * path anyway — they come up via LocalWorkerActivationService.
+ *
+ * `directory-plugin`, `dsh-yaml-patch` and `detection-only` are simply deferred
+ * to the daemon for now; nothing about them is unsafe, they just have not been
+ * exercised on this path.
+ */
+const EAGER_DEPLOY_MODES = new Set(['hook', 'plugin-inject']);
+
+export interface InjectArgs {
+  agents: string[];
+  dataDir?: string;
+  pilotDir?: string;
+  unknownFlags: string[];
+}
+
+export type EagerAction = 'deploy' | 'deferred' | 'unknown-id';
+
+export interface EagerPlanEntry {
+  agentId: string;
+  action: EagerAction;
+  deployMode?: string;
+}
+
+/**
+ * Split a comma-separated id list: trim, drop empties, de-duplicate.
+ * Mirrors splitIds() in deploy-command.ts, plus the dedupe.
+ */
+function splitIds(raw: string): string[] {
+  return [...new Set(raw.split(',').map(s => s.trim()).filter(Boolean))];
+}
+
+/**
+ * Parse argv.
+ *
+ * `--agents` matches the installers' existing flag (deploy/installer.sh), so the
+ * repo has one name for "which agents am I talking about" rather than several.
+ * It is optional: absent or empty means "detect them all" (planEagerDeploys),
+ * which is why an empty value is not an error here.
+ * There are deliberately no aliases: the only two callers are start.sh and
+ * k8s-preload.cjs, both of which ship in the same payload built by the same
+ * assemble-payload.sh run, so they can never be a version behind this binary.
+ * (start.sh does still accept `--agent=` for its own callers — the committed Job
+ * example passes it — but it normalises that into `--agents=` before calling us.)
+ *
+ * Unknown flags are collected and reported, never thrown on — the deliberate
+ * opposite of deploy-command.ts, which throws on an unrecognized option. That
+ * throw is right for a build-time gate you want to fail loudly; here refusing to
+ * start over a stray argument would mean total loss of eager injection, which is
+ * precisely the silent gap this entry point exists to close.
+ */
+export function parseInjectArgs(argv: string[]): InjectArgs {
+  const out: InjectArgs = { agents: [], unknownFlags: [] };
+  for (const arg of argv) {
+    if (arg.startsWith('--agents=')) {
+      out.agents = splitIds(arg.slice('--agents='.length));
+    } else if (arg.startsWith('--data-dir=')) {
+      out.dataDir = arg.slice('--data-dir='.length);
+    } else if (arg.startsWith('--pilot-dir=')) {
+      out.pilotDir = arg.slice('--pilot-dir='.length);
+    } else if (arg.startsWith('--')) {
+      out.unknownFlags.push(arg);
+    }
+  }
+  return out;
+}
+
+/**
+ * Decide what to do with each requested id, given the loaded definitions.
+ *
+ * An empty `requestedIds` means "nobody told us which agents to expect" — the
+ * common case, since the id list comes from an optional K8s label. We then plan
+ * every eager-safe definition and let detect() decide, which is exactly what the
+ * daemon does moments later. Detection is the same detectAgent() call in both
+ * paths and is cheap (stat misses are free; the cost is ~14ms per `which`, ~9 of
+ * them, so ~130ms worst case in a container with nothing installed). Paying that
+ * makes eager injection work without the label, which in turn makes the
+ * operator-side label plumbing a pure optimisation rather than a requirement.
+ *
+ * Sweep mode deliberately emits no `deferred` entries. `deferred` answers "you
+ * asked for this agent and here is why it is not being done now"; when nobody
+ * asked, the same lines are six warnings per Pod about work no one requested.
+ *
+ * Note what neither mode does: derive the deploy set from the requested list.
+ * Requested ids only ever select a subset of definitions that already exist, so
+ * an unrecognized id yields a diagnostic and nothing else — the daemon still
+ * deploys every agent it detects. Contrast collectUnmet() in deploy-command.ts,
+ * which turns the same "unknown id" input into a fatal exit: that is a build-time
+ * assertion about a promise the caller made, this is a runtime hint that is
+ * allowed to be wrong. Do not unify them.
+ */
+export function planEagerDeploys(defs: AgentDefinition[], requestedIds: string[]): EagerPlanEntry[] {
+  if (requestedIds.length === 0) {
+    return defs
+      .filter(def => EAGER_DEPLOY_MODES.has(def.deployMode))
+      .map(def => ({ agentId: def.id, action: 'deploy' as const, deployMode: def.deployMode }));
+  }
+
+  const byId = new Map(defs.map(def => [def.id, def]));
+  return requestedIds.map(agentId => {
+    const def = byId.get(agentId);
+    if (!def) return { agentId, action: 'unknown-id' as const };
+    if (!EAGER_DEPLOY_MODES.has(def.deployMode)) {
+      return { agentId, action: 'deferred' as const, deployMode: def.deployMode };
+    }
+    return { agentId, action: 'deploy' as const, deployMode: def.deployMode };
+  });
+}
+
+function warn(msg: string): void {
+  try {
+    process.stderr.write(`[pilot-inject] ${msg}\n`);
+  } catch { /* ignore */ }
+}
+
+/**
+ * Resolve the data dir exactly as loadConfig() does, including the config
+ * file's `dataDir`. The chain lives in utils/data-dir.ts — the single home of
+ * that precedence — because the hookCommand written into the agent's settings
+ * embeds $PILOT_DATA: if this resolves to a different directory than the
+ * daemon's loadConfig() will, the two produce different command strings and
+ * the daemon appends a duplicate hook.
+ */
+
+async function main(): Promise<number> {
+  const args = parseInjectArgs(process.argv.slice(2));
+
+  for (const flag of args.unknownFlags) {
+    warn(`ignoring unrecognized option ${flag}`);
+  }
+
+  // No id list means "detect them all" (see planEagerDeploys). This is the normal
+  // case — the list comes from an optional label — so it must not be treated as a
+  // missing argument.
+  const sweep = args.agents.length === 0;
+
+  const pilotDir = args.pilotDir ? resolveHome(args.pilotDir) : path.resolve(__inject_dirname, '..');
+  const dataDir = resolveDataDir(args.dataDir);
+
+  // Constructed to match DeploymentManager argument for argument — see the
+  // duplicate-hook hazard in resolveDataDir().
+  const loader = new AgentDefLoader({
+    builtinDir: path.join(pilotDir, 'agents.d'),
+    localDir: path.join(dataDir, 'agents.d.local'),
+    pilotDir,
+    dataDir,
+  });
+  const hookManager = new HookManager(path.join(dataDir, 'hooks'), path.join(dataDir, 'logs'));
+  const hookStrategy = new HookStrategy(hookManager);
+  const pluginInjectStrategy = new PluginInjectStrategy(dataDir, pilotDir);
+
+  const defs = await loader.load();
+  const plan = planEagerDeploys(defs, args.agents);
+  const byId = new Map(defs.map(def => [def.id, def]));
+
+  // Names of the agents actually written to, not of the agents considered. Under
+  // sweep the plan holds every eager-safe definition while typically one is
+  // installed, so reporting the plan would name 19 agents alongside "injected 1".
+  const injected: string[] = [];
+  let failed = 0;
+
+  for (const entry of plan) {
+    if (entry.action === 'unknown-id') {
+      warn(`no agent definition has id "${entry.agentId}" — skipping it;`
+        + ' the daemon will still deploy every agent it detects, so collection is unaffected');
+      continue;
+    }
+    if (entry.action === 'deferred') {
+      warn(`${entry.agentId} uses deployMode=${entry.deployMode}, which is not deployed eagerly`
+        + ' — leaving it to the daemon');
+      continue;
+    }
+
+    const def = byId.get(entry.agentId)!;
+    const strategy = def.deployMode === 'hook' ? hookStrategy : pluginInjectStrategy;
+    try {
+      if (!await strategy.detect(def)) {
+        // Silent under sweep: "not detected" is the expected answer for ~18 of
+        // the 19 candidates, and one line each would be 18 stderr lines in every
+        // Pod. When a caller named the agent explicitly it is worth a line —
+        // they asserted it should be here and it is not.
+        if (!sweep) warn(`${def.id} not detected in this container — skipping`);
+        continue;
+      }
+      // Kept even though both eager strategies' deploy() are idempotent: it
+      // makes "already present" a distinct, reportable outcome, and it is the
+      // guard that keeps this loop safe if EAGER_DEPLOY_MODES ever widens.
+      if (!await strategy.needsDeploy(def)) {
+        continue;
+      }
+      const result = await strategy.deploy(def);
+      if (result.success) {
+        injected.push(def.id);
+      } else {
+        failed++;
+        warn(`failed to inject ${def.id}: ${result.error ?? 'unknown error'}`);
+      }
+    } catch (err) {
+      failed++;
+      warn(`failed to inject ${def.id}: ${(err as Error).message}`);
+    }
+  }
+
+  if (injected.length > 0) {
+    warn(`injected ${injected.length} agent(s) before startup: ${injected.join(', ')}`);
+  }
+
+  // Non-zero only when an eligible, detected agent actually failed to deploy.
+  // The caller uses this to decide whether to keep its "already done" sentinel,
+  // so unknown ids and undetected agents must NOT be reported as failures.
+  return failed > 0 ? 1 : 0;
+}
+
+// Only run when executed as the entry point. Without this guard, importing the
+// module to unit-test parseInjectArgs/planEagerDeploys would run the whole
+// injection and call process.exit() out from under the test runner.
+const isEntryPoint = typeof require !== 'undefined'
+  && typeof module !== 'undefined'
+  && require.main === module;
+
+if (isEntryPoint) {
+  main()
+    .then(code => {
+      // Explicit exit rather than falling off the end. This entry never calls
+      // initFileLogging() (which is what starts pino-roll, whose rotation timer
+      // keeps the event loop alive — see the same hazard called out in
+      // src/index.ts), but the caller blocks on us in spawnSync, so anything
+      // holding the loop open would stall the agent until its timeout fires.
+      // Exit unconditionally rather than trusting that invariant forever.
+      process.exit(code);
+    })
+    .catch(err => {
+      // Never let a throw here surface as a crash the caller has to interpret;
+      // it must also never be silent, since the whole point is that a missing
+      // injection is invisible otherwise.
+      warn(`aborted: ${(err as Error)?.message ?? String(err)}`);
+      process.exit(1);
+    });
+}

--- a/src/inputs/base/base-input.ts
+++ b/src/inputs/base/base-input.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events';
+import * as fs from 'node:fs/promises';
 import type { AgentActivityEntry, InputState } from '../../types/index.js';
 import { ClientType, CollectionMethod } from '../../types/index.js';
 import { type BoundLogger, createLogger } from '../../utils/logger.js';
@@ -8,6 +9,14 @@ export interface InputOptions {
   stateStore: StateStore;
   pollIntervalMs?: number;
 }
+
+/**
+ * Upper bound on per-path ownership warnings remembered for dedup. The set is
+ * keyed by path and the condition is stable, so in practice it holds a handful
+ * of entries; the cap only guards against unbounded growth if a writer keeps
+ * recreating files under fresh names.
+ */
+const OWNERSHIP_WARN_CAP = 512;
 
 /**
  * Abstract base for every input.
@@ -25,6 +34,8 @@ export abstract class BaseInput extends EventEmitter {
   private timer: ReturnType<typeof setInterval> | null = null;
   private cyclePromise: Promise<void> | null = null;
   private _running = false;
+  /** Paths already reported by diagnoseUnreadablePath (dedup across cycles). */
+  private readonly ownershipWarned = new Set<string>();
 
   constructor(opts: InputOptions) {
     super();
@@ -103,5 +114,80 @@ export abstract class BaseInput extends EventEmitter {
 
   protected setState(state: Partial<InputState>): void {
     this.stateStore.update(this.id, state);
+  }
+
+  /** Whether an error is a permission failure (EACCES/EPERM) on a path. */
+  protected isUnreadableError(err: unknown): boolean {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    return code === 'EACCES' || code === 'EPERM';
+  }
+
+  /**
+   * Diagnose an EACCES/EPERM on an input path by comparing the path's owner uid
+   * with this daemon's own uid, and warn at most once per path.
+   *
+   * The ownership invariant behind this: the in-process plugin writes its event
+   * files 0600 inside whatever process loaded it, so every process loading the
+   * plugin must run as the same uid as this daemon — otherwise the daemon can
+   * neither list the session directory nor read the files. A mismatch means a
+   * second, differently-privileged process (in practice: a root helper or a
+   * second gateway that never dropped privileges) loaded the plugin. Nothing
+   * this daemon does after the fact fixes that; the remediation is dropping the
+   * offending process's privileges, and the warning says exactly that.
+   *
+   * Lives on BaseInput (not just BaseSessionInput) because inputs that override
+   * collect() with their own fs.open (dsh-log, qoder-work-*) need the same
+   * contain-and-diagnose behaviour instead of aborting the whole cycle.
+   */
+  protected async diagnoseUnreadablePath(
+    targetPath: string,
+    kind: 'event file' | 'session directory',
+  ): Promise<void> {
+    const warnKey = `${kind}:${targetPath}`;
+    if (this.ownershipWarned.has(warnKey)) return;
+    if (this.ownershipWarned.size >= OWNERSHIP_WARN_CAP) {
+      // Evict the single oldest entry (Set iterates in insertion order) rather
+      // than clearing the whole set: clear() would let every still-unreadable
+      // path be re-warned on the next cycle, the exact log/SLS-cardinality
+      // explosion the cap exists to prevent.
+      const oldest = this.ownershipWarned.values().next();
+      if (!oldest.done) this.ownershipWarned.delete(oldest.value);
+    }
+    this.ownershipWarned.add(warnKey);
+
+    let ownerUid: number | undefined;
+    try {
+      ownerUid = (await fs.stat(targetPath)).uid;
+    } catch {
+      // Path vanished between the failed read and this stat; warn without the
+      // owner detail rather than not at all.
+    }
+    const daemonUid = typeof process.getuid === 'function' ? process.getuid() : undefined;
+    const meta = { path: targetPath, kind, ownerUid, daemonUid };
+
+    if (daemonUid === undefined) {
+      this.logger.warn(
+        `ownership-mismatch: cannot read ${kind} (EACCES); this platform exposes no ` +
+          'process uid, so ensure the process writing agent events runs as the same user as this daemon',
+        meta,
+      );
+      return;
+    }
+    if (ownerUid !== undefined && ownerUid !== daemonUid) {
+      this.logger.warn(
+        `ownership-mismatch: cannot read ${kind} (EACCES): owned by uid ${ownerUid}, but this ` +
+          `daemon runs as uid ${daemonUid}. A process running as a different uid loaded the pilot ` +
+          'plugin and writes event files this daemon cannot read. Fix: run every process that loads ' +
+          `the plugin as uid ${daemonUid} (drop the privileges of the uid-${ownerUid} process, ` +
+          'e.g. via su or runAsUser)',
+        meta,
+      );
+      return;
+    }
+    this.logger.warn(
+      `ownership-mismatch: cannot read ${kind} (EACCES) despite matching uid ${daemonUid}; ` +
+        'check the surrounding directory permissions or security modules (SELinux/AppArmor/ACLs)',
+      meta,
+    );
   }
 }

--- a/src/inputs/base/base-session-input.ts
+++ b/src/inputs/base/base-session-input.ts
@@ -4,14 +4,6 @@ import { CollectionMethod } from '../../types/index.js';
 import type { AgentActivityEntry } from '../../types/index.js';
 import { BaseInput, type InputOptions } from './base-input.js';
 
-/**
- * Upper bound on per-path ownership warnings remembered for dedup. The set is
- * keyed by path and the condition is stable, so in practice it holds a handful
- * of entries; the cap only guards against unbounded growth if a writer keeps
- * recreating files under fresh names.
- */
-const OWNERSHIP_WARN_CAP = 512;
-
 export interface SessionInputOptions extends InputOptions {
   /** Glob-like base directory to scan for session files. */
   sessionDir: string;
@@ -32,9 +24,6 @@ export abstract class BaseSessionInput extends BaseInput {
 
   protected readonly sessionDir: string;
   protected readonly filePattern: string;
-
-  /** Paths already reported by diagnoseUnreadablePath (dedup across cycles). */
-  private readonly ownershipWarned = new Set<string>();
 
   constructor(opts: SessionInputOptions) {
     super(opts);
@@ -128,64 +117,6 @@ export abstract class BaseSessionInput extends BaseInput {
     } finally {
       await handle.close();
     }
-  }
-
-  /**
-   * Diagnose an EACCES/EPERM on a session path by comparing the path's owner
-   * uid with this daemon's own uid, and warn at most once per path.
-   *
-   * The ownership invariant behind this: the in-process plugin writes its event
-   * files 0600 inside whatever process loaded it, so every process loading the
-   * plugin must run as the same uid as this daemon — otherwise the daemon can
-   * neither list the session directory nor read the files. A mismatch means a
-   * second, differently-privileged process (in practice: a root helper or a
-   * second gateway that never dropped privileges) loaded the plugin. Nothing
-   * this daemon does after the fact fixes that; the remediation is dropping the
-   * offending process's privileges, and the warning says exactly that.
-   */
-  protected async diagnoseUnreadablePath(
-    targetPath: string,
-    kind: 'event file' | 'session directory',
-  ): Promise<void> {
-    const warnKey = `${kind}:${targetPath}`;
-    if (this.ownershipWarned.has(warnKey)) return;
-    if (this.ownershipWarned.size >= OWNERSHIP_WARN_CAP) this.ownershipWarned.clear();
-    this.ownershipWarned.add(warnKey);
-
-    let ownerUid: number | undefined;
-    try {
-      ownerUid = (await fs.stat(targetPath)).uid;
-    } catch {
-      // Path vanished between the failed read and this stat; warn without the
-      // owner detail rather than not at all.
-    }
-    const daemonUid = typeof process.getuid === 'function' ? process.getuid() : undefined;
-    const meta = { path: targetPath, kind, ownerUid, daemonUid };
-
-    if (daemonUid === undefined) {
-      this.logger.warn(
-        `ownership-mismatch: cannot read ${kind} (EACCES); this platform exposes no ` +
-          'process uid, so ensure the process writing agent events runs as the same user as this daemon',
-        meta,
-      );
-      return;
-    }
-    if (ownerUid !== undefined && ownerUid !== daemonUid) {
-      this.logger.warn(
-        `ownership-mismatch: cannot read ${kind} (EACCES): owned by uid ${ownerUid}, but this ` +
-          `daemon runs as uid ${daemonUid}. A process running as a different uid loaded the pilot ` +
-          'plugin and writes event files this daemon cannot read. Fix: run every process that loads ' +
-          `the plugin as uid ${daemonUid} (drop the privileges of the uid-${ownerUid} process, ` +
-          'e.g. via su or runAsUser)',
-        meta,
-      );
-      return;
-    }
-    this.logger.warn(
-      `ownership-mismatch: cannot read ${kind} (EACCES) despite matching uid ${daemonUid}; ` +
-        'check the surrounding directory permissions or security modules (SELinux/AppArmor/ACLs)',
-      meta,
-    );
   }
 
   /** Discover session files to process. */

--- a/src/inputs/base/base-session-input.ts
+++ b/src/inputs/base/base-session-input.ts
@@ -1,7 +1,16 @@
 import * as fs from 'node:fs/promises';
+import type { FileHandle } from 'node:fs/promises';
 import { CollectionMethod } from '../../types/index.js';
 import type { AgentActivityEntry } from '../../types/index.js';
 import { BaseInput, type InputOptions } from './base-input.js';
+
+/**
+ * Upper bound on per-path ownership warnings remembered for dedup. The set is
+ * keyed by path and the condition is stable, so in practice it holds a handful
+ * of entries; the cap only guards against unbounded growth if a writer keeps
+ * recreating files under fresh names.
+ */
+const OWNERSHIP_WARN_CAP = 512;
 
 export interface SessionInputOptions extends InputOptions {
   /** Glob-like base directory to scan for session files. */
@@ -23,6 +32,9 @@ export abstract class BaseSessionInput extends BaseInput {
 
   protected readonly sessionDir: string;
   protected readonly filePattern: string;
+
+  /** Paths already reported by diagnoseUnreadablePath (dedup across cycles). */
+  private readonly ownershipWarned = new Set<string>();
 
   constructor(opts: SessionInputOptions) {
     super(opts);
@@ -73,7 +85,22 @@ export abstract class BaseSessionInput extends BaseInput {
     }
     if (stat.size <= offset) return [];
 
-    const handle = await fs.open(filePath, 'r');
+    let handle: FileHandle;
+    try {
+      handle = await fs.open(filePath, 'r');
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') return []; // rotated away between discovery and open
+      if (code === 'EACCES' || code === 'EPERM') {
+        // Almost always an ownership mismatch: a process running as a different
+        // uid (commonly root) loaded the plugin and wrote this file 0600. One
+        // unreadable file must not abort the whole cycle — diagnose it once and
+        // keep collecting the remaining files.
+        await this.diagnoseUnreadablePath(filePath, 'event file');
+        return [];
+      }
+      throw err;
+    }
     try {
       const buf = Buffer.alloc(stat.size - offset);
       const { bytesRead } = await handle.read(buf, 0, buf.length, offset);
@@ -101,6 +128,64 @@ export abstract class BaseSessionInput extends BaseInput {
     } finally {
       await handle.close();
     }
+  }
+
+  /**
+   * Diagnose an EACCES/EPERM on a session path by comparing the path's owner
+   * uid with this daemon's own uid, and warn at most once per path.
+   *
+   * The ownership invariant behind this: the in-process plugin writes its event
+   * files 0600 inside whatever process loaded it, so every process loading the
+   * plugin must run as the same uid as this daemon — otherwise the daemon can
+   * neither list the session directory nor read the files. A mismatch means a
+   * second, differently-privileged process (in practice: a root helper or a
+   * second gateway that never dropped privileges) loaded the plugin. Nothing
+   * this daemon does after the fact fixes that; the remediation is dropping the
+   * offending process's privileges, and the warning says exactly that.
+   */
+  protected async diagnoseUnreadablePath(
+    targetPath: string,
+    kind: 'event file' | 'session directory',
+  ): Promise<void> {
+    const warnKey = `${kind}:${targetPath}`;
+    if (this.ownershipWarned.has(warnKey)) return;
+    if (this.ownershipWarned.size >= OWNERSHIP_WARN_CAP) this.ownershipWarned.clear();
+    this.ownershipWarned.add(warnKey);
+
+    let ownerUid: number | undefined;
+    try {
+      ownerUid = (await fs.stat(targetPath)).uid;
+    } catch {
+      // Path vanished between the failed read and this stat; warn without the
+      // owner detail rather than not at all.
+    }
+    const daemonUid = typeof process.getuid === 'function' ? process.getuid() : undefined;
+    const meta = { path: targetPath, kind, ownerUid, daemonUid };
+
+    if (daemonUid === undefined) {
+      this.logger.warn(
+        `ownership-mismatch: cannot read ${kind} (EACCES); this platform exposes no ` +
+          'process uid, so ensure the process writing agent events runs as the same user as this daemon',
+        meta,
+      );
+      return;
+    }
+    if (ownerUid !== undefined && ownerUid !== daemonUid) {
+      this.logger.warn(
+        `ownership-mismatch: cannot read ${kind} (EACCES): owned by uid ${ownerUid}, but this ` +
+          `daemon runs as uid ${daemonUid}. A process running as a different uid loaded the pilot ` +
+          'plugin and writes event files this daemon cannot read. Fix: run every process that loads ' +
+          `the plugin as uid ${daemonUid} (drop the privileges of the uid-${ownerUid} process, ` +
+          'e.g. via su or runAsUser)',
+        meta,
+      );
+      return;
+    }
+    this.logger.warn(
+      `ownership-mismatch: cannot read ${kind} (EACCES) despite matching uid ${daemonUid}; ` +
+        'check the surrounding directory permissions or security modules (SELinux/AppArmor/ACLs)',
+      meta,
+    );
   }
 
   /** Discover session files to process. */

--- a/src/inputs/dsh-log/dsh-log-input.ts
+++ b/src/inputs/dsh-log/dsh-log-input.ts
@@ -71,7 +71,17 @@ export class DshLogInput extends BaseSessionInput {
     const files = await this.discoverSessionFiles();
     const entries: AgentActivityEntry[] = [];
     for (const filePath of files) {
-      entries.push(...await this.processDshFile(filePath));
+      try {
+        entries.push(...await this.processDshFile(filePath));
+      } catch (err) {
+        if (this.isUnreadableError(err)) {
+          // An unreadable file (ownership mismatch) must not abort the whole
+          // cycle — diagnose it once and keep collecting the remaining files.
+          await this.diagnoseUnreadablePath(filePath, 'event file');
+          continue;
+        }
+        throw err;
+      }
     }
 
     if (this.discoveryComplete) {
@@ -99,7 +109,11 @@ export class DshLogInput extends BaseSessionInput {
       // previously tracked files were deleted. Preserve checkpoints so a
       // remount/recreate does not replay their full history.
       this.discoveryComplete = false;
-      if (!missing) {
+      if (this.isUnreadableError(err)) {
+        // Ownership mismatch on the session dir — diagnose once, same contract
+        // as the per-file path, instead of a generic warn.
+        await this.diagnoseUnreadablePath(this.sessionDir, 'session directory');
+      } else if (!missing) {
         logger.warn('failed to discover dsh event logs', {
           sessionDir: this.sessionDir,
           error: String(err),

--- a/src/inputs/hermes-log/hermes-log-input.ts
+++ b/src/inputs/hermes-log/hermes-log-input.ts
@@ -48,7 +48,15 @@ export class HermesLogInput extends BaseSessionInput {
     try {
       entries = await fs.readdir(this.sessionDir, { withFileTypes: true });
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'EACCES' || code === 'EPERM') {
+        // The plugin creates its session directory 0700 inside the process that
+        // loaded it; an unreadable directory means a differently-privileged
+        // process (commonly root) is the one writing events. Diagnose once.
+        await this.diagnoseUnreadablePath(this.sessionDir, 'session directory');
+        return [];
+      }
+      if (code !== 'ENOENT') {
         logger.warn('failed to discover Hermes event logs', {
           sessionDir: this.sessionDir,
           error: String(err),

--- a/src/inputs/qoder-work-log/qoder-work-log-input.ts
+++ b/src/inputs/qoder-work-log/qoder-work-log-input.ts
@@ -284,8 +284,18 @@ export class QoderWorkLogInput extends BaseSessionInput {
 
     for (const filePath of files) {
       this.currentFilePath = filePath;
-      const fileEntries = await this.processLogFile(filePath);
-      allEntries.push(...fileEntries);
+      try {
+        const fileEntries = await this.processLogFile(filePath);
+        allEntries.push(...fileEntries);
+      } catch (err) {
+        if (this.isUnreadableError(err)) {
+          // An unreadable file (ownership mismatch) must not abort the whole
+          // cycle — diagnose it once and keep collecting the remaining files.
+          await this.diagnoseUnreadablePath(filePath, 'event file');
+          continue;
+        }
+        throw err;
+      }
     }
     this.currentFilePath = '';
 

--- a/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
+++ b/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
@@ -142,6 +142,16 @@ export class QoderWorkTraceInput extends BaseInput {
         allEntries.push(...turnEntries);
       }
       return allEntries;
+    } catch (err) {
+      if (this.isUnreadableError(err)) {
+        // An unreadable hook/segment file (ownership mismatch) must not abort the
+        // whole cycle — diagnose it once and skip this round; the next cycle
+        // retries. Without this the error reaches runCycleOnce's catch-all and
+        // drops every source for this input this round.
+        await this.diagnoseUnreadablePath(this.logDir, 'session directory');
+        return [];
+      }
+      throw err;
     } finally {
       this.evictStaleState();
     }

--- a/src/native-deps-guard.ts
+++ b/src/native-deps-guard.ts
@@ -73,9 +73,13 @@ function writeFatalMarker(reasonFirstLine: string): void {
     // mirrors, containerIdentity the same token the preload compares against.
     const dir = resolveDataDir();
     mkdirSync(dir, { recursive: true });
+    // The marker is whitespace-delimited (`fatal <identity> <timestamp> <reason>`)
+    // and the reader splits it on whitespace, so any newline/tab the loader put in
+    // the message must not spill into extra fields; collapse to single spaces.
+    const reason = reasonFirstLine.trim().replace(/\s+/g, ' ');
     writeFileSync(
       path.join(dir, 'daemon.fatal'),
-      `fatal ${containerIdentity()} ${new Date().toISOString()} ${reasonFirstLine}\n`,
+      `fatal ${containerIdentity()} ${new Date().toISOString()} ${reason}\n`,
       'utf8',
     );
   } catch { /* the stderr diagnostic is the primary channel; the marker is best-effort */ }
@@ -98,7 +102,9 @@ function fail(moduleName: string, err: unknown): never {
     '[pilot]',
     '[pilot] Impact: the collector cannot start. Hooks already installed keep',
     '[pilot] writing events to local files, but nothing will ship them.',
-    '[pilot] See the compatibility matrix in deploy/docker/README.md.',
+    '[pilot] Fix: run the agent container on a glibc base image (Debian/Ubuntu/',
+    '[pilot] Alibaba Cloud Linux), not musl/Alpine, and ensure the payload was',
+    '[pilot] built with a working node + native addon pairing.',
   ];
   try {
     process.stderr.write(lines.join('\n') + '\n');

--- a/src/native-deps-guard.ts
+++ b/src/native-deps-guard.ts
@@ -1,0 +1,115 @@
+// native-deps-guard — fail loudly and early when the payload's native modules
+// cannot load on this container's libc.
+//
+// Why this exists: the daemon's module graph imports sqlite3 unconditionally at
+// startup (orchestrator.ts → the qoder-*-sqlite inputs), so on a container whose
+// libc cannot load the prebuilt addon — most commonly musl/Alpine, where no
+// glibc-linked .node can be dlopen'd at all, but also a glibc older than the
+// addon's own requirement — the daemon crashes
+// during module load. That crash used to be invisible twice over: it happens
+// before initFileLogging() runs, and the spawners redirected daemon stderr to
+// /dev/null. The user saw "no telemetry" and nothing else.
+//
+// build.mjs prepends `import './native-deps-guard.cjs'` to the daemon bundle, so
+// this runs before any of that graph loads and turns the silent crash into an
+// actionable diagnostic with a non-zero exit.
+//
+// Deliberately checks ONLY what the startup graph actually loads: sqlite3.
+// zstd-napi also ships in the payload but nothing in src/ imports it, so a
+// broken zstd-napi must not stop the daemon. Keep this list in sync with the
+// daemon's real top-level native imports, not with package.json.
+//
+// Never import this from the daemon itself — it must run before the daemon's
+// imports execute, which is only possible from a separately loaded module.
+
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { resolveDataDir } from './utils/data-dir.js';
+
+/** Best-effort libc identification for the diagnostic; never throws. */
+function libcInfo(): string {
+  try {
+    const r = spawnSync('ldd', ['--version'], { encoding: 'utf8', timeout: 2000 });
+    const line = ((r.stdout || '') + (r.stderr || '')).split('\n').find(l => l.trim()) ?? '';
+    if (line) return line.trim();
+  } catch { /* ldd missing (distroless etc.) — fall through */ }
+  return 'unknown';
+}
+
+/**
+ * Identity of "this container instance", matching k8s-preload.cjs: container
+ * id from the process's own cgroup (changes on every container (re)creation),
+ * falling back to the host boot_id outside a container, then 'unknown'. The
+ * preload compares the marker against this same identity, so writer and reader
+ * must compute it the same way, or the crash-loop breaker silently disarms.
+ * boot_id alone is wrong on K8s: it is the HOST's, so a fixed init image
+ * restarted on the same node would stay blocked until the node reboots.
+ */
+function containerIdentity(): string {
+  try {
+    const m = readFileSync('/proc/self/cgroup', 'utf8').match(/[0-9a-f]{64}/);
+    if (m) return m[0];
+  } catch { /* not containerized, or /proc unavailable */ }
+  try {
+    return readFileSync('/proc/sys/kernel/random/boot_id', 'utf8').trim() || 'unknown';
+  } catch {
+    return 'unknown'; // non-Linux or /proc unavailable
+  }
+}
+
+/**
+ * Record the failure so k8s-preload.cjs does not respawn the daemon. Without
+ * this, the failure below is deterministic while the preload's stale-lock
+ * takeover has no backoff: every node process in the container would take over
+ * the lock, spawn a daemon, and watch it die here again — a crash loop, plus
+ * one appended diagnostic per round in daemon.stderr.log.
+ */
+function writeFatalMarker(reasonFirstLine: string): void {
+  try {
+    // Both halves of this call must resolve exactly as k8s-preload.cjs does, or
+    // the marker lands somewhere the preload never looks and the crash-loop
+    // breaker silently disarms: resolveDataDir is the shared chain the preload
+    // mirrors, containerIdentity the same token the preload compares against.
+    const dir = resolveDataDir();
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      path.join(dir, 'daemon.fatal'),
+      `fatal ${containerIdentity()} ${new Date().toISOString()} ${reasonFirstLine}\n`,
+      'utf8',
+    );
+  } catch { /* the stderr diagnostic is the primary channel; the marker is best-effort */ }
+}
+
+function fail(moduleName: string, err: unknown): never {
+  const raw = (err as Error)?.message ?? String(err);
+  const firstLine = raw.split('\n').find(l => l.trim()) ?? raw;
+  const lines = [
+    `[pilot] FATAL: native module "${moduleName}" cannot be loaded in this container.`,
+    '[pilot]',
+    `[pilot]   loader said: ${firstLine}`,
+    `[pilot]   system libc: ${libcInfo()}`,
+    '[pilot]',
+    '[pilot] The sqlite3 in this payload is the upstream prebuilt binary, which',
+    '[pilot] needs only a very old glibc (~2.4), and the process printing this',
+    '[pilot] is already running a working node. A load failure here typically',
+    "[pilot] means this container's libc is musl-based (Alpine), where glibc-linked",
+    '[pilot] addons cannot load — or the payload on the shared volume is corrupted.',
+    '[pilot]',
+    '[pilot] Impact: the collector cannot start. Hooks already installed keep',
+    '[pilot] writing events to local files, but nothing will ship them.',
+    '[pilot] See the compatibility matrix in deploy/docker/README.md.',
+  ];
+  try {
+    process.stderr.write(lines.join('\n') + '\n');
+  } catch { /* last-ditch: there is nowhere else to write */ }
+  writeFatalMarker(firstLine);
+  process.exit(1);
+}
+
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('sqlite3');
+} catch (err) {
+  fail('sqlite3', err);
+}

--- a/src/utils/data-dir.ts
+++ b/src/utils/data-dir.ts
@@ -66,6 +66,22 @@ export function pickDataDir(explicit: string | undefined, fileDataDir: string | 
 }
 
 /**
+ * LOONGSUITE_PILOT_DATA_DIR read with the SAME semantics as loadConfig()'s
+ * env() helper: on win32 the value is trimmed (Windows environment variables
+ * routinely pick up padding), elsewhere it is returned raw; undefined stays
+ * undefined. loadConfig() resolves the data dir through env(), so a divergent
+ * read here — e.g. the raw, untrimmed process.env — would make the eager
+ * injection path and the daemon disagree about the directory whenever the
+ * value is padded on Windows, reintroducing exactly the duplicate-hook class
+ * of bug this module exists to prevent.
+ */
+export function readEnvDataDir(): string | undefined {
+  const v = process.env.LOONGSUITE_PILOT_DATA_DIR;
+  if (v === undefined) return undefined;
+  return process.platform === 'win32' ? v.trim() : v;
+}
+
+/**
  * Fully resolved data dir (absolute, `~` expanded) for callers outside the
  * daemon module graph — inject-hooks.ts today. The daemon itself keeps the
  * two-step shape: loadConfig() returns the raw value via pickDataDir(), and
@@ -74,6 +90,26 @@ export function pickDataDir(explicit: string | undefined, fileDataDir: string | 
  */
 export function resolveDataDir(explicit?: string): string {
   return resolveHome(
-    pickDataDir(explicit ?? process.env.LOONGSUITE_PILOT_DATA_DIR, readConfigFileDataDir()),
+    pickDataDir(explicit ?? readEnvDataDir(), readConfigFileDataDir()),
   );
+}
+
+/**
+ * The config file's `agents` gate, or undefined when the file is absent,
+ * unreadable, unparsable, or carries no `agents` object. Mirrors loadConfig()'s
+ * view of the same file (including the BOM strip). Used by the eager injection
+ * path to honour the same enabled/disabled gate the daemon applies via
+ * isAgentGatedEnabled(), so a disabled agent is not eagerly instrumented.
+ */
+export function readConfigAgentsGate(): Record<string, { enabled?: boolean } | undefined> | undefined {
+  try {
+    const text = fs.readFileSync(configJsonPath(), 'utf8').replace(/^\uFEFF/, '');
+    const parsed = JSON.parse(text) as { agents?: unknown };
+    if (parsed.agents && typeof parsed.agents === 'object') {
+      return parsed.agents as Record<string, { enabled?: boolean } | undefined>;
+    }
+  } catch {
+    // No readable/parsable config file — same conclusion loadConfig() reaches.
+  }
+  return undefined;
 }

--- a/src/utils/data-dir.ts
+++ b/src/utils/data-dir.ts
@@ -1,0 +1,79 @@
+import * as fs from 'node:fs';
+import { resolveHome } from './fs-utils.js';
+
+// The single home of "where is the pilot data dir". Three consumers used to
+// carry private copies of this precedence chain — loadConfig() here,
+// inject-hooks.ts, and the plain-CJS k8s-preload.cjs — with a comment asking
+// the reader to keep them in sync. A comment is not a mechanism: when
+// loadConfig() grew the config-file `dataDir` source, the preload copy did not
+// follow, and the two resolved different directories (the daemon read one, the
+// preload's symlinks/sentinels/lock and the injected hookCommand pointed at the
+// other, and isHookInstalled saw every hook as "not installed" and appended
+// duplicates). The chain now lives here; the CJS preload still cannot import
+// this file (it runs from the shared volume with no daemon bundle around), so
+// it mirrors the chain — but k8s-preload-coordination.test.mjs asserts the two
+// agree, which is what turns "keep in sync" from a wish into a check.
+
+/** Default data dir (`~`-prefixed; resolve with resolveHome()). */
+export const DEFAULT_DATA_DIR = '~/.loongsuite-pilot';
+
+/** Default config-file location when AGENT_DATA_COLLECTION_CONFIG is unset. */
+export const DEFAULT_CONFIG_PATH = `${DEFAULT_DATA_DIR}/config.json`;
+
+/**
+ * The config file loadConfig() reads: AGENT_DATA_COLLECTION_CONFIG (if set)
+ * else the default location, `~` expanded. Whitespace-only values count as
+ * unset (a path cannot meaningfully start or end with a space).
+ */
+export function configJsonPath(): string {
+  const fromEnv = (process.env.AGENT_DATA_COLLECTION_CONFIG ?? '').trim();
+  return resolveHome(fromEnv || DEFAULT_CONFIG_PATH);
+}
+
+/**
+ * The config file's `dataDir` field, or undefined when the file is absent,
+ * unreadable, unparsable, or the field is missing/empty/non-string. Mirrors
+ * loadConfig()'s view of the same file, including the BOM readJsonFile()
+ * strips (Windows writes BOMs routinely; JSON.parse rejects them).
+ */
+export function readConfigFileDataDir(): string | undefined {
+  try {
+    const text = fs.readFileSync(configJsonPath(), 'utf8').replace(/^\uFEFF/, '');
+    const parsed = JSON.parse(text) as { dataDir?: unknown };
+    if (typeof parsed.dataDir === 'string' && parsed.dataDir) return parsed.dataDir;
+  } catch {
+    // No readable/parsable config file — the same conclusion loadConfig()
+    // reaches via readJsonFile(), and the chain falls through to the default.
+  }
+  return undefined;
+}
+
+/**
+ * The raw (unresolved) precedence chain, highest first:
+ *   1. explicit value / LOONGSUITE_PILOT_DATA_DIR env
+ *   2. config file `dataDir`
+ *   3. DEFAULT_DATA_DIR
+ *
+ * Empty strings count as unset: loadConfig() historically returned them raw
+ * and the orchestrator's `config.dataDir || DEFAULT` already treated them as
+ * the default — skipping them here makes every consumer agree without any of
+ * them resolving an empty path.
+ */
+export function pickDataDir(explicit: string | undefined, fileDataDir: string | undefined): string {
+  if (explicit) return explicit;
+  if (fileDataDir) return fileDataDir;
+  return DEFAULT_DATA_DIR;
+}
+
+/**
+ * Fully resolved data dir (absolute, `~` expanded) for callers outside the
+ * daemon module graph — inject-hooks.ts today. The daemon itself keeps the
+ * two-step shape: loadConfig() returns the raw value via pickDataDir(), and
+ * the orchestrator resolves it, so the config object stays a faithful echo of
+ * what was configured.
+ */
+export function resolveDataDir(explicit?: string): string {
+  return resolveHome(
+    pickDataDir(explicit ?? process.env.LOONGSUITE_PILOT_DATA_DIR, readConfigFileDataDir()),
+  );
+}

--- a/tests/unit/deploy/native-deps-guard.test.mjs
+++ b/tests/unit/deploy/native-deps-guard.test.mjs
@@ -1,0 +1,114 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { buildSync } from 'esbuild';
+import { spawnSync } from 'node:child_process';
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+/**
+ * On a container whose libc cannot load the payload's native addons, the daemon
+ * used to die during module load with nobody watching: the crash happens before
+ * its logging exists, and the spawners dropped its stderr. The guard replaces
+ * that silent death with a readable FATAL and a non-zero exit. These tests run
+ * the real guard as a real process, because process.exit + stderr text are the
+ * contract — importing it in-process would exit the test runner instead.
+ *
+ * The glibc mismatch itself cannot be reproduced on the test host, so the
+ * failure case stands in with a sqlite3 that throws on load: the same failure
+ * class (require() throws during module load), which is all the guard reacts to.
+ */
+
+const REPO = resolve('.');
+const tmp = mkdtempSync(join(tmpdir(), 'native-deps-guard-'));
+const guardPath = join(tmp, 'native-deps-guard.cjs');
+
+// Same shape as build.mjs: CJS, packages external — the sqlite3 require must
+// resolve at runtime against whatever node_modules the location provides.
+buildSync({
+  entryPoints: ['src/native-deps-guard.ts'],
+  outfile: guardPath,
+  platform: 'node',
+  target: 'es2022',
+  format: 'cjs',
+  bundle: true,
+  packages: 'external',
+});
+
+function runGuard(cwd, extraEnv = {}) {
+  return spawnSync(process.execPath, [cwd === tmp ? guardPath : join(cwd, 'native-deps-guard.cjs')], {
+    cwd,
+    env: { ...process.env, ...extraEnv },
+    encoding: 'utf8',
+    timeout: 15000,
+  });
+}
+
+afterAll(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('native-deps-guard', () => {
+  it('exits 0 silently when sqlite3 loads, and writes no fatal marker', () => {
+    // The tmp dir has no node_modules of its own; NODE_PATH points at the real
+    // one, exactly like the payload layout where the guard resolves against the
+    // shipped node_modules.
+    const dataDir = join(tmp, 'data-ok');
+    const r = runGuard(tmp, { NODE_PATH: join(REPO, 'node_modules'), LOONGSUITE_PILOT_DATA_DIR: dataDir });
+    expect(r.stderr).not.toContain('FATAL');
+    expect(r.status).toBe(0);
+    // A marker left by a successful run would wrongly suppress every later spawn.
+    expect(() => readFileSync(join(dataDir, 'daemon.fatal'))).toThrow();
+  });
+
+  it('prints an actionable FATAL and exits 1 when sqlite3 cannot load', () => {
+    const failDir = join(tmp, 'fail');
+    mkdirSync(join(failDir, 'node_modules', 'sqlite3'), { recursive: true });
+    writeFileSync(
+      join(failDir, 'node_modules', 'sqlite3', 'package.json'),
+      JSON.stringify({ name: 'sqlite3', version: '0.0.0', main: 'index.js' }),
+    );
+    writeFileSync(
+      join(failDir, 'node_modules', 'sqlite3', 'index.js'),
+      "throw new Error(\"/lib64/libc.so.6: version `GLIBC_2.28' not found (simulated)\");\n",
+    );
+    copyFileSync(guardPath, join(failDir, 'native-deps-guard.cjs'));
+
+    // NODE_PATH cleared so the fake is the only candidate, as on a container
+    // with nothing but the payload.
+    const dataDir = join(failDir, 'data');
+    const r = runGuard(failDir, { NODE_PATH: '', LOONGSUITE_PILOT_DATA_DIR: dataDir });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('[pilot] FATAL');
+    expect(r.stderr).toContain('"sqlite3"');
+    // The loader's own message must survive into the diagnostic — it is what
+    // distinguishes "glibc too old" from "file missing" when triaging.
+    expect(r.stderr).toContain('GLIBC_2.28');
+    // And the reader must be told what it means and where to look next. The
+    // payload's sqlite3 is the upstream prebuild (ancient glibc floor), so the
+    // diagnostic points at musl/corruption rather than a build-floor story.
+    expect(r.stderr).toContain('upstream prebuilt');
+    expect(r.stderr).toContain('musl');
+    expect(r.stderr).toContain('compatibility matrix');
+
+    // The crash-loop breaker: the failure is recorded where the preload looks,
+    // with the loader's message, so the deterministic failure is not respawned.
+    const marker = readFileSync(join(dataDir, 'daemon.fatal'), 'utf8');
+    expect(marker.startsWith('fatal ')).toBe(true);
+    expect(marker).toContain('GLIBC_2.28');
+  });
+
+  it('names the right module in the diagnostic even when the error text is empty', () => {
+    const failDir = join(tmp, 'fail-empty');
+    mkdirSync(join(failDir, 'node_modules', 'sqlite3'), { recursive: true });
+    writeFileSync(
+      join(failDir, 'node_modules', 'sqlite3', 'package.json'),
+      JSON.stringify({ name: 'sqlite3', version: '0.0.0', main: 'index.js' }),
+    );
+    writeFileSync(join(failDir, 'node_modules', 'sqlite3', 'index.js'), 'throw new Error("");\n');
+    copyFileSync(guardPath, join(failDir, 'native-deps-guard.cjs'));
+
+    const r = runGuard(failDir, { NODE_PATH: '', LOONGSUITE_PILOT_DATA_DIR: join(failDir, 'data') });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('"sqlite3"');
+  });
+});

--- a/tests/unit/deploy/native-deps-guard.test.mjs
+++ b/tests/unit/deploy/native-deps-guard.test.mjs
@@ -85,10 +85,12 @@ describe('native-deps-guard', () => {
     expect(r.stderr).toContain('GLIBC_2.28');
     // And the reader must be told what it means and where to look next. The
     // payload's sqlite3 is the upstream prebuild (ancient glibc floor), so the
-    // diagnostic points at musl/corruption rather than a build-floor story.
+    // diagnostic points at musl/corruption rather than a build-floor story, and
+    // ends with a self-contained remediation (no external file reference — the
+    // guard must stay actionable from this repo alone).
     expect(r.stderr).toContain('upstream prebuilt');
     expect(r.stderr).toContain('musl');
-    expect(r.stderr).toContain('compatibility matrix');
+    expect(r.stderr).toContain('glibc base image');
 
     // The crash-loop breaker: the failure is recorded where the preload looks,
     // with the loader's message, so the deterministic failure is not respawned.

--- a/tests/unit/deployment/eager-vs-daemon-parity.test.ts
+++ b/tests/unit/deployment/eager-vs-daemon-parity.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { AgentDefLoader } from '../../../src/deployment/agent-def-loader.js';
+import { DeploymentManager } from '../../../src/deployment/deployment-manager.js';
+import { HookManager } from '../../../src/hooks/hook-manager.js';
+import { HookStrategy } from '../../../src/deployment/hook-strategy.js';
+import { planEagerDeploys } from '../../../src/inject-hooks.js';
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+vi.mock('../../../src/deployment/detect-utils.js', () => ({
+  detectAgent: vi.fn().mockResolvedValue(true),
+  commandExists: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('../../../src/deployment/deploy-notification.js', () => ({
+  writeDeployNotification: vi.fn().mockResolvedValue(undefined),
+}));
+
+/**
+ * The load-bearing invariant of eager injection.
+ *
+ * inject-hooks (spawned by k8s-preload before the workload starts) and the
+ * daemon's deployAll both write hooks into the agent's settings, and they must
+ * produce the *same* hookCommand string. If they diverge by even one character,
+ * the daemon's isHookInstalled() check reads "not installed" and appends a
+ * second entry — so every event fires twice, silently. That is a worse failure
+ * than the startup race eager injection exists to fix, so it gets a test that
+ * compares the actual bytes rather than trusting that both paths call the same
+ * function.
+ *
+ * The two share HookStrategy/HookManager deliberately; what this pins is that
+ * they are also *constructed* with the same dataDir/pilotDir, which is the part
+ * a refactor can quietly break.
+ *
+ * Scope, established by mutating each input and checking this test fails:
+ *  - the `dataDir` given to AgentDefLoader IS caught — it resolves $PILOT_DATA
+ *    inside hookCommand, and is therefore the actual divergence risk.
+ *  - HookManager's hookScriptDir argument is NOT caught, because it does not
+ *    reach the written command at all (HookManager only ever writes to the
+ *    agent's own settings file). Do not add coverage for it expecting to guard
+ *    the command string; guard dataDir/pilotDir resolution instead.
+ */
+describe('eager injection vs daemon deployAll parity', () => {
+  let tmp: string;
+  let dataDir: string;
+  let pilotDir: string;
+  let builtinDir: string;
+  let settingsPath: string;
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'pilot-parity-'));
+    dataDir = path.join(tmp, 'data');
+    pilotDir = path.join(tmp, 'pilot');
+    builtinDir = path.join(pilotDir, 'agents.d');
+    settingsPath = path.join(tmp, 'agent-home', 'settings.json');
+    await fs.mkdir(builtinDir, { recursive: true });
+    await fs.mkdir(path.join(dataDir, 'agents.d.local'), { recursive: true });
+    await fs.mkdir(path.join(tmp, 'agent-home'), { recursive: true });
+
+    // A hook agent whose settings live inside the temp tree. $PILOT_DATA in the
+    // hookCommand is what both paths must resolve identically.
+    await fs.writeFile(
+      path.join(builtinDir, 'test-agent.json'),
+      JSON.stringify({
+        id: 'test-agent',
+        displayName: 'Test Agent',
+        deployMode: 'hook',
+        detection: { paths: [tmp], commands: [] },
+        hook: {
+          settingsPath,
+          events: ['Stop'],
+          hookCommand: '$PILOT_DATA/hooks/test-agent-hook.sh',
+          format: 'nested',
+          matcher: '*',
+        },
+      }),
+      'utf8',
+    );
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  /**
+   * Deploys exactly as src/inject-hooks.ts does: same classes, same args, and the
+   * same plan. The plan is built with an empty id list on purpose — that is the
+   * default path now, since the id list comes from an optional K8s label, so it
+   * is the selection this parity guarantee has to hold for.
+   */
+  async function runEagerInjection(): Promise<void> {
+    const loader = new AgentDefLoader({
+      builtinDir,
+      localDir: path.join(dataDir, 'agents.d.local'),
+      pilotDir,
+      dataDir,
+    });
+    const hookManager = new HookManager(path.join(dataDir, 'hooks'), path.join(dataDir, 'logs'));
+    const strategy = new HookStrategy(hookManager);
+    const defs = await loader.load();
+    const plan = planEagerDeploys(defs, []);
+    const entry = plan.find(p => p.agentId === 'test-agent');
+    expect(entry?.action, 'sweep must select the fixture agent for eager deploy').toBe('deploy');
+    await strategy.deploy(defs.find(d => d.id === entry!.agentId)!);
+  }
+
+  function countHookEntries(settings: Record<string, any>): number {
+    let n = 0;
+    for (const event of Object.keys(settings.hooks ?? {})) {
+      for (const group of settings.hooks[event] ?? []) {
+        n += (group.hooks ?? []).length;
+      }
+    }
+    return n;
+  }
+
+  it('leaves the settings file byte-identical when the daemon runs afterwards', async () => {
+    await runEagerInjection();
+    const afterEager = await fs.readFile(settingsPath, 'utf8');
+    expect(countHookEntries(JSON.parse(afterEager))).toBe(1);
+
+    const manager = new DeploymentManager({ dataDir, pilotDir, builtinAgentsDir: builtinDir });
+    const results = await manager.deployAll();
+
+    const afterDaemon = await fs.readFile(settingsPath, 'utf8');
+    // Byte equality, not just "still one entry": a divergent-but-same-count
+    // rewrite would mean the two paths disagree about the command string.
+    expect(afterDaemon).toBe(afterEager);
+    expect(countHookEntries(JSON.parse(afterDaemon))).toBe(1);
+
+    const result = results.find(r => r.agentId === 'test-agent');
+    expect(result?.skipped).toBe(true);
+    expect(result?.reason).toBe('up-to-date');
+  });
+
+  it('is itself idempotent, so a repeated preload cannot double the hooks', async () => {
+    await runEagerInjection();
+    const first = await fs.readFile(settingsPath, 'utf8');
+    await runEagerInjection();
+    const second = await fs.readFile(settingsPath, 'utf8');
+    expect(second).toBe(first);
+    expect(countHookEntries(JSON.parse(second))).toBe(1);
+  });
+
+  it('deploys the agent when eager injection never ran (the control)', async () => {
+    const manager = new DeploymentManager({ dataDir, pilotDir, builtinAgentsDir: builtinDir });
+    const results = await manager.deployAll();
+    const result = results.find(r => r.agentId === 'test-agent');
+    // Without this, the test above could pass simply because nothing ever
+    // deployed anything.
+    expect(result?.skipped).toBeFalsy();
+    expect(result?.success).toBe(true);
+  });
+});

--- a/tests/unit/deployment/inject-hooks-contract.test.ts
+++ b/tests/unit/deployment/inject-hooks-contract.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentDefinition } from '../../../src/types/index.js';
+import { parseInjectArgs, planEagerDeploys } from '../../../src/inject-hooks.js';
+
+/**
+ * inject-hooks runs on the agent's startup critical path, spawned by
+ * k8s-preload.cjs before the workload's first module executes. Two properties
+ * matter more than anything about its output:
+ *
+ *  1. A bad agent id must never reduce collection. The id list comes from a K8s
+ *     label, so a typo is a matter of when, not if — and the daemon deploys
+ *     everything it detects moments later regardless.
+ *  2. It must never refuse to run because of an argument it does not know. The
+ *     caller is a shell script and an operator-injected env var, both of which
+ *     can be older or newer than this binary.
+ */
+
+function def(over: Partial<AgentDefinition> & { id: string }): AgentDefinition {
+  return {
+    displayName: over.id,
+    deployMode: 'hook',
+    detection: { paths: [], commands: [] },
+    ...over,
+  } as AgentDefinition;
+}
+
+const DEFS = [
+  def({ id: 'claude-code', deployMode: 'hook' }),
+  def({ id: 'openclaw', deployMode: 'plugin-inject' }),
+  def({ id: 'agentteams-codex-local-runtime', deployMode: 'plugin-probe' }),
+  def({ id: 'hermes-agent', deployMode: 'directory-plugin' }),
+  def({ id: 'dsh', deployMode: 'dsh-yaml-patch' }),
+  def({ id: 'qoder-jetbrains', deployMode: 'detection-only' }),
+];
+
+describe('parseInjectArgs', () => {
+  it('splits, trims and de-duplicates the id list', () => {
+    const args = parseInjectArgs(['--agents=claude-code, openclaw ,claude-code,,']);
+    expect(args.agents).toEqual(['claude-code', 'openclaw']);
+  });
+
+  it('yields an empty list for an empty value rather than throwing', () => {
+    expect(parseInjectArgs(['--agents=']).agents).toEqual([]);
+    expect(parseInjectArgs(['--agents=  ,  ']).agents).toEqual([]);
+  });
+
+  it('reads the dir overrides the callers pass', () => {
+    const args = parseInjectArgs([
+      '--agents=claude-code',
+      '--data-dir=/mnt/pilot/data',
+      '--pilot-dir=/mnt/pilot',
+    ]);
+    expect(args.dataDir).toBe('/mnt/pilot/data');
+    expect(args.pilotDir).toBe('/mnt/pilot');
+  });
+
+  // Deliberately the opposite of deploy-command's parseArgs, which throws on an
+  // unrecognized option. That throw guards an image build; here refusing to start
+  // over a stray argument would mean total loss of eager injection.
+  //
+  // This is also the safety net for having no flag aliases: `--agents` is the one
+  // spelling, and anything else — including the `--agent=` that start.sh accepts
+  // from its own callers and normalises away — degrades to a warning rather than
+  // an abort.
+  it('collects unknown flags instead of throwing, and still parses the rest', () => {
+    const args = parseInjectArgs(['--agents=claude-code', '--nope', '--agent=x']);
+    expect(args.agents).toEqual(['claude-code']);
+    expect(args.unknownFlags).toEqual(['--nope', '--agent=x']);
+  });
+});
+
+describe('planEagerDeploys', () => {
+  it('plans hook and plugin-inject agents for eager deployment', () => {
+    const plan = planEagerDeploys(DEFS, ['claude-code', 'openclaw']);
+    expect(plan.map(p => p.action)).toEqual(['deploy', 'deploy']);
+  });
+
+  // plugin-probe's deploy() stops the running worker, runs the old package's
+  // uninstall.sh and re-extracts a tarball, and its needsDeploy() can hit the
+  // network. None of that may happen in front of a business process.
+  it('defers plugin-probe rather than deploying it eagerly', () => {
+    const plan = planEagerDeploys(DEFS, ['agentteams-codex-local-runtime']);
+    expect(plan).toEqual([
+      { agentId: 'agentteams-codex-local-runtime', action: 'deferred', deployMode: 'plugin-probe' },
+    ]);
+  });
+
+  it('defers the other modes not yet exercised on this path', () => {
+    const plan = planEagerDeploys(DEFS, ['hermes-agent', 'dsh', 'qoder-jetbrains']);
+    expect(plan.map(p => p.action)).toEqual(['deferred', 'deferred', 'deferred']);
+  });
+
+  it('reports an unknown id without disturbing the ids it does know', () => {
+    const plan = planEagerDeploys(DEFS, ['clade-code', 'claude-code']);
+    expect(plan).toEqual([
+      { agentId: 'clade-code', action: 'unknown-id' },
+      { agentId: 'claude-code', action: 'deploy', deployMode: 'hook' },
+    ]);
+  });
+
+  it('plans nothing when every id is unknown, and reports each one', () => {
+    const plan = planEagerDeploys(DEFS, ['nope-1', 'nope-2']);
+    expect(plan.every(p => p.action === 'unknown-id')).toBe(true);
+    expect(plan).toHaveLength(2);
+  });
+
+  it('preserves the caller-supplied order', () => {
+    const plan = planEagerDeploys(DEFS, ['openclaw', 'claude-code']);
+    expect(plan.map(p => p.agentId)).toEqual(['openclaw', 'claude-code']);
+  });
+});
+
+/**
+ * No id list is the common case, not a missing argument: the list comes from an
+ * optional K8s label. Sweeping keeps eager injection working without the label,
+ * which is what demotes the operator-side plumbing from prerequisite to
+ * optimisation. detect() then decides, exactly as it does for the daemon.
+ */
+describe('planEagerDeploys with no requested ids (sweep)', () => {
+  it('plans every eager-safe definition', () => {
+    const plan = planEagerDeploys(DEFS, []);
+    expect(plan.map(p => p.agentId)).toEqual(['claude-code', 'openclaw']);
+    expect(plan.every(p => p.action === 'deploy')).toBe(true);
+  });
+
+  // `deferred` answers "you asked for this and here is why it is not happening
+  // now". With nobody asking, the same entries become one warning per
+  // non-eager definition in every Pod's log — six today, for work no caller
+  // requested. Silence is the correct output, so this asserts absence.
+  it('emits no deferred or unknown-id entries', () => {
+    const plan = planEagerDeploys(DEFS, []);
+    expect(plan.some(p => p.action === 'deferred')).toBe(false);
+    expect(plan.some(p => p.action === 'unknown-id')).toBe(false);
+  });
+
+  // The destructive mode must be unreachable by omission as well as by request:
+  // plugin-probe's deploy() stops a worker, runs uninstall.sh and re-extracts a
+  // tarball. Sweeping is the path that runs without anyone opting in, so this is
+  // the more important of the two exclusion tests.
+  it('never sweeps plugin-probe in, even though no caller excluded it', () => {
+    const plan = planEagerDeploys(DEFS, []);
+    expect(plan.map(p => p.deployMode)).not.toContain('plugin-probe');
+  });
+
+  it('plans nothing when no definition uses an eager-safe mode', () => {
+    const plan = planEagerDeploys(DEFS.filter(d => d.deployMode === 'plugin-probe'), []);
+    expect(plan).toEqual([]);
+  });
+
+  // parseInjectArgs turns `--agents=` and `--agents=  ,  ` into [], so the two
+  // spellings of "no ids" must reach the same plan as omitting the flag.
+  it('treats an explicitly empty --agents the same as omitting it', () => {
+    const viaFlag = planEagerDeploys(DEFS, parseInjectArgs(['--agents=  ,  ']).agents);
+    expect(viaFlag).toEqual(planEagerDeploys(DEFS, []));
+  });
+});

--- a/tests/unit/deployment/inject-hooks-contract.test.ts
+++ b/tests/unit/deployment/inject-hooks-contract.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { AgentDefinition } from '../../../src/types/index.js';
-import { parseInjectArgs, planEagerDeploys } from '../../../src/inject-hooks.js';
+import { parseInjectArgs, planEagerDeploys, isGateEnabled } from '../../../src/inject-hooks.js';
+import { isAgentGatedEnabled } from '../../../src/deployment/deploy-command.js';
 
 /**
  * inject-hooks runs on the agent's startup critical path, spawned by
@@ -153,4 +154,33 @@ describe('planEagerDeploys with no requested ids (sweep)', () => {
     const viaFlag = planEagerDeploys(DEFS, parseInjectArgs(['--agents=  ,  ']).agents);
     expect(viaFlag).toEqual(planEagerDeploys(DEFS, []));
   });
+});
+
+/**
+ * The eager path re-decides the enabled gate instead of importing
+ * isAgentGatedEnabled (this entry must stay a self-contained bundle), so the two
+ * implementations must not drift: a disabled agent that eager-injects anyway
+ * keeps firing its hook until the daemon's next undeploy pass — admission
+ * control silently off. Pin them against the same matrix.
+ */
+describe('isGateEnabled parity with deploy-command.isAgentGatedEnabled', () => {
+  const ids = ['claude-code', 'openclaw', 'hermes-agent'];
+  const gates: Array<Record<string, { enabled?: boolean }> | undefined> = [
+    undefined,
+    {},
+    { 'claude-code': { enabled: true } },
+    { 'claude-code': { enabled: false } },
+    { openclaw: { enabled: false } },
+    { 'claude-code': { enabled: false }, openclaw: { enabled: false }, 'hermes-agent': { enabled: false } },
+    { 'claude-code': {} },
+  ];
+
+  for (const gate of gates) {
+    for (const id of ids) {
+      it(`agrees for gate=${JSON.stringify(gate)} id=${id}`, () => {
+        const config = { agents: gate } as never as Parameters<typeof isAgentGatedEnabled>[0];
+        expect(isGateEnabled(gate, id)).toBe(isAgentGatedEnabled(config, id));
+      });
+    }
+  }
 });

--- a/tests/unit/inputs/base-session-input.test.ts
+++ b/tests/unit/inputs/base-session-input.test.ts
@@ -199,4 +199,72 @@ describe('BaseSessionInput', () => {
       await input.stop();
     });
   });
+
+  // EACCES reproduction needs real permission checks: skipped when the test
+  // process is root (root reads anything) or the platform has no getuid.
+  describe.runIf(typeof process.getuid === 'function' && process.getuid() !== 0)(
+    'ownership diagnostics',
+    () => {
+      it('unreadable event file: warns once with owner/daemon uids and keeps collecting sibling files', async () => {
+        const blocked = path.join(tmpDir, 'blocked.jsonl');
+        const readable = path.join(tmpDir, 'readable.jsonl');
+        await fs.writeFile(blocked, JSON.stringify({ file_path: '/blocked.ts' }) + '\n');
+        await fs.writeFile(readable, JSON.stringify({ file_path: '/ok.ts' }) + '\n');
+        await fs.chmod(blocked, 0o000);
+
+        input.discoverFn = async () => [blocked, readable];
+        const warnSpy = vi.spyOn((input as any).logger, 'warn');
+        const realUid = process.getuid();
+        // Force the daemon side of the comparison to a different uid so the
+        // mismatch branch fires deterministically regardless of the test user.
+        const getuidSpy = vi.spyOn(process, 'getuid').mockReturnValue(realUid + 1);
+
+        const allEntries: AgentActivityEntry[] = [];
+        input.on('entries', (e: AgentActivityEntry[]) => allEntries.push(...e));
+
+        try {
+          await input.start();
+          // Containment: the unreadable file must not abort the cycle.
+          expect(allEntries.map(e => e.filePath)).toEqual(['/ok.ts']);
+
+          expect(warnSpy).toHaveBeenCalledTimes(1);
+          const message = String(warnSpy.mock.calls[0][0]);
+          expect(message).toContain('ownership-mismatch');
+          expect(message).toContain(`owned by uid ${realUid}`);
+          expect(message).toContain(`daemon runs as uid ${realUid + 1}`);
+
+          // Second cycle against the same broken file: no duplicate warning.
+          await input.stop();
+          await input.start();
+          expect(warnSpy).toHaveBeenCalledTimes(1);
+        } finally {
+          getuidSpy.mockRestore();
+          warnSpy.mockRestore();
+          await fs.chmod(blocked, 0o644).catch(() => {});
+        }
+        await input.stop();
+      });
+
+      it('unreadable despite matching uid: points at directory permissions or security modules', async () => {
+        const blocked = path.join(tmpDir, 'blocked.jsonl');
+        await fs.writeFile(blocked, JSON.stringify({ file_path: '/x.ts' }) + '\n');
+        await fs.chmod(blocked, 0o000);
+
+        input.discoverFn = async () => [blocked];
+        const warnSpy = vi.spyOn((input as any).logger, 'warn');
+
+        try {
+          await input.start();
+          expect(warnSpy).toHaveBeenCalledTimes(1);
+          const message = String(warnSpy.mock.calls[0][0]);
+          expect(message).toContain('ownership-mismatch');
+          expect(message).toContain('despite matching uid');
+        } finally {
+          warnSpy.mockRestore();
+          await fs.chmod(blocked, 0o644).catch(() => {});
+        }
+        await input.stop();
+      });
+    },
+  );
 });

--- a/tests/unit/inputs/hermes-log-input.test.ts
+++ b/tests/unit/inputs/hermes-log-input.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -161,6 +161,43 @@ describe('HermesLogInput', () => {
     await appendRecord(file, makeRecord('event-2'));
     expect((await input.collectOnce()).map(entry => entry['event.id'])).toEqual(['event-2']);
   });
+
+  // Reproducing EACCES needs real permission checks; root bypasses them.
+  const itNonRoot =
+    typeof process.getuid === 'function' && process.getuid() !== 0 ? it : it.skip;
+
+  itNonRoot(
+    'diagnoses an unreadable session directory once instead of failing silently',
+    async () => {
+      const lockedDir = path.join(tmpDir, 'locked');
+      await fs.mkdir(lockedDir);
+      await fs.writeFile(
+        path.join(lockedDir, 'hermes-agent-100.jsonl'),
+        JSON.stringify(makeRecord('event-1')) + '\n',
+      );
+      // The plugin creates this directory 0700 inside its host process; a
+      // differently-privileged writer makes it unreadable for this daemon.
+      await fs.chmod(lockedDir, 0o000);
+
+      const input = makeInput({ sessionDir: lockedDir });
+      const warnSpy = vi.spyOn((input as any).logger, 'warn');
+
+      try {
+        await expect(input.discoverOnce()).resolves.toEqual([]);
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const message = String(warnSpy.mock.calls[0][0]);
+        expect(message).toContain('ownership-mismatch');
+        expect(message).toContain('session directory');
+
+        // The condition is stable across cycles; the warning is not repeated.
+        await expect(input.discoverOnce()).resolves.toEqual([]);
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        warnSpy.mockRestore();
+        await fs.chmod(lockedDir, 0o755).catch(() => {});
+      }
+    },
+  );
 
   function makeInput(
     overrides: Partial<Omit<HermesLogInputOptions, 'stateStore'>> = {},

--- a/tests/unit/utils/data-dir-parity.test.ts
+++ b/tests/unit/utils/data-dir-parity.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import { loadConfig } from '../../../src/core/config-loader.js';
+import {
+  DEFAULT_DATA_DIR,
+  configJsonPath,
+  pickDataDir,
+  readConfigFileDataDir,
+  resolveDataDir,
+} from '../../../src/utils/data-dir.js';
+import { resolveHome } from '../../../src/utils/fs-utils.js';
+
+/**
+ * One precedence chain, three consumers: loadConfig() (the daemon),
+ * inject-hooks.ts, and k8s-preload.cjs (which mirrors it in plain CJS — pinned
+ * separately in k8s-preload-coordination.test.mjs). This test pins the first
+ * two to each other: if loadConfig() ever grows a new dataDir source that
+ * resolveDataDir() misses, the preload's symlinks/sentinels/lock and the
+ * injected hookCommand strings land in a different directory than the daemon
+ * reads, isHookInstalled() sees every hook as "not installed", and the daemon
+ * appends duplicates — every event fires twice, silently.
+ */
+
+let tmp: string;
+
+function setConfig(contents: string | null, name = 'config.json'): string {
+  const p = path.join(tmp, name);
+  if (contents !== null) fs.writeFileSync(p, contents, 'utf8');
+  vi.stubEnv('AGENT_DATA_COLLECTION_CONFIG', p);
+  return p;
+}
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'data-dir-parity-'));
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+/** Both sides resolve from the same env state; they must land identically. */
+async function assertParity(): Promise<void> {
+  const config = await loadConfig();
+  // The daemon resolves the raw config value at use time (orchestrator); the
+  // eager path resolves up front. Both views of the SAME chain must agree.
+  expect(resolveDataDir()).toBe(resolveHome(config.dataDir || DEFAULT_DATA_DIR));
+}
+
+describe('data-dir precedence parity: loadConfig vs resolveDataDir', () => {
+  it('falls back to the default when neither env nor config file says anything', async () => {
+    setConfig(JSON.stringify({ sls: { enabled: true } }));
+    await assertParity();
+    expect(resolveDataDir()).toBe(resolveHome(DEFAULT_DATA_DIR));
+  });
+
+  it('reads the config-file dataDir when the env var is absent', async () => {
+    const custom = path.join(tmp, 'from-config');
+    setConfig(JSON.stringify({ dataDir: custom }));
+    await assertParity();
+    expect(resolveDataDir()).toBe(custom);
+  });
+
+  it('lets the env var win over the config-file dataDir', async () => {
+    setConfig(JSON.stringify({ dataDir: path.join(tmp, 'from-config') }));
+    vi.stubEnv('LOONGSUITE_PILOT_DATA_DIR', path.join(tmp, 'from-env'));
+    await assertParity();
+    expect(resolveDataDir()).toBe(path.join(tmp, 'from-env'));
+  });
+
+  it('expands ~ in the config-file dataDir on both sides', async () => {
+    setConfig(JSON.stringify({ dataDir: '~/some-dir' }));
+    await assertParity();
+    expect(resolveDataDir()).toBe(path.join(os.homedir(), 'some-dir'));
+  });
+
+  it('treats an empty config-file dataDir as unset on both sides', async () => {
+    // Historical quirk, pinned deliberately: `?? ` would keep '' and the
+    // orchestrator's `|| DEFAULT` turned it into the default only later in the
+    // chain — the shared pickDataDir() collapses both views to one answer.
+    setConfig(JSON.stringify({ dataDir: '' }));
+    await assertParity();
+    expect(resolveDataDir()).toBe(resolveHome(DEFAULT_DATA_DIR));
+  });
+
+  it('survives an unreadable config file (both sides fall through)', async () => {
+    setConfig(null); // AGENT_DATA_COLLECTION_CONFIG points at a missing file
+    await assertParity();
+    expect(resolveDataDir()).toBe(resolveHome(DEFAULT_DATA_DIR));
+  });
+
+  it('survives an unparsable config file', async () => {
+    setConfig('this is not json');
+    await assertParity();
+    expect(resolveDataDir()).toBe(resolveHome(DEFAULT_DATA_DIR));
+  });
+
+  it('strips a leading BOM exactly like readJsonFile does', async () => {
+    // Windows writes BOMs routinely; JSON.parse rejects them. loadConfig()
+    // reads via readJsonFile() which strips; resolveDataDir() must too, or the
+    // two diverge on exactly the machines that produce BOMs.
+    const custom = path.join(tmp, 'bom-dir');
+    setConfig('\uFEFF' + JSON.stringify({ dataDir: custom }));
+    expect(readConfigFileDataDir()).toBe(custom);
+    await assertParity();
+    expect(resolveDataDir()).toBe(custom);
+  });
+});
+
+describe('pickDataDir', () => {
+  it.each([
+    ['/explicit', '/from/file', '/explicit'],
+    [undefined, '/from/file', '/from/file'],
+    [undefined, undefined, DEFAULT_DATA_DIR],
+    ['', '/from/file', '/from/file'],
+    ['', '', DEFAULT_DATA_DIR],
+    ['/explicit', undefined, '/explicit'],
+  ])('(%s, %s) -> %s', (explicit, fileDataDir, expected) => {
+    expect(pickDataDir(explicit, fileDataDir)).toBe(expected);
+  });
+});
+
+describe('configJsonPath', () => {
+  it('uses AGENT_DATA_COLLECTION_CONFIG when set', () => {
+    vi.stubEnv('AGENT_DATA_COLLECTION_CONFIG', path.join(tmp, 'elsewhere.json'));
+    expect(configJsonPath()).toBe(path.join(tmp, 'elsewhere.json'));
+  });
+
+  it('treats a whitespace-only value as unset', () => {
+    vi.stubEnv('AGENT_DATA_COLLECTION_CONFIG', '   ');
+    expect(configJsonPath()).toBe(resolveHome(`${DEFAULT_DATA_DIR}/config.json`));
+  });
+});

--- a/tests/unit/utils/data-dir-parity.test.ts
+++ b/tests/unit/utils/data-dir-parity.test.ts
@@ -114,6 +114,28 @@ describe('data-dir precedence parity: loadConfig vs resolveDataDir', () => {
   });
 });
 
+describe('win32 env padding parity', () => {
+  // Windows environment variables routinely carry leading/trailing padding.
+  // loadConfig() reads LOONGSUITE_PILOT_DATA_DIR through env(), which trims on
+  // win32; the eager path used to read the raw, untrimmed process.env, so the
+  // two resolved different directories and the daemon re-appended hooks. This
+  // pins both consumers to the same trimmed answer.
+  it('loadConfig and resolveDataDir agree on a padded LOONGSUITE_PILOT_DATA_DIR', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    try {
+      setConfig(JSON.stringify({ sls: { enabled: true } }));
+      const dir = path.join(tmp, 'padded-dir');
+      vi.stubEnv('LOONGSUITE_PILOT_DATA_DIR', `  ${dir}  `);
+      await assertParity();
+      // The resolved dir must be the trimmed value — any surviving padding means
+      // the two sides diverged again.
+      expect(resolveDataDir()).toBe(resolveHome(dir));
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+});
+
 describe('pickDataDir', () => {
   it.each([
     ['/explicit', '/from/file', '/explicit'],


### PR DESCRIPTION
## 背景

本 PR 是内部仓 `feat/k8s-init-container-image` 分支（K8s init 容器镜像，MR !247，72 条评审意见已全部解决）按「严格拆分、零重叠」约定拆分后的**开源侧**。

对齐本仓既有先例（`deploy/container` 等容器部署机制不进开源仓）：K8s/容器部署机制 —— 镜像构建（`deploy/docker`）、K8s 接入清单（`deploy/k8s`）、部署契约测试、集团 CI —— 整体保留在内部仓（内部侧 CR：`codereview/29555844`）；本 PR 只包含**核心运行时改进**，与部署形态无关，任何运行环境都受益。

两侧文件集合无交集：原分支 35 个文件 = 本 PR 14 个 + 内部侧 21 个。

## 改动内容（14 个文件）

### 新增

- `src/native-deps-guard.ts` —— 原生模块加载守卫：容器的 libc 无法加载原生模块（如 sqlite3）时，不再是无声崩溃，而是打印可读的 FATAL 诊断（失败模块、loader 原始报错、系统 libc 版本、影响与建议）并写 `daemon.fatal` 标记，非零退出。构建为独立入口 `dist/native-deps-guard.cjs`，经 `build.mjs` banner 注入、先于 daemon 模块图执行（模块图顶层 import sqlite3，守卫必须跑在它之前）。
- `src/inject-hooks.ts` —— 自包含的 eager hook 注入器：在 agent 主模块执行前同步装好 hook，消除 daemon 冷启动窗口（约 1-3s）的事件漏采。构建为 `dist/inject-hooks.cjs`，运行期不依赖 node_modules（preload 阻塞业务进程执行它，必须以裸 node 成本启动）。
- `src/utils/data-dir.ts` —— data-dir 优先级链（env > 配置文件 `dataDir` > 默认值）的唯一权威实现。此前 `loadConfig`、`inject-hooks` 与 K8s preload 各持一份拷贝、靠注释「保持同步」，曾经漂移导致 hook 与 daemon 指向不同数据目录；现在收敛到一处，由 `data-dir-parity` 测试钉住。

### 修改

- `build.mjs` —— 新增上述两个构建入口；为 daemon 主 bundle 注入 native-deps-guard banner。
- `src/core/config-loader.ts` —— 改用共享的 data-dir 链（`configJsonPath()` / `pickDataDir()`）；基于当前 main rebase，upstream-link 与 grok-build 改动原样保留。
- `src/index.ts` —— `daemon.spawn.lock` 的 PID 写入权归 daemon 自身：只有真正持有 `collector.lock` 的 daemon 才发布 pid，避免 preStop 把信号打到已退出的进程、真 daemon 却随 SIGKILL 丢缓冲；环境里配置了 SLS 目标（`LOONGSUITE_SLS_PROJECT/LOGSTORE`）但 SLS flusher 未启用时输出告警（此前静默只落本地不上报，极难诊断）。
- `src/inputs/base/base-session-input.ts` —— 会话路径属主不匹配导致 EACCES 时：按路径去重输出一条含 `ownership-mismatch` 关键字的诊断告警（文件属主 uid、daemon uid、修复指引），不中断同周期内其他文件的采集。
- `src/inputs/hermes-log/hermes-log-input.ts` —— 同款处理：会话目录 0700 被其他属主（常见为 root）创建而不可读时，走一次性诊断而不是普通报错。

### 测试

`tests/unit/deploy/native-deps-guard.test.mjs`、`tests/unit/deployment/inject-hooks-contract.test.ts`、`tests/unit/deployment/eager-vs-daemon-parity.test.ts`、`tests/unit/utils/data-dir-parity.test.ts`、`tests/unit/inputs/base-session-input.test.ts`、`tests/unit/inputs/hermes-log-input.test.ts`。

> 读取 `deploy/docker` 文件的部署契约测试随部署机制留在内部仓，不在本 PR。

## 验证

- `tsc --noEmit` 干净
- 相关测试套件全部通过（958 tests）

## 落地顺序

本 PR 合入并经 `sync-opensource` 回流内部仓后，内部侧 CR（`codereview/29555844`，21 个部署机制文件）再合入 —— 其部署契约测试断言本 PR 的 `build.mjs` / `src/index.ts` / `src/native-deps-guard.ts` 内容，回流前会红。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
