### PR TITLE
feat(openclaw): support AGENTTEAMS_WORKER_NAME

### DIFF
--- a/assets/plugins/openclaw/plugin.mjs
+++ b/assets/plugins/openclaw/plugin.mjs
@@ -28,6 +28,10 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import crypto from "node:crypto";
+import {
+  agentBaseFieldPatch,
+  collectResourceAttributesFromEnv,
+} from "../shared/resource-context.mjs";
 
 const AGENT_TYPE = "openclaw";
 const PLUGIN_ID = "loongsuite-pilot-openclaw";
@@ -38,6 +42,16 @@ const MAX_CONTENT_SIZE = 64 * 1024;
 const MAX_TOOL_RESULT_SIZE = 64 * 1024;
 const PILOT_CONFIG_CACHE_TTL_MS = 5_000;
 const MIN_OPENCLAW_VERSION = "2026.5.12";
+const RESOURCE_ATTRIBUTES = collectResourceAttributesFromEnv(process.env, {
+  agentId: AGENT_TYPE,
+  fieldMap: {
+    AGENTTEAMS_WORKER_NAME: "agentteams.worker.name",
+  },
+});
+const RESOURCE_BASE_FIELD_PATCH = agentBaseFieldPatch(RESOURCE_ATTRIBUTES);
+const RESOURCE_ATTRIBUTE_FIELDS = Object.keys(RESOURCE_ATTRIBUTES).length > 0
+  ? { resourceAttributes: RESOURCE_ATTRIBUTES }
+  : {};
 
 // ---------------------------------------------------------------------------
 // Caller-supplied span attributes (inlined mirror of resource-context.mjs)
@@ -498,6 +512,8 @@ function buildCommonFields(run, sessionId, userId) {
     "user.id": userId,
     ...(agentCwd ? { "agent.openclaw.cwd": agentCwd } : {}),
     ...SPAN_ATTRIBUTES,
+    ...RESOURCE_BASE_FIELD_PATCH,
+    ...RESOURCE_ATTRIBUTE_FIELDS,
   };
   if (run) {
     base.trace_id = run.traceId;

--- a/docs/zh-CN/custom-agent-identity.md
+++ b/docs/zh-CN/custom-agent-identity.md
@@ -14,8 +14,13 @@
 | MiMo Code | `mimo-code` | `mimo` |
 | Qwen Code CLI | `qwen-code-cli` | `qwen` |
 | Cursor CLI | `cursor-cli` | `cursor-agent` |
+| OpenClaw | `openclaw` | `openclaw` |
 
 Cursor Desktop 不支持这组变量。
+
+OpenClaw 当前仅支持 `AGENTTEAMS_WORKER_NAME`，暂不支持
+`AGENTTEAMS_INSTANCE_ID`。如果 OpenClaw 运行在容器中，环境变量必须注入
+OpenClaw Gateway 所在的容器和进程；修改变量后需要重启或重建容器。
 
 ## 设置环境变量
 

--- a/tests/unit/hooks/openclaw/plugin.test.mjs
+++ b/tests/unit/hooks/openclaw/plugin.test.mjs
@@ -40,8 +40,11 @@ function readJsonl(name) {
 let tmpDir;
 let pilotDataDir;
 let pluginLoadSequence = 0;
+let previousWorkerName;
 
 beforeEach(async () => {
+  previousWorkerName = process.env.AGENTTEAMS_WORKER_NAME;
+  delete process.env.AGENTTEAMS_WORKER_NAME;
   tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pilot-openclaw-'));
   pilotDataDir = path.join(tmpDir, 'pilot-data');
   fs.mkdirSync(path.join(pilotDataDir, 'logs', 'openclaw'), { recursive: true });
@@ -54,6 +57,8 @@ afterEach(async () => {
   delete process.env.LOONGSUITE_USER_ID;
   delete process.env.LOONGSUITE_PILOT_DEBUG;
   delete process.env.LOONGSUITE_PILOT_SPAN_ATTRIBUTES;
+  if (previousWorkerName === undefined) delete process.env.AGENTTEAMS_WORKER_NAME;
+  else process.env.AGENTTEAMS_WORKER_NAME = previousWorkerName;
   vi.restoreAllMocks();
   await fs.promises.rm(tmpDir, { recursive: true, force: true });
 });
@@ -285,6 +290,37 @@ describe('OpenClaw plugin stateful pipeline', () => {
       expect(record['gen_ai.session.id']).not.toBe('env-session');
       expect(record['gen_ai.agent.name']).not.toBe('blocked');
     }
+  });
+
+  it('uses AGENTTEAMS_WORKER_NAME as the agent name and Resource marker', async () => {
+    process.env.AGENTTEAMS_WORKER_NAME = ' planner ';
+    const plugin = await loadPlugin();
+    const records = await replay(plugin, readJsonl('pilot-probe-events-smoke.jsonl'));
+
+    expect(records.length).toBeGreaterThan(0);
+    for (const record of records) {
+      expect(record['gen_ai.agent.name']).toBe('planner');
+      expect(record.resourceAttributes).toEqual({
+        'agentteams.worker.name': 'planner',
+      });
+    }
+  });
+
+  it.each([
+    ['blank', '   '],
+    ['too long', 'x'.repeat(513)],
+  ])('retains the default agent name for a %s worker name', async (_label, workerName) => {
+    process.env.AGENTTEAMS_WORKER_NAME = workerName;
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const plugin = await loadPlugin();
+    const records = await replay(plugin, readJsonl('pilot-probe-events-smoke.jsonl'));
+
+    expect(records.length).toBeGreaterThan(0);
+    for (const record of records) {
+      expect(record['gen_ai.agent.name']).toBe('openclaw');
+      expect(record.resourceAttributes).toBeUndefined();
+    }
+    stderr.mockRestore();
   });
 
   it('attaches the user prompt to the first request and tool results to the next request', async () => {


### PR DESCRIPTION
## Summary

- read `AGENTTEAMS_WORKER_NAME` from the OpenClaw Gateway process environment
- use the validated value as `gen_ai.agent.name`
- project the same value as the OTLP Resource attribute `agentteams.worker.name`
- preserve the existing `openclaw` name for missing, blank, or overlong values
- document OpenClaw support and the container process/restart requirement

## Scope

This change does not modify `gen_ai.agent.id` and does not add `AGENTTEAMS_INSTANCE_ID` support for OpenClaw.

## Validation

- OpenClaw and related Resource/input/OTLP tests: 76 passed
- `npm run typecheck`: passed
- `npm run build`: passed
- full test run: 3637 passed, 56 skipped, with one unrelated Qoder cold-start concurrency test failing only under the full concurrent suite; the same test passed 7/7 when rerun independently

Closes #337