### PR TITLE
fix(otlp): stop cross-source preemption from fragmenting Qoder CLI turns

### DIFF
--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -1468,7 +1468,12 @@ function buildLegacyEvents(contentEvents, turnId, sessionId, agentId, runtimeCon
   // When no progress events are available, use the old per-line normalization
   for (const row of contentEvents) {
     const record = buildQoderHookRecord(row, { agentId, runtimeConfig, turnId });
-    if (record) existingRecords.push(record);
+    if (!record) continue;
+    // Same stamp the boundary path applies. The OTLP flusher uses agent.source to
+    // tell collection paths apart before letting one turn close another's buffer,
+    // so a turn falling back to the legacy path must not look like a foreign source.
+    record['agent.source'] = 'qoder-transcript-hook';
+    existingRecords.push(record);
   }
 
   // Apply step.id with timestamp proximity (legacy logic)

--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -65,6 +65,11 @@ interface TurnBuffer {
   keyValue: string;
   agentType: string;
   sessionId?: string;
+  // Which collection path produced these records (agent.source). Two inputs may
+  // collect the same agent+session concurrently; Signal B must not treat one
+  // path's turn as a boundary for the other's. Undefined when the source does
+  // not stamp agent.source, in which case all such buffers count as one path.
+  dataSource?: string;
   records: AgentActivityEntry[];
   completed: boolean;
   lastActivityMs: number;
@@ -517,9 +522,18 @@ export class OtlpTraceFlusher extends BaseFlusher {
     // Different or unknown sessions may be concurrent; preempting one would
     // split its records and synthesize duplicate ENTRY/AGENT spans.
     const incomingSessionId = (entry['gen_ai.session.id'] as string | undefined) || undefined;
+    const incomingDataSource = (entry['agent.source'] as string | undefined) || undefined;
     for (const [bufKey, buf] of this.turnBuffers) {
       if (buf.agentType !== agentType || bufKey === key || buf.completed) continue;
       if (!incomingSessionId || !buf.sessionId || incomingSessionId !== buf.sessionId) continue;
+      // Signal B assumes turns within a session arrive one after another, which
+      // only holds inside a single collection path. When two inputs collect the
+      // same session at once (qoder-transcript-hook + qoder-cli-session-segment),
+      // each mints turn ids from its own id space, so their buffers are
+      // concurrent rather than successive. Preempting across paths cuts both
+      // mid-turn: the truncated buffer often holds just the turn-entry "other",
+      // which converts standalone into a phantom ENTRY+AGENT pair.
+      if (buf.dataSource !== incomingDataSource) continue;
       buf.completed = true;
       this.triggerFlush(buf, false);
     }
@@ -547,13 +561,19 @@ export class OtlpTraceFlusher extends BaseFlusher {
         keyValue: value,
         agentType,
         sessionId: incomingSessionId,
+        dataSource: incomingDataSource,
         records: [],
         completed: false,
         lastActivityMs: Date.now(),
       };
       this.turnBuffers.set(key, buf);
-    } else if (!buf.sessionId && incomingSessionId) {
-      buf.sessionId = incomingSessionId;
+    } else {
+      if (!buf.sessionId && incomingSessionId) {
+        buf.sessionId = incomingSessionId;
+      }
+      if (!buf.dataSource && incomingDataSource) {
+        buf.dataSource = incomingDataSource;
+      }
     }
     buf.records.push(entry);
     buf.lastActivityMs = Date.now();

--- a/tests/unit/flushers/otlp-trace-flusher/concurrent-subagent.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/concurrent-subagent.test.ts
@@ -350,37 +350,58 @@ describe('OtlpTraceFlusher - concurrent subagent regression', () => {
     expect(mockConvert).not.toHaveBeenCalled();
   });
 
-  it('does NOT let a second collection path preempt the first one in the same session', async () => {
-    // Qoder CLI is collected by two inputs at once while qoder-trace is off:
-    // qoder-transcript-hook (turn id = crypto.randomUUID()) and
-    // qoder-cli-session-segment (turn id = record.turn_id). They share the
-    // session id but mint turn ids from separate id spaces, so their buffers
-    // are concurrent, not successive. Preempting across paths truncated the
-    // hook buffer down to its turn-entry `other`, which the converter turns
-    // into a phantom ENTRY+AGENT pair with no turn/step/llm children.
+  // Qoder CLI is collected by two inputs at once while qoder-trace is off:
+  // qoder-transcript-hook (turn id = crypto.randomUUID()) and
+  // qoder-cli-session-segment (turn id = record.turn_id). They share the
+  // session id but mint turn ids from separate id spaces, so their buffers
+  // are concurrent, not successive. Preempting across paths truncated the
+  // hook buffer down to its turn-entry `other`, which the converter turns
+  // into a phantom ENTRY+AGENT pair with no turn/step/llm children.
+  //
+  // The two paths group under different key shapes, and that shape changes with
+  // #342, so both are covered below: Signal B walks every buffer of the same
+  // agent+session regardless of key shape, and the guard must hold either way.
+  const QODER_SESSION = 'qoder-cli-session-1';
+  const QODER_HOOK = {
+    'gen_ai.agent.type': 'qoder-cli',
+    'gen_ai.session.id': QODER_SESSION,
+    'gen_ai.turn.id': 'c0ffee00-0000-4000-8000-000000000001',
+    'agent.source': 'qoder-transcript-hook',
+    // The hook processor writes no trace_id, so turn.id decides the key.
+    'trace_id': undefined,
+  };
+
+  function findCall(
+    mockConvert: { mock: { calls: unknown[][] } },
+    source: string,
+  ): Record<string, unknown>[] | undefined {
+    const call = mockConvert.mock.calls.find(
+      (args) => ((args[0] as Record<string, unknown>[])[0])['agent.source'] === source,
+    );
+    return call?.[0] as Record<string, unknown>[] | undefined;
+  }
+
+  it('does NOT let the session-keyed segment path preempt the hook path in the same session', async () => {
+    // Production shape on this branch: qoder-cli-session-segment stamps neither
+    // gen_ai.turn.id nor trace_id — no input writes trace_id for Qoder CLI and
+    // upstreamLink is off by default — so its records fall through
+    // resolveGroupKey to `session:<sid>` while the hook path uses `turn:<uuid>`.
+    // This is the shape CI must cover until #342 lands.
     const { convertEventLogToTrace } = await import('@loongsuite/otel-util-genai');
     const mockConvert = vi.mocked(convertEventLogToTrace);
     mockConvert.mockClear();
 
-    const session = 'qoder-cli-session-1';
-    const hook = {
-      'gen_ai.agent.type': 'qoder-cli',
-      'gen_ai.session.id': session,
-      'gen_ai.turn.id': 'c0ffee00-0000-4000-8000-000000000001',
-      'agent.source': 'qoder-transcript-hook',
-      'trace_id': 'ddd12f3577b34da6a3ce929d0e0e4736',
-    };
     const segment = {
       'gen_ai.agent.type': 'qoder-cli',
-      'gen_ai.session.id': session,
-      'gen_ai.turn.id': 'segment-turn-7',
+      'gen_ai.session.id': QODER_SESSION,
       'agent.source': 'qoder-cli-session-segment',
-      'trace_id': 'eee12f3577b34da6a3ce929d0e0e4736',
+      'trace_id': undefined,
     };
 
     // Hook turn opens with the entry `other` carrying the user prompt.
-    await flusher.send(makeEntry({ ...hook, 'event.name': 'other' }));
-    // Segment path emits a record for the same session mid-stream.
+    await flusher.send(makeEntry({ ...QODER_HOOK, 'event.name': 'other' }));
+    // Segment path emits a record for the same session mid-stream. `tool_call`
+    // is not in TERMINAL_FINISH_REASONS, so Signal A does not fire here.
     await flusher.send(makeEntry({
       ...segment,
       'event.name': 'llm.response',
@@ -389,21 +410,122 @@ describe('OtlpTraceFlusher - concurrent subagent regression', () => {
     // The hook buffer must still be open — nothing flushed yet.
     expect(mockConvert).not.toHaveBeenCalled();
 
+    // The segment buffer really is session-keyed, and on this branch it has no
+    // closer of its own: no terminal finish reason (that is what #342 supplies)
+    // and turnIdleTimeoutMs defaults to 0, leaving only the 64-buffer cap and
+    // shutdown. Read through the internal map because no public API exposes a
+    // buffer's key or completion state, and because triggerFlush deletes the
+    // buffer synchronously — so this observation cannot race the async export.
+    const buffers = (flusher as unknown as {
+      turnBuffers: Map<string, { completed: boolean }>;
+    }).turnBuffers;
+    expect([...buffers.keys()]).toContain(`session:${QODER_SESSION}`);
+    expect(buffers.get(`session:${QODER_SESSION}`)!.completed).toBe(false);
+
     // Hook turn finishes on its own signal.
-    await flusher.send(makeEntry({ ...hook, 'event.name': 'llm.request' }));
+    await flusher.send(makeEntry({ ...QODER_HOOK, 'event.name': 'llm.request' }));
     await flusher.send(makeEntry({
-      ...hook,
+      ...QODER_HOOK,
       'event.name': 'llm.response',
       'gen_ai.response.finish_reasons': ['stop'],
     }));
     await flusher.flush();
 
-    const hookCall = mockConvert.mock.calls.find(
-      ([records]) => (records[0] as Record<string, unknown>)['agent.source'] === 'qoder-transcript-hook',
-    );
-    expect(hookCall).toBeDefined();
     // All three hook records converted together — not an `other`-only skeleton.
-    expect(hookCall![0]).toHaveLength(3);
+    const hookRecords = findCall(mockConvert, 'qoder-transcript-hook');
+    expect(hookRecords).toBeDefined();
+    expect(hookRecords).toHaveLength(3);
+    // And the segment payload is intact rather than dropped: the guard prevents
+    // preemption, it does not discard the other path's records.
+    const segmentRecords = findCall(mockConvert, 'qoder-cli-session-segment');
+    expect(segmentRecords).toBeDefined();
+    expect(segmentRecords).toHaveLength(1);
+  });
+
+  it('does NOT let the turn-keyed segment path preempt the hook path once #342 lands', async () => {
+    // After #342 the segment input lifts turn_id and finish_reasons to
+    // top-level fields, so its records group under `turn:<record.turn_id>` and
+    // close on Signal A. This PR merges after #342, so that is the shape
+    // production will actually run — the guard has to hold there too, and the
+    // two turn ids still come from unrelated id spaces.
+    const { convertEventLogToTrace } = await import('@loongsuite/otel-util-genai');
+    const mockConvert = vi.mocked(convertEventLogToTrace);
+    mockConvert.mockClear();
+
+    const segment = {
+      'gen_ai.agent.type': 'qoder-cli',
+      'gen_ai.session.id': QODER_SESSION,
+      'gen_ai.turn.id': 'segment-turn-7',
+      'agent.source': 'qoder-cli-session-segment',
+      'trace_id': undefined,
+    };
+
+    await flusher.send(makeEntry({ ...QODER_HOOK, 'event.name': 'other' }));
+    await flusher.send(makeEntry({
+      ...segment,
+      'event.name': 'llm.request',
+    }));
+    await flusher.send(makeEntry({ ...QODER_HOOK, 'event.name': 'llm.request' }));
+    expect(mockConvert).not.toHaveBeenCalled();
+
+    // Each path now closes on its own Signal A, in interleaved order.
+    await flusher.send(makeEntry({
+      ...segment,
+      'event.name': 'llm.response',
+      'gen_ai.response.finish_reasons': ['end_turn'],
+    }));
+    await flusher.send(makeEntry({
+      ...QODER_HOOK,
+      'event.name': 'llm.response',
+      'gen_ai.response.finish_reasons': ['stop'],
+    }));
+    await flusher.flush();
+
+    // Neither path truncated the other: both payloads are complete.
+    expect(findCall(mockConvert, 'qoder-transcript-hook')).toHaveLength(3);
+    expect(findCall(mockConvert, 'qoder-cli-session-segment')).toHaveLength(2);
+  });
+
+  it('does NOT let a hook turn preempt a segment buffer that opened first', async () => {
+    // Mirror image of the hook-first case. Signal B is evaluated on the
+    // incoming record, so whichever path arrives second is the one doing the
+    // preempting — the hook's records must not close a segment buffer either.
+    // Ordering between the two inputs is not controlled by anything, so both
+    // directions occur in the field.
+    const { convertEventLogToTrace } = await import('@loongsuite/otel-util-genai');
+    const mockConvert = vi.mocked(convertEventLogToTrace);
+    mockConvert.mockClear();
+
+    const segment = {
+      'gen_ai.agent.type': 'qoder-cli',
+      'gen_ai.session.id': QODER_SESSION,
+      'agent.source': 'qoder-cli-session-segment',
+      'trace_id': undefined,
+    };
+
+    // Segment path opens first, with a non-terminal response.
+    await flusher.send(makeEntry({
+      ...segment,
+      'event.name': 'llm.response',
+      'gen_ai.response.finish_reasons': ['tool_call'],
+    }));
+    // Hook turn starts mid-stream and runs to its own terminal record.
+    await flusher.send(makeEntry({ ...QODER_HOOK, 'event.name': 'other' }));
+    await flusher.send(makeEntry({
+      ...segment,
+      'event.name': 'llm.request',
+    }));
+    await flusher.send(makeEntry({
+      ...QODER_HOOK,
+      'event.name': 'llm.response',
+      'gen_ai.response.finish_reasons': ['stop'],
+    }));
+    await flusher.flush();
+
+    // Both payloads survive intact: the segment buffer kept both of its records
+    // instead of being cut in half by the hook turn starting.
+    expect(findCall(mockConvert, 'qoder-cli-session-segment')).toHaveLength(2);
+    expect(findCall(mockConvert, 'qoder-transcript-hook')).toHaveLength(2);
   });
 
   it('still preempts within one collection path', async () => {

--- a/tests/unit/flushers/otlp-trace-flusher/concurrent-subagent.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/concurrent-subagent.test.ts
@@ -350,6 +350,93 @@ describe('OtlpTraceFlusher - concurrent subagent regression', () => {
     expect(mockConvert).not.toHaveBeenCalled();
   });
 
+  it('does NOT let a second collection path preempt the first one in the same session', async () => {
+    // Qoder CLI is collected by two inputs at once while qoder-trace is off:
+    // qoder-transcript-hook (turn id = crypto.randomUUID()) and
+    // qoder-cli-session-segment (turn id = record.turn_id). They share the
+    // session id but mint turn ids from separate id spaces, so their buffers
+    // are concurrent, not successive. Preempting across paths truncated the
+    // hook buffer down to its turn-entry `other`, which the converter turns
+    // into a phantom ENTRY+AGENT pair with no turn/step/llm children.
+    const { convertEventLogToTrace } = await import('@loongsuite/otel-util-genai');
+    const mockConvert = vi.mocked(convertEventLogToTrace);
+    mockConvert.mockClear();
+
+    const session = 'qoder-cli-session-1';
+    const hook = {
+      'gen_ai.agent.type': 'qoder-cli',
+      'gen_ai.session.id': session,
+      'gen_ai.turn.id': 'c0ffee00-0000-4000-8000-000000000001',
+      'agent.source': 'qoder-transcript-hook',
+      'trace_id': 'ddd12f3577b34da6a3ce929d0e0e4736',
+    };
+    const segment = {
+      'gen_ai.agent.type': 'qoder-cli',
+      'gen_ai.session.id': session,
+      'gen_ai.turn.id': 'segment-turn-7',
+      'agent.source': 'qoder-cli-session-segment',
+      'trace_id': 'eee12f3577b34da6a3ce929d0e0e4736',
+    };
+
+    // Hook turn opens with the entry `other` carrying the user prompt.
+    await flusher.send(makeEntry({ ...hook, 'event.name': 'other' }));
+    // Segment path emits a record for the same session mid-stream.
+    await flusher.send(makeEntry({
+      ...segment,
+      'event.name': 'llm.response',
+      'gen_ai.response.finish_reasons': ['tool_call'],
+    }));
+    // The hook buffer must still be open — nothing flushed yet.
+    expect(mockConvert).not.toHaveBeenCalled();
+
+    // Hook turn finishes on its own signal.
+    await flusher.send(makeEntry({ ...hook, 'event.name': 'llm.request' }));
+    await flusher.send(makeEntry({
+      ...hook,
+      'event.name': 'llm.response',
+      'gen_ai.response.finish_reasons': ['stop'],
+    }));
+    await flusher.flush();
+
+    const hookCall = mockConvert.mock.calls.find(
+      ([records]) => (records[0] as Record<string, unknown>)['agent.source'] === 'qoder-transcript-hook',
+    );
+    expect(hookCall).toBeDefined();
+    // All three hook records converted together — not an `other`-only skeleton.
+    expect(hookCall![0]).toHaveLength(3);
+  });
+
+  it('still preempts within one collection path', async () => {
+    // The same-source guard must not disable Signal B: two successive turns
+    // from the same input are still sequential, so the abandoned one closes.
+    const { convertEventLogToTrace } = await import('@loongsuite/otel-util-genai');
+    const mockConvert = vi.mocked(convertEventLogToTrace);
+    mockConvert.mockClear();
+
+    const base = {
+      'gen_ai.agent.type': 'qoder-cli',
+      'gen_ai.session.id': 'same-path-session',
+      'agent.source': 'qoder-transcript-hook',
+    };
+
+    await flusher.send(makeEntry({
+      ...base,
+      'gen_ai.turn.id': 'hook-turn-1',
+      'trace_id': 'fff12f3577b34da6a3ce929d0e0e4736',
+      'event.name': 'other',
+    }));
+    await flusher.send(makeEntry({
+      ...base,
+      'gen_ai.turn.id': 'hook-turn-2',
+      'trace_id': 'fff22f3577b34da6a3ce929d0e0e4736',
+      'event.name': 'other',
+    }));
+
+    expect(mockConvert).toHaveBeenCalledTimes(1);
+    const preempted = mockConvert.mock.calls[0][0];
+    expect((preempted[0] as Record<string, unknown>)['gen_ai.turn.id']).toBe('hook-turn-1');
+  });
+
   it('force-flushes oldest incomplete buffers when MAX_TURN_BUFFERS is exceeded', async () => {
     // Bounded cleanup: if buffers accumulate past the hard cap (neither
     // Signal A, same-session successor, nor idle timeout ever fires for


### PR DESCRIPTION
> [!IMPORTANT]
> **Depends on #342 — merge #342 first.** This PR stops the two Qoder CLI
> collection paths from cutting each other's turns short, but it also removes one
> of the ways a segment-source buffer used to get closed. #342 supplies the
> replacement (`gen_ai.response.finish_reasons`, letting Signal A close that
> buffer). Landing this one alone leaves segment buffers dependent on the
> 64-buffer cap on any turn whose last response is not terminal — on the
> reporter's machine that is 3 of 11 turns, because `stop_reason` is
> `tool_use` 69 times vs `end_turn` 8 times and `turnIdleTimeoutMs` defaults to 0.

## Problem

On the reporter's machine, 14 Qoder CLI traces contained nothing but an
`enter_ai_application_system` + `invoke_agent` pair — no turn/step/llm children,
`start == end`. The prompts inside them were ordinary user input (`# GitHub
Trending Deep Research …`), and the same turn's real content was scattered across
21–125 sibling traces.

This is **not** the defect PR #333 fixes. #333 removes slash-command control rows
at the processor layer (transcript → events) and only fires on abnormal input.
This one lives at the flusher layer (events → trace grouping), fires on perfectly
normal input, and loses nothing — the data is complete but cut apart. The two
merely share an exit: a truncated buffer holding only the turn-entry `other`.

## Root cause

Signal B closes a turn buffer when another turn of the same `agentType` +
`gen_ai.session.id` arrives. The assumption is that turns within a session are
**successive**. That holds inside one collection path — not across two.

Whenever `qoder-trace` is off, `orchestrator.ts` enables both Qoder CLI inputs
(L1248 `qoder-cli-hook`, L1265 `qoder-cli-session`, both gated on
`!qoderTraceEnabled()`):

| | turn id source | `agent.source` |
|---|---|---|
| `qoder-transcript-hook` | `crypto.randomUUID()` (processor L621) | `qoder-transcript-hook` |
| `qoder-cli-session-segment` | `record.turn_id` | `qoder-cli-session-segment` |

Same session id, **separate turn-id spaces** → the two buffers are concurrent,
not successive → each path's records preempt the other's mid-turn.

The truncated buffer often held just the turn-entry `other`. That record carries
`gen_ai.input.messages_delta`, so `isMetadataOnlyOtherEvent`
(`otlp-trace-flusher.ts:1582-1592`) deliberately lets it through — and its own
comment spells out the consequence: *"Converting such records standalone via the
ephemeral path still produces a phantom ENTRY+AGENT pair."* Two spans, zero
duration, a real prompt inside, no children. Exactly the observed symptom.

## Fix

Gate Signal B on the collection path:

```ts
if (buf.dataSource !== incomingDataSource) continue;
```

`dataSource` comes from `agent.source`, recorded at buffer creation and learned
lazily from later records, the same way `sessionId` already is.

**Backward compatible.** Agents that don't stamp `agent.source` (claude-code,
cursor, codex, …) compare `undefined` to `undefined` → equal → Signal B behaves
exactly as before. The guard only decides *whether to preempt*; it never changes
how records are grouped.

### Why the discriminator had a gap

`buildLegacyEvents` builds records through the shared `buildQoderHookRecord`
(`agent-event-normalizer.mjs`, also used by the Qoder IDE hook), which does not
stamp `agent.source`. Left alone, a legacy-path turn (`dataSource: undefined`)
and a boundary-path turn (`'qoder-transcript-hook'`) would read as different
sources and neither would close the other — a **same-path** regression that
matters because `turnIdleTimeoutMs` defaults to `0`, leaving only Signal A and
the 64-buffer cap as closers. Stamped at the qoder-only call site instead of in
the shared normalizer, so no other agent's records change.

## Dependency on #342

**This PR depends on #342. Merge order: #342, then this one.** The two changes
are halves of one fix — either alone leaves a gap:

- **#342 alone does not fix this.** Giving the segment source a top-level
  `gen_ai.turn.id` moves the group keys from `turn:` vs `session:` to
  `turn:A` vs `turn:B`. The preemption condition (same agentType + same session
  + different key) is still satisfied.
- **This PR alone is incomplete too.** The same-source guard is what keeps Signal
  B available *within* a path — and after #342, that is the only closer left for
  a segment turn ending on a non-terminal `stop_reason`. #342's `finish_reasons`
  restores Signal A as the primary closer for those buffers.
- **Together** they reduce fragmentation from "1 turn → 21–125 sibling traces"
  down to "1 turn → 2 traces" (one per collection path). The remaining 2-trace
  split is *not* fixed by either PR and is tracked separately — see the issue
  linked below.

Verified on a local merge of both branches: no conflicts, 996 tests passed /
8 skipped / 0 failed, `tsc --noEmit` clean.

## Verification

| Check | Result |
|---|---|
| `concurrent-subagent.test.ts` | 12 passed (4 new) |
| Teeth check: `if (false && buf.dataSource !== …)` | exactly the 3 cross-source cases fail; same-source preemption still passes |
| Stacked on #342 locally (`git merge`) | no conflict, same 12 passed |
| `tests/unit/flushers` | 20 files / 182 passed |
| `tests/unit/hooks --no-file-parallelism` | 57 passed \| 2 skipped, 792 passed |
| `tests/contract` + `tests/unit/normalization` | 13 files / 152 passed |
| `npx tsc --noEmit` | clean |

The tests are deliberately a set rather than a single case:

- **Both key shapes.** The segment input stamps neither `gen_ai.turn.id` nor
  `trace_id` today (`trace_id` comes only from `trace-linker.ts`, and
  `upstreamLink` is off by default), so its records group under `session:<sid>`;
  after #342 they group under `turn:<record.turn_id>`. Signal B walks every
  buffer of the same agent+session regardless of key shape, so both shapes are
  covered — the suite needs no fixture churn when the branches stack.
- **Both interleavings.** Signal B is evaluated on the *incoming* record, so
  whichever input arrives second does the preempting, and nothing orders the two
  inputs. The segment-first mirror case fails with `length 2 → 1` when the guard
  is off, which is the truncation symptom itself.
- **Both payloads.** Each test asserts the record count on *both* paths, so a
  guard that stopped preemption by dropping the other path's records would fail.
- **Same-source preemption still fires**, so the guard cannot quietly switch
  Signal B off.

The `session:`-keyed test also pins down what this PR does *not* fix: once the
hook turn closes, the segment buffer is still open and not `completed`. That is
asserted directly, so the missing real-time closer stays visible in CI instead of
being masked by the shutdown flush — and it is the concrete reason for the merge
order above.

## Out of scope

Three other skeleton-trace causes were diagnosed on the same machine and are
**not** touched here:

- **LLM 0-duration spans** — `agents.d/qoder.json` declares `"events": ["Stop"]`,
  so `buildLlmBoundaries` never sees `PreToolUse`/`PostToolUse`. Separate change,
  larger surface.
- **Segment collapse (one step holding N zero-duration LLM spans)** — handled by #342.
- **`null` token spans** — deployment issue (daemon spawned the bare binary,
  bypassing the wrapper so `intercept.mjs` never loaded); already resolved by env injection.

A fourth reported symptom, "every span emitted twice by two listeners", is **not
a bug**: `getOrCreateExportState` (L1425-1426) filters endpoints by
`serviceName`, so the 908 = 454 × 2 count is ordinary `service.name` fan-out,
not duplicate delivery.


