### PR TITLE
feat: add agent.input

### DIFF
--- a/docs/output-event-schema.md
+++ b/docs/output-event-schema.md
@@ -18,7 +18,15 @@ boundary.
 | `tool.result` | The result returned by a tool execution. |
 | `skill.use` | A skill, extension, or agent capability invocation. |
 | `tool.approve` | A user approval event for a tool or action. |
+| `agent.input` | A compatibility copy of an input-bearing `other`, for querying Agent input by event name. |
 | `other` | Other events that cannot be classified into the above event names. |
+
+During the compatibility period, an `other` carrying `gen_ai.input.messages` or
+`gen_ai.input.messages_delta` is preserved and followed by one `agent.input`.
+The two events have identical fields except `event.name` and `event.id`; the new
+ID is deterministically derived from the original. SLS, JSONL, and HTTP retain
+both events. OTLP Trace conversion continues to consume the legacy `other` and
+excludes the compatibility copy, so the Span tree does not gain an empty STEP.
 
 The four core `event.name` values map to GenAI audit events as follows:
 

--- a/docs/output-event-schema.md
+++ b/docs/output-event-schema.md
@@ -23,10 +23,14 @@ boundary.
 
 During the compatibility period, an `other` carrying `gen_ai.input.messages` or
 `gen_ai.input.messages_delta` is preserved and followed by one `agent.input`.
-The two events have identical fields except `event.name` and `event.id`; the new
-ID is deterministically derived from the original. SLS, JSONL, and HTTP retain
-both events. OTLP Trace conversion continues to consume the legacy `other` and
-excludes the compatibility copy, so the Span tree does not gain an empty STEP.
+The compatibility copy preserves the input content and context, but has a
+deterministically derived `event.id` and omits `gen_ai.turn.start` and
+`gen_ai.turn.end`; the legacy `other` remains the sole owner of Turn boundaries.
+Expansion runs after the content policy, so no `agent.input` is generated when
+that policy removes both canonical input fields. SLS, JSONL, and HTTP retain both
+events when a copy is generated. OTLP Trace conversion continues to consume the
+legacy `other` and excludes the compatibility copy, so the Span tree does not
+gain an empty STEP.
 
 The four core `event.name` values map to GenAI audit events as follows:
 

--- a/docs/zh-CN/output-event-schema.md
+++ b/docs/zh-CN/output-event-schema.md
@@ -16,7 +16,14 @@ LoongSuite Pilot 会将采集到的活动归一化为 GenAI 遥测事件。Pilot
 | `tool.result` | 工具执行返回的结果。 |
 | `skill.use` | 技能、扩展能力或 Agent 能力调用。 |
 | `tool.approve` | 用户批准工具或动作执行的事件。 |
+| `agent.input` | 输入型 `other` 的兼容副本，便于按事件名查询 Agent 输入。 |
 | `other` | 无法归类到上述类型的其他事件。 |
+
+兼容期内，携带 `gen_ai.input.messages` 或 `gen_ai.input.messages_delta` 的
+`other` 会被原样保留，并紧邻追加一条 `agent.input`。两条事件除
+`event.name` 和 `event.id` 外完全一致，新 ID 从原 ID 确定性派生。SLS、
+JSONL 和 HTTP 保留两条事件；OTLP Trace 转换继续消费旧 `other`，并在
+转换前排除兼容副本，因此不会增加空 STEP。
 
 四类核心事件的 `event.name` 与 GenAI audit-event 对应关系如下：
 

--- a/docs/zh-CN/output-event-schema.md
+++ b/docs/zh-CN/output-event-schema.md
@@ -20,10 +20,12 @@ LoongSuite Pilot 会将采集到的活动归一化为 GenAI 遥测事件。Pilot
 | `other` | 无法归类到上述类型的其他事件。 |
 
 兼容期内，携带 `gen_ai.input.messages` 或 `gen_ai.input.messages_delta` 的
-`other` 会被原样保留，并紧邻追加一条 `agent.input`。两条事件除
-`event.name` 和 `event.id` 外完全一致，新 ID 从原 ID 确定性派生。SLS、
-JSONL 和 HTTP 保留两条事件；OTLP Trace 转换继续消费旧 `other`，并在
-转换前排除兼容副本，因此不会增加空 STEP。
+`other` 会被原样保留，并紧邻追加一条 `agent.input`。兼容副本保留输入内容
+和上下文字段，使用从原 ID 确定性派生的新 `event.id`，但不复制
+`gen_ai.turn.start` 和 `gen_ai.turn.end`；旧 `other` 仍是唯一的 Turn 边界事件。
+双写发生在内容策略之后，因此两个规范输入字段都被策略删除时不会生成
+`agent.input`。生成副本时，SLS、JSONL 和 HTTP 保留两条事件；OTLP Trace
+转换继续消费旧 `other`，并在转换前排除兼容副本，因此不会增加空 STEP。
 
 四类核心事件的 `event.name` 与 GenAI audit-event 对应关系如下：
 

--- a/scripts/e2e/lib/e2e-scenarios.mjs
+++ b/scripts/e2e/lib/e2e-scenarios.mjs
@@ -760,7 +760,7 @@ const COMMON_REQUIRED = [
 ];
 const EVENT_NAME_ENUM = new Set([
   'llm.request', 'llm.response', 'tool.call', 'tool.result',
-  'skill.use', 'tool.approve', 'other',
+  'skill.use', 'tool.approve', 'agent.input', 'other',
 ]);
 const CONDITIONAL_REQUIRED = {
   'tool.call': ['gen_ai.tool.name', 'gen_ai.tool.call.id'],

--- a/src/core/input-manager.ts
+++ b/src/core/input-manager.ts
@@ -19,6 +19,7 @@ import type { TraceLinker } from './upstream-link/trace-linker.js';
 import type { MultimodalProcessor } from '../multimodal/processor.js';
 import { TurnBoundaryProcessor } from '../normalization/turn-boundary-processor.js';
 import { applyInvocationIdentity } from '../normalization/invocation-identity.js';
+import { expandAgentInputEvents } from '../normalization/agent-input-dual-write.js';
 
 const logger = createLogger('InputManager');
 
@@ -251,13 +252,11 @@ export class InputManager extends EventEmitter {
     }
 
     const counter = this.counters.get(inputId);
-    let batchBytes = 0;
     if (counter) {
       counter.inEvents += entries.length;
       for (const entry of entries) {
         const b = Buffer.byteLength(JSON.stringify(entry));
         counter.inBytes += b;
-        batchBytes += b;
       }
       counter.lastPollTime = formatTime(new Date());
       counter.lastActiveTime = Date.now();
@@ -302,8 +301,14 @@ export class InputManager extends EventEmitter {
             maskAgentActivityEntry(entry, this.maskConfig, this.maskPlan),
           );
 
-    logger.info('dispatching entries', { inputId, count: maskedEntries.length });
-    await this.dispatchEntries(inputId, maskedEntries, batchBytes);
+    const expandedEntries = expandAgentInputEvents(maskedEntries);
+    const outputBatchBytes = expandedEntries.reduce(
+      (total, entry) => total + Buffer.byteLength(JSON.stringify(entry)),
+      0,
+    );
+
+    logger.info('dispatching entries', { inputId, count: expandedEntries.length });
+    await this.dispatchEntries(inputId, expandedEntries, outputBatchBytes);
   }
 
   markInputStarted(id: string): void {

--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -834,13 +834,21 @@ export class OtlpTraceFlusher extends BaseFlusher {
           grokMetadata = prepared.metadata;
         }
 
+        // agent.input is a compatibility copy of the input-bearing `other`.
+        // Keep it in the normal OTLP flusher path, but exclude it at the
+        // EventLog-to-Trace boundary so the converter does not emit an extra
+        // empty STEP for the duplicate input boundary.
+        const traceConversionRecords = recordsForConversion.filter(
+          record => record['event.name'] !== 'agent.input',
+        );
+
         // Drop orphan llm.request / tool.call events before conversion so the
         // converter doesn't emit empty LLM/TOOL spans with duration=0 and
         // missing output.messages / tool.call.result. This happens when a
         // turn is interrupted before llm.response / tool.result arrive (e.g.
         // user Ctrl+C, agent errored mid-step). The converter library would
         // otherwise still emit a span for the orphan request/call.
-        const sanitized = dropOrphanPairs(recordsForConversion);
+        const sanitized = dropOrphanPairs(traceConversionRecords);
         toolSpanIds.prepare(sanitized);
         let result;
         try {

--- a/src/normalization/agent-input-dual-write.ts
+++ b/src/normalization/agent-input-dual-write.ts
@@ -29,8 +29,11 @@ export function expandAgentInputEvents(
     if (existingEventIds.has(derivedEventId)) continue;
 
     existingEventIds.add(derivedEventId);
+    const derivedEntry = { ...entry };
+    delete derivedEntry['gen_ai.turn.start'];
+    delete derivedEntry['gen_ai.turn.end'];
     expanded.push({
-      ...entry,
+      ...derivedEntry,
       'event.id': derivedEventId,
       'event.name': 'agent.input',
     });

--- a/src/normalization/agent-input-dual-write.ts
+++ b/src/normalization/agent-input-dual-write.ts
@@ -1,0 +1,40 @@
+import { v5 as uuidv5 } from 'uuid';
+import type { AgentActivityEntry } from '../types/index.js';
+
+export const AGENT_INPUT_EVENT_NAMESPACE = '29afa46e-d5de-5c48-946b-90c1d0537f36';
+
+export function isInputOtherEvent(entry: AgentActivityEntry): boolean {
+  return entry['event.name'] === 'other'
+    && (
+      entry['gen_ai.input.messages'] !== undefined
+      || entry['gen_ai.input.messages_delta'] !== undefined
+    );
+}
+
+export function deriveAgentInputEventId(originalEventId: string): string {
+  return uuidv5(originalEventId, AGENT_INPUT_EVENT_NAMESPACE);
+}
+
+export function expandAgentInputEvents(
+  entries: AgentActivityEntry[],
+): AgentActivityEntry[] {
+  const existingEventIds = new Set(entries.map(entry => entry['event.id']));
+  const expanded: AgentActivityEntry[] = [];
+
+  for (const entry of entries) {
+    expanded.push(entry);
+    if (!isInputOtherEvent(entry)) continue;
+
+    const derivedEventId = deriveAgentInputEventId(entry['event.id']);
+    if (existingEventIds.has(derivedEventId)) continue;
+
+    existingEventIds.add(derivedEventId);
+    expanded.push({
+      ...entry,
+      'event.id': derivedEventId,
+      'event.name': 'agent.input',
+    });
+  }
+
+  return expanded;
+}

--- a/src/normalization/entry-builder.ts
+++ b/src/normalization/entry-builder.ts
@@ -398,6 +398,8 @@ export function normalizeEventName(value: unknown): AgentEventName {
       return 'skill.use';
     case 'tool.approve':
       return 'tool.approve';
+    case 'agent.input':
+      return 'agent.input';
     case 'event':
     case 'other':
     default:

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -18,6 +18,7 @@ export type AgentEventName =
   | 'tool.result'
   | 'skill.use'
   | 'tool.approve'
+  | 'agent.input'
   | 'other';
 
 export type JsonValue =

--- a/tests/contract/agent-activity-entry.test.ts
+++ b/tests/contract/agent-activity-entry.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { AgentActivityEntrySchema } from './agent-activity-schema.js';
-import { buildAgentActivityEntry } from '../../src/normalization/entry-builder.js';
+import {
+  buildAgentActivityEntry,
+  normalizeEventName,
+} from '../../src/normalization/entry-builder.js';
 import { ClientType, ActionType } from '../../src/types/index.js';
 
 describe('AgentActivityEntry contract', () => {
@@ -82,6 +85,21 @@ describe('AgentActivityEntry contract', () => {
 
     const result = AgentActivityEntrySchema.safeParse(bad);
     expect(result.success).toBe(false);
+  });
+
+  it('should accept and preserve agent.input', () => {
+    const entry = {
+      time_unix_nano: '1700000000000000000',
+      'event.id': 'agent-input-event',
+      'event.name': 'agent.input',
+      'user.id': 'u',
+      'gen_ai.session.id': 'sess',
+      'gen_ai.agent.type': ClientType.Qoder,
+      'gen_ai.provider.name': 'qwen',
+    };
+
+    expect(AgentActivityEntrySchema.safeParse(entry).success).toBe(true);
+    expect(normalizeEventName(entry['event.name'])).toBe('agent.input');
   });
 
   it('should reject a non-numeric time_unix_nano', () => {

--- a/tests/contract/agent-activity-schema.ts
+++ b/tests/contract/agent-activity-schema.ts
@@ -9,6 +9,7 @@ const eventNameValues = [
   'tool.result',
   'skill.use',
   'tool.approve',
+  'agent.input',
   'other',
 ] as const;
 

--- a/tests/e2e-remote/jsonl-validate.test.mjs
+++ b/tests/e2e-remote/jsonl-validate.test.mjs
@@ -280,6 +280,26 @@ describe('JSONL_VALIDATOR_JS (integration)', () => {
     expect(r.out).toContain('turn_boundary_error=0');
   });
 
+  it('accepts a compatibility input pair with the turn boundary only on other', () => {
+    const inputMessages = [
+      { role: 'user', parts: [{ type: 'text', content: 'SYNTHETIC_INPUT' }] },
+    ];
+    writeJsonl('workbuddy-2026-05-11.jsonl', [
+      graphEntry('evt-input-other', 'other', {
+        'gen_ai.turn.start': true,
+        'gen_ai.input.messages_delta': inputMessages,
+      }),
+      graphEntry('evt-agent-input', 'agent.input', {
+        'gen_ai.input.messages_delta': inputMessages,
+      }),
+    ]);
+
+    const r = runWorkBuddyValidator();
+    expect(r.code).toBe(0);
+    expect(r.out).toContain('bad_event_name=0');
+    expect(r.out).toContain('turn_boundary_error=0');
+  });
+
   it('never prints prompt, tool payload, result, or user path values in validation errors', () => {
     const entries = validMultiToolGraph();
     entries[2]['gen_ai.tool.call.arguments'] =

--- a/tests/e2e-remote/jsonl-validate.test.mjs
+++ b/tests/e2e-remote/jsonl-validate.test.mjs
@@ -212,6 +212,13 @@ describe('JSONL_VALIDATOR_JS (integration)', () => {
     expect(r.out).toContain('bad_event_name=1');
   });
 
+  it('accepts agent.input as a valid event name', () => {
+    writeJsonl('claude-code-2026-05-11.jsonl', [goodEntry({ 'event.name': 'agent.input' })]);
+    const r = runValidator({ _JV_LOG_DIR: tmpDir, E2E_JSONL_STRICT: '1' });
+    expect(r.code).toBe(0);
+    expect(r.out).toContain('bad_event_name=0');
+  });
+
   it.each([
     {
       name: 'duplicate event IDs',

--- a/tests/integration/openclaw-plugin-event-log-flow.test.ts
+++ b/tests/integration/openclaw-plugin-event-log-flow.test.ts
@@ -97,7 +97,8 @@ describe('OpenClaw plugin to InputManager trace flow', () => {
       'gen_ai.turn.end': true,
     });
     const turnStarts = records.filter(record => record['gen_ai.turn.start'] === true);
-    expect(turnStarts.map(record => record['event.name'])).toEqual(['other', 'agent.input']);
+    expect(turnStarts).toHaveLength(1);
+    expect(turnStarts[0]['event.name']).toBe('other');
     expect(records.filter(record => record['gen_ai.turn.end'] === true)).toHaveLength(1);
     expect(terminal?.['gen_ai.usage.input_tokens']).toBeUndefined();
     expect(terminal?.['gen_ai.output.messages']).toBeUndefined();

--- a/tests/integration/openclaw-plugin-event-log-flow.test.ts
+++ b/tests/integration/openclaw-plugin-event-log-flow.test.ts
@@ -96,7 +96,8 @@ describe('OpenClaw plugin to InputManager trace flow', () => {
       'agent.openclaw.per_call_usage.count': 2,
       'gen_ai.turn.end': true,
     });
-    expect(records.filter(record => record['gen_ai.turn.start'] === true)).toHaveLength(1);
+    const turnStarts = records.filter(record => record['gen_ai.turn.start'] === true);
+    expect(turnStarts.map(record => record['event.name'])).toEqual(['other', 'agent.input']);
     expect(records.filter(record => record['gen_ai.turn.end'] === true)).toHaveLength(1);
     expect(terminal?.['gen_ai.usage.input_tokens']).toBeUndefined();
     expect(terminal?.['gen_ai.output.messages']).toBeUndefined();
@@ -117,7 +118,8 @@ describe('OpenClaw plugin to InputManager trace flow', () => {
     process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'gen_ai_latest_experimental';
     process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT = 'SPAN_ONLY';
     try {
-      const converted = await convertEventLogToReadableSpans(records as EventLogRecord[], { strict: false });
+      const traceRecords = records.filter(record => record['event.name'] !== 'agent.input');
+      const converted = await convertEventLogToReadableSpans(traceRecords as EventLogRecord[], { strict: false });
       expect(converted.warnings).toEqual([]);
       const kindCounts = converted.spans.reduce<Record<string, number>>((counts, span) => {
         const kind = String(span.attributes['gen_ai.span.kind']);

--- a/tests/unit/core/input-manager.test.ts
+++ b/tests/unit/core/input-manager.test.ts
@@ -545,19 +545,46 @@ describe('InputManager', () => {
       expect(other['event.id']).toBe('input-other');
       expect(agentInput['event.name']).toBe('agent.input');
       expect(agentInput['event.id']).toBe(deriveAgentInputEventId('input-other'));
+      expect(other['gen_ai.turn.start']).toBe(true);
+      expect(agentInput['gen_ai.turn.start']).toBeUndefined();
+      expect(agentInput['gen_ai.turn.end']).toBeUndefined();
       expect(JSON.stringify(other)).toContain('[ACCESSKEY_MASKED]');
       expect(JSON.stringify(agentInput)).toContain('[ACCESSKEY_MASKED]');
       expect(JSON.stringify(other)).not.toContain(accessKey);
       expect(JSON.stringify(agentInput)).not.toContain(accessKey);
 
-      const stripIdentity = ({
-        'event.id': _eventId,
-        'event.name': _eventName,
-        ...rest
-      }: AgentActivityEntry) => rest;
-      expect(stripIdentity(agentInput)).toEqual(stripIdentity(other));
+      const stripDerivedFields = (entry: AgentActivityEntry) => {
+        const comparable = { ...entry };
+        delete comparable['event.id'];
+        delete comparable['event.name'];
+        delete comparable['gen_ai.turn.start'];
+        delete comparable['gen_ai.turn.end'];
+        return comparable;
+      };
+      expect(stripDerivedFields(agentInput)).toEqual(stripDerivedFields(other));
       expect(source['event.name']).toBe('other');
       expect(source['event.id']).toBe('input-other');
+    });
+
+    it('does not generate agent.input after content policy removes input fields', async () => {
+      const input = new StubInput('dual-write-content-policy');
+      manager.registerInput(input as any);
+      manager.setAgentsConfig({
+        [ClientType.Cursor]: { captureMessageContent: false },
+      });
+      const source = buildTestEntry({
+        agentType: ClientType.Cursor,
+        'event.id': 'content-policy-input',
+        'gen_ai.input.messages_delta': [{ role: 'user', content: 'secret prompt' }],
+      });
+
+      input.emit('entries', [source]);
+      await manager.stopAll();
+
+      expect(flusher.batchCalls).toHaveLength(1);
+      expect(flusher.batchCalls[0]).toHaveLength(1);
+      expect(flusher.batchCalls[0][0]['event.name']).toBe('other');
+      expect(flusher.batchCalls[0][0]).not.toHaveProperty('gen_ai.input.messages_delta');
     });
 
     it('does not copy a non-input other event', async () => {

--- a/tests/unit/core/input-manager.test.ts
+++ b/tests/unit/core/input-manager.test.ts
@@ -19,6 +19,7 @@ import {
   INVOCATION_SESSION_ID_FIELD,
   INVOCATION_USER_ID_FIELD,
 } from '../../../src/normalization/invocation-identity.js';
+import { deriveAgentInputEventId } from '../../../src/normalization/agent-input-dual-write.js';
 
 vi.mock('../../../src/utils/logger.js', () => ({
   createLogger: () => ({
@@ -516,6 +517,127 @@ describe('InputManager', () => {
         expect(JSON.stringify(child.batchCalls[0][0])).not.toContain(apiKey);
         expect(JSON.stringify(child.batchCalls[0][0])).not.toContain(phone);
       }
+    });
+  });
+
+  describe('agent.input compatibility dual-write', () => {
+    it('dual-writes masked input other after shared enrichment', async () => {
+      const input = new StubInput('dual-write-mask');
+      manager.registerInput(input as any);
+      manager.setMaskConfig({ mode: 'all', types: [] });
+
+      const accessKey = 'AKIAIOSFODNN7EXAMPLE';
+      const source = buildTestEntry({
+        'event.id': 'input-other',
+        'gen_ai.turn.id': 'turn-dual-write',
+        'gen_ai.input.messages_delta': [
+          { role: 'user', content: `use ${accessKey}` },
+        ],
+      });
+
+      input.emit('entries', [source]);
+      await manager.stopAll();
+
+      expect(flusher.batchCalls).toHaveLength(1);
+      const [other, agentInput] = flusher.batchCalls[0];
+      expect(flusher.batchCalls[0]).toHaveLength(2);
+      expect(other['event.name']).toBe('other');
+      expect(other['event.id']).toBe('input-other');
+      expect(agentInput['event.name']).toBe('agent.input');
+      expect(agentInput['event.id']).toBe(deriveAgentInputEventId('input-other'));
+      expect(JSON.stringify(other)).toContain('[ACCESSKEY_MASKED]');
+      expect(JSON.stringify(agentInput)).toContain('[ACCESSKEY_MASKED]');
+      expect(JSON.stringify(other)).not.toContain(accessKey);
+      expect(JSON.stringify(agentInput)).not.toContain(accessKey);
+
+      const stripIdentity = ({
+        'event.id': _eventId,
+        'event.name': _eventName,
+        ...rest
+      }: AgentActivityEntry) => rest;
+      expect(stripIdentity(agentInput)).toEqual(stripIdentity(other));
+      expect(source['event.name']).toBe('other');
+      expect(source['event.id']).toBe('input-other');
+    });
+
+    it('does not copy a non-input other event', async () => {
+      const input = new StubInput('non-input-other');
+      manager.registerInput(input as any);
+      const source = buildTestEntry({ 'event.id': 'metadata-other' });
+
+      input.emit('entries', [source]);
+      await manager.stopAll();
+
+      expect(flusher.batchCalls).toHaveLength(1);
+      expect(flusher.batchCalls[0]).toHaveLength(1);
+      expect(flusher.batchCalls[0][0]['event.id']).toBe('metadata-other');
+    });
+
+    it('dispatches the same expanded pair to every child flusher', async () => {
+      const jsonl = new MockFlusher('jsonl');
+      const sls = new MockFlusher('sls');
+      const http = new MockFlusher('http');
+      manager.setFlusher(new MultiFlusher([jsonl, sls, http]));
+      const input = new StubInput('dual-write-multi');
+      manager.registerInput(input as any);
+      const source = buildTestEntry({
+        'event.id': 'multi-input',
+        'gen_ai.input.messages': [{ role: 'user', content: 'hello' }],
+      });
+
+      input.emit('entries', [source]);
+      await manager.stopAll();
+
+      const expectedIds = ['multi-input', deriveAgentInputEventId('multi-input')];
+      for (const child of [jsonl, sls, http]) {
+        expect(child.batchCalls).toHaveLength(1);
+        expect(child.batchCalls[0].map(entry => entry['event.id'])).toEqual(expectedIds);
+      }
+    });
+
+    it('counts ingress before expansion and successful egress after expansion', async () => {
+      const input = new StubInput('dual-write-metrics');
+      manager.registerInput(input as any);
+      const source = buildTestEntry({
+        'event.id': 'metrics-input',
+        'gen_ai.input.messages_delta': [{ role: 'user', content: 'hello' }],
+      });
+      let flushed: { count: number; bytes: number } | undefined;
+      manager.on('flushed', payload => {
+        flushed = payload as { count: number; bytes: number };
+      });
+
+      input.emit('entries', [source]);
+      await manager.stopAll();
+
+      const counter = manager.getInputCounters().get(input.id)!;
+      const dispatched = flusher.batchCalls[0];
+      const expectedBytes = dispatched.reduce(
+        (total, entry) => total + Buffer.byteLength(JSON.stringify(entry)),
+        0,
+      );
+      expect(counter.inEvents).toBe(1);
+      expect(counter.outEvents).toBe(2);
+      expect(counter.outFailed).toBe(0);
+      expect(flushed).toEqual({ count: 2, bytes: expectedBytes });
+    });
+
+    it('counts the full expanded batch when dispatch fails', async () => {
+      const input = new StubInput('dual-write-failure');
+      manager.registerInput(input as any);
+      flusher.shouldFail = true;
+      const source = buildTestEntry({
+        'event.id': 'failed-input',
+        'gen_ai.input.messages_delta': [{ role: 'user', content: 'hello' }],
+      });
+
+      input.emit('entries', [source]);
+      await manager.stopAll();
+
+      const counter = manager.getInputCounters().get(input.id)!;
+      expect(counter.inEvents).toBe(1);
+      expect(counter.outEvents).toBe(0);
+      expect(counter.outFailed).toBe(2);
     });
   });
 

--- a/tests/unit/flushers/otlp-trace-flusher/agent-input-dual-write.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/agent-input-dual-write.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import { ExportResultCode } from '@opentelemetry/core';
+import type { ExportResult } from '@opentelemetry/core';
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { OtlpTraceFlusher } from '../../../../src/flushers/otlp-trace-flusher.js';
+import type { TraceExporterLike } from '../../../../src/flushers/otlp-trace-flusher.js';
+import { expandAgentInputEvents } from '../../../../src/normalization/agent-input-dual-write.js';
+import type { AgentActivityEntry } from '../../../../src/types/index.js';
+
+interface CapturedSpan extends ReadableSpan {
+  attributes: Record<string, unknown>;
+}
+
+function makeConfig() {
+  return {
+    enabled: true,
+    endpoints: [{ name: 'primary', endpoint: 'http://localhost:4318/v1/traces', headers: {} }],
+    protocol: 'http/protobuf' as const,
+    serviceName: 'agent-input-dual-write-test',
+    debug: false,
+  };
+}
+
+function makeCapturingExporter(captured: CapturedSpan[]): TraceExporterLike {
+  return {
+    export(spans: ReadableSpan[], callback: (result: ExportResult) => void): void {
+      captured.push(...spans as CapturedSpan[]);
+      callback({ code: ExportResultCode.SUCCESS });
+    },
+    shutdown: async () => {},
+  };
+}
+
+function makeLegacyTurn(): AgentActivityEntry[] {
+  const common = {
+    'user.id': 'user-1',
+    'gen_ai.session.id': 'session-1',
+    'gen_ai.turn.id': 'turn-1',
+    'gen_ai.agent.type': 'claude-code',
+    'gen_ai.provider.name': 'anthropic',
+  } as const;
+
+  return [
+    {
+      ...common,
+      time_unix_nano: '1700000000000000000',
+      'event.id': 'input-other',
+      'event.name': 'other',
+      'gen_ai.input.messages_delta': [
+        { role: 'user', parts: [{ type: 'text', content: 'hello' }] },
+      ],
+    },
+    {
+      ...common,
+      time_unix_nano: '1700000000100000000',
+      'event.id': 'request',
+      'event.name': 'llm.request',
+      'gen_ai.step.id': 'step-1',
+      'gen_ai.response.id': 'response-1',
+      'gen_ai.request.model': 'claude-test',
+      'gen_ai.input.messages_delta': [
+        { role: 'user', parts: [{ type: 'text', content: 'hello' }] },
+      ],
+    },
+    {
+      ...common,
+      time_unix_nano: '1700000001000000000',
+      'event.id': 'response',
+      'event.name': 'llm.response',
+      'gen_ai.step.id': 'step-1',
+      'gen_ai.response.id': 'response-1',
+      'gen_ai.response.model': 'claude-test',
+      'gen_ai.response.finish_reasons': ['stop'],
+      'gen_ai.output.messages': [
+        { role: 'assistant', parts: [{ type: 'text', content: 'world' }] },
+      ],
+    },
+  ];
+}
+
+async function convert(records: AgentActivityEntry[]): Promise<CapturedSpan[]> {
+  const captured: CapturedSpan[] = [];
+  const flusher = new OtlpTraceFlusher(
+    makeConfig(),
+    undefined,
+    () => makeCapturingExporter(captured),
+  );
+  await flusher.sendBatch(records);
+  await flusher.shutdown();
+  return captured;
+}
+
+function semanticSnapshot(spans: CapturedSpan[]) {
+  const kindBySpanId = new Map(
+    spans.map(span => [
+      span.spanContext().spanId,
+      String(span.attributes['gen_ai.span.kind'] ?? 'UNKNOWN'),
+    ]),
+  );
+
+  return spans
+    .map(span => ({
+      name: span.name,
+      kind: String(span.attributes['gen_ai.span.kind'] ?? 'UNKNOWN'),
+      parentKind: span.parentSpanId ? kindBySpanId.get(span.parentSpanId) ?? null : null,
+      attributes: Object.fromEntries(
+        Object.entries(span.attributes).sort(([left], [right]) => left.localeCompare(right)),
+      ),
+    }))
+    .sort((left, right) => `${left.kind}:${left.name}`.localeCompare(`${right.kind}:${right.name}`));
+}
+
+describe('OtlpTraceFlusher agent.input compatibility dual-write', () => {
+  it('preserves real converter Span semantics at the compatibility boundary', async () => {
+    const legacy = makeLegacyTurn();
+    const expanded = expandAgentInputEvents(legacy);
+    expect(expanded.map(entry => entry['event.name'])).toEqual([
+      'other',
+      'agent.input',
+      'llm.request',
+      'llm.response',
+    ]);
+
+    const legacySpans = await convert(legacy);
+    const expandedSpans = await convert(expanded);
+
+    expect(legacySpans.length).toBeGreaterThan(0);
+    expect(expandedSpans).toHaveLength(legacySpans.length);
+    expect(semanticSnapshot(expandedSpans)).toEqual(semanticSnapshot(legacySpans));
+
+    const kinds = expandedSpans.map(span => span.attributes['gen_ai.span.kind']);
+    expect(kinds.filter(kind => kind === 'ENTRY')).toHaveLength(1);
+    expect(kinds.filter(kind => kind === 'AGENT')).toHaveLength(1);
+    expect(new Set(expandedSpans.map(span => span.spanContext().spanId)).size)
+      .toBe(expandedSpans.length);
+  });
+});

--- a/tests/unit/flushers/otlp-trace-flusher/conversion.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/conversion.test.ts
@@ -16,6 +16,7 @@ import { OtlpTraceFlusher } from '../../../../src/flushers/otlp-trace-flusher.js
 import { convertEventLogToTrace } from '@loongsuite/otel-util-genai';
 import type { AgentActivityEntry } from '../../../../src/types/index.js';
 import { GlobalAttributesProvider } from '../../../../src/normalization/global-attributes.js';
+import { expandAgentInputEvents } from '../../../../src/normalization/agent-input-dual-write.js';
 
 function makeConfig() {
   return {
@@ -51,6 +52,36 @@ describe('OtlpTraceFlusher - conversion', () => {
     const callArgs = vi.mocked(convertEventLogToTrace).mock.calls[0];
     expect(callArgs[0]).toHaveLength(2);
     expect(callArgs[1]).toMatchObject({ strict: false });
+  });
+
+  it('excludes agent.input only at the EventLog-to-Trace boundary', async () => {
+    const inputOther = {
+      time_unix_nano: '1700000000000000000',
+      'event.id': 'input-other',
+      'event.name': 'other',
+      'user.id': 'user-1',
+      'gen_ai.session.id': 'session-1',
+      'gen_ai.agent.type': 'claude-code',
+      'gen_ai.provider.name': 'anthropic',
+      'gen_ai.turn.id': 'dual-write-turn',
+      'gen_ai.input.messages_delta': [{ role: 'user', content: 'hello' }],
+    } as AgentActivityEntry;
+    const terminal = {
+      ...inputOther,
+      time_unix_nano: '1700000001000000000',
+      'event.id': 'terminal',
+      'event.name': 'llm.response',
+      'gen_ai.response.finish_reasons': ['stop'],
+      'gen_ai.input.messages_delta': undefined,
+    } as AgentActivityEntry;
+
+    await flusher.sendBatch([...expandAgentInputEvents([inputOther]), terminal]);
+
+    const records = vi.mocked(convertEventLogToTrace).mock.calls[0][0] as AgentActivityEntry[];
+    expect(records.map(record => record['event.name'])).toEqual([
+      'other',
+      'llm.response',
+    ]);
   });
 
   it('passes handler from per-agent convert state', async () => {

--- a/tests/unit/normalization/agent-input-dual-write.test.ts
+++ b/tests/unit/normalization/agent-input-dual-write.test.ts
@@ -49,19 +49,32 @@ describe('agent input compatibility dual-write', () => {
     expect(result[1]['event.name']).toBe('agent.input');
   });
 
-  it('changes only event.name and event.id on the derived event', () => {
+  it('preserves content while omitting turn boundaries from the derived event', () => {
     const source = makeEntry({
       'gen_ai.input.messages_delta': [{ role: 'user', content: 'hello' }],
       trace_id: '0123456789abcdef0123456789abcdef',
       'gen_ai.turn.id': 'turn-1',
+      'gen_ai.turn.start': true,
+      'gen_ai.turn.end': true,
       custom: { nested: ['value'] },
     });
 
     const [, derived] = expandAgentInputEvents([source]);
-    const stripIdentity = ({ 'event.id': _eventId, 'event.name': _eventName, ...rest }: AgentActivityEntry) => rest;
+    const stripDerivedFields = (entry: AgentActivityEntry) => {
+      const comparable = { ...entry };
+      delete comparable['event.id'];
+      delete comparable['event.name'];
+      delete comparable['gen_ai.turn.start'];
+      delete comparable['gen_ai.turn.end'];
+      return comparable;
+    };
 
-    expect(stripIdentity(derived)).toEqual(stripIdentity(source));
+    expect(stripDerivedFields(derived)).toEqual(stripDerivedFields(source));
     expect(derived['event.id']).not.toBe(source['event.id']);
+    expect(derived['gen_ai.turn.start']).toBeUndefined();
+    expect(derived['gen_ai.turn.end']).toBeUndefined();
+    expect(source['gen_ai.turn.start']).toBe(true);
+    expect(source['gen_ai.turn.end']).toBe(true);
     expect(source['event.name']).toBe('other');
     expect(source['event.id']).toBe('source-event');
   });

--- a/tests/unit/normalization/agent-input-dual-write.test.ts
+++ b/tests/unit/normalization/agent-input-dual-write.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { v5 as uuidv5 } from 'uuid';
+import {
+  AGENT_INPUT_EVENT_NAMESPACE,
+  deriveAgentInputEventId,
+  expandAgentInputEvents,
+  isInputOtherEvent,
+} from '../../../src/normalization/agent-input-dual-write.js';
+import type { AgentActivityEntry } from '../../../src/types/index.js';
+
+function makeEntry(overrides: Partial<AgentActivityEntry> = {}): AgentActivityEntry {
+  return {
+    time_unix_nano: '1700000000000000000',
+    'event.id': 'source-event',
+    'event.name': 'other',
+    'user.id': 'user-1',
+    'gen_ai.session.id': 'session-1',
+    'gen_ai.agent.type': 'codex',
+    'gen_ai.provider.name': 'openai',
+    ...overrides,
+  };
+}
+
+describe('agent input compatibility dual-write', () => {
+  it('recognizes only other events with canonical input fields', () => {
+    expect(isInputOtherEvent(makeEntry({ 'gen_ai.input.messages': [] }))).toBe(true);
+    expect(isInputOtherEvent(makeEntry({ 'gen_ai.input.messages_delta': [] }))).toBe(true);
+    expect(isInputOtherEvent(makeEntry())).toBe(false);
+    expect(isInputOtherEvent(makeEntry({
+      'event.name': 'llm.request',
+      'gen_ai.input.messages': [],
+    }))).toBe(false);
+    expect(isInputOtherEvent(makeEntry({
+      'event.name': 'agent.input',
+      'gen_ai.input.messages': [],
+    }))).toBe(false);
+  });
+
+  it.each([
+    ['messages', { 'gen_ai.input.messages': [{ role: 'user', content: 'hello' }] }],
+    ['messages_delta', { 'gen_ai.input.messages_delta': [{ role: 'user', content: 'hello' }] }],
+    ['empty messages_delta', { 'gen_ai.input.messages_delta': [] }],
+  ])('expands input other with %s', (_name, inputFields) => {
+    const source = makeEntry(inputFields as Partial<AgentActivityEntry>);
+    const result = expandAgentInputEvents([source]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(source);
+    expect(result[1]['event.name']).toBe('agent.input');
+  });
+
+  it('changes only event.name and event.id on the derived event', () => {
+    const source = makeEntry({
+      'gen_ai.input.messages_delta': [{ role: 'user', content: 'hello' }],
+      trace_id: '0123456789abcdef0123456789abcdef',
+      'gen_ai.turn.id': 'turn-1',
+      custom: { nested: ['value'] },
+    });
+
+    const [, derived] = expandAgentInputEvents([source]);
+    const stripIdentity = ({ 'event.id': _eventId, 'event.name': _eventName, ...rest }: AgentActivityEntry) => rest;
+
+    expect(stripIdentity(derived)).toEqual(stripIdentity(source));
+    expect(derived['event.id']).not.toBe(source['event.id']);
+    expect(source['event.name']).toBe('other');
+    expect(source['event.id']).toBe('source-event');
+  });
+
+  it('derives a deterministic UUID v5 in the fixed namespace', () => {
+    const expected = uuidv5('source-event', AGENT_INPUT_EVENT_NAMESPACE);
+    expect(deriveAgentInputEventId('source-event')).toBe(expected);
+    expect(deriveAgentInputEventId('source-event')).toBe(expected);
+    expect(expected).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+
+  it('preserves original order and inserts the derived event next to its source', () => {
+    const before = makeEntry({ 'event.id': 'before', 'event.name': 'tool.call' });
+    const source = makeEntry({
+      'event.id': 'input',
+      'gen_ai.input.messages_delta': [{ role: 'user', content: 'hello' }],
+    });
+    const after = makeEntry({ 'event.id': 'after', 'event.name': 'tool.result' });
+
+    const result = expandAgentInputEvents([before, source, after]);
+    expect(result.map(entry => entry['event.id'])).toEqual([
+      'before',
+      'input',
+      deriveAgentInputEventId('input'),
+      'after',
+    ]);
+  });
+
+  it('is idempotent when an expanded batch is processed again', () => {
+    const source = makeEntry({
+      'gen_ai.input.messages_delta': [{ role: 'user', content: 'hello' }],
+    });
+    const once = expandAgentInputEvents([source]);
+    const twice = expandAgentInputEvents(once);
+
+    expect(twice.map(entry => entry['event.id'])).toEqual(
+      once.map(entry => entry['event.id']),
+    );
+  });
+
+  it('does not append when the derived ID already exists in the batch', () => {
+    const source = makeEntry({
+      'gen_ai.input.messages': [{ role: 'user', content: 'hello' }],
+    });
+    const existingDerived = makeEntry({
+      'event.id': deriveAgentInputEventId(source['event.id']),
+      'event.name': 'agent.input',
+      'gen_ai.input.messages': source['gen_ai.input.messages'],
+    });
+
+    const result = expandAgentInputEvents([source, existingDerived]);
+    expect(result).toEqual([source, existingDerived]);
+  });
+
+  it('preserves non-input other and all non-other events unchanged', () => {
+    const metadataOther = makeEntry({ 'event.id': 'metadata' });
+    const request = makeEntry({
+      'event.id': 'request',
+      'event.name': 'llm.request',
+      'gen_ai.input.messages': [{ role: 'user', content: 'hello' }],
+    });
+
+    expect(expandAgentInputEvents([metadataOther, request])).toEqual([
+      metadataOther,
+      request,
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- centrally duplicate every input-bearing `other` event as an adjacent `agent.input` after shared enrichment, content policy, and masking
- preserve the original event and all derived fields, while assigning the compatibility event a deterministic UUID v5
- send the expanded batch to SLS, JSONL, HTTP, and OTLP; exclude `agent.input` only at the EventLog-to-Trace conversion boundary so Trace spans remain unchanged
- extend strict event-name contracts, documentation, and regression coverage

## Testing

- `npx vitest run tests/unit/normalization/agent-input-dual-write.test.ts tests/unit/core/input-manager.test.ts tests/contract/agent-activity-entry.test.ts tests/e2e-remote/jsonl-validate.test.mjs tests/unit/flushers/otlp-trace-flusher/conversion.test.ts tests/unit/flushers/otlp-trace-flusher/agent-input-dual-write.test.ts tests/integration/openclaw-plugin-event-log-flow.test.ts` (7 files, 100 tests passed)
- `npm run typecheck`
- `npm run build`
- `npm test` (3666 passed; 15 local failures are the existing Hermes Python child-process `SIGKILL`, reproduced on the unchanged `main` checkout)

## Verification gap

- `./scripts/e2e/run-e2e.sh install-smoke` was not run because the local E2E environment does not provide `E2E_SLS_ACCESS_KEY_ID` or `E2E_SLS_ACCESS_KEY_SECRET`.