### PR TITLE
fix(sls): report Pilot version consistently

### DIFF
--- a/assets/hooks/qoderwork-hook-processor.mjs
+++ b/assets/hooks/qoderwork-hook-processor.mjs
@@ -119,11 +119,10 @@ function processTranscript(parsed, sessionId, agentId, runtimeConfig, cwd, opts 
   const firstRow = turns[0]?.[0] || contentRows[0];
   const userId = resolveUserId(firstRow, runtimeConfig);
   const providerName = inferProviderName({ 'gen_ai.agent.type': agentId });
-  const version = getStringValue(firstRow, 'version') || '';
 
   for (const turn of turns) {
     const turnId = getTurnIdForRows(turn);
-    const turnRecords = buildTurnEvents(turn, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, cwd, agentId);
+    const turnRecords = buildTurnEvents(turn, turnId, sessionId, userId, providerName, observedTs, runtimeConfig, cwd, agentId);
     records.push(...turnRecords);
   }
 
@@ -182,7 +181,7 @@ function isPureSystemReminder(text) {
     && text.replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, '').trim().length === 0;
 }
 
-function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, cwd, agentId) {
+function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, observedTs, runtimeConfig, cwd, agentId) {
   const records = [];
 
   // Find the user prompt
@@ -205,7 +204,6 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
         'gen_ai.input.messages_delta': [{ role: 'user', parts: [{ type: 'text', content: userText }] }],
         time_unix_nano: timestampToUnixNanos(userRow.timestamp),
         observed_time_unix_nano: observedTs,
-        version,
       }, turnRows[0], runtimeConfig, cwd));
     }
   }
@@ -289,7 +287,7 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
     const llmRequestTs = stepCounter === 1 ? userTs : prevStepLastToolResultTs;
 
     const assistantOutput = extractAssistantOutput(group);
-    const stepRecords = buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, agentId, inputDelta, cwd, llmRequestTs, turnMetadata);
+    const stepRecords = buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, turnId, sessionId, userId, providerName, observedTs, runtimeConfig, agentId, inputDelta, cwd, llmRequestTs, turnMetadata);
     records.push(...stepRecords);
 
     // Collect this step's tool_calls for next step's input delta
@@ -397,7 +395,7 @@ function extractAssistantOutput(group) {
   return { outputParts, toolCalls };
 }
 
-function buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, agentId, inputDelta, cwd, llmRequestTs, turnMetadata = {}) {
+function buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, turnId, sessionId, userId, providerName, observedTs, runtimeConfig, agentId, inputDelta, cwd, llmRequestTs, turnMetadata = {}) {
   const records = [];
   const firstRow = group[0];
   const lastRow = group[group.length - 1];
@@ -442,7 +440,6 @@ function buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, tur
     'user.id': userId,
     time_unix_nano: llmRequestTs || timestampToUnixNanos(firstRow.timestamp),
     observed_time_unix_nano: observedTs,
-    version,
   };
   if (inputDelta) {
     llmRequestFields['gen_ai.input.messages_delta'] = inputDelta;
@@ -467,7 +464,6 @@ function buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, tur
       'gen_ai.output.messages': [{ role: 'assistant', parts: outputParts, finish_reason: finishReason }],
       time_unix_nano: llmResponseTs,
       observed_time_unix_nano: observedTs,
-      version,
     }, firstRow, runtimeConfig, cwd));
   }
 
@@ -487,7 +483,6 @@ function buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, tur
       'user.id': userId,
       time_unix_nano: timestampToUnixNanos(lastRow.timestamp),
       observed_time_unix_nano: observedTs,
-      version,
     }, firstRow, runtimeConfig, cwd));
 
     // Find matching tool_result
@@ -510,7 +505,6 @@ function buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, tur
         'user.id': userId,
         time_unix_nano: timestampToUnixNanos(resultRow.timestamp),
         observed_time_unix_nano: observedTs,
-        version,
       }, resultRow, runtimeConfig, cwd));
     }
   }

--- a/assets/hooks/qwen-work-cn-hook-processor.mjs
+++ b/assets/hooks/qwen-work-cn-hook-processor.mjs
@@ -159,7 +159,6 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, observedTs, runtim
   const promptRow = turnRows.find(isPromptRow);
   const promptText = extractText(promptRow);
   const promptTs = timestampToUnixNanos(promptRow.timestamp);
-  const version = stringValue(promptRow.version);
   const turnMetadata = { 'agent.qwenworkcn.promptId': stringValue(promptRow.promptId) || turnId };
 
   if (promptText) {
@@ -174,7 +173,6 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, observedTs, runtim
       'gen_ai.input.messages_delta': [{ role: 'user', parts: [{ type: 'text', content: promptText }] }],
       time_unix_nano: promptTs,
       observed_time_unix_nano: observedTs,
-      version,
     }, promptRow, runtimeConfig, cwd, `${turnId}:other`));
   }
 
@@ -221,7 +219,6 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, observedTs, runtim
       observedTs,
       runtimeConfig,
       cwd,
-      version,
       inputDelta,
       requestTs: index === 0 ? promptTs : previousToolResultTs,
       isLastStep: index === groups.length - 1,
@@ -265,7 +262,7 @@ function indexToolResults(rows) {
 function buildStepEvents(opts) {
   const {
     group, toolResults, stepId, turnId, sessionId, userId, observedTs,
-    runtimeConfig, cwd, version, inputDelta, requestTs, isLastStep, turnMetadata,
+    runtimeConfig, cwd, inputDelta, requestTs, isLastStep, turnMetadata,
   } = opts;
   const firstRow = group[0];
   const lastRow = group[group.length - 1];
@@ -302,7 +299,6 @@ function buildStepEvents(opts) {
     'gen_ai.agent.type': 'qwen-work-cn',
     'gen_ai.provider.name': provider,
     'user.id': userId,
-    version,
   };
   const records = [];
 

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -214,7 +214,7 @@ export class Orchestrator extends EventEmitter {
       this.config.globalSpanAttributes ?? {},
       path.join(this.dataDir, 'span-attributes.json'),
     );
-    this.flusher = await this.buildFlusher();
+    this.flusher = await this.buildFlusher(this.readPackageVersion());
 
     // 4. Build InputManager & AlarmManager
     const version = readInstalledVersion(this.dataDir);
@@ -715,12 +715,12 @@ export class Orchestrator extends EventEmitter {
     return path.isAbsolute(resolved) ? resolved : null;
   }
 
-  private async buildFlusher(): Promise<BaseFlusher> {
+  private async buildFlusher(pilotVersion: string): Promise<BaseFlusher> {
     const flushers: BaseFlusher[] = [];
     const cfg = this.config.flushers;
 
     if (cfg.sls?.enabled && this.config.collectLog !== false) {
-      const r = new SlsFlusher(cfg.sls, this.dataDir);
+      const r = new SlsFlusher(cfg.sls, this.dataDir, pilotVersion);
       await r.start().catch(err => logger.warn('sls flusher start failed', { error: String(err) }));
       flushers.push(r);
     }

--- a/src/flushers/sls-flusher.ts
+++ b/src/flushers/sls-flusher.ts
@@ -12,6 +12,7 @@ import { createLogger } from '../utils/logger.js';
 import { formatTime } from '../utils/time-utils.js';
 import { normalizeAgentType } from '../utils/agent-type-normalize.js';
 import { LOCAL_IP, buildUserAgent } from '../utils/network-utils.js';
+import { readInstalledVersion } from '../utils/fs-utils.js';
 import * as path from 'node:path';
 import { SlsFailureLogWriter } from './sls-failure-log-writer.js';
 import {
@@ -115,6 +116,7 @@ export class SlsFlusher extends BaseFlusher {
   private readonly serviceName: string;
   private readonly serviceNamePrefix: string;
   private readonly userAgent: string;
+  private readonly pilotVersion: string;
 
   private readonly resolvedTimeoutMs: number;
   private readonly resolvedRetryMaxAttempts: number;
@@ -124,7 +126,11 @@ export class SlsFlusher extends BaseFlusher {
   private readonly dispatcher: UndiciAgent | undefined;
   private flushing = false;
 
-  constructor(config: SlsFlusherConfig, dataDir: string) {
+  constructor(
+    config: SlsFlusherConfig,
+    dataDir: string,
+    pilotVersion = readInstalledVersion(dataDir),
+  ) {
     super();
     this.config = config;
     this.failedLogWriter = new SlsFailureLogWriter(
@@ -133,6 +139,7 @@ export class SlsFlusher extends BaseFlusher {
     this.serviceName = config.serviceName || '';
     this.serviceNamePrefix = config.serviceNamePrefix || '';
     this.userAgent = buildUserAgent(dataDir);
+    this.pilotVersion = pilotVersion;
 
     const tc = config.timeout ?? {};
     const rc = config.retry ?? {};
@@ -192,6 +199,7 @@ export class SlsFlusher extends BaseFlusher {
 
   async send(entry: AgentActivityEntry): Promise<void> {
     const serialized = serialiseLogEntry(entry, { dropAgentScopedFields: true });
+    serialized.version = this.pilotVersion;
     const agentType = normalizeAgentType(String(entry['gen_ai.agent.type'] ?? 'unknown'));
 
     for (const endpoint of this.config.endpoints) {

--- a/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
+++ b/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
@@ -203,6 +203,7 @@ export class QoderWorkTraceInput extends BaseInput {
         if (!line.trim()) continue;
         try {
           const record = JSON.parse(line) as AgentActivityEntry;
+          delete record.version;
           if (record['event.name']) entries.push(record);
         } catch {
           this.logger.warn('invalid JSONL line');

--- a/src/inputs/qwen-work-cn/qwen-work-cn-input.ts
+++ b/src/inputs/qwen-work-cn/qwen-work-cn-input.ts
@@ -40,8 +40,9 @@ export class QwenWorkCNInput extends BaseHookInput {
     if (typeof record['event.id'] !== 'string') return null;
     if (typeof record.time_unix_nano !== 'string') return null;
 
-    const version = record.version;
+    const version = record['agent.qwenworkcn.version'] ?? record.version;
     if (typeof version === 'string' && version) this.lastAgentVersion = version;
+    delete record.version;
 
     const entry = {
       ...record,

--- a/src/inputs/qwen-work-cn/qwen-work-cn-trace-input.ts
+++ b/src/inputs/qwen-work-cn/qwen-work-cn-trace-input.ts
@@ -182,6 +182,7 @@ export class QwenWorkCNTraceInput extends BaseInput {
         if (!line.trim()) continue;
         try {
           const record = JSON.parse(line) as AgentActivityEntry;
+          delete record.version;
           if (record['event.name']) entries.push(record);
         } catch {
           this.logger.warn('invalid QwenWorkCN history JSONL line');

--- a/tests/unit/flushers/sls-flusher.test.ts
+++ b/tests/unit/flushers/sls-flusher.test.ts
@@ -125,6 +125,15 @@ describe('SlsFlusher', () => {
       expect(content['agent.file_path']).toBe('/tmp/test/file.ts');
       expect(content['gen_ai.agent.type']).toBe('qoder');
     });
+
+    it('sets version to the Pilot version for every SLS entry', async () => {
+      const entry = buildTestEntry({ version: 'agent-runtime-version' });
+      await flusher.send(entry);
+      await flusher.flush();
+
+      const logGroup = mockPostLogStoreLogs.mock.calls[0][2];
+      expect(logGroup.logs[0].content.version).toBe('0.0.0-test');
+    });
   });
 
   describe('redact logic (T013)', () => {

--- a/tests/unit/hooks/qoderwork/hook-processor.test.mjs
+++ b/tests/unit/hooks/qoderwork/hook-processor.test.mjs
@@ -177,6 +177,21 @@ describe('qoderwork-hook-processor cursor recovery', () => {
 });
 
 describe('qoderwork-hook-processor user prompt extraction', () => {
+  test('keeps the QoderWork runtime version agent-scoped', () => {
+    writeTranscript(baseRows([{ type: 'text', text: 'check version fields' }]).map((row) => ({
+      ...row,
+      version: '1.1.26',
+    })));
+
+    const result = runHook('sess-no-runtime-version');
+    expect(result.status).toBe(0);
+
+    const records = readJsonlRecords();
+    expect(records.length).toBeGreaterThan(0);
+    expect(records.every((record) => record.version === undefined)).toBe(true);
+    expect(records.every((record) => record['agent.qoderwork.version'] === '1.1.26')).toBe(true);
+  });
+
   test('emits per-step input deltas that the converter accumulates', async () => {
     writeTranscript([
       {

--- a/tests/unit/hooks/qwen-work-cn-hook-processor.test.mjs
+++ b/tests/unit/hooks/qwen-work-cn-hook-processor.test.mjs
@@ -157,6 +157,8 @@ describe('QwenWorkCN hook processor', () => {
       'llm.request', 'llm.response',
     ]);
     expect(events.every(event => event['gen_ai.agent.type'] === 'qwen-work-cn')).toBe(true);
+    expect(events.every(event => event.version === undefined)).toBe(true);
+    expect(events.every(event => event['agent.qwenworkcn.version'] === '0.1.5')).toBe(true);
     expect(events.every(event => event['gen_ai.turn.id'] === 'prompt-turn-1')).toBe(true);
     expect(events.filter(event => event['event.name'] !== 'other').map(event => event['gen_ai.step.id'])).toEqual([
       'prompt-turn-1:s1', 'prompt-turn-1:s1', 'prompt-turn-1:s1', 'prompt-turn-1:s1',

--- a/tests/unit/inputs/qoder-work-input.test.ts
+++ b/tests/unit/inputs/qoder-work-input.test.ts
@@ -452,6 +452,7 @@ describe('QoderWorkInput', () => {
         'event.name': 'llm.response',
         'gen_ai.agent.type': ClientType.QoderWork,
         'gen_ai.session.id': 'sess-ver',
+        version: '1.2.3',
         'agent.qoderwork.version': '1.2.3',
         'gen_ai.output.messages': [{ role: 'assistant', parts: [{ type: 'text', content: 'hi' }] }],
       };
@@ -463,6 +464,7 @@ describe('QoderWorkInput', () => {
       await input.start();
       expect(allEntries).toHaveLength(1);
       const entry = allEntries[0]!;
+      expect(entry['version']).toBeUndefined();
       expect(entry['agent.qoderwork.version']).toBe('1.2.3');
       expect(input.getAgentVersion()).toBe('1.2.3');
       await input.stop();

--- a/tests/unit/inputs/qoder-work-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-work-trace-input.test.ts
@@ -187,6 +187,23 @@ describe('QoderWorkTraceInput', () => {
     expect(entries[0]['workspace.path']).toBe(TEST_CWD);
   });
 
+  it('strips a legacy bare runtime version while preserving the agent-scoped version', async () => {
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const entry = buildHookEntry({
+      version: '1.1.26',
+      'agent.qoderwork.version': '1.1.26',
+    });
+    await fs.writeFile(hookFile, JSON.stringify(entry) + '\n');
+
+    const input = makeInput();
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].version).toBeUndefined();
+    expect(entries[0]['agent.qoderwork.version']).toBe('1.1.26');
+  });
+
   it('resumes from offset on second poll', async () => {
     const hookFile = path.join(hookLogDir, todayFileName());
     const entry1 = buildHookEntry({ 'event.id': 'e1', 'gen_ai.turn.id': 'turn-1' });

--- a/tests/unit/inputs/qwen-work-cn-input.test.ts
+++ b/tests/unit/inputs/qwen-work-cn-input.test.ts
@@ -42,6 +42,7 @@ describe('QwenWorkCNInput', () => {
       time_unix_nano: '1770000000000000000',
       observed_time_unix_nano: '1770000000000000000',
       version: '0.1.5',
+      'agent.qwenworkcn.version': '0.1.5',
       'agent.qwenworkcn.cwd': '/workspace/qwen-work-cn',
     })}\n`);
     const entries: AgentActivityEntry[] = [];
@@ -53,6 +54,8 @@ describe('QwenWorkCNInput', () => {
     expect(entries[0]!['gen_ai.agent.type']).toBe(ClientType.QwenWorkCN);
     expect(entries[0]!['gen_ai.session.id']).toBe('qwen-session-1');
     expect(entries[0]!['workspace.path']).toBe('/workspace/qwen-work-cn');
+    expect(entries[0]!.version).toBeUndefined();
+    expect(entries[0]!['agent.qwenworkcn.version']).toBe('0.1.5');
     expect(input.getAgentVersion()).toBe('0.1.5');
   });
 });

--- a/tests/unit/inputs/qwen-work-cn-trace-input.test.ts
+++ b/tests/unit/inputs/qwen-work-cn-trace-input.test.ts
@@ -84,6 +84,21 @@ describe('QwenWorkCNTraceInput', () => {
     })).toEqual([historyDir, segmentsRoot, interceptFile]);
   });
 
+  it('strips a legacy bare runtime version while preserving the agent-scoped version', async () => {
+    await writeHistory([
+      entry({
+        version: '0.1.5',
+        'agent.qwenworkcn.version': '0.1.5',
+      }),
+    ]);
+
+    const entries = await collectOnce(makeInput());
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].version).toBeUndefined();
+    expect(entries[0]['agent.qwenworkcn.version']).toBe('0.1.5');
+  });
+
   it('enriches zero-token Qwen segments from qwenworkcn-intercept by response id', async () => {
     await writeHistory([
       entry({


### PR DESCRIPTION
## Summary

- stop Qoder Work, Qoder Work CN, and QwenWorkCN hooks from emitting runtime versions as the bare `version` field
- preserve runtime versions under the agent-scoped `agent.qoderwork.version` and `agent.qwenworkcn.version` fields
- strip the legacy bare runtime version while consuming hook history
- set the SLS `version` field centrally from the active Pilot package version for every agent
- keep JSONL, HTTP, and OTLP output behavior unchanged apart from removing the ambiguous bare alias

## Why

Commercial SLS serialization drops agent-scoped fields. Qoder Work-family records therefore retained only the bare runtime `version`, making it appear to be the Pilot version. Centralizing the bare field in `SlsFlusher` gives it one stable meaning across agents, while the namespaced fields continue to expose the agent runtime version where supported.

## Verification

- focused unit/integration suite: 77 tests passed for the original change
- agent-scoped version follow-up: 68 focused tests passed
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- original full-suite run: 3543 passed, 56 skipped; 3 unrelated concurrent hook tests failed on the first run and all 41 assertions passed when those files were rerun serially