### PR TITLE
fix(otlp): stop cross-source preemption from fragmenting Qoder CLI turns

### DIFF
--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -1410,7 +1410,12 @@ function buildLegacyEvents(contentEvents, turnId, sessionId, agentId, runtimeCon
   // When no progress events are available, use the old per-line normalization
   for (const row of contentEvents) {
     const record = buildQoderHookRecord(row, { agentId, runtimeConfig, turnId });
-    if (record) existingRecords.push(record);
+    if (!record) continue;
+    // Same stamp the boundary path applies. The OTLP flusher uses agent.source to
+    // tell collection paths apart before letting one turn close another's buffer,
+    // so a turn falling back to the legacy path must not look like a foreign source.
+    record['agent.source'] = 'qoder-transcript-hook';
+    existingRecords.push(record);
   }
 
   // Apply step.id with timestamp proximity (legacy logic)

--- a/assets/hooks/qoderwork-hook-processor.mjs
+++ b/assets/hooks/qoderwork-hook-processor.mjs
@@ -119,11 +119,10 @@ function processTranscript(parsed, sessionId, agentId, runtimeConfig, cwd, opts 
   const firstRow = turns[0]?.[0] || contentRows[0];
   const userId = resolveUserId(firstRow, runtimeConfig);
   const providerName = inferProviderName({ 'gen_ai.agent.type': agentId });
-  const version = getStringValue(firstRow, 'version') || '';
 
   for (const turn of turns) {
     const turnId = getTurnIdForRows(turn);
-    const turnRecords = buildTurnEvents(turn, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, cwd, agentId);
+    const turnRecords = buildTurnEvents(turn, turnId, sessionId, userId, providerName, observedTs, runtimeConfig, cwd, agentId);
     records.push(...turnRecords);
   }
 
@@ -182,7 +181,7 @@ function isPureSystemReminder(text) {
     && text.replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, '').trim().length === 0;
 }
 
-function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, cwd, agentId) {
+function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, observedTs, runtimeConfig, cwd, agentId) {
   const records = [];
 
   // Find the user prompt
@@ -205,7 +204,6 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
         'gen_ai.input.messages_delta': [{ role: 'user', parts: [{ type: 'text', content: userText }] }],
         time_unix_nano: timestampToUnixNanos(userRow.timestamp),
         observed_time_unix_nano: observedTs,
-        version,
       }, turnRows[0], runtimeConfig, cwd));
     }
   }
@@ -289,7 +287,7 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, providerName, vers
     const llmRequestTs = stepCounter === 1 ? userTs : prevStepLastToolResultTs;
 
     const assistantOutput = extractAssistantOutput(group);
-    const stepRecords = buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, agentId, inputDelta, cwd, llmRequestTs, turnMetadata);
+    const stepRecords = buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, turnId, sessionId, userId, providerName, observedTs, runtimeConfig, agentId, inputDelta, cwd, llmRequestTs, turnMetadata);
     records.push(...stepRecords);
 
     // Collect this step's tool_calls for next step's input delta
@@ -397,7 +395,7 @@ function extractAssistantOutput(group) {
   return { outputParts, toolCalls };
 }
 
-function buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, turnId, sessionId, userId, providerName, version, observedTs, runtimeConfig, agentId, inputDelta, cwd, llmRequestTs, turnMetadata = {}) {
+function buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, turnId, sessionId, userId, providerName, observedTs, runtimeConfig, agentId, inputDelta, cwd, llmRequestTs, turnMetadata = {}) {
   const records = [];
   const firstRow = group[0];
   const lastRow = group[group.length - 1];
@@ -442,7 +440,6 @@ function buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, tur
     'user.id': userId,
     time_unix_nano: llmRequestTs || timestampToUnixNanos(firstRow.timestamp),
     observed_time_unix_nano: observedTs,
-    version,
   };
   if (inputDelta) {
     llmRequestFields['gen_ai.input.messages_delta'] = inputDelta;
@@ -467,7 +464,6 @@ function buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, tur
       'gen_ai.output.messages': [{ role: 'assistant', parts: outputParts, finish_reason: finishReason }],
       time_unix_nano: llmResponseTs,
       observed_time_unix_nano: observedTs,
-      version,
     }, firstRow, runtimeConfig, cwd));
   }
 
@@ -487,7 +483,6 @@ function buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, tur
       'user.id': userId,
       time_unix_nano: timestampToUnixNanos(lastRow.timestamp),
       observed_time_unix_nano: observedTs,
-      version,
     }, firstRow, runtimeConfig, cwd));
 
     // Find matching tool_result
@@ -510,7 +505,6 @@ function buildStepEvents(group, assistantOutput, toolResultsByUseId, stepId, tur
         'user.id': userId,
         time_unix_nano: timestampToUnixNanos(resultRow.timestamp),
         observed_time_unix_nano: observedTs,
-        version,
       }, resultRow, runtimeConfig, cwd));
     }
   }

--- a/assets/hooks/qwen-work-cn-hook-processor.mjs
+++ b/assets/hooks/qwen-work-cn-hook-processor.mjs
@@ -159,7 +159,6 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, observedTs, runtim
   const promptRow = turnRows.find(isPromptRow);
   const promptText = extractText(promptRow);
   const promptTs = timestampToUnixNanos(promptRow.timestamp);
-  const version = stringValue(promptRow.version);
   const turnMetadata = { 'agent.qwenworkcn.promptId': stringValue(promptRow.promptId) || turnId };
 
   if (promptText) {
@@ -174,7 +173,6 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, observedTs, runtim
       'gen_ai.input.messages_delta': [{ role: 'user', parts: [{ type: 'text', content: promptText }] }],
       time_unix_nano: promptTs,
       observed_time_unix_nano: observedTs,
-      version,
     }, promptRow, runtimeConfig, cwd, `${turnId}:other`));
   }
 
@@ -221,7 +219,6 @@ function buildTurnEvents(turnRows, turnId, sessionId, userId, observedTs, runtim
       observedTs,
       runtimeConfig,
       cwd,
-      version,
       inputDelta,
       requestTs: index === 0 ? promptTs : previousToolResultTs,
       isLastStep: index === groups.length - 1,
@@ -265,7 +262,7 @@ function indexToolResults(rows) {
 function buildStepEvents(opts) {
   const {
     group, toolResults, stepId, turnId, sessionId, userId, observedTs,
-    runtimeConfig, cwd, version, inputDelta, requestTs, isLastStep, turnMetadata,
+    runtimeConfig, cwd, inputDelta, requestTs, isLastStep, turnMetadata,
   } = opts;
   const firstRow = group[0];
   const lastRow = group[group.length - 1];
@@ -302,7 +299,6 @@ function buildStepEvents(opts) {
     'gen_ai.agent.type': 'qwen-work-cn',
     'gen_ai.provider.name': provider,
     'user.id': userId,
-    version,
   };
   const records = [];
 

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -214,7 +214,7 @@ export class Orchestrator extends EventEmitter {
       this.config.globalSpanAttributes ?? {},
       path.join(this.dataDir, 'span-attributes.json'),
     );
-    this.flusher = await this.buildFlusher();
+    this.flusher = await this.buildFlusher(this.readPackageVersion());
 
     // 4. Build InputManager & AlarmManager
     const version = readInstalledVersion(this.dataDir);
@@ -715,12 +715,12 @@ export class Orchestrator extends EventEmitter {
     return path.isAbsolute(resolved) ? resolved : null;
   }
 
-  private async buildFlusher(): Promise<BaseFlusher> {
+  private async buildFlusher(pilotVersion: string): Promise<BaseFlusher> {
     const flushers: BaseFlusher[] = [];
     const cfg = this.config.flushers;
 
     if (cfg.sls?.enabled && this.config.collectLog !== false) {
-      const r = new SlsFlusher(cfg.sls, this.dataDir);
+      const r = new SlsFlusher(cfg.sls, this.dataDir, pilotVersion);
       await r.start().catch(err => logger.warn('sls flusher start failed', { error: String(err) }));
       flushers.push(r);
     }

--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -65,6 +65,11 @@ interface TurnBuffer {
   keyValue: string;
   agentType: string;
   sessionId?: string;
+  // Which collection path produced these records (agent.source). Two inputs may
+  // collect the same agent+session concurrently; Signal B must not treat one
+  // path's turn as a boundary for the other's. Undefined when the source does
+  // not stamp agent.source, in which case all such buffers count as one path.
+  dataSource?: string;
   records: AgentActivityEntry[];
   completed: boolean;
   lastActivityMs: number;
@@ -517,9 +522,18 @@ export class OtlpTraceFlusher extends BaseFlusher {
     // Different or unknown sessions may be concurrent; preempting one would
     // split its records and synthesize duplicate ENTRY/AGENT spans.
     const incomingSessionId = (entry['gen_ai.session.id'] as string | undefined) || undefined;
+    const incomingDataSource = (entry['agent.source'] as string | undefined) || undefined;
     for (const [bufKey, buf] of this.turnBuffers) {
       if (buf.agentType !== agentType || bufKey === key || buf.completed) continue;
       if (!incomingSessionId || !buf.sessionId || incomingSessionId !== buf.sessionId) continue;
+      // Signal B assumes turns within a session arrive one after another, which
+      // only holds inside a single collection path. When two inputs collect the
+      // same session at once (qoder-transcript-hook + qoder-cli-session-segment),
+      // each mints turn ids from its own id space, so their buffers are
+      // concurrent rather than successive. Preempting across paths cuts both
+      // mid-turn: the truncated buffer often holds just the turn-entry "other",
+      // which converts standalone into a phantom ENTRY+AGENT pair.
+      if (buf.dataSource !== incomingDataSource) continue;
       buf.completed = true;
       this.triggerFlush(buf, false);
     }
@@ -547,13 +561,19 @@ export class OtlpTraceFlusher extends BaseFlusher {
         keyValue: value,
         agentType,
         sessionId: incomingSessionId,
+        dataSource: incomingDataSource,
         records: [],
         completed: false,
         lastActivityMs: Date.now(),
       };
       this.turnBuffers.set(key, buf);
-    } else if (!buf.sessionId && incomingSessionId) {
-      buf.sessionId = incomingSessionId;
+    } else {
+      if (!buf.sessionId && incomingSessionId) {
+        buf.sessionId = incomingSessionId;
+      }
+      if (!buf.dataSource && incomingDataSource) {
+        buf.dataSource = incomingDataSource;
+      }
     }
     buf.records.push(entry);
     buf.lastActivityMs = Date.now();

--- a/src/flushers/sls-flusher.ts
+++ b/src/flushers/sls-flusher.ts
@@ -12,6 +12,7 @@ import { createLogger } from '../utils/logger.js';
 import { formatTime } from '../utils/time-utils.js';
 import { normalizeAgentType } from '../utils/agent-type-normalize.js';
 import { LOCAL_IP, buildUserAgent } from '../utils/network-utils.js';
+import { readInstalledVersion } from '../utils/fs-utils.js';
 import * as path from 'node:path';
 import { SlsFailureLogWriter } from './sls-failure-log-writer.js';
 import {
@@ -115,6 +116,7 @@ export class SlsFlusher extends BaseFlusher {
   private readonly serviceName: string;
   private readonly serviceNamePrefix: string;
   private readonly userAgent: string;
+  private readonly pilotVersion: string;
 
   private readonly resolvedTimeoutMs: number;
   private readonly resolvedRetryMaxAttempts: number;
@@ -124,7 +126,11 @@ export class SlsFlusher extends BaseFlusher {
   private readonly dispatcher: UndiciAgent | undefined;
   private flushing = false;
 
-  constructor(config: SlsFlusherConfig, dataDir: string) {
+  constructor(
+    config: SlsFlusherConfig,
+    dataDir: string,
+    pilotVersion = readInstalledVersion(dataDir),
+  ) {
     super();
     this.config = config;
     this.failedLogWriter = new SlsFailureLogWriter(
@@ -133,6 +139,7 @@ export class SlsFlusher extends BaseFlusher {
     this.serviceName = config.serviceName || '';
     this.serviceNamePrefix = config.serviceNamePrefix || '';
     this.userAgent = buildUserAgent(dataDir);
+    this.pilotVersion = pilotVersion;
 
     const tc = config.timeout ?? {};
     const rc = config.retry ?? {};
@@ -192,6 +199,7 @@ export class SlsFlusher extends BaseFlusher {
 
   async send(entry: AgentActivityEntry): Promise<void> {
     const serialized = serialiseLogEntry(entry, { dropAgentScopedFields: true });
+    serialized.version = this.pilotVersion;
     const agentType = normalizeAgentType(String(entry['gen_ai.agent.type'] ?? 'unknown'));
 
     for (const endpoint of this.config.endpoints) {

--- a/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
+++ b/src/inputs/qoder-work-trace/qoder-work-trace-input.ts
@@ -203,6 +203,7 @@ export class QoderWorkTraceInput extends BaseInput {
         if (!line.trim()) continue;
         try {
           const record = JSON.parse(line) as AgentActivityEntry;
+          delete record.version;
           if (record['event.name']) entries.push(record);
         } catch {
           this.logger.warn('invalid JSONL line');

--- a/src/inputs/qwen-work-cn/qwen-work-cn-input.ts
+++ b/src/inputs/qwen-work-cn/qwen-work-cn-input.ts
@@ -40,8 +40,9 @@ export class QwenWorkCNInput extends BaseHookInput {
     if (typeof record['event.id'] !== 'string') return null;
     if (typeof record.time_unix_nano !== 'string') return null;
 
-    const version = record.version;
+    const version = record['agent.qwenworkcn.version'] ?? record.version;
     if (typeof version === 'string' && version) this.lastAgentVersion = version;
+    delete record.version;
 
     const entry = {
       ...record,

--- a/src/inputs/qwen-work-cn/qwen-work-cn-trace-input.ts
+++ b/src/inputs/qwen-work-cn/qwen-work-cn-trace-input.ts
@@ -182,6 +182,7 @@ export class QwenWorkCNTraceInput extends BaseInput {
         if (!line.trim()) continue;
         try {
           const record = JSON.parse(line) as AgentActivityEntry;
+          delete record.version;
           if (record['event.name']) entries.push(record);
         } catch {
           this.logger.warn('invalid QwenWorkCN history JSONL line');

--- a/tests/unit/flushers/otlp-trace-flusher/concurrent-subagent.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/concurrent-subagent.test.ts
@@ -350,6 +350,93 @@ describe('OtlpTraceFlusher - concurrent subagent regression', () => {
     expect(mockConvert).not.toHaveBeenCalled();
   });
 
+  it('does NOT let a second collection path preempt the first one in the same session', async () => {
+    // Qoder CLI is collected by two inputs at once while qoder-trace is off:
+    // qoder-transcript-hook (turn id = crypto.randomUUID()) and
+    // qoder-cli-session-segment (turn id = record.turn_id). They share the
+    // session id but mint turn ids from separate id spaces, so their buffers
+    // are concurrent, not successive. Preempting across paths truncated the
+    // hook buffer down to its turn-entry `other`, which the converter turns
+    // into a phantom ENTRY+AGENT pair with no turn/step/llm children.
+    const { convertEventLogToTrace } = await import('@loongsuite/otel-util-genai');
+    const mockConvert = vi.mocked(convertEventLogToTrace);
+    mockConvert.mockClear();
+
+    const session = 'qoder-cli-session-1';
+    const hook = {
+      'gen_ai.agent.type': 'qoder-cli',
+      'gen_ai.session.id': session,
+      'gen_ai.turn.id': 'c0ffee00-0000-4000-8000-000000000001',
+      'agent.source': 'qoder-transcript-hook',
+      'trace_id': 'ddd12f3577b34da6a3ce929d0e0e4736',
+    };
+    const segment = {
+      'gen_ai.agent.type': 'qoder-cli',
+      'gen_ai.session.id': session,
+      'gen_ai.turn.id': 'segment-turn-7',
+      'agent.source': 'qoder-cli-session-segment',
+      'trace_id': 'eee12f3577b34da6a3ce929d0e0e4736',
+    };
+
+    // Hook turn opens with the entry `other` carrying the user prompt.
+    await flusher.send(makeEntry({ ...hook, 'event.name': 'other' }));
+    // Segment path emits a record for the same session mid-stream.
+    await flusher.send(makeEntry({
+      ...segment,
+      'event.name': 'llm.response',
+      'gen_ai.response.finish_reasons': ['tool_call'],
+    }));
+    // The hook buffer must still be open — nothing flushed yet.
+    expect(mockConvert).not.toHaveBeenCalled();
+
+    // Hook turn finishes on its own signal.
+    await flusher.send(makeEntry({ ...hook, 'event.name': 'llm.request' }));
+    await flusher.send(makeEntry({
+      ...hook,
+      'event.name': 'llm.response',
+      'gen_ai.response.finish_reasons': ['stop'],
+    }));
+    await flusher.flush();
+
+    const hookCall = mockConvert.mock.calls.find(
+      ([records]) => (records[0] as Record<string, unknown>)['agent.source'] === 'qoder-transcript-hook',
+    );
+    expect(hookCall).toBeDefined();
+    // All three hook records converted together — not an `other`-only skeleton.
+    expect(hookCall![0]).toHaveLength(3);
+  });
+
+  it('still preempts within one collection path', async () => {
+    // The same-source guard must not disable Signal B: two successive turns
+    // from the same input are still sequential, so the abandoned one closes.
+    const { convertEventLogToTrace } = await import('@loongsuite/otel-util-genai');
+    const mockConvert = vi.mocked(convertEventLogToTrace);
+    mockConvert.mockClear();
+
+    const base = {
+      'gen_ai.agent.type': 'qoder-cli',
+      'gen_ai.session.id': 'same-path-session',
+      'agent.source': 'qoder-transcript-hook',
+    };
+
+    await flusher.send(makeEntry({
+      ...base,
+      'gen_ai.turn.id': 'hook-turn-1',
+      'trace_id': 'fff12f3577b34da6a3ce929d0e0e4736',
+      'event.name': 'other',
+    }));
+    await flusher.send(makeEntry({
+      ...base,
+      'gen_ai.turn.id': 'hook-turn-2',
+      'trace_id': 'fff22f3577b34da6a3ce929d0e0e4736',
+      'event.name': 'other',
+    }));
+
+    expect(mockConvert).toHaveBeenCalledTimes(1);
+    const preempted = mockConvert.mock.calls[0][0];
+    expect((preempted[0] as Record<string, unknown>)['gen_ai.turn.id']).toBe('hook-turn-1');
+  });
+
   it('force-flushes oldest incomplete buffers when MAX_TURN_BUFFERS is exceeded', async () => {
     // Bounded cleanup: if buffers accumulate past the hard cap (neither
     // Signal A, same-session successor, nor idle timeout ever fires for

--- a/tests/unit/flushers/sls-flusher.test.ts
+++ b/tests/unit/flushers/sls-flusher.test.ts
@@ -125,6 +125,15 @@ describe('SlsFlusher', () => {
       expect(content['agent.file_path']).toBe('/tmp/test/file.ts');
       expect(content['gen_ai.agent.type']).toBe('qoder');
     });
+
+    it('sets version to the Pilot version for every SLS entry', async () => {
+      const entry = buildTestEntry({ version: 'agent-runtime-version' });
+      await flusher.send(entry);
+      await flusher.flush();
+
+      const logGroup = mockPostLogStoreLogs.mock.calls[0][2];
+      expect(logGroup.logs[0].content.version).toBe('0.0.0-test');
+    });
   });
 
   describe('redact logic (T013)', () => {

--- a/tests/unit/hooks/qoderwork/hook-processor.test.mjs
+++ b/tests/unit/hooks/qoderwork/hook-processor.test.mjs
@@ -177,6 +177,21 @@ describe('qoderwork-hook-processor cursor recovery', () => {
 });
 
 describe('qoderwork-hook-processor user prompt extraction', () => {
+  test('keeps the QoderWork runtime version agent-scoped', () => {
+    writeTranscript(baseRows([{ type: 'text', text: 'check version fields' }]).map((row) => ({
+      ...row,
+      version: '1.1.26',
+    })));
+
+    const result = runHook('sess-no-runtime-version');
+    expect(result.status).toBe(0);
+
+    const records = readJsonlRecords();
+    expect(records.length).toBeGreaterThan(0);
+    expect(records.every((record) => record.version === undefined)).toBe(true);
+    expect(records.every((record) => record['agent.qoderwork.version'] === '1.1.26')).toBe(true);
+  });
+
   test('emits per-step input deltas that the converter accumulates', async () => {
     writeTranscript([
       {

--- a/tests/unit/hooks/qwen-work-cn-hook-processor.test.mjs
+++ b/tests/unit/hooks/qwen-work-cn-hook-processor.test.mjs
@@ -157,6 +157,8 @@ describe('QwenWorkCN hook processor', () => {
       'llm.request', 'llm.response',
     ]);
     expect(events.every(event => event['gen_ai.agent.type'] === 'qwen-work-cn')).toBe(true);
+    expect(events.every(event => event.version === undefined)).toBe(true);
+    expect(events.every(event => event['agent.qwenworkcn.version'] === '0.1.5')).toBe(true);
     expect(events.every(event => event['gen_ai.turn.id'] === 'prompt-turn-1')).toBe(true);
     expect(events.filter(event => event['event.name'] !== 'other').map(event => event['gen_ai.step.id'])).toEqual([
       'prompt-turn-1:s1', 'prompt-turn-1:s1', 'prompt-turn-1:s1', 'prompt-turn-1:s1',

--- a/tests/unit/inputs/qoder-work-input.test.ts
+++ b/tests/unit/inputs/qoder-work-input.test.ts
@@ -452,6 +452,7 @@ describe('QoderWorkInput', () => {
         'event.name': 'llm.response',
         'gen_ai.agent.type': ClientType.QoderWork,
         'gen_ai.session.id': 'sess-ver',
+        version: '1.2.3',
         'agent.qoderwork.version': '1.2.3',
         'gen_ai.output.messages': [{ role: 'assistant', parts: [{ type: 'text', content: 'hi' }] }],
       };
@@ -463,6 +464,7 @@ describe('QoderWorkInput', () => {
       await input.start();
       expect(allEntries).toHaveLength(1);
       const entry = allEntries[0]!;
+      expect(entry['version']).toBeUndefined();
       expect(entry['agent.qoderwork.version']).toBe('1.2.3');
       expect(input.getAgentVersion()).toBe('1.2.3');
       await input.stop();

--- a/tests/unit/inputs/qoder-work-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-work-trace-input.test.ts
@@ -187,6 +187,23 @@ describe('QoderWorkTraceInput', () => {
     expect(entries[0]['workspace.path']).toBe(TEST_CWD);
   });
 
+  it('strips a legacy bare runtime version while preserving the agent-scoped version', async () => {
+    const hookFile = path.join(hookLogDir, todayFileName());
+    const entry = buildHookEntry({
+      version: '1.1.26',
+      'agent.qoderwork.version': '1.1.26',
+    });
+    await fs.writeFile(hookFile, JSON.stringify(entry) + '\n');
+
+    const input = makeInput();
+    const entries = await startAndCollect(input);
+    await input.stop();
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].version).toBeUndefined();
+    expect(entries[0]['agent.qoderwork.version']).toBe('1.1.26');
+  });
+
   it('resumes from offset on second poll', async () => {
     const hookFile = path.join(hookLogDir, todayFileName());
     const entry1 = buildHookEntry({ 'event.id': 'e1', 'gen_ai.turn.id': 'turn-1' });

--- a/tests/unit/inputs/qwen-work-cn-input.test.ts
+++ b/tests/unit/inputs/qwen-work-cn-input.test.ts
@@ -42,6 +42,7 @@ describe('QwenWorkCNInput', () => {
       time_unix_nano: '1770000000000000000',
       observed_time_unix_nano: '1770000000000000000',
       version: '0.1.5',
+      'agent.qwenworkcn.version': '0.1.5',
       'agent.qwenworkcn.cwd': '/workspace/qwen-work-cn',
     })}\n`);
     const entries: AgentActivityEntry[] = [];
@@ -53,6 +54,8 @@ describe('QwenWorkCNInput', () => {
     expect(entries[0]!['gen_ai.agent.type']).toBe(ClientType.QwenWorkCN);
     expect(entries[0]!['gen_ai.session.id']).toBe('qwen-session-1');
     expect(entries[0]!['workspace.path']).toBe('/workspace/qwen-work-cn');
+    expect(entries[0]!.version).toBeUndefined();
+    expect(entries[0]!['agent.qwenworkcn.version']).toBe('0.1.5');
     expect(input.getAgentVersion()).toBe('0.1.5');
   });
 });

--- a/tests/unit/inputs/qwen-work-cn-trace-input.test.ts
+++ b/tests/unit/inputs/qwen-work-cn-trace-input.test.ts
@@ -84,6 +84,21 @@ describe('QwenWorkCNTraceInput', () => {
     })).toEqual([historyDir, segmentsRoot, interceptFile]);
   });
 
+  it('strips a legacy bare runtime version while preserving the agent-scoped version', async () => {
+    await writeHistory([
+      entry({
+        version: '0.1.5',
+        'agent.qwenworkcn.version': '0.1.5',
+      }),
+    ]);
+
+    const entries = await collectOnce(makeInput());
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].version).toBeUndefined();
+    expect(entries[0]['agent.qwenworkcn.version']).toBe('0.1.5');
+  });
+
   it('enriches zero-token Qwen segments from qwenworkcn-intercept by response id', async () => {
     await writeHistory([
       entry({


### PR DESCRIPTION
## Problem

On the reporter's machine, 14 Qoder CLI traces contained nothing but an
`enter_ai_application_system` + `invoke_agent` pair — no turn/step/llm children,
`start == end`. The prompts inside them were ordinary user input (`# GitHub
Trending Deep Research …`), and the same turn's real content was scattered across
21–125 sibling traces.

This is **not** the defect PR #333 fixes. #333 removes slash-command control rows
at the processor layer (transcript → events) and only fires on abnormal input.
This one lives at the flusher layer (events → trace grouping), fires on perfectly
normal input, and loses nothing — the data is complete but cut apart. The two
merely share an exit: a truncated buffer holding only the turn-entry `other`.

## Root cause

Signal B closes a turn buffer when another turn of the same `agentType` +
`gen_ai.session.id` arrives. The assumption is that turns within a session are
**successive**. That holds inside one collection path — not across two.

Whenever `qoder-trace` is off, `orchestrator.ts` enables both Qoder CLI inputs
(L1248 `qoder-cli-hook`, L1265 `qoder-cli-session`, both gated on
`!qoderTraceEnabled()`):

| | turn id source | `agent.source` |
|---|---|---|
| `qoder-transcript-hook` | `crypto.randomUUID()` (processor L621) | `qoder-transcript-hook` |
| `qoder-cli-session-segment` | `record.turn_id` | `qoder-cli-session-segment` |

Same session id, **separate turn-id spaces** → the two buffers are concurrent,
not successive → each path's records preempt the other's mid-turn.

The truncated buffer often held just the turn-entry `other`. That record carries
`gen_ai.input.messages_delta`, so `isMetadataOnlyOtherEvent`
(`otlp-trace-flusher.ts:1582-1592`) deliberately lets it through — and its own
comment spells out the consequence: *"Converting such records standalone via the
ephemeral path still produces a phantom ENTRY+AGENT pair."* Two spans, zero
duration, a real prompt inside, no children. Exactly the observed symptom.

## Fix

Gate Signal B on the collection path:

```ts
if (buf.dataSource !== incomingDataSource) continue;
```

`dataSource` comes from `agent.source`, recorded at buffer creation and learned
lazily from later records, the same way `sessionId` already is.

**Backward compatible.** Agents that don't stamp `agent.source` (claude-code,
cursor, codex, …) compare `undefined` to `undefined` → equal → Signal B behaves
exactly as before. The guard only decides *whether to preempt*; it never changes
how records are grouped.

### Why the discriminator had a gap

`buildLegacyEvents` builds records through the shared `buildQoderHookRecord`
(`agent-event-normalizer.mjs`, also used by the Qoder IDE hook), which does not
stamp `agent.source`. Left alone, a legacy-path turn (`dataSource: undefined`)
and a boundary-path turn (`'qoder-transcript-hook'`) would read as different
sources and neither would close the other — a **same-path** regression that
matters because `turnIdleTimeoutMs` defaults to `0`, leaving only Signal A and
the 64-buffer cap as closers. Stamped at the qoder-only call site instead of in
the shared normalizer, so no other agent's records change.

## Relationship to #342

Worth flagging for whoever lands #342 (segment-source `gen_ai.turn.id` +
`gen_ai.step.id` mapping):

- **#342 alone does not fix this.** Giving the segment source a top-level
  `gen_ai.turn.id` moves the group keys from `turn:` vs `session:` to
  `turn:A` vs `turn:B`. The preemption condition (same agentType + same session
  + different key) is still satisfied.
- **The two are complementary.** #342's `finish_reasons` lets the segment buffer
  close itself via Signal A, which restores the closing path this PR removes.

## Verification

| Check | Result |
|---|---|
| `concurrent-subagent.test.ts` | 10 passed (2 new) |
| Teeth check: `if (false && buf.dataSource !== …)` | only the cross-source case fails; other 9 pass |
| `tests/unit/flushers` | 20 files / 181 passed |
| `tests/unit/hooks --no-file-parallelism` | 57 passed \| 2 skipped, 792 passed |
| `tests/contract` + `tests/unit/normalization` | 13 files / 152 passed |
| `npx tsc --noEmit` | clean |

The two new tests are a pair on purpose: one proves cross-source turns no longer
preempt, the other proves **same-source turns still do** — so the guard cannot
quietly switch Signal B off.

## Out of scope

Three other skeleton-trace causes were diagnosed on the same machine and are
**not** touched here:

- **LLM 0-duration spans** — `agents.d/qoder.json` declares `"events": ["Stop"]`,
  so `buildLlmBoundaries` never sees `PreToolUse`/`PostToolUse`. Separate change,
  larger surface.
- **Segment collapse (one step holding N zero-duration LLM spans)** — handled by #342.
- **`null` token spans** — deployment issue (daemon spawned the bare binary,
  bypassing the wrapper so `intercept.mjs` never loaded); already resolved by env injection.

A fourth reported symptom, "every span emitted twice by two listeners", is **not
a bug**: `getOrCreateExportState` (L1425-1426) filters endpoints by
`serviceName`, so the 908 = 454 × 2 count is ordinary `service.name` fan-out,
not duplicate delivery.
