### PR TITLE
feat(installer): support custom dashboard ports

### DIFF
--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -17,6 +17,9 @@
 # Install a specific version:
 #   .\installer-opensource.ps1 install -Version 1.2.0
 #
+# Optional Dashboard port (default: 8765; preserve existing port on reinstall):
+#   .\installer-opensource.ps1 install -DashboardPort 9000
+#
 # Upgrade (preserve config, auto-rollback on failure):
 #   .\installer-opensource.ps1 upgrade
 #
@@ -38,6 +41,7 @@ param(
     [string]$SlsApiKey,
     [string]$PackageUrl,
     [string]$DataDir,
+    [string]$DashboardPort,
     [string]$LogLevel,
     [Alias("user.id")]
     [string]$UserId,
@@ -99,8 +103,14 @@ if (-not $PackageUrl -and $env:LOONGSUITE_PILOT_PACKAGE_URL) {
 }
 
 # ============================================================
-# Validate mask options
+# Validate install options
 # ============================================================
+if ($PSBoundParameters.ContainsKey('DashboardPort')) {
+    if ($DashboardPort -notmatch '\A[0-9]{1,5}\z' -or [int]$DashboardPort -lt 1 -or [int]$DashboardPort -gt 65535) {
+        Write-Error "-DashboardPort must be an integer between 1 and 65535"
+        exit 1
+    }
+}
 if ($MaskMode) {
     if ($MaskMode -notin @("all", "none", "custom")) {
         Write-Error "Unknown mask mode: $MaskMode (use 'all', 'custom', or 'none')"
@@ -916,6 +926,7 @@ function Confirm-ConfigOverwrite {
         cmsEndpoint = $CmsEndpoint
         cmsWorkspace = $CmsWorkspace
         serviceNamePrefix = $ServiceNamePrefix
+        dashboardPort = $DashboardPort
         maskMode = $MaskMode
         maskTypes = $MaskTypes
     } | ConvertTo-Json -Compress
@@ -943,6 +954,7 @@ const checks = [
   { label: 'cms.endpoint',      oldVal: (old.cms||{}).endpoint||'',      newVal: newVals.cmsEndpoint },
   { label: 'cms.workspace',     oldVal: (old.cms||{}).workspace||'',     newVal: newVals.cmsWorkspace },
   { label: 'serviceNamePrefix', oldVal: old.serviceNamePrefix||'',       newVal: newVals.serviceNamePrefix },
+  { label: 'dashboard.port',    oldVal: (old.dashboard||{}).port||'',   newVal: newVals.dashboardPort ? Number(newVals.dashboardPort) : '' },
   { label: 'mask.mode',         oldVal: (old.mask||{}).mode||'',         newVal: newVals.maskMode },
   { label: 'mask.types',        oldVal: Array.isArray((old.mask||{}).types) ? normalizeCsv(old.mask.types.join(',')) : '', newVal: normalizeCsv(newVals.maskTypes) },
 ];
@@ -1195,6 +1207,7 @@ function Write-Config {
     $cfgArgs = [ordered]@{
         configPath        = $configFile
         dataDir           = $DataDir
+        dashboardPort     = "$DashboardPort"
         slsEndpoint       = "$SlsEndpoint"
         slsProject        = "$SlsProject"
         slsLogstore       = "$SlsLogstore"
@@ -1242,6 +1255,7 @@ const config = {
 if (!config.dashboard || typeof config.dashboard !== 'object' || Array.isArray(config.dashboard)) {
   config.dashboard = {};
 }
+if (opts.dashboardPort) config.dashboard.port = Number(opts.dashboardPort);
 if (config.dashboard.port === undefined) config.dashboard.port = 8765;
 delete config.internal;
 if (config.userId === undefined && config['user.id'] !== undefined) {

--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -105,7 +105,7 @@ if (-not $PackageUrl -and $env:LOONGSUITE_PILOT_PACKAGE_URL) {
 # ============================================================
 # Validate install options
 # ============================================================
-if ($PSBoundParameters.ContainsKey('DashboardPort')) {
+if ($PSBoundParameters.Keys -contains 'DashboardPort') {
     if ($DashboardPort -notmatch '\A[0-9]{1,5}\z' -or [int]$DashboardPort -lt 1 -or [int]$DashboardPort -gt 65535) {
         Write-Error "-DashboardPort must be an integer between 1 and 65535"
         exit 1

--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -18,6 +18,9 @@
 # Install a specific version:
 #   curl -fsSL <URL>/installer.sh | bash -s -- install --version 1.2.0
 #
+# Optional Dashboard port (default: 8765; preserve existing port on reinstall):
+#   curl -fsSL <URL>/installer.sh | bash -s -- install --dashboard-port 9000
+#
 # Upgrade (preserve config, auto-rollback on failure):
 #   curl -fsSL <URL>/installer.sh | bash -s -- upgrade
 #
@@ -55,6 +58,8 @@ SLS_AK_ID=""
 SLS_AK_SECRET=""
 SLS_API_KEY=""
 DATA_DIR="$DEFAULT_DATA_DIR"
+DASHBOARD_PORT=""
+DASHBOARD_PORT_SET=0
 LOG_LEVEL=""
 USER_ID=""
 COLLECT_LOG=""
@@ -102,6 +107,13 @@ while [[ $# -gt 0 ]]; do
         --package-url=*)      PACKAGE_URL="${1#--package-url=}"; shift ;;
         --data-dir)           DATA_DIR="$2"; shift 2 ;;
         --data-dir=*)         DATA_DIR="${1#*=}"; shift ;;
+        --dashboard-port)
+            if [ "$#" -lt 2 ] || [[ "$2" == --* ]]; then
+                echo "--dashboard-port requires an integer between 1 and 65535" >&2
+                exit 1
+            fi
+            DASHBOARD_PORT="$2"; DASHBOARD_PORT_SET=1; shift 2 ;;
+        --dashboard-port=*)   DASHBOARD_PORT="${1#*=}"; DASHBOARD_PORT_SET=1; shift ;;
         --log-level)          LOG_LEVEL="$2"; shift 2 ;;
         --log-level=*)        LOG_LEVEL="${1#*=}"; shift ;;
         --userId|--user.id)   USER_ID="$2"; shift 2 ;;
@@ -139,6 +151,13 @@ while [[ $# -gt 0 ]]; do
             exit 1 ;;
     esac
 done
+
+if [ "$DASHBOARD_PORT_SET" -eq 1 ]; then
+    if ! [[ "$DASHBOARD_PORT" =~ ^[0-9]{1,5}$ ]] || (( 10#$DASHBOARD_PORT < 1 || 10#$DASHBOARD_PORT > 65535 )); then
+        echo "--dashboard-port must be an integer between 1 and 65535" >&2
+        exit 1
+    fi
+fi
 
 if [ -n "$MASK_MODE" ]; then
     case "$MASK_MODE" in
@@ -771,6 +790,7 @@ const checks = [
   { label: 'cms.endpoint',       oldVal: (old.cms||{}).endpoint||'',       newVal: newVals.cmsEndpoint },
   { label: 'cms.workspace',      oldVal: (old.cms||{}).workspace||'',      newVal: newVals.cmsWorkspace },
   { label: 'serviceNamePrefix',  oldVal: old.serviceNamePrefix||'',        newVal: newVals.serviceNamePrefix },
+  { label: 'dashboard.port',     oldVal: (old.dashboard||{}).port||'',    newVal: newVals.dashboardPort ? Number(newVals.dashboardPort) : '' },
   { label: 'mask.mode',          oldVal: (old.mask||{}).mode||'',          newVal: newVals.maskMode },
   { label: 'mask.types',         oldVal: Array.isArray((old.mask||{}).types) ? normalizeCsv(old.mask.types.join(',')) : '', newVal: normalizeCsv(newVals.maskTypes) },
 ];
@@ -781,8 +801,8 @@ if (!changed.length) process.exit(0);
 for (const c of changed) {
   console.log(c.label + ': ' + c.oldVal + ' -> ' + c.newVal);
 }
-" -- "$config_file" "$(printf '{"slsEndpoint":"%s","slsProject":"%s","slsLogstore":"%s","slsMode":"%s","cmsLicenseKey":"%s","cmsEndpoint":"%s","cmsWorkspace":"%s","serviceNamePrefix":"%s","maskMode":"%s","maskTypes":"%s"}' \
-        "$SLS_ENDPOINT" "$SLS_PROJECT" "$SLS_LOGSTORE" "$([ -n "$SLS_API_KEY" ] && echo "apiKey" || { [ -n "$SLS_AK_ID" ] && [ -n "$SLS_AK_SECRET" ] && echo "ak" || true; })" "$CMS_LICENSE_KEY" "$CMS_ENDPOINT" "$CMS_WORKSPACE" "$SERVICE_NAME_PREFIX" "$MASK_MODE" "$MASK_TYPES")" 2>/dev/null || true)
+" -- "$config_file" "$(printf '{"slsEndpoint":"%s","slsProject":"%s","slsLogstore":"%s","slsMode":"%s","cmsLicenseKey":"%s","cmsEndpoint":"%s","cmsWorkspace":"%s","serviceNamePrefix":"%s","dashboardPort":"%s","maskMode":"%s","maskTypes":"%s"}' \
+        "$SLS_ENDPOINT" "$SLS_PROJECT" "$SLS_LOGSTORE" "$([ -n "$SLS_API_KEY" ] && echo "apiKey" || { [ -n "$SLS_AK_ID" ] && [ -n "$SLS_AK_SECRET" ] && echo "ak" || true; })" "$CMS_LICENSE_KEY" "$CMS_ENDPOINT" "$CMS_WORKSPACE" "$SERVICE_NAME_PREFIX" "$DASHBOARD_PORT" "$MASK_MODE" "$MASK_TYPES")" 2>/dev/null || true)
 
     if [ -z "$diffs" ]; then return 0; fi
 
@@ -982,6 +1002,7 @@ write_config() {
     printf '%s' "$PROBE_RESULT" | \
         LP_SLS_API_KEY="$SLS_API_KEY" \
         LP_SELECTED_AGENTS="$SELECTED_AGENTS" \
+        LP_DASHBOARD_PORT="$DASHBOARD_PORT" \
         "$NODE_BIN" -e "
 const fs = require('fs');
 const path = '$config_file';
@@ -997,6 +1018,8 @@ const config = {
 if (!config.dashboard || typeof config.dashboard !== 'object' || Array.isArray(config.dashboard)) {
   config.dashboard = {};
 }
+const dashboardPort = process.env.LP_DASHBOARD_PORT || '';
+if (dashboardPort) config.dashboard.port = Number(dashboardPort);
 if (config.dashboard.port === undefined) config.dashboard.port = 8765;
 delete config.internal;
 if (config.userId === undefined && config['user.id'] !== undefined) {

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -73,6 +73,7 @@ The Linux/macOS installer uses `--kebab-case` options. The Windows PowerShell in
 | `--agents <list>` | Comma-separated agent list. Skips interactive selection. |
 | `--userId <id>` | Set user identity written to output events. |
 | `--data-dir <path>` | Override data directory. Default is `~/.loongsuite-pilot`. |
+| `--dashboard-port <port>` | Optional Dashboard port, an integer from `1` to `65535`. Defaults to `8765` on first install; preserves the existing port on reinstall when omitted. Windows: `-DashboardPort <port>`. |
 | `--package-url <url>` | Install from a custom URL or local `file://` path. |
 | `--sls-endpoint <url>` | SLS endpoint URL. |
 | `--sls-project <name>` | SLS project name. |
@@ -90,6 +91,8 @@ The Linux/macOS installer uses `--kebab-case` options. The Windows PowerShell in
 | `--service-name-prefix <name>` | Service name prefix used by reporting backends. |
 | `--system-service` | **Deprecated** — ignored. Init system is now auto-detected (systemd-user → systemd-system → init.d). |
 | `--lang <lang>` | Output language: `zh` or `en`. |
+
+For example, use port `9000` by appending `--dashboard-port 9000` (or `--dashboard-port=9000`) to the Linux/macOS install command, or `-DashboardPort 9000` to the Windows command. The installer writes `dashboard.port` to `config.json` before starting the service. Open `http://127.0.0.1:9000/` after installation. Invalid or missing port values stop installation before downloads or service changes.
 
 ## Verify Installation
 
@@ -122,7 +125,7 @@ loongsuite-pilot token-usage
 loongsuite-pilot rollback
 ```
 
-The local dashboard starts and stops with the collector. Open:
+The local dashboard starts and stops with the collector. Open the default address below, or use your configured port:
 
 ```text
 http://127.0.0.1:8765/

--- a/docs/zh-CN/installation.md
+++ b/docs/zh-CN/installation.md
@@ -72,6 +72,7 @@ Linux/macOS 安装器使用 `--kebab-case` 参数；Windows PowerShell 安装器
 | `--agents <list>` | 逗号分隔的 Agent 列表，跳过交互选择。 |
 | `--userId <id>` | 设置写入输出事件的用户标识。 |
 | `--data-dir <path>` | 覆盖数据目录，默认 `~/.loongsuite-pilot`。 |
+| `--dashboard-port <port>` | 可选的 Dashboard 端口，取值为 `1–65535` 的整数。首次安装不指定时使用 `8765`；重新安装不指定时保留已有端口。Windows 对应 `-DashboardPort <port>`。 |
 | `--package-url <url>` | 从自定义 URL 或本地 `file://` 路径安装。 |
 | `--sls-endpoint <url>` | SLS endpoint。 |
 | `--sls-project <name>` | SLS project。 |
@@ -90,6 +91,8 @@ Linux/macOS 安装器使用 `--kebab-case` 参数；Windows PowerShell 安装器
 | `--system-service` | **已废弃** — 忽略。Init 系统现在自动检测（systemd-user → systemd-system → init.d）。 |
 | `--prefer-system-node` | 优先使用系统已安装的 Node.js，仅当系统没有可用 node 时才下载托管运行时（默认行为是始终下载并固定托管运行时）。 |
 | `--lang <lang>` | 输出语言：`zh` 或 `en`。 |
+
+例如要使用 `9000` 端口，在 Linux/macOS 安装命令末尾加 `--dashboard-port 9000`（也支持 `--dashboard-port=9000`）；Windows 则加 `-DashboardPort 9000`。安装器会在启动服务前，将端口写入 `config.json` 的 `dashboard.port`。安装完成后访问 `http://127.0.0.1:9000/`。传入非法端口或只写参数却没有提供值时，会在下载、修改服务之前报错退出。
 
 ## 托管 Node.js 运行时
 
@@ -164,7 +167,7 @@ loongsuite-pilot token-usage
 loongsuite-pilot rollback
 ```
 
-本地 Dashboard 会随采集服务一起启动和停止，直接打开：
+本地 Dashboard 会随采集服务一起启动和停止，默认地址如下；指定了其他端口时，请替换地址中的端口：
 
 ```text
 http://127.0.0.1:8765/

--- a/tests/unit/scripts/dashboard-lifecycle.test.mjs
+++ b/tests/unit/scripts/dashboard-lifecycle.test.mjs
@@ -1,5 +1,5 @@
 import { spawn, spawnSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
@@ -251,16 +251,155 @@ describe('dashboard service lifecycle', () => {
     expect(runtimeSh).not.toContain('18765');
     expect(runtimePs1).not.toContain('18765');
   });
+});
 
-  it('public installers add the default port without overwriting an explicit port', () => {
-    for (const installer of [
-      opensourceInstallerSh,
-      opensourceInstallerPs1,
-    ]) {
-      expect(installer).toContain("if (config.dashboard.port === undefined) config.dashboard.port = 8765;");
-      expect(installer).not.toContain('config.dashboard.port = 8765;\nif (config.dashboard.port');
+describe('dashboard installer configuration', () => {
+  const bashPrelude = opensourceInstallerSh.slice(0, opensourceInstallerSh.indexOf('# Validate current user'));
+  const bashConfig = opensourceInstallerSh.slice(
+    opensourceInstallerSh.indexOf('write_config() {'),
+    opensourceInstallerSh.indexOf('install_loongsuite_pilot_command() {'),
+  );
+  const bashConfirm = opensourceInstallerSh.slice(
+    opensourceInstallerSh.indexOf('confirm_config_overwrite() {'),
+    opensourceInstallerSh.indexOf('deploy_bootstrap_scripts() {'),
+  );
+  const psPrelude = opensourceInstallerPs1.slice(0, opensourceInstallerPs1.indexOf('# Resolve package URL'));
+  const psConfig = opensourceInstallerPs1.slice(
+    opensourceInstallerPs1.indexOf('function Write-Config {'),
+    opensourceInstallerPs1.indexOf('# QoderWork-family runtime wrapper:'),
+  );
+  const psConfigJs = psConfig.match(/-e @'\r?\n([\s\S]*?)\r?\n'@ \$cfgTmp/)?.[1];
+  const powershell = process.platform === 'win32' ? 'powershell.exe' : 'pwsh';
+  const hasPowerShell = spawnSync(powershell, ['-NoProfile', '-NonInteractive', '-Command', 'exit 0']).status === 0;
+
+  // Execute the real parser/config writer only; never download, deploy, or touch services.
+  function runConfig(platform, args = [], existing) {
+    const root = mkdtempSync(resolve(tmpdir(), 'pilot-dashboard-config-'));
+    const configPath = resolve(root, 'config.json');
+    try {
+      if (existing !== undefined) writeFileSync(configPath, JSON.stringify(existing));
+      let result;
+      if (platform === 'bash') {
+        result = spawnSync('bash', ['-c', `${bashPrelude}
+msg() { :; }
+NODE_BIN="$PILOT_TEST_NODE"
+PROBE_RESULT='[]'
+${bashConfirm}
+${bashConfig}
+confirm_config_overwrite
+write_config`, 'installer-test', 'install', '--data-dir', root, ...args], {
+          encoding: 'utf8',
+          env: { ...process.env, PILOT_TEST_NODE: process.execPath },
+        });
+      } else if (platform === 'powershell') {
+        const scriptPath = resolve(root, 'installer-test.ps1');
+        writeFileSync(scriptPath, `${psPrelude}
+function Msg { }
+$script:NODE_BIN = $env:PILOT_TEST_NODE
+$script:PROBE_RESULT = '[]'
+${psConfig}
+Write-Config`);
+        result = spawnSync(powershell, ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', scriptPath,
+          'install', '-DataDir', root, ...args], {
+          encoding: 'utf8',
+          env: { ...process.env, USERPROFILE: root, TEMP: root, LOONGSUITE_PILOT_CACHE_DIR: root, PILOT_TEST_NODE: process.execPath },
+        });
+      } else {
+        expect(psConfigJs).toBeTruthy();
+        const optsPath = resolve(root, 'options.json');
+        writeFileSync(optsPath, JSON.stringify({ configPath, dataDir: root, dashboardPort: args[0] ?? '' }));
+        result = spawnSync(process.execPath, ['-e', psConfigJs, optsPath], { encoding: 'utf8' });
+      }
+      expect(result.error).toBeUndefined();
+      const config = existsSync(configPath) ? JSON.parse(readFileSync(configPath, 'utf8')) : undefined;
+      return { ...result, config };
+    } finally {
+      rmSync(root, { recursive: true, force: true });
     }
+  }
+
+  for (const platform of ['bash', 'powershell-js']) {
+    describe(platform, () => {
+      it.each([undefined, { dashboard: { extra: true } }])('defaults to 8765 without a configured port: %j', existing => {
+        const result = runConfig(platform, [], existing);
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.config.dashboard).toEqual({ ...existing?.dashboard, port: 8765 });
+      });
+
+      it('preserves an existing port and other config when the option is omitted', () => {
+        const existing = { dashboard: { port: 9010, extra: true }, logLevel: 'debug' };
+        const result = runConfig(platform, [], existing);
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.config).toMatchObject(existing);
+      });
+
+      it.each(['9000', '1', '65535', '08765'])('writes %s as a numeric port without losing other config', port => {
+        const args = platform === 'bash' ? ['--dashboard-port', port] : [port];
+        const result = runConfig(platform, args, { dashboard: { port: 9010, extra: true }, logLevel: 'debug' });
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.config).toMatchObject({ dashboard: { port: Number(port), extra: true }, logLevel: 'debug' });
+      });
+    });
+  }
+
+  it('accepts the Bash --dashboard-port=9000 form', () => {
+    const result = runConfig('bash', ['--dashboard-port=9000']);
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.config.dashboard.port).toBe(9000);
   });
+
+  it('shows a changed port in the overwrite prompt but ignores an unchanged numeric port', () => {
+    const existing = { dashboard: { port: 8765 } };
+    const changed = runConfig('bash', ['--dashboard-port', '9000'], existing);
+    expect(changed.status, changed.stderr).toBe(0);
+    expect(changed.stdout).toContain('dashboard.port: 8765 -> 9000');
+    const unchanged = runConfig('bash', ['--dashboard-port', '08765'], existing);
+    expect(unchanged.status, unchanged.stderr).toBe(0);
+    expect(unchanged.stdout).not.toContain('dashboard.port:');
+  });
+
+  it.each(['', '0', '-1', '65536', '1.5', 'abc', '0x2328', '9e3', '9000\n', '99999999999999999999', "9000';process.exit(0);//"])(
+    'rejects invalid Bash port %j before changing existing config', port => {
+      const existing = { dashboard: { port: 9010 }, logLevel: 'debug' };
+      for (const args of [['--dashboard-port', port], [`--dashboard-port=${port}`]]) {
+        const result = runConfig('bash', args, existing);
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('--dashboard-port must be an integer between 1 and 65535');
+        expect(result.config).toEqual(existing);
+      }
+    },
+  );
+
+  it.each([['--dashboard-port'], ['--dashboard-port', '--log-level', 'debug']])(
+    'rejects a missing Bash port: %j', (...args) => {
+      const result = runConfig('bash', args);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('--dashboard-port');
+      expect(result.config).toBeUndefined();
+    },
+  );
+
+  it.runIf(hasPowerShell)('parses and validates the native PowerShell option before writing config', () => {
+    const defaults = runConfig('powershell');
+    expect(defaults.status, defaults.stderr).toBe(0);
+    expect(defaults.config.dashboard.port).toBe(8765);
+    const existing = { dashboard: { port: 9010, extra: true }, logLevel: 'debug' };
+    const preserved = runConfig('powershell', [], existing);
+    expect(preserved.status, preserved.stderr).toBe(0);
+    expect(preserved.config).toMatchObject(existing);
+    for (const port of ['9000', '1', '65535', '08765']) {
+      const result = runConfig('powershell', ['-DashboardPort', port], existing);
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.config).toMatchObject({ ...existing, dashboard: { ...existing.dashboard, port: Number(port) } });
+    }
+    for (const port of [undefined, '', '0', '-1', '65536', '1.5', 'abc', '9000\n', '99999999999999999999']) {
+      const args = port === undefined ? ['-DashboardPort'] : ['-DashboardPort', port];
+      const result = runConfig('powershell', args, existing);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain('DashboardPort');
+      expect(result.config).toEqual(existing);
+    }
+  }, 30_000);
 });
 
 describe('dashboard static page', () => {

--- a/tests/unit/scripts/ps1-clm-safe.test.mjs
+++ b/tests/unit/scripts/ps1-clm-safe.test.mjs
@@ -150,6 +150,14 @@ describe('the CLM-safe rewrites stay in place', () => {
     expect(cli).not.toMatch(/Select-Object -ExcludeProperty/);
   });
 
+  it('the public installer checks bound parameters without ContainsKey', () => {
+    // installer-opensource.ps1 is still in KNOWN_CLM_UNSAFE for older violations,
+    // so pin this top-level check separately: it runs for every subcommand.
+    const installer = codeOf(readFileSync('deploy/installer-opensource.ps1', 'utf-8'));
+    expect(installer).toContain("$PSBoundParameters.Keys -contains 'DashboardPort'");
+    expect(installer).not.toMatch(/\$PSBoundParameters\.ContainsKey\(/);
+  });
+
   it('the CLI wrapper validates an absolute path with a regex, not IsPathRooted', () => {
     const cli = codeOf(readFileSync('scripts/loongsuite-pilot.ps1', 'utf-8'));
     expect(cli).not.toContain('IsPathRooted');


### PR DESCRIPTION
## Summary

- Add optional `--dashboard-port <port>` / `--dashboard-port=<port>` to the macOS/Linux installer and `-DashboardPort <port>` to the Windows installer.
- Validate decimal integer ports in the range `1–65535` before downloads or service changes, and persist the selected port to `config.json` as a number.
- Default new installations to `8765`. Preserve the configured port on reinstall unless the option is explicitly provided, and show explicit port changes in the existing overwrite confirmation.
- Update the English/Chinese installation guides and extend the existing Dashboard tests to cover defaults, overrides, preserved configuration, invalid/missing values, and both config writers.

## Validation

- `bash -n deploy/installer-opensource.sh` — passed.
- `npm run typecheck` — passed.
- `npx --no-install vitest run tests/unit/deploy tests/unit/scripts/dashboard-lifecycle.test.mjs tests/unit/core/config-loader.test.ts tests/unit/dashboard/dashboard-server.test.ts` — 36 test files passed; 729 tests passed and 39 skipped.
- `git diff --check` — passed.

The native PowerShell test is conditional and was skipped because PowerShell is not installed on the local macOS host. The JavaScript config writer embedded in the Windows installer was executed and verified. No real Windows installation or release deployment was performed.
