### PR TITLE
test(mask): stabilize fragmented numeric performance smoke

### DIFF
--- a/tests/unit/mask/string-masker.performance.test.ts
+++ b/tests/unit/mask/string-masker.performance.test.ts
@@ -69,6 +69,8 @@ describe('mask string masker performance smoke', () => {
 
     expect(masked.slice(0, fragmented.length)).toBe(fragmented);
     expect(masked.slice(fragmented.length)).toBe('[PHONE_MASKED]');
-    expect(elapsedMs).toBeLessThan(50);
+    // Leave headroom for shared-runner scheduling jitter while still catching
+    // an unbounded numeric-scanning regression.
+    expect(elapsedMs).toBeLessThan(100);
   });
 });


### PR DESCRIPTION
## Summary

- raise the fragmented numeric masking smoke-test limit from 50 ms to 100 ms
- document why the wall-clock check needs headroom on shared CI runners
- keep the functional masking assertions and the performance guard intact

## Why

Two separate Node.js 22 CI jobs on different shared runners measured this one-shot check at about 65 ms and failed the 50 ms limit. The same code passes on rerun, so the current limit is too close to normal runner scheduling jitter. A 100 ms limit covers the observed variance while remaining far below the 2-second smoke limits used for the larger masking scenarios.

## Validation

- Node.js 22.23.2: target test file passed 50 consecutive runs
- `npm run typecheck`
- `npm test`: 287 test files passed, 3 skipped; 3,635 tests passed, 56 skipped
- `npm run build`
- `git diff --check`
