### PR TITLE
feat: add upgrade CLI

### DIFF
--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -57,6 +57,7 @@ $CONFIG_FILE = Join-Path $DATA_DIR "config.json"
 $SPAN_ATTR_FILE = Join-Path $DATA_DIR "span-attributes.json"
 $NODE_PIN_FILE = Join-Path $CACHE_DIR "node-bin"
 $INIT_TYPE_FILE = Join-Path $DATA_DIR "init-type"
+$OPEN_SOURCE_INSTALLER_URL = "https://loongcollector-community-edition.oss-cn-shanghai.aliyuncs.com/loongsuite-pilot/installer.ps1"
 
 # >>> pilot-account-identity >>>
 # Windows account identity, DOMAIN\user, without whoami. On 5.1 a native command's
@@ -246,6 +247,27 @@ function Resolve-CurrentVersion {
     $indexJs = Join-Path $PACKAGE_DIR "dist\index.js"
     if (Test-Path $indexJs) { return $PACKAGE_DIR }
     return $null
+}
+
+function Get-BuildEdition {
+    try {
+        $versionDir = Resolve-CurrentVersion
+        if (-not $versionDir) { return "" }
+
+        $probe = Join-Path $versionDir "dist\cli-probe.cjs"
+        if (-not (Test-Path -LiteralPath $probe)) { return "" }
+
+        $nodeBin = Resolve-Node
+        if (-not $nodeBin) { return "" }
+
+        return ([string](& $nodeBin $probe --build-edition 2>$null)).Trim()
+    } catch {
+        return ""
+    }
+}
+
+function Test-OpenSourceBuild {
+    return (Get-BuildEdition) -eq "opensource"
 }
 
 function Resolve-PreviousVersion {
@@ -1250,6 +1272,72 @@ function Cmd-Info {
     }
 }
 
+function Show-UpgradeUsage {
+    Write-Host "Usage: loongsuite-pilot upgrade [--version <version>]"
+    Write-Host ""
+    Write-Host "Upgrade the open-source edition to the latest release, or to a specific version."
+}
+
+function Cmd-Upgrade {
+    $version = ""
+    for ($i = 0; $i -lt $SubArgs.Count; $i++) {
+        $arg = [string]$SubArgs[$i]
+        if ($arg -in @("--version", "-Version")) {
+            if ($i + 1 -ge $SubArgs.Count -or -not $SubArgs[$i + 1]) {
+                Write-Error "--version requires a value"
+                exit 1
+            }
+            $i++
+            $version = [string]$SubArgs[$i]
+        } elseif ($arg -match '^--version=(.*)$') {
+            $version = [string]$Matches[1]
+            if (-not $version) {
+                Write-Error "--version requires a value"
+                exit 1
+            }
+        } elseif ($arg -in @("help", "--help", "-h")) {
+            Show-UpgradeUsage
+            return
+        } else {
+            Write-Host "Unknown upgrade option: $arg" -ForegroundColor Red
+            Show-UpgradeUsage
+            exit 1
+        }
+    }
+
+    if ($version -and $version -notmatch '^\d+\.\d+\.\d+(?:[.-][0-9A-Za-z.-]+)?$') {
+        Write-Host "Invalid version: $version (expected e.g. 1.6.0)" -ForegroundColor Red
+        exit 1
+    }
+
+    $tempRoot = if ($env:TEMP) { $env:TEMP } else { $DEFAULT_PILOT_DIR }
+    if (-not (Test-Path -LiteralPath $tempRoot)) {
+        New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+    }
+    $installerFile = Join-Path $tempRoot ("loongsuite-pilot-installer-" + (Get-Random) + ".ps1")
+
+    try {
+        Invoke-WebRequest -Uri $OPEN_SOURCE_INSTALLER_URL -OutFile $installerFile -UseBasicParsing
+        $installerArgs = @(
+            "-NoProfile",
+            "-ExecutionPolicy", "Bypass",
+            "-File", $installerFile,
+            "upgrade",
+            "-DataDir", $DATA_DIR
+        )
+        if ($version) { $installerArgs += @("-Version", $version) }
+
+        $env:LOONGSUITE_PILOT_DATA_DIR = $DATA_DIR
+        $env:LOONGSUITE_PILOT_CACHE_DIR = $CACHE_DIR
+        & powershell.exe @installerArgs
+        $installerExit = $LASTEXITCODE
+    } finally {
+        Remove-Item -LiteralPath $installerFile -Force -ErrorAction SilentlyContinue
+    }
+
+    if ($installerExit -ne 0) { exit $installerExit }
+}
+
 # ============================================================
 # CMD: rollback
 # ============================================================
@@ -1567,6 +1655,9 @@ function Cmd-Help {
     Write-Host "  tokens          Alias for token-usage"
     Write-Host "  span-attr ...   Manage custom trace span attributes (set/unset/list/clear)"
     Write-Host "  agent ...       Register/list/diagnose PI SDK Agents"
+    if (Test-OpenSourceBuild) {
+        Write-Host "  upgrade [opts]  Upgrade to latest or --version <version> (open-source only)"
+    }
     Write-Host "  rollback        Roll back to the previous version"
     Write-Host "  worker          Manage local Workers:"
     Write-Host "                    worker connect/list/status/disconnect/delete"
@@ -1586,6 +1677,15 @@ switch ($Command.ToLower()) {
     "deploy"             { Cmd-Deploy }
     "token-usage"        { Cmd-TokenUsage }
     "tokens"             { Cmd-TokenUsage }
+    "upgrade" {
+        if (Test-OpenSourceBuild) {
+            Cmd-Upgrade
+        } else {
+            Write-Host "Unknown command: upgrade"
+            Cmd-Help
+            exit 1
+        }
+    }
     "rollback"           { Cmd-Rollback }
     "worker"             { Cmd-Worker }
     "agent"              { Cmd-Agent }

--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -1316,8 +1316,18 @@ function Cmd-Upgrade {
     }
     $installerFile = Join-Path $tempRoot ("loongsuite-pilot-installer-" + (Get-Random) + ".ps1")
 
+    $installerExit = 1
     try {
-        Invoke-WebRequest -Uri $OPEN_SOURCE_INSTALLER_URL -OutFile $installerFile -UseBasicParsing
+        # Windows PowerShell 5.1 may still default to TLS 1.0. Match the
+        # open-source installer's best-effort TLS 1.2 compatibility handling;
+        # the assignment can be blocked under Constrained Language Mode.
+        try { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 } catch {}
+        try {
+            Invoke-WebRequest -Uri $OPEN_SOURCE_INSTALLER_URL -OutFile $installerFile -UseBasicParsing
+        } catch {
+            Write-Host "Failed to download the open-source installer: $_" -ForegroundColor Red
+            exit 1
+        }
         $installerArgs = @(
             "-NoProfile",
             "-ExecutionPolicy", "Bypass",
@@ -1332,7 +1342,17 @@ function Cmd-Upgrade {
         & powershell.exe @installerArgs
         $installerExit = $LASTEXITCODE
     } finally {
-        Remove-Item -LiteralPath $installerFile -Force -ErrorAction SilentlyContinue
+        # Cleanup must not replace the installer's real success/failure result.
+        # In particular, some 8.3-short %TEMP% paths make the FileSystem
+        # provider throw a terminating normalization error that SilentlyContinue
+        # cannot suppress.
+        try {
+            if (Test-Path -LiteralPath $installerFile -ErrorAction SilentlyContinue) {
+                Remove-Item -LiteralPath $installerFile -Force -ErrorAction Stop
+            }
+        } catch {
+            Write-Warning "Failed to remove temporary installer: $_"
+        }
     }
 
     if ($installerExit -ne 0) { exit $installerExit }

--- a/scripts/loongsuite-pilot.sh
+++ b/scripts/loongsuite-pilot.sh
@@ -1338,6 +1338,19 @@ cmd_upgrade() {
         return 1
     fi
 
+    # The published Unix installer still stores version pointers and packages
+    # under the default ~/.loongsuite-pilot tree. Passing a custom cache env to
+    # it would either upgrade a stale default install or report success without
+    # changing the version this CLI actually uses, so fail closed until the
+    # installer supports a custom cache directory end to end.
+    local default_cache_dir="$HOME/.loongsuite-pilot"
+    if [ "$CACHE_DIR" != "$default_cache_dir" ]; then
+        echo "❌ Manual upgrade does not yet support a custom cache directory on macOS/Linux." >&2
+        echo "   Current cache directory: $CACHE_DIR" >&2
+        echo "   Supported cache directory: $default_cache_dir" >&2
+        return 1
+    fi
+
     local installer_file
     installer_file=$(mktemp "${TMPDIR:-/tmp}/loongsuite-pilot-installer.XXXXXX") || {
         echo "❌ Failed to create temporary installer file" >&2

--- a/scripts/loongsuite-pilot.sh
+++ b/scripts/loongsuite-pilot.sh
@@ -18,6 +18,7 @@ LOG_FILE="$LOG_DIR/loongsuite-pilot-service.log"
 UPDATER_LOG_FILE="$LOG_DIR/loongsuite-pilot-updater.log"
 CONFIG_FILE="$DATA_DIR/config.json"
 SPAN_ATTR_FILE="$DATA_DIR/span-attributes.json"
+OPEN_SOURCE_INSTALLER_URL="https://loongcollector-community-edition.oss-cn-shanghai.aliyuncs.com/loongsuite-pilot/installer.sh"
 
 SERVICE_LABEL="com.loongsuite-pilot"
 UPDATER_LABEL="com.loongsuite-pilot.updater"
@@ -566,6 +567,22 @@ resolve_current_version() {
         return 0
     fi
     return 1
+}
+
+build_edition() {
+    local version_dir
+    version_dir=$(resolve_current_version 2>/dev/null) || return 1
+
+    local probe="$version_dir/dist/cli-probe.cjs"
+    [ -f "$probe" ] || return 1
+
+    local node_bin
+    node_bin=$(resolve_node 2>/dev/null) || return 1
+    "$node_bin" "$probe" --build-edition 2>/dev/null
+}
+
+is_opensource_build() {
+    [ "$(build_edition 2>/dev/null || true)" = "opensource" ]
 }
 
 resolve_previous_version() {
@@ -1276,6 +1293,84 @@ cmd_token_usage() {
 
     export AGENT_DATA_COLLECTION_CONFIG="$CONFIG_FILE"
     exec "$node_bin" "$entry" token-usage "$@"
+}
+
+print_upgrade_usage() {
+    echo "Usage: loongsuite-pilot upgrade [--version <version>]"
+    echo ""
+    echo "Upgrade the open-source edition to the latest release, or to a specific version."
+}
+
+cmd_upgrade() {
+    local version=""
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --version)
+                if [ "$#" -lt 2 ] || [ -z "$2" ]; then
+                    echo "❌ --version requires a value" >&2
+                    return 1
+                fi
+                version="$2"
+                shift 2
+                ;;
+            --version=*)
+                version="${1#*=}"
+                if [ -z "$version" ]; then
+                    echo "❌ --version requires a value" >&2
+                    return 1
+                fi
+                shift
+                ;;
+            help|--help|-h)
+                print_upgrade_usage
+                return 0
+                ;;
+            *)
+                echo "Unknown upgrade option: $1" >&2
+                print_upgrade_usage >&2
+                return 1
+                ;;
+        esac
+    done
+
+    if [ -n "$version" ] && ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+        echo "❌ Invalid version: $version (expected e.g. 1.6.0)" >&2
+        return 1
+    fi
+
+    local installer_file
+    installer_file=$(mktemp "${TMPDIR:-/tmp}/loongsuite-pilot-installer.XXXXXX") || {
+        echo "❌ Failed to create temporary installer file" >&2
+        return 1
+    }
+
+    local download_ok=0
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$OPEN_SOURCE_INSTALLER_URL" -o "$installer_file" && download_ok=1
+    elif command -v wget >/dev/null 2>&1; then
+        wget -q "$OPEN_SOURCE_INSTALLER_URL" -O "$installer_file" && download_ok=1
+    else
+        echo "❌ curl or wget is required to download the installer" >&2
+    fi
+
+    if [ "$download_ok" -ne 1 ]; then
+        rm -f "$installer_file"
+        echo "❌ Failed to download the open-source installer" >&2
+        return 1
+    fi
+
+    local result=0
+    if [ -n "$version" ]; then
+        LOONGSUITE_PILOT_DATA_DIR="$DATA_DIR" \
+        LOONGSUITE_PILOT_CACHE_DIR="$CACHE_DIR" \
+            bash "$installer_file" upgrade --data-dir "$DATA_DIR" --version "$version" || result=$?
+    else
+        LOONGSUITE_PILOT_DATA_DIR="$DATA_DIR" \
+        LOONGSUITE_PILOT_CACHE_DIR="$CACHE_DIR" \
+            bash "$installer_file" upgrade --data-dir "$DATA_DIR" || result=$?
+    fi
+    rm -f "$installer_file"
+    return "$result"
 }
 
 cleanup_hermes_for_rollback() {
@@ -2216,6 +2311,9 @@ cmd_help() {
     echo "  agent ...       Register/list/diagnose PI SDK Agents"
     echo "  span-attr ...   Manage custom trace span attributes (set/unset/list/clear)"
     echo "  worker ...      Manage local remote-controlled workers"
+    if is_opensource_build; then
+        echo "  upgrade [opts]  Upgrade to latest or --version <version> (open-source only)"
+    fi
     echo "  rollback        Roll back to the previous version"
     echo "  help            Show this help message"
 }
@@ -2234,6 +2332,16 @@ case "${1:-status}" in
     span-attr)   shift; cmd_span_attr "$@" ;;
     worker)              shift; cmd_worker "$@" ;;
     agent)               shift; cmd_agent "$@" ;;
+    upgrade)
+        shift
+        if is_opensource_build; then
+            cmd_upgrade "$@"
+        else
+            echo "Unknown command: upgrade"
+            cmd_help
+            exit 1
+        fi
+        ;;
     rollback)            cmd_rollback ;;
     restart-collector)   cmd_restart_collector ;;
     restart-updater)     cmd_restart_updater ;;

--- a/src/cli-probe.ts
+++ b/src/cli-probe.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path';
+import { PROPRIETARY_BUILD } from './core/build-constants.js';
 import { AgentDefLoader } from './deployment/agent-def-loader.js';
 import { probeAgentDefinitions } from './deployment/cli-probe-detector.js';
 import { resolveHome } from './utils/fs-utils.js';
@@ -7,6 +8,15 @@ import { resolveHome } from './utils/fs-utils.js';
 const __probe_dirname = __dirname;
 
 async function main(): Promise<void> {
+  // The installed service wrappers use this private probe to expose commands
+  // that only make sense for the open-source distribution. Keep the edition
+  // decision tied to the existing compile-time build flag instead of mutable
+  // user configuration such as autoUpdate.packageUrl.
+  if (process.argv.includes('--build-edition')) {
+    process.stdout.write(PROPRIETARY_BUILD ? 'proprietary' : 'opensource');
+    return;
+  }
+
   const builtinDir = path.resolve(__probe_dirname, '..', 'agents.d');
   const pilotDir = path.resolve(__probe_dirname, '..');
   const dataDir = resolveHome('~/.loongsuite-pilot');

--- a/tests/unit/scripts/opensource-upgrade-cli.test.mjs
+++ b/tests/unit/scripts/opensource-upgrade-cli.test.mjs
@@ -46,10 +46,11 @@ async function builtEdition(proprietary) {
   return result.stdout.trim();
 }
 
-function shellFixture(edition) {
+function shellFixture(edition, { customCache = false, customData = false } = {}) {
   const root = makeTemporaryRoot('pilot-upgrade-cli-');
   const profile = path.join(root, 'profile');
-  const cacheDir = path.join(profile, '.loongsuite-pilot');
+  const cacheDir = customCache ? path.join(root, 'custom-cache') : path.join(profile, '.loongsuite-pilot');
+  const dataDir = customData ? path.join(root, 'custom-data') : cacheDir;
   const versionDir = path.join(cacheDir, 'versions', 'test-version');
   const fakeBin = path.join(root, 'bin');
   const tempDir = path.join(root, 'tmp');
@@ -89,7 +90,7 @@ INSTALLER
   const env = {
     ...process.env,
     HOME: profile,
-    LOONGSUITE_PILOT_DATA_DIR: cacheDir,
+    LOONGSUITE_PILOT_DATA_DIR: dataDir,
     LOONGSUITE_PILOT_CACHE_DIR: cacheDir,
     PATH: `${fakeBin}${path.delimiter}${process.env.PATH || ''}`,
     TMPDIR: tempDir,
@@ -100,6 +101,7 @@ INSTALLER
 
   return {
     curlArgs,
+    dataDir,
     installerArgs,
     run(...args) {
       return spawnSync('bash', [shellCli, ...args], {
@@ -214,6 +216,25 @@ describeShellRuntime('open-source upgrade shell command', () => {
     expect(fs.existsSync(fixture.curlArgs)).toBe(false);
   });
 
+  it('rejects a custom cache directory before downloading on Unix', () => {
+    const fixture = shellFixture('opensource', { customCache: true });
+    const result = fixture.run('upgrade');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('does not yet support a custom cache directory');
+    expect(fs.existsSync(fixture.curlArgs)).toBe(false);
+  });
+
+  it('still supports a custom data directory when the cache directory is default', () => {
+    const fixture = shellFixture('opensource', { customData: true });
+    const result = fixture.run('upgrade');
+
+    expect(result.status).toBe(0);
+    expect(fs.readFileSync(fixture.installerArgs, 'utf8')).toBe(
+      `upgrade\n--data-dir\n${fixture.dataDir}\n`,
+    );
+  });
+
   it('rejects the command for proprietary or unidentified builds', () => {
     for (const edition of ['proprietary', '']) {
       const fixture = shellFixture(edition);
@@ -237,6 +258,18 @@ describe('open-source upgrade PowerShell contract', () => {
     expect(script).toContain('$env:LOONGSUITE_PILOT_CACHE_DIR = $CACHE_DIR');
     expect(script).toContain('$installerArgs += @("-Version", $version)');
     expect(script).toContain('"upgrade" {');
+  });
+
+  it('protects the initial download and preserves the installer exit result during cleanup', () => {
+    const script = fs.readFileSync(powershellCli, 'utf8');
+    const upgrade = script.slice(script.indexOf('function Cmd-Upgrade'), script.indexOf('# CMD: rollback'));
+
+    expect(upgrade).toContain('$installerExit = 1');
+    expect(upgrade).toContain('[Net.SecurityProtocolType]::Tls12');
+    expect(upgrade).toContain('Failed to download the open-source installer');
+    expect(upgrade).toContain('Remove-Item -LiteralPath $installerFile -Force -ErrorAction Stop');
+    expect(upgrade).toContain('Write-Warning "Failed to remove temporary installer: $_"');
+    expect(upgrade).not.toContain('Remove-Item -LiteralPath $installerFile -Force -ErrorAction SilentlyContinue');
   });
 });
 

--- a/tests/unit/scripts/opensource-upgrade-cli.test.mjs
+++ b/tests/unit/scripts/opensource-upgrade-cli.test.mjs
@@ -1,0 +1,255 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const shellCli = path.join(projectRoot, 'scripts', 'loongsuite-pilot.sh');
+const powershellCli = path.join(projectRoot, 'scripts', 'loongsuite-pilot.ps1');
+const temporaryRoots = [];
+
+function makeTemporaryRoot(prefix) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  temporaryRoots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  while (temporaryRoots.length > 0) {
+    fs.rmSync(temporaryRoots.pop(), { recursive: true, force: true });
+  }
+});
+
+async function builtEdition(proprietary) {
+  const root = makeTemporaryRoot('pilot-build-edition-');
+  const output = path.join(root, 'cli-probe.cjs');
+  await build({
+    entryPoints: [path.join(projectRoot, 'src', 'cli-probe.ts')],
+    outfile: output,
+    platform: 'node',
+    target: 'es2022',
+    format: 'cjs',
+    bundle: true,
+    define: {
+      __PROPRIETARY_BUILD__: String(proprietary),
+    },
+    logLevel: 'silent',
+  });
+
+  const result = spawnSync(process.execPath, [output, '--build-edition'], {
+    encoding: 'utf8',
+  });
+  expect(result.status).toBe(0);
+  return result.stdout.trim();
+}
+
+function shellFixture(edition) {
+  const root = makeTemporaryRoot('pilot-upgrade-cli-');
+  const profile = path.join(root, 'profile');
+  const cacheDir = path.join(profile, '.loongsuite-pilot');
+  const versionDir = path.join(cacheDir, 'versions', 'test-version');
+  const fakeBin = path.join(root, 'bin');
+  const tempDir = path.join(root, 'tmp');
+  const curlArgs = path.join(root, 'curl-args.txt');
+  const installerArgs = path.join(root, 'installer-args.txt');
+
+  fs.mkdirSync(path.join(versionDir, 'dist'), { recursive: true });
+  fs.mkdirSync(fakeBin, { recursive: true });
+  fs.mkdirSync(tempDir, { recursive: true });
+  fs.writeFileSync(path.join(cacheDir, 'current'), 'test-version\n');
+  fs.writeFileSync(path.join(cacheDir, 'node-bin'), `${process.execPath}\n`);
+  fs.writeFileSync(
+    path.join(versionDir, 'dist', 'cli-probe.cjs'),
+    'if (process.argv.includes("--build-edition")) process.stdout.write(process.env.PILOT_TEST_EDITION || "");\n',
+  );
+  fs.writeFileSync(
+    path.join(fakeBin, 'curl'),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$@" > "$PILOT_TEST_CURL_ARGS"
+output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) output="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$output" ]
+cat > "$output" <<'INSTALLER'
+#!/usr/bin/env bash
+printf '%s\\n' "$@" > "$PILOT_TEST_INSTALLER_ARGS"
+INSTALLER
+`,
+    { mode: 0o755 },
+  );
+
+  const env = {
+    ...process.env,
+    HOME: profile,
+    LOONGSUITE_PILOT_DATA_DIR: cacheDir,
+    LOONGSUITE_PILOT_CACHE_DIR: cacheDir,
+    PATH: `${fakeBin}${path.delimiter}${process.env.PATH || ''}`,
+    TMPDIR: tempDir,
+    PILOT_TEST_EDITION: edition,
+    PILOT_TEST_CURL_ARGS: curlArgs,
+    PILOT_TEST_INSTALLER_ARGS: installerArgs,
+  };
+
+  return {
+    curlArgs,
+    installerArgs,
+    run(...args) {
+      return spawnSync('bash', [shellCli, ...args], {
+        env,
+        encoding: 'utf8',
+        timeout: 15_000,
+      });
+    },
+  };
+}
+
+function powershellFixture(edition) {
+  const root = makeTemporaryRoot('pilot-upgrade-powershell-');
+  const profile = path.join(root, 'profile');
+  const cacheDir = path.join(profile, '.loongsuite-pilot');
+  const versionDir = path.join(cacheDir, 'versions', 'test-version');
+
+  fs.mkdirSync(path.join(versionDir, 'dist'), { recursive: true });
+  fs.writeFileSync(path.join(cacheDir, 'current'), 'test-version\n');
+  fs.writeFileSync(path.join(cacheDir, 'node-bin'), `${process.execPath}\n`);
+  fs.writeFileSync(
+    path.join(versionDir, 'dist', 'cli-probe.cjs'),
+    'if (process.argv.includes("--build-edition")) process.stdout.write(process.env.PILOT_TEST_EDITION || "");\n',
+  );
+
+  return spawnSync(
+    'powershell.exe',
+    ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', powershellCli, 'help'],
+    {
+      env: {
+        ...process.env,
+        USERPROFILE: profile,
+        LOONGSUITE_PILOT_DATA_DIR: cacheDir,
+        LOONGSUITE_PILOT_CACHE_DIR: cacheDir,
+        PILOT_TEST_EDITION: edition,
+      },
+      encoding: 'utf8',
+      timeout: 15_000,
+    },
+  );
+}
+
+describe('open-source upgrade build gate', () => {
+  it('reports the edition from the existing compile-time build flag', async () => {
+    await expect(builtEdition(false)).resolves.toBe('opensource');
+    await expect(builtEdition(true)).resolves.toBe('proprietary');
+  });
+
+  it('does not use mutable config or updater files as the edition signal', () => {
+    const shell = fs.readFileSync(shellCli, 'utf8');
+    const powershell = fs.readFileSync(powershellCli, 'utf8');
+    const shellGate = shell.slice(shell.indexOf('build_edition()'), shell.indexOf('resolve_previous_version()'));
+    const powershellGate = powershell.slice(
+      powershell.indexOf('function Get-BuildEdition'),
+      powershell.indexOf('function Resolve-PreviousVersion'),
+    );
+
+    for (const gate of [shellGate, powershellGate]) {
+      expect(gate).toContain('--build-edition');
+      expect(gate).not.toContain('config.json');
+      expect(gate).not.toContain('packageUrl');
+      expect(gate).not.toContain('updater-daemon.js');
+    }
+  });
+});
+
+const describeShellRuntime = process.platform === 'win32' ? describe.skip : describe;
+
+describeShellRuntime('open-source upgrade shell command', () => {
+  it('shows the command only for open-source builds', () => {
+    const opensource = shellFixture('opensource').run('help');
+    const proprietary = shellFixture('proprietary').run('help');
+    const unidentified = shellFixture('').run('help');
+
+    expect(opensource.status).toBe(0);
+    expect(opensource.stdout).toContain('upgrade [opts]');
+    expect(proprietary.status).toBe(0);
+    expect(proprietary.stdout).not.toContain('upgrade [opts]');
+    expect(unidentified.status).toBe(0);
+    expect(unidentified.stdout).not.toContain('upgrade [opts]');
+  });
+
+  it('downloads the fixed public installer and upgrades to latest', () => {
+    const fixture = shellFixture('opensource');
+    const result = fixture.run('upgrade');
+
+    expect(result.status).toBe(0);
+    expect(fs.readFileSync(fixture.curlArgs, 'utf8')).toContain(
+      'https://loongcollector-community-edition.oss-cn-shanghai.aliyuncs.com/loongsuite-pilot/installer.sh',
+    );
+    expect(fs.readFileSync(fixture.installerArgs, 'utf8')).toBe(
+      `upgrade\n--data-dir\n${path.dirname(fixture.installerArgs)}/profile/.loongsuite-pilot\n`,
+    );
+  });
+
+  it('forwards a requested version to the installer', () => {
+    const fixture = shellFixture('opensource');
+    const result = fixture.run('upgrade', '--version', '1.6.0');
+
+    expect(result.status).toBe(0);
+    expect(fs.readFileSync(fixture.installerArgs, 'utf8')).toBe(
+      `upgrade\n--data-dir\n${path.dirname(fixture.installerArgs)}/profile/.loongsuite-pilot\n--version\n1.6.0\n`,
+    );
+  });
+
+  it('rejects invalid versions before downloading', () => {
+    const fixture = shellFixture('opensource');
+    const result = fixture.run('upgrade', '--version', '../../commercial');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Invalid version');
+    expect(fs.existsSync(fixture.curlArgs)).toBe(false);
+  });
+
+  it('rejects the command for proprietary or unidentified builds', () => {
+    for (const edition of ['proprietary', '']) {
+      const fixture = shellFixture(edition);
+      const result = fixture.run('upgrade');
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain('Unknown command: upgrade');
+      expect(fs.existsSync(fixture.curlArgs)).toBe(false);
+    }
+  });
+});
+
+describe('open-source upgrade PowerShell contract', () => {
+  it('uses the same build gate, fixed installer, and version forwarding', () => {
+    const script = fs.readFileSync(powershellCli, 'utf8');
+
+    expect(script).toContain('function Test-OpenSourceBuild');
+    expect(script).toContain('if (Test-OpenSourceBuild)');
+    expect(script).toContain('loongsuite-pilot/installer.ps1');
+    expect(script).toContain('"-DataDir", $DATA_DIR');
+    expect(script).toContain('$env:LOONGSUITE_PILOT_CACHE_DIR = $CACHE_DIR');
+    expect(script).toContain('$installerArgs += @("-Version", $version)');
+    expect(script).toContain('"upgrade" {');
+  });
+});
+
+const describePowerShellRuntime = process.platform === 'win32' ? describe : describe.skip;
+
+describePowerShellRuntime('open-source upgrade PowerShell runtime', () => {
+  it('shows the command only for open-source builds', () => {
+    const opensource = powershellFixture('opensource');
+    const proprietary = powershellFixture('proprietary');
+
+    expect(opensource.status).toBe(0);
+    expect(opensource.stdout).toContain('upgrade [opts]');
+    expect(proprietary.status).toBe(0);
+    expect(proprietary.stdout).not.toContain('upgrade [opts]');
+  });
+});


### PR DESCRIPTION
## Summary

- add `loongsuite-pilot upgrade` only for open-source builds
- reuse the fixed public installer URL to upgrade to the latest release or a specified `--version`
- hide and reject the command for proprietary or unidentified builds
- preserve custom data directories when invoking the installer
- fail closed on Unix custom cache directories until the published installer supports them end to end

## Edition behavior

| Build edition | Help | `upgrade` behavior |
| --- | --- | --- |
| Open source | Shown | Download the public installer and run its existing upgrade flow |
| Proprietary | Hidden | Return `Unknown command: upgrade` |
| Unidentified | Hidden | Return `Unknown command: upgrade` |

No packaging logic is changed. The CLI uses the existing `__PROPRIETARY_BUILD__` build marker and fails closed when the edition cannot be identified.

## Validation

- `npm run typecheck`
- `bash -n scripts/loongsuite-pilot.sh`
- focused upgrade/probe tests: 16 passed, 1 Windows-only test skipped on macOS
- script test suite: 123 passed, 10 platform-specific tests skipped
- GitHub CI on Node.js 18/20/22, CodeQL, Secret Scan, and CLA passed for `34ebb0d0`

Closes #331