### PR TITLE
fix(qoder-trace): LLM duration=0 + cross-turn swap + step.id passthrough

### DIFF
--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -294,6 +294,7 @@ const DEFAULT_MAX_EXPORT_BATCH_BYTES = 10 * 1024 * 1024; // 10 MB
 const MAX_CONVERT_STATES = 64;
 const GEN_AI_HIERARCHY_PASSTHROUGH_KEYS = [
   'gen_ai.turn.id',
+  'gen_ai.step.id',
   'gen_ai.agent.scope',
   'gen_ai.agent.depth',
   'gen_ai.agent.parent.id',

--- a/src/inputs/qoder-trace/qoder-trace-input.ts
+++ b/src/inputs/qoder-trace/qoder-trace-input.ts
@@ -18,6 +18,7 @@ import { readInterceptData, type InterceptData } from './intercept-token-reader.
 import { enrichCliTurn, enrichIdeTurn, injectTraceId } from './token-enricher.js';
 import { enrichCliMultimodal } from './qoder-cli-multimodal.js';
 import { clearAttachedImagePathsCache, enrichIdeMultimodal } from './qoder-ide-multimodal.js';
+import { groupSegmentsByTurn, pickSegGroupByTimeOverlap } from './segment-turn-pairing.js';
 
 export interface QoderTraceInputOptions extends InputOptions {
   logDir?: string;
@@ -155,16 +156,17 @@ export class QoderTraceInput extends BaseInput {
     let interceptData: InterceptData | null = null;
     const ideSessionGroups = new Map<string, AgentActivityEntry[]>();
     const cliTurns: AgentActivityEntry[][] = [];
-    // Segment turns are paired with OTLP turns by sequential order (ts asc).
-    // seg.turn_id and OTLP gen_ai.turn.id come from different sources and do NOT
-    // match (segment turn_id = qoder-cli's per-turn UUID; OTLP turn.id = hook
-    // processor's per-turn UUID). Both are per-session and time-ordered, so the
-    // i-th cli turn (per session, ts asc) pairs with the i-th segment turn group
-    // (per session, min responseEndTs asc). Without this scoping, T2's OTLP
-    // steps would steal T1's segments (T1 segs have lower responseEndTs, so they
-    // sort first and pair with whatever OTLP steps are present in entries).
+    // Segment turns are paired with OTLP turns by timestamp overlap
+    // (stateless). seg.turn_id (qoder-cli per-turn UUID) and OTLP
+    // gen_ai.turn.id (hook-processor per-turn UUID) come from different sources
+    // and do NOT match. A prior sequential-index approach (sessionCliTurnIdx)
+    // was stateful and reset per collect() call under incremental collection,
+    // so T2/T3 OTLP turns always picked segGroups[0] = T1's segments. TS overlap
+    // pairing is stateless: for each OTLP turn, pick the segment group whose
+    // [min requestStartTs, max responseEndTs] range overlaps with the OTLP
+    // turn's [min, max time_unix_nano] range. Picked groups are spliced out so
+    // subsequent turns in the same collect() call don't re-pick them.
     const sessionSegGroups = new Map<string, SegmentTokenData[][]>();
-    const sessionCliTurnIdx = new Map<string, number>();
     for (const [, turnEntries] of turnGroups) {
       const variant = this.inferTurnVariant(turnEntries);
       const sessionId = this.extractSessionId(turnEntries);
@@ -177,9 +179,7 @@ export class QoderTraceInput extends BaseInput {
           segGroups = groupSegmentsByTurn(allSegs);
           sessionSegGroups.set(sessionId, segGroups);
         }
-        const turnIdx = sessionCliTurnIdx.get(sessionId) ?? 0;
-        sessionCliTurnIdx.set(sessionId, turnIdx + 1);
-        const turnSegs = segGroups[turnIdx] ?? [];
+        const turnSegs = pickSegGroupByTimeOverlap(segGroups, turnEntries);
         enrichCliTurn(
           turnEntries,
           turnSegs,
@@ -342,21 +342,7 @@ export class QoderTraceInput extends BaseInput {
   }
 }
 
-// Group segments by their segment turn_id, then sort groups by min responseEndTs
-// asc. Used to pair segment turns with OTLP turns by sequential order (ts asc)
-// since seg.turn_id and OTLP gen_ai.turn.id come from different sources and do
-// not match directly.
-function groupSegmentsByTurn(segments: SegmentTokenData[]): SegmentTokenData[][] {
-  const groupsByTurn = new Map<string, SegmentTokenData[]>();
-  for (const seg of segments) {
-    const tid = seg.turnId || '';
-    const list = groupsByTurn.get(tid) ?? [];
-    list.push(seg);
-    groupsByTurn.set(tid, list);
-  }
-  return [...groupsByTurn.values()].sort((a, b) => {
-    const aMin = a.reduce((m, s) => Math.min(m, s.responseEndTs || s.requestStartTs || Infinity), Infinity);
-    const bMin = b.reduce((m, s) => Math.min(m, s.responseEndTs || s.requestStartTs || Infinity), Infinity);
-    return aMin - bMin;
-  });
-}
+// Segment turn pairing helpers (groupSegmentsByTurn, pickSegGroupByTimeOverlap)
+// live in ./segment-turn-pairing.ts — pure logic, unit-testable without
+// loading the heavy QoderTraceInput module.
+

--- a/src/inputs/qoder-trace/qoder-trace-input.ts
+++ b/src/inputs/qoder-trace/qoder-trace-input.ts
@@ -12,7 +12,7 @@ import { buildCanonicalHookEntry } from '../base/canonical-hook-record.js';
 import { filterBootstrapHistoryTurns } from '../base/bootstrap-turn-filter.js';
 import { createHookHistoryStartupCheckpoint } from '../base/hook-history-checkpoint.js';
 import { enrichCanonicalEntryWithGit } from '../../normalization/enrich-git-context.js';
-import { readSegmentTokensForSession } from './segment-token-reader.js';
+import { readSegmentTokensForSession, type SegmentTokenData } from './segment-token-reader.js';
 import { readSqliteTokensForSession, isIdeaDbPath, resolveQoderAppRoot } from './sqlite-token-reader.js';
 import { readInterceptData, type InterceptData } from './intercept-token-reader.js';
 import { enrichCliTurn, enrichIdeTurn, injectTraceId } from './token-enricher.js';
@@ -155,16 +155,34 @@ export class QoderTraceInput extends BaseInput {
     let interceptData: InterceptData | null = null;
     const ideSessionGroups = new Map<string, AgentActivityEntry[]>();
     const cliTurns: AgentActivityEntry[][] = [];
+    // Segment turns are paired with OTLP turns by sequential order (ts asc).
+    // seg.turn_id and OTLP gen_ai.turn.id come from different sources and do NOT
+    // match (segment turn_id = qoder-cli's per-turn UUID; OTLP turn.id = hook
+    // processor's per-turn UUID). Both are per-session and time-ordered, so the
+    // i-th cli turn (per session, ts asc) pairs with the i-th segment turn group
+    // (per session, min responseEndTs asc). Without this scoping, T2's OTLP
+    // steps would steal T1's segments (T1 segs have lower responseEndTs, so they
+    // sort first and pair with whatever OTLP steps are present in entries).
+    const sessionSegGroups = new Map<string, SegmentTokenData[][]>();
+    const sessionCliTurnIdx = new Map<string, number>();
     for (const [, turnEntries] of turnGroups) {
       const variant = this.inferTurnVariant(turnEntries);
       const sessionId = this.extractSessionId(turnEntries);
 
       if (variant === 'qoder-cli' && sessionId) {
         interceptData ??= await readInterceptData();
-        const segments = await readSegmentTokensForSession(sessionId);
+        let segGroups = sessionSegGroups.get(sessionId);
+        if (!segGroups) {
+          const allSegs = await readSegmentTokensForSession(sessionId);
+          segGroups = groupSegmentsByTurn(allSegs);
+          sessionSegGroups.set(sessionId, segGroups);
+        }
+        const turnIdx = sessionCliTurnIdx.get(sessionId) ?? 0;
+        sessionCliTurnIdx.set(sessionId, turnIdx + 1);
+        const turnSegs = segGroups[turnIdx] ?? [];
         enrichCliTurn(
           turnEntries,
-          segments,
+          turnSegs,
           interceptData.systemPrompt?.content,
           interceptData.tokens,
         );
@@ -322,4 +340,23 @@ export class QoderTraceInput extends BaseInput {
     }
     return undefined;
   }
+}
+
+// Group segments by their segment turn_id, then sort groups by min responseEndTs
+// asc. Used to pair segment turns with OTLP turns by sequential order (ts asc)
+// since seg.turn_id and OTLP gen_ai.turn.id come from different sources and do
+// not match directly.
+function groupSegmentsByTurn(segments: SegmentTokenData[]): SegmentTokenData[][] {
+  const groupsByTurn = new Map<string, SegmentTokenData[]>();
+  for (const seg of segments) {
+    const tid = seg.turnId || '';
+    const list = groupsByTurn.get(tid) ?? [];
+    list.push(seg);
+    groupsByTurn.set(tid, list);
+  }
+  return [...groupsByTurn.values()].sort((a, b) => {
+    const aMin = a.reduce((m, s) => Math.min(m, s.responseEndTs || s.requestStartTs || Infinity), Infinity);
+    const bMin = b.reduce((m, s) => Math.min(m, s.responseEndTs || s.requestStartTs || Infinity), Infinity);
+    return aMin - bMin;
+  });
 }

--- a/src/inputs/qoder-trace/segment-token-reader.ts
+++ b/src/inputs/qoder-trace/segment-token-reader.ts
@@ -30,6 +30,7 @@ interface SegmentEvent {
   ts: number;
   requestId?: string;
   turnId?: string;
+  filePath: string;
   data?: Record<string, unknown>;
 }
 
@@ -38,6 +39,7 @@ interface StartedEvent {
   requestId?: string;
   turnId?: string;
   requestIndex?: number;
+  filePath: string;
 }
 
 export async function readSegmentTokensForSession(sessionId: string): Promise<SegmentTokenData[]> {
@@ -47,8 +49,16 @@ export async function readSegmentTokensForSession(sessionId: string): Promise<Se
   const files = await findSegmentFilesForSession(sessionId);
   if (files.length === 0) return [];
 
-  // Collect all events in order to properly associate tool.execution.finished with LLM calls
+  // Segment files are emitted per-turn by qoder-cli (one segment-N.jsonl per
+  // turn). Pairing is therefore scoped to within the same file. This is the
+  // critical boundary that prevents cross-turn timestamp leaks: even when
+  // `model.request.started` lacks `turn_id` (only `model.response.completed`
+  // carries it), the file boundary keeps the pairing within the right turn.
+  // The prior fix (ad34e14f) used a global startedList with a turnId-based
+  // filter; when started lacked turnId the filter rejected all candidates,
+  // startTs fell back to evt.ts (completed), and duration collapsed to 0.
   const allEvents: SegmentEvent[] = [];
+  const fileBuckets: Array<{ path: string; events: SegmentEvent[] }> = [];
 
   for (const filePath of files) {
     let content: string;
@@ -58,6 +68,7 @@ export async function readSegmentTokensForSession(sessionId: string): Promise<Se
       continue;
     }
 
+    const bucket: { path: string; events: SegmentEvent[] } = { path: filePath, events: [] };
     for (const line of content.split('\n')) {
       if (!line.trim()) continue;
       let record: Record<string, unknown>;
@@ -79,21 +90,24 @@ export async function readSegmentTokensForSession(sessionId: string): Promise<Se
       const data = (record.data && typeof record.data === 'object' && !Array.isArray(record.data))
         ? record.data as Record<string, unknown>
         : undefined;
-      allEvents.push({
+      const evt: SegmentEvent = {
         type,
         ts,
         requestId: requestId || undefined,
         turnId: turnId || undefined,
+        filePath,
         data,
-      });
+      };
+      allEvents.push(evt);
+      bucket.events.push(evt);
     }
+    fileBuckets.push(bucket);
   }
 
-  // Build a complete list of started events with their turn_id and request_index.
-  // request_index resets per turn, so the composite key `${turnId}:${requestIndex}`
-  // is what makes the lookup unambiguous in multi-turn sessions. The prior fix
-  // (b30a2ef6) used request_index alone as the key, which collided across turns
-  // and caused turn 2/3 LLM span timestamps to be sourced from turn 1.
+  // Global startedList sorted by ts asc. Exact requestId and composite-key
+  // matches can look across files when needed (rare; qoder-cli rotates
+  // mid-turn). The per-file fallback below is the primary path; cross-file
+  // is only a last resort.
   const startedList: StartedEvent[] = [];
   for (const evt of allEvents) {
     if (evt.type !== 'model.request.started') continue;
@@ -103,91 +117,131 @@ export async function readSegmentTokensForSession(sessionId: string): Promise<Se
       ts: evt.ts,
       requestId: evt.requestId,
       turnId: evt.turnId,
-      requestIndex: requestIndex,
+      requestIndex,
+      filePath: evt.filePath,
     });
   }
   startedList.sort((a, b) => a.ts - b.ts);
 
-  const startedByRequestId = new Map<string, number>();
-  const startedByTurnIndex = new Map<string, number>();
-  for (const s of startedList) {
-    if (s.requestId && !startedByRequestId.has(s.requestId)) {
-      startedByRequestId.set(s.requestId, s.ts);
-    }
-    if (s.turnId && s.requestIndex !== undefined && !startedByTurnIndex.has(turnIndexKey(s.turnId, s.requestIndex))) {
-      startedByTurnIndex.set(turnIndexKey(s.turnId, s.requestIndex), s.ts);
-    }
-  }
-
-  // Track which started events have been consumed so the order fallback only
-  // uses genuinely unclaimed starts. Pairing strategy per completed event:
-  //   1. exact requestId match (UUID globally unique — preserved)
-  //   2. composite (turnId, requestIndex) match — fixes the cross-turn collision
-  //      that occurred when request_index alone was used as the key
-  //   3. order fallback scoped to the same turn: first unclaimed started event
-  //      in the SAME turn (ts asc). When turnId is absent (older segment format
-  //      without turn_id), fall back to global order to preserve prior behavior.
+  // Pairing strategy per completed event (processed per-file, so cross-turn
+  // leakage is structurally impossible):
+  //   1. exact requestId match (UUID globally unique — preserved across files)
+  //   2. same-file composite (turnId, requestIndex) match — both fields
+  //      present, same file → strongest signal
+  //   3. cross-file composite (turnId, requestIndex) match — when started
+  //      lives in a different file but turnId+requestIndex align
+  //   4. same-file order fallback — first unclaimed started in THIS file
+  //      (ts asc). Handles started events that lack turn_id/request_index
+  //      (the production shape that broke ad34e14f).
+  //   5. same-turn order fallback — when turnId present but no same-file
+  //      candidate. Accepts started events whose turnId matches OR is
+  //      undefined (older started events without turn_id field).
+  //   6. legacy global order fallback — when turnId is absent on completed
+  //      (older segment format). Preserves b30a2ef6 behavior.
   const usedStarted = new Set<number>();
   const results: SegmentTokenData[] = [];
 
-  for (const evt of allEvents) {
-    if (evt.type !== 'model.response.completed') continue;
-    const data = evt.data || {};
-    const turnId = evt.turnId ?? '';
-    const requestIndex = finiteNum(data.request_index);
+  for (const bucket of fileBuckets) {
+    for (const evt of bucket.events) {
+      if (evt.type !== 'model.response.completed') continue;
+      const data = evt.data || {};
+      const turnId = evt.turnId ?? '';
+      const requestIndex = finiteNum(data.request_index);
 
-    let startTs: number | undefined;
-    let claimedStartedIdx = -1;
+      let startTs: number | undefined;
+      let claimedStartedIdx = -1;
 
-    if (evt.requestId) {
-      const idx = startedList.findIndex(s => s.requestId === evt.requestId);
-      if (idx >= 0) {
-        startTs = startedList[idx].ts;
-        claimedStartedIdx = idx;
+      // 1. Exact requestId match (UUID globally unique)
+      if (evt.requestId) {
+        const idx = startedList.findIndex(s => s.requestId === evt.requestId);
+        if (idx >= 0) {
+          startTs = startedList[idx].ts;
+          claimedStartedIdx = idx;
+        }
       }
-    }
 
-    if (startTs === undefined && turnId && requestIndex !== undefined) {
-      const idx = startedList.findIndex(s => s.turnId === turnId && s.requestIndex === requestIndex);
-      if (idx >= 0) {
-        startTs = startedList[idx].ts;
-        claimedStartedIdx = idx;
+      // 2. Same-file composite (turnId, requestIndex) match
+      if (startTs === undefined && turnId && requestIndex !== undefined) {
+        for (let i = 0; i < startedList.length; i++) {
+          if (usedStarted.has(i)) continue;
+          if (startedList[i].filePath !== bucket.path) continue;
+          if (startedList[i].turnId !== turnId) continue;
+          if (startedList[i].requestIndex !== requestIndex) continue;
+          startTs = startedList[i].ts;
+          claimedStartedIdx = i;
+          break;
+        }
       }
-    }
 
-    if (startTs === undefined) {
-      // Order fallback. When turnId is present, scope the search to the same
-      // turn only — a cross-turn fallback would reproduce the cross-turn
-      // timestamp mismatch this fix targets. When turnId is absent (older
-      // segment format), fall back to global order.
-      for (let i = 0; i < startedList.length; i++) {
-        if (usedStarted.has(i)) continue;
-        if (turnId && startedList[i].turnId !== turnId) continue;
-        startTs = startedList[i].ts;
-        claimedStartedIdx = i;
-        break;
+      // 3. Cross-file composite (turnId, requestIndex) match
+      if (startTs === undefined && turnId && requestIndex !== undefined) {
+        for (let i = 0; i < startedList.length; i++) {
+          if (usedStarted.has(i)) continue;
+          if (startedList[i].turnId !== turnId) continue;
+          if (startedList[i].requestIndex !== requestIndex) continue;
+          startTs = startedList[i].ts;
+          claimedStartedIdx = i;
+          break;
+        }
       }
+
+      // 4. Same-file order fallback (first unclaimed started in THIS file)
+      if (startTs === undefined) {
+        for (let i = 0; i < startedList.length; i++) {
+          if (usedStarted.has(i)) continue;
+          if (startedList[i].filePath !== bucket.path) continue;
+          startTs = startedList[i].ts;
+          claimedStartedIdx = i;
+          break;
+        }
+      }
+
+      // 5. Same-turn order fallback (when turnId present, no same-file start).
+      //    Accept started events whose turnId matches OR is undefined — the
+      //    undefined case covers older started events that lack turn_id field
+      //    but live in the same logical turn (step 4 is the primary path via
+      //    file boundary; this step only runs when step 4 found nothing).
+      if (startTs === undefined && turnId) {
+        for (let i = 0; i < startedList.length; i++) {
+          if (usedStarted.has(i)) continue;
+          if (startedList[i].turnId !== undefined && startedList[i].turnId !== turnId) continue;
+          startTs = startedList[i].ts;
+          claimedStartedIdx = i;
+          break;
+        }
+      }
+
+      // 6. Legacy global order fallback (no turnId on completed — older format)
+      if (startTs === undefined) {
+        for (let i = 0; i < startedList.length; i++) {
+          if (usedStarted.has(i)) continue;
+          startTs = startedList[i].ts;
+          claimedStartedIdx = i;
+          break;
+        }
+      }
+
+      if (claimedStartedIdx >= 0) usedStarted.add(claimedStartedIdx);
+
+      results.push({
+        requestId: evt.requestId || '',
+        turnId,
+        inputTokens: finiteNum(data.input_tokens) ?? 0,
+        outputTokens: finiteNum(data.output_tokens) ?? 0,
+        cacheReadTokens: finiteNum(data.cache_read_input_tokens) ?? 0,
+        cacheCreationTokens: finiteNum(data.cache_creation_input_tokens) ?? 0,
+        requestStartTs: startTs ?? evt.ts,
+        responseEndTs: evt.ts,
+        toolFinishedTs: 0,
+        stopReason: (data.stop_reason as string) ?? '',
+        model: (data.model as string) ?? '',
+      });
     }
-
-    if (claimedStartedIdx >= 0) usedStarted.add(claimedStartedIdx);
-
-    results.push({
-      requestId: evt.requestId || '',
-      turnId,
-      inputTokens: finiteNum(data.input_tokens) ?? 0,
-      outputTokens: finiteNum(data.output_tokens) ?? 0,
-      cacheReadTokens: finiteNum(data.cache_read_input_tokens) ?? 0,
-      cacheCreationTokens: finiteNum(data.cache_creation_input_tokens) ?? 0,
-      requestStartTs: startTs ?? evt.ts,
-      responseEndTs: evt.ts,
-      toolFinishedTs: 0,
-      stopReason: (data.stop_reason as string) ?? '',
-      model: (data.model as string) ?? '',
-    });
   }
 
   // Associate tool.execution.finished with the preceding LLM call.
   // The last tool.execution.finished before the next model.request.started belongs to that step.
+  // Tool events are processed globally (they may or may not be in the same file).
   for (let i = 0; i < results.length; i++) {
     const currentEnd = results[i].responseEndTs;
     const nextStart = i + 1 < results.length ? results[i + 1].requestStartTs : Infinity;
@@ -213,10 +267,6 @@ export async function readSegmentTokensForSession(sessionId: string): Promise<Se
 
   sessionCache.set(sessionId, { data: results, ts: now });
   return results;
-}
-
-function turnIndexKey(turnId: string, requestIndex: number): string {
-  return `${turnId}:${requestIndex}`;
 }
 
 async function findSegmentFilesForSession(sessionId: string): Promise<string[]> {

--- a/src/inputs/qoder-trace/segment-token-reader.ts
+++ b/src/inputs/qoder-trace/segment-token-reader.ts
@@ -13,6 +13,7 @@ const CACHE_MAX_SIZE = 50;
 
 export interface SegmentTokenData {
   requestId: string;
+  turnId: string;
   inputTokens: number;
   outputTokens: number;
   cacheReadTokens: number;
@@ -24,6 +25,21 @@ export interface SegmentTokenData {
   model: string;
 }
 
+interface SegmentEvent {
+  type: string;
+  ts: number;
+  requestId?: string;
+  turnId?: string;
+  data?: Record<string, unknown>;
+}
+
+interface StartedEvent {
+  ts: number;
+  requestId?: string;
+  turnId?: string;
+  requestIndex?: number;
+}
+
 export async function readSegmentTokensForSession(sessionId: string): Promise<SegmentTokenData[]> {
   const cached = sessionCache.get(sessionId);
   if (cached && Date.now() - cached.ts < CACHE_TTL_MS) return cached.data;
@@ -32,7 +48,7 @@ export async function readSegmentTokensForSession(sessionId: string): Promise<Se
   if (files.length === 0) return [];
 
   // Collect all events in order to properly associate tool.execution.finished with LLM calls
-  const allEvents: Array<{ type: string; ts: number; requestId?: string; data?: Record<string, unknown> }> = [];
+  const allEvents: SegmentEvent[] = [];
 
   for (const filePath of files) {
     let content: string;
@@ -55,20 +71,30 @@ export async function readSegmentTokensForSession(sessionId: string): Promise<Se
       if (!type) continue;
 
       const ts = parseTs(record.ts);
-      if (type === 'model.request.started' || type === 'model.response.completed' || type === 'tool.execution.finished') {
-        const requestId = record.request_id as string | undefined;
-        const data = (record.data && typeof record.data === 'object' && !Array.isArray(record.data))
-          ? record.data as Record<string, unknown>
-          : undefined;
-        allEvents.push({ type, ts, requestId: requestId || undefined, data });
+      if (type !== 'model.request.started' && type !== 'model.response.completed' && type !== 'tool.execution.finished') {
+        continue;
       }
+      const requestId = record.request_id as string | undefined;
+      const turnId = record.turn_id as string | undefined;
+      const data = (record.data && typeof record.data === 'object' && !Array.isArray(record.data))
+        ? record.data as Record<string, unknown>
+        : undefined;
+      allEvents.push({
+        type,
+        ts,
+        requestId: requestId || undefined,
+        turnId: turnId || undefined,
+        data,
+      });
     }
   }
 
-  // Build a complete map of started events, indexed by both requestId and
-  // request_index. Order-fallback below consumes started events that neither
-  // exact requestId nor request_index could place.
-  const startedList: Array<{ ts: number; requestId?: string; requestIndex?: number }> = [];
+  // Build a complete list of started events with their turn_id and request_index.
+  // request_index resets per turn, so the composite key `${turnId}:${requestIndex}`
+  // is what makes the lookup unambiguous in multi-turn sessions. The prior fix
+  // (b30a2ef6) used request_index alone as the key, which collided across turns
+  // and caused turn 2/3 LLM span timestamps to be sourced from turn 1.
+  const startedList: StartedEvent[] = [];
   for (const evt of allEvents) {
     if (evt.type !== 'model.request.started') continue;
     if (evt.ts <= 0) continue;
@@ -76,37 +102,39 @@ export async function readSegmentTokensForSession(sessionId: string): Promise<Se
     startedList.push({
       ts: evt.ts,
       requestId: evt.requestId,
+      turnId: evt.turnId,
       requestIndex: requestIndex,
     });
   }
   startedList.sort((a, b) => a.ts - b.ts);
 
   const startedByRequestId = new Map<string, number>();
-  const startedByIndex = new Map<number, number>();
+  const startedByTurnIndex = new Map<string, number>();
   for (const s of startedList) {
     if (s.requestId && !startedByRequestId.has(s.requestId)) {
       startedByRequestId.set(s.requestId, s.ts);
     }
-    if (s.requestIndex !== undefined && !startedByIndex.has(s.requestIndex)) {
-      startedByIndex.set(s.requestIndex, s.ts);
+    if (s.turnId && s.requestIndex !== undefined && !startedByTurnIndex.has(turnIndexKey(s.turnId, s.requestIndex))) {
+      startedByTurnIndex.set(turnIndexKey(s.turnId, s.requestIndex), s.ts);
     }
   }
 
-  // Track which started events have been consumed by exact match (requestId or
-  // request_index) so the order fallback only uses genuinely unclaimed starts.
-  // Pairing strategy per completed event (in file order):
-  //   1. exact requestId match (prior behavior — preserved)
-  //   2. request_index match (segment-native field, fixes s5/s6 case where
-  //      completed.request_id differs from started.request_id but both carry
-  //      the same request_index)
-  //   3. order fallback: first unconsumed started event in ts asc order
-  //      (matches i-th completed ↔ i-th started when ids diverge entirely)
+  // Track which started events have been consumed so the order fallback only
+  // uses genuinely unclaimed starts. Pairing strategy per completed event:
+  //   1. exact requestId match (UUID globally unique — preserved)
+  //   2. composite (turnId, requestIndex) match — fixes the cross-turn collision
+  //      that occurred when request_index alone was used as the key
+  //   3. order fallback scoped to the same turn: first unclaimed started event
+  //      in the SAME turn (ts asc). When turnId is absent (older segment format
+  //      without turn_id), fall back to global order to preserve prior behavior.
   const usedStarted = new Set<number>();
   const results: SegmentTokenData[] = [];
 
   for (const evt of allEvents) {
     if (evt.type !== 'model.response.completed') continue;
     const data = evt.data || {};
+    const turnId = evt.turnId ?? '';
+    const requestIndex = finiteNum(data.request_index);
 
     let startTs: number | undefined;
     let claimedStartedIdx = -1;
@@ -119,23 +147,22 @@ export async function readSegmentTokensForSession(sessionId: string): Promise<Se
       }
     }
 
-    if (startTs === undefined) {
-      const idx = finiteNum(data.request_index);
-      if (idx !== undefined) {
-        const startedIdx = startedList.findIndex(s => s.requestIndex === idx);
-        if (startedIdx >= 0) {
-          startTs = startedList[startedIdx].ts;
-          claimedStartedIdx = startedIdx;
-        }
+    if (startTs === undefined && turnId && requestIndex !== undefined) {
+      const idx = startedList.findIndex(s => s.turnId === turnId && s.requestIndex === requestIndex);
+      if (idx >= 0) {
+        startTs = startedList[idx].ts;
+        claimedStartedIdx = idx;
       }
     }
 
     if (startTs === undefined) {
-      // Order fallback: first unused started event in ts asc order. This handles
-      // the s5/s6 case where neither requestId nor request_index line up — the
-      // i-th completed event pairs with the i-th (unclaimed) started event.
+      // Order fallback. When turnId is present, scope the search to the same
+      // turn only — a cross-turn fallback would reproduce the cross-turn
+      // timestamp mismatch this fix targets. When turnId is absent (older
+      // segment format), fall back to global order.
       for (let i = 0; i < startedList.length; i++) {
         if (usedStarted.has(i)) continue;
+        if (turnId && startedList[i].turnId !== turnId) continue;
         startTs = startedList[i].ts;
         claimedStartedIdx = i;
         break;
@@ -146,6 +173,7 @@ export async function readSegmentTokensForSession(sessionId: string): Promise<Se
 
     results.push({
       requestId: evt.requestId || '',
+      turnId,
       inputTokens: finiteNum(data.input_tokens) ?? 0,
       outputTokens: finiteNum(data.output_tokens) ?? 0,
       cacheReadTokens: finiteNum(data.cache_read_input_tokens) ?? 0,
@@ -185,6 +213,10 @@ export async function readSegmentTokensForSession(sessionId: string): Promise<Se
 
   sessionCache.set(sessionId, { data: results, ts: now });
   return results;
+}
+
+function turnIndexKey(turnId: string, requestIndex: number): string {
+  return `${turnId}:${requestIndex}`;
 }
 
 async function findSegmentFilesForSession(sessionId: string): Promise<string[]> {

--- a/src/inputs/qoder-trace/segment-token-reader.ts
+++ b/src/inputs/qoder-trace/segment-token-reader.ts
@@ -31,9 +31,6 @@ export async function readSegmentTokensForSession(sessionId: string): Promise<Se
   const files = await findSegmentFilesForSession(sessionId);
   if (files.length === 0) return [];
 
-  const requestStarts = new Map<string, number>();
-  const results: SegmentTokenData[] = [];
-
   // Collect all events in order to properly associate tool.execution.finished with LLM calls
   const allEvents: Array<{ type: string; ts: number; requestId?: string; data?: Record<string, unknown> }> = [];
 
@@ -68,29 +65,97 @@ export async function readSegmentTokensForSession(sessionId: string): Promise<Se
     }
   }
 
-  // Build results from ordered events
+  // Build a complete map of started events, indexed by both requestId and
+  // request_index. Order-fallback below consumes started events that neither
+  // exact requestId nor request_index could place.
+  const startedList: Array<{ ts: number; requestId?: string; requestIndex?: number }> = [];
   for (const evt of allEvents) {
-    if (evt.type === 'model.request.started' && evt.requestId && evt.ts > 0) {
-      requestStarts.set(evt.requestId, evt.ts);
+    if (evt.type !== 'model.request.started') continue;
+    if (evt.ts <= 0) continue;
+    const requestIndex = finiteNum(evt.data?.request_index);
+    startedList.push({
+      ts: evt.ts,
+      requestId: evt.requestId,
+      requestIndex: requestIndex,
+    });
+  }
+  startedList.sort((a, b) => a.ts - b.ts);
+
+  const startedByRequestId = new Map<string, number>();
+  const startedByIndex = new Map<number, number>();
+  for (const s of startedList) {
+    if (s.requestId && !startedByRequestId.has(s.requestId)) {
+      startedByRequestId.set(s.requestId, s.ts);
+    }
+    if (s.requestIndex !== undefined && !startedByIndex.has(s.requestIndex)) {
+      startedByIndex.set(s.requestIndex, s.ts);
+    }
+  }
+
+  // Track which started events have been consumed by exact match (requestId or
+  // request_index) so the order fallback only uses genuinely unclaimed starts.
+  // Pairing strategy per completed event (in file order):
+  //   1. exact requestId match (prior behavior — preserved)
+  //   2. request_index match (segment-native field, fixes s5/s6 case where
+  //      completed.request_id differs from started.request_id but both carry
+  //      the same request_index)
+  //   3. order fallback: first unconsumed started event in ts asc order
+  //      (matches i-th completed ↔ i-th started when ids diverge entirely)
+  const usedStarted = new Set<number>();
+  const results: SegmentTokenData[] = [];
+
+  for (const evt of allEvents) {
+    if (evt.type !== 'model.response.completed') continue;
+    const data = evt.data || {};
+
+    let startTs: number | undefined;
+    let claimedStartedIdx = -1;
+
+    if (evt.requestId) {
+      const idx = startedList.findIndex(s => s.requestId === evt.requestId);
+      if (idx >= 0) {
+        startTs = startedList[idx].ts;
+        claimedStartedIdx = idx;
+      }
     }
 
-    if (evt.type === 'model.response.completed' && evt.requestId) {
-      const data = evt.data || {};
-      const startTs = requestStarts.get(evt.requestId) ?? evt.ts;
-
-      results.push({
-        requestId: evt.requestId,
-        inputTokens: finiteNum(data.input_tokens) ?? 0,
-        outputTokens: finiteNum(data.output_tokens) ?? 0,
-        cacheReadTokens: finiteNum(data.cache_read_input_tokens) ?? 0,
-        cacheCreationTokens: finiteNum(data.cache_creation_input_tokens) ?? 0,
-        requestStartTs: startTs,
-        responseEndTs: evt.ts,
-        toolFinishedTs: 0,
-        stopReason: (data.stop_reason as string) ?? '',
-        model: (data.model as string) ?? '',
-      });
+    if (startTs === undefined) {
+      const idx = finiteNum(data.request_index);
+      if (idx !== undefined) {
+        const startedIdx = startedList.findIndex(s => s.requestIndex === idx);
+        if (startedIdx >= 0) {
+          startTs = startedList[startedIdx].ts;
+          claimedStartedIdx = startedIdx;
+        }
+      }
     }
+
+    if (startTs === undefined) {
+      // Order fallback: first unused started event in ts asc order. This handles
+      // the s5/s6 case where neither requestId nor request_index line up — the
+      // i-th completed event pairs with the i-th (unclaimed) started event.
+      for (let i = 0; i < startedList.length; i++) {
+        if (usedStarted.has(i)) continue;
+        startTs = startedList[i].ts;
+        claimedStartedIdx = i;
+        break;
+      }
+    }
+
+    if (claimedStartedIdx >= 0) usedStarted.add(claimedStartedIdx);
+
+    results.push({
+      requestId: evt.requestId || '',
+      inputTokens: finiteNum(data.input_tokens) ?? 0,
+      outputTokens: finiteNum(data.output_tokens) ?? 0,
+      cacheReadTokens: finiteNum(data.cache_read_input_tokens) ?? 0,
+      cacheCreationTokens: finiteNum(data.cache_creation_input_tokens) ?? 0,
+      requestStartTs: startTs ?? evt.ts,
+      responseEndTs: evt.ts,
+      toolFinishedTs: 0,
+      stopReason: (data.stop_reason as string) ?? '',
+      model: (data.model as string) ?? '',
+    });
   }
 
   // Associate tool.execution.finished with the preceding LLM call.

--- a/src/inputs/qoder-trace/segment-turn-pairing.ts
+++ b/src/inputs/qoder-trace/segment-turn-pairing.ts
@@ -1,0 +1,104 @@
+import type { AgentActivityEntry } from '../../types/index.js';
+import type { SegmentTokenData } from './segment-token-reader.js';
+
+// Group segments by their segment turn_id, then sort groups by min responseEndTs
+// asc. Used to pair segment turns with OTLP turns by timestamp overlap since
+// seg.turn_id and OTLP gen_ai.turn.id come from different sources and do not
+// match directly.
+export function groupSegmentsByTurn(segments: SegmentTokenData[]): SegmentTokenData[][] {
+  const groupsByTurn = new Map<string, SegmentTokenData[]>();
+  for (const seg of segments) {
+    const tid = seg.turnId || '';
+    const list = groupsByTurn.get(tid) ?? [];
+    list.push(seg);
+    groupsByTurn.set(tid, list);
+  }
+  return [...groupsByTurn.values()].sort((a, b) => {
+    const aMin = a.reduce((m, s) => Math.min(m, s.responseEndTs || s.requestStartTs || Infinity), Infinity);
+    const bMin = b.reduce((m, s) => Math.min(m, s.responseEndTs || s.requestStartTs || Infinity), Infinity);
+    return aMin - bMin;
+  });
+}
+
+// Pick the segment group whose [min requestStartTs, max responseEndTs] range
+// overlaps with the OTLP turn's [min, max time_unix_nano] range. Stateless —
+// safe under incremental collection (one new turn per collect() call) where a
+// stateful sequential index would reset and always pick segGroups[0] = T1's
+// segments. Picked group is spliced out of segGroups so subsequent turns in the
+// same collect() call don't re-pick it.
+export function pickSegGroupByTimeOverlap(
+  segGroups: SegmentTokenData[][],
+  turnEntries: AgentActivityEntry[],
+): SegmentTokenData[] {
+  if (segGroups.length === 0) return [];
+  if (segGroups.length === 1) {
+    const picked = segGroups[0];
+    segGroups.length = 0;
+    return picked;
+  }
+
+  let minNanos: bigint | undefined;
+  let maxNanos: bigint | undefined;
+  for (const e of turnEntries) {
+    const ts = e.time_unix_nano;
+    if (typeof ts !== 'string' || ts.length === 0) continue;
+    let v: bigint;
+    try { v = BigInt(ts); } catch { continue; }
+    if (minNanos === undefined || v < minNanos) minNanos = v;
+    if (maxNanos === undefined || v > maxNanos) maxNanos = v;
+  }
+
+  if (minNanos === undefined || maxNanos === undefined) {
+    const picked = segGroups[0];
+    segGroups.shift();
+    return picked;
+  }
+
+  const otlpMinMs = Number(minNanos / 1_000_000n);
+  const otlpMaxMs = Number(maxNanos / 1_000_000n);
+
+  let bestIdx = -1;
+  let bestOverlap = -1;
+  for (let i = 0; i < segGroups.length; i++) {
+    const grp = segGroups[i];
+    let grpMinMs = Infinity;
+    let grpMaxMs = 0;
+    for (const s of grp) {
+      const start = s.requestStartTs || s.responseEndTs;
+      const end = s.responseEndTs || s.requestStartTs;
+      if (start < grpMinMs) grpMinMs = start;
+      if (end > grpMaxMs) grpMaxMs = end;
+    }
+    const overlapMs = Math.max(0, Math.min(otlpMaxMs, grpMaxMs) - Math.max(otlpMinMs, grpMinMs));
+    if (overlapMs > bestOverlap) {
+      bestOverlap = overlapMs;
+      bestIdx = i;
+    }
+  }
+
+  if (bestIdx < 0 || bestOverlap === 0) {
+    const otlpMidMs = (otlpMinMs + otlpMaxMs) / 2;
+    let bestDist = Infinity;
+    for (let i = 0; i < segGroups.length; i++) {
+      const grp = segGroups[i];
+      let grpMinMs = Infinity;
+      let grpMaxMs = 0;
+      for (const s of grp) {
+        const start = s.requestStartTs || s.responseEndTs;
+        const end = s.responseEndTs || s.requestStartTs;
+        if (start < grpMinMs) grpMinMs = start;
+        if (end > grpMaxMs) grpMaxMs = end;
+      }
+      const grpMidMs = (grpMinMs + grpMaxMs) / 2;
+      const dist = Math.abs(grpMidMs - otlpMidMs);
+      if (dist < bestDist) {
+        bestDist = dist;
+        bestIdx = i;
+      }
+    }
+  }
+
+  const picked = segGroups[bestIdx];
+  segGroups.splice(bestIdx, 1);
+  return picked;
+}

--- a/src/inputs/qoder-trace/token-enricher.ts
+++ b/src/inputs/qoder-trace/token-enricher.ts
@@ -27,98 +27,182 @@ export function enrichCliTurn(
     }
   }
 
+  // Pass 1: exact response.id match. Preserved as the preferred path — no
+  // regression for IDE/sqlite/intercept enrichment paths.
+  const claimedEntries = new Set<AgentActivityEntry>();
+  const unmatchedSegs: SegmentTokenData[] = [];
+
   for (const seg of segments) {
     const matches = entries.filter(e =>
       e['gen_ai.response.id'] === seg.requestId && e['event.name'] === 'llm.response',
     );
 
-    if (matches.length === 0) continue;
-
-    // Segment usage is a compatibility fallback only. New qodercli releases
-    // emit zero token fields in segments, while intercept observes the actual
-    // provider usage. Preserve any native usage already present on the entry.
-    const shouldUseSegmentTokens =
-      !hasPositiveEntryUsage(matches[0]) &&
-      (seg.inputTokens > 0 || seg.outputTokens > 0);
-
-    if (shouldUseSegmentTokens) {
-      matches[0]['gen_ai.usage.input_tokens'] = seg.inputTokens;
-      matches[0]['gen_ai.usage.output_tokens'] = seg.outputTokens;
-      matches[0]['gen_ai.usage.total_tokens'] = seg.inputTokens + seg.outputTokens;
-      matches[0]['gen_ai.usage.cache_read.input_tokens'] = seg.cacheReadTokens;
-      matches[0]['gen_ai.usage.cache_creation.input_tokens'] = seg.cacheCreationTokens;
-
-      for (let i = 1; i < matches.length; i++) {
-        zeroUsage(matches[i]);
-      }
+    if (matches.length === 0) {
+      unmatchedSegs.push(seg);
+      continue;
     }
 
-    if (seg.stopReason && !matches[0]['gen_ai.response.finish_reasons']) {
-      matches[0]['gen_ai.response.finish_reasons'] = [seg.stopReason];
-    }
+    for (const m of matches) claimedEntries.add(m);
+    applySegmentToMatch(entries, seg, matches);
+  }
 
-    // Inject segment-derived timestamps and model for the entire step (unified clock source)
-    const stepId = matches[0]['gen_ai.step.id'];
-
-    // Inject real model name from segment (overrides 'auto' from hook-processor)
-    if (seg.model && seg.model !== 'unknown') {
-      matches[0]['gen_ai.request.model'] = seg.model;
-      matches[0]['gen_ai.response.model'] = seg.model;
-      const req = entries.find(e =>
-        e['event.name'] === 'llm.request' && e['gen_ai.step.id'] === stepId,
-      );
-      if (req) req['gen_ai.request.model'] = seg.model;
-    }
-
-    // llm.request: use segment requestStartTs
-    if (seg.requestStartTs > 0) {
-      const req = entries.find(e =>
-        e['event.name'] === 'llm.request' && e['gen_ai.step.id'] === stepId,
-      );
-      if (req) {
-        req.time_unix_nano = String(BigInt(seg.requestStartTs) * 1_000_000n);
-      }
-    }
-
-    // llm.response: use segment responseEndTs
-    if (seg.responseEndTs > 0) {
-      matches[0].time_unix_nano = String(BigInt(seg.responseEndTs) * 1_000_000n);
-    }
-
-    // Preserve per-tool hook timestamps when available. Segment timing has no
-    // tool ID, so it is only a fallback for legacy hook records.
-    if (stepId && seg.toolFinishedTs > 0) {
-      const toolCalls = entries.filter(e =>
-        e['event.name'] === 'tool.call' && e['gen_ai.step.id'] === stepId,
-      );
-      const toolResults = entries.filter(e =>
-        e['event.name'] === 'tool.result' && e['gen_ai.step.id'] === stepId,
-      );
-      const toolCallTs = String(BigInt(seg.responseEndTs) * 1_000_000n);
-      const toolResultTs = String(BigInt(seg.toolFinishedTs) * 1_000_000n);
-      const toolDurationMs = seg.responseEndTs > 0
-        ? seg.toolFinishedTs - seg.responseEndTs
-        : 0;
-      for (const tc of toolCalls) {
-        if (parseUnixNanos(tc.time_unix_nano) === undefined) {
-          tc.time_unix_nano = toolCallTs;
-        }
-      }
-      for (const tr of toolResults) {
-        if (parseUnixNanos(tr.time_unix_nano) === undefined) {
-          tr.time_unix_nano = toolResultTs;
-        }
-        if (tr['gen_ai.tool.call.duration'] === undefined && toolDurationMs > 0) {
-          (tr as Record<string, unknown>)['gen_ai.tool.call.duration'] = toolDurationMs;
-        }
-      }
-    }
+  // Pass 2: order fallback. When response.id does not match (e.g. history has
+  // Anthropic message.id "resp_xxx" while segment request_id is a UUID), pair
+  // unmatched segments with unclaimed llm.response entries by step.id order.
+  // Segments are sorted by responseEndTs asc (model.response.completed order);
+  // steps are paired in numeric step order (segment i ↔ step s(i+1)). This is
+  // additive — only kicks in when exact match missed.
+  if (unmatchedSegs.length > 0) {
+    applyOrderFallback(entries, unmatchedSegs, claimedEntries);
   }
 
   // Intercept is the authoritative qodercli token source. Apply it last so an
   // exact response-id match overrides native/legacy segment usage, but never
   // guesses by order or timestamp when ids differ.
   applyInterceptUsage(entries, interceptTokens);
+}
+
+function applySegmentToMatch(
+  entries: AgentActivityEntry[],
+  seg: SegmentTokenData,
+  matches: AgentActivityEntry[],
+): void {
+  // Segment usage is a compatibility fallback only. New qodercli releases
+  // emit zero token fields in segments, while intercept observes the actual
+  // provider usage. Preserve any native usage already present on the entry.
+  const shouldUseSegmentTokens =
+    !hasPositiveEntryUsage(matches[0]) &&
+    (seg.inputTokens > 0 || seg.outputTokens > 0);
+
+  if (shouldUseSegmentTokens) {
+    matches[0]['gen_ai.usage.input_tokens'] = seg.inputTokens;
+    matches[0]['gen_ai.usage.output_tokens'] = seg.outputTokens;
+    matches[0]['gen_ai.usage.total_tokens'] = seg.inputTokens + seg.outputTokens;
+    matches[0]['gen_ai.usage.cache_read.input_tokens'] = seg.cacheReadTokens;
+    matches[0]['gen_ai.usage.cache_creation.input_tokens'] = seg.cacheCreationTokens;
+
+    for (let i = 1; i < matches.length; i++) {
+      zeroUsage(matches[i]);
+    }
+  }
+
+  if (seg.stopReason && !matches[0]['gen_ai.response.finish_reasons']) {
+    matches[0]['gen_ai.response.finish_reasons'] = [seg.stopReason];
+  }
+
+  // Inject segment-derived timestamps and model for the entire step (unified clock source)
+  const stepId = matches[0]['gen_ai.step.id'];
+
+  // Inject real model name from segment (overrides 'auto' from hook-processor)
+  if (seg.model && seg.model !== 'unknown') {
+    matches[0]['gen_ai.request.model'] = seg.model;
+    matches[0]['gen_ai.response.model'] = seg.model;
+    const req = entries.find(e =>
+      e['event.name'] === 'llm.request' && e['gen_ai.step.id'] === stepId,
+    );
+    if (req) req['gen_ai.request.model'] = seg.model;
+  }
+
+  // llm.request: use segment requestStartTs
+  if (seg.requestStartTs > 0) {
+    const req = entries.find(e =>
+      e['event.name'] === 'llm.request' && e['gen_ai.step.id'] === stepId,
+    );
+    if (req) {
+      req.time_unix_nano = String(BigInt(seg.requestStartTs) * 1_000_000n);
+    }
+  }
+
+  // llm.response: use segment responseEndTs
+  if (seg.responseEndTs > 0) {
+    matches[0].time_unix_nano = String(BigInt(seg.responseEndTs) * 1_000_000n);
+  }
+
+  // Preserve per-tool hook timestamps when available. Segment timing has no
+  // tool ID, so it is only a fallback for legacy hook records.
+  if (stepId && seg.toolFinishedTs > 0) {
+    const toolCalls = entries.filter(e =>
+      e['event.name'] === 'tool.call' && e['gen_ai.step.id'] === stepId,
+    );
+    const toolResults = entries.filter(e =>
+      e['event.name'] === 'tool.result' && e['gen_ai.step.id'] === stepId,
+    );
+    const toolCallTs = String(BigInt(seg.responseEndTs) * 1_000_000n);
+    const toolResultTs = String(BigInt(seg.toolFinishedTs) * 1_000_000n);
+    const toolDurationMs = seg.responseEndTs > 0
+      ? seg.toolFinishedTs - seg.responseEndTs
+      : 0;
+    for (const tc of toolCalls) {
+      if (parseUnixNanos(tc.time_unix_nano) === undefined) {
+        tc.time_unix_nano = toolCallTs;
+      }
+    }
+    for (const tr of toolResults) {
+      if (parseUnixNanos(tr.time_unix_nano) === undefined) {
+        tr.time_unix_nano = toolResultTs;
+      }
+      if (tr['gen_ai.tool.call.duration'] === undefined && toolDurationMs > 0) {
+        (tr as Record<string, unknown>)['gen_ai.tool.call.duration'] = toolDurationMs;
+      }
+    }
+  }
+}
+
+function applyOrderFallback(
+  entries: AgentActivityEntry[],
+  unmatchedSegs: SegmentTokenData[],
+  claimedEntries: Set<AgentActivityEntry>,
+): void {
+  if (unmatchedSegs.length === 0) return;
+
+  // Segments sorted by responseEndTs asc (model.response.completed order).
+  // Stable order ensures consistent pairing when ts ties.
+  const sortedSegs = [...unmatchedSegs].sort((a, b) => a.responseEndTs - b.responseEndTs);
+
+  // Unclaimed llm.response entries grouped by step.id (preserving entry order
+  // within a step for the multi-part response case).
+  const stepToResponses = new Map<string, AgentActivityEntry[]>();
+  for (const entry of entries) {
+    if (entry['event.name'] !== 'llm.response') continue;
+    if (claimedEntries.has(entry)) continue;
+    const stepId = entry['gen_ai.step.id'];
+    if (!stepId) continue;
+    const list = stepToResponses.get(stepId) ?? [];
+    list.push(entry);
+    stepToResponses.set(stepId, list);
+  }
+
+  // Sort step IDs by numeric step number. Format: `${turn}:s${n}`.
+  const sortedStepIds = [...stepToResponses.keys()].sort((a, b) => {
+    const an = parseStepNumber(a);
+    const bn = parseStepNumber(b);
+    if (an !== bn) return an - bn;
+    return a.localeCompare(b);
+  });
+
+  let stepCursor = 0;
+  for (const seg of sortedSegs) {
+    // Advance to the next step that still has unclaimed responses.
+    while (stepCursor < sortedStepIds.length) {
+      const stepId = sortedStepIds[stepCursor];
+      const list = stepToResponses.get(stepId);
+      if (!list || list.length === 0) {
+        stepCursor++;
+        continue;
+      }
+      const entry = list.shift()!;
+      claimedEntries.add(entry);
+      applySegmentToMatch(entries, seg, [entry]);
+      if (list.length === 0) stepCursor++;
+      break;
+    }
+    // If no step left, leave remaining segs unmatched (no regression).
+  }
+}
+
+function parseStepNumber(stepId: string): number {
+  const m = /:s(\d+)$/.exec(stepId);
+  return m ? Number(m[1]) : Number.MAX_SAFE_INTEGER;
 }
 
 function applyInterceptUsage(
@@ -225,7 +309,7 @@ export function enrichIdeTurn(
 
       if (bestEntry && bestDiff <= TIMESTAMP_THRESHOLD_MS) {
         used.add(bestEntry);
-        (bestEntry as Record<string, unknown>).__matched_gmt_create = row.gmtCreate;
+        (bestEntry as Record<string, unknown>)['__matched_gmt_create'] = row.gmtCreate;
 
         if (!bestEntry['gen_ai.response.id']) {
           bestEntry['gen_ai.response.id'] = row.messageId || requestId;
@@ -266,7 +350,7 @@ export function enrichIdeTurn(
   const matchedPairs: { entry: AgentActivityEntry; gmtCreate: number }[] = [];
   for (const entry of responseEntries) {
     if (!used.has(entry)) continue;
-    const gmtCreate = (entry as Record<string, unknown>).__matched_gmt_create as number | undefined;
+    const gmtCreate = (entry as Record<string, unknown>)['__matched_gmt_create'] as number | undefined;
     if (gmtCreate) matchedPairs.push({ entry, gmtCreate });
   }
   matchedPairs.sort((a, b) => a.gmtCreate - b.gmtCreate);
@@ -495,7 +579,7 @@ function applySqliteRowsToIdeResponse(
   // absorbed multiple provider calls.
   const representative = rows[rows.length - 1];
   used.add(response);
-  (response as Record<string, unknown>).__matched_gmt_create = representative.gmtCreate;
+  (response as Record<string, unknown>)['__matched_gmt_create'] = representative.gmtCreate;
   response['gen_ai.request.id'] = requestId;
   (response as Record<string, unknown>)['agent.request_id'] = requestId;
   response['gen_ai.response.id'] = representative.messageId || requestId;

--- a/src/inputs/qoder-trace/token-enricher.ts
+++ b/src/inputs/qoder-trace/token-enricher.ts
@@ -172,9 +172,26 @@ function applyOrderFallback(
   // steps in different turns have the same numeric step number (turn1:s1 and
   // turn2:s1 both parse as 1). Pairing seg[i] ↔ step s(i+1) globally would
   // cross turns and reproduce the cross-turn timestamp mismatch the
-  // segment-token-reader fix targets. When seg.turnId is set, restrict pairing
-  // to steps in the same turn. When seg.turnId is empty (older segment format
-  // without turn_id), fall back to global order to preserve prior behavior.
+  // segment-token-reader fix targets.
+  //
+  // CRITICAL: seg.turn_id and OTLP gen_ai.turn.id come from DIFFERENT sources
+  // (qoder-cli's per-turn UUID vs hook processor's per-turn UUID) and do NOT
+  // match. Filtering stepToResponses by `${seg.turnId}:s` finds nothing in
+  // production (Round 6 regression): all unmatched segs stay unpaired,
+  // llm.request.time_unix_nano keeps the hook processor's `group[0].timestamp`
+  // fallback (= completed time), and duration collapses to 0.
+  //
+  // Fix: extract OTLP turn.id set from `entries` and filter stepToResponses by
+  // those prefixes. The caller (QoderTraceInput.collect) pre-scopes segs per
+  // OTLP turn by sequential order, so all unmatched segs passed in belong to
+  // the current OTLP turn. For multi-turn test entries (seg.turnId == OTLP
+  // turn.id), this still works — OTLP turn.id set includes seg.turnIds.
+  const otlpTurnIds = new Set<string>();
+  for (const entry of entries) {
+    const tid = entry['gen_ai.turn.id'] as string | undefined;
+    if (tid) otlpTurnIds.add(tid);
+  }
+
   const segsByTurn = new Map<string, SegmentTokenData[]>();
   const legacySegs: SegmentTokenData[] = [];
   for (const seg of unmatchedSegs) {
@@ -188,7 +205,7 @@ function applyOrderFallback(
   }
 
   for (const [turnId, segs] of segsByTurn) {
-    pairSegsWithStepsInTurn(segs, turnId, stepToResponses, claimedEntries, entries);
+    pairSegsWithStepsInTurn(segs, turnId, otlpTurnIds, stepToResponses, claimedEntries, entries);
   }
   if (legacySegs.length > 0) {
     pairSegsGlobally(legacySegs, stepToResponses, claimedEntries, entries);
@@ -198,6 +215,7 @@ function applyOrderFallback(
 function pairSegsWithStepsInTurn(
   segs: SegmentTokenData[],
   turnId: string,
+  otlpTurnIds: Set<string>,
   stepToResponses: Map<string, AgentActivityEntry[]>,
   claimedEntries: Set<AgentActivityEntry>,
   entries: AgentActivityEntry[],
@@ -205,8 +223,10 @@ function pairSegsWithStepsInTurn(
   // Segments sorted by responseEndTs asc (model.response.completed order).
   const sortedSegs = [...segs].sort((a, b) => a.responseEndTs - b.responseEndTs);
 
-  // Steps in this turn, sorted by numeric step number.
-  const turnStepIds = [...stepToResponses.keys()]
+  // Steps in this turn. Try seg.turnId prefix first (preserves Case 4 behavior
+  // where seg.turnId == OTLP turn.id). If empty, fall back to OTLP turn.id set
+  // from entries (prod-shape: seg.turnId ≠ OTLP turn.id).
+  let turnStepIds = [...stepToResponses.keys()]
     .filter(stepId => stepId.startsWith(`${turnId}:s`))
     .sort((a, b) => {
       const an = parseStepNumber(a);
@@ -214,6 +234,20 @@ function pairSegsWithStepsInTurn(
       if (an !== bn) return an - bn;
       return a.localeCompare(b);
     });
+
+  if (turnStepIds.length === 0 && otlpTurnIds.size > 0) {
+    turnStepIds = [...stepToResponses.keys()]
+      .filter(stepId => {
+        const prefix = stepId.slice(0, stepId.lastIndexOf(':s'));
+        return otlpTurnIds.has(prefix);
+      })
+      .sort((a, b) => {
+        const an = parseStepNumber(a);
+        const bn = parseStepNumber(b);
+        if (an !== bn) return an - bn;
+        return a.localeCompare(b);
+      });
+  }
 
   let stepCursor = 0;
   for (const seg of sortedSegs) {

--- a/src/inputs/qoder-trace/token-enricher.ts
+++ b/src/inputs/qoder-trace/token-enricher.ts
@@ -155,10 +155,6 @@ function applyOrderFallback(
 ): void {
   if (unmatchedSegs.length === 0) return;
 
-  // Segments sorted by responseEndTs asc (model.response.completed order).
-  // Stable order ensures consistent pairing when ts ties.
-  const sortedSegs = [...unmatchedSegs].sort((a, b) => a.responseEndTs - b.responseEndTs);
-
   // Unclaimed llm.response entries grouped by step.id (preserving entry order
   // within a step for the multi-part response case).
   const stepToResponses = new Map<string, AgentActivityEntry[]>();
@@ -172,7 +168,82 @@ function applyOrderFallback(
     stepToResponses.set(stepId, list);
   }
 
-  // Sort step IDs by numeric step number. Format: `${turn}:s${n}`.
+  // Pairing is turn-scoped. gen_ai.step.id format is `${turnId}:s${n}`, so
+  // steps in different turns have the same numeric step number (turn1:s1 and
+  // turn2:s1 both parse as 1). Pairing seg[i] ↔ step s(i+1) globally would
+  // cross turns and reproduce the cross-turn timestamp mismatch the
+  // segment-token-reader fix targets. When seg.turnId is set, restrict pairing
+  // to steps in the same turn. When seg.turnId is empty (older segment format
+  // without turn_id), fall back to global order to preserve prior behavior.
+  const segsByTurn = new Map<string, SegmentTokenData[]>();
+  const legacySegs: SegmentTokenData[] = [];
+  for (const seg of unmatchedSegs) {
+    if (seg.turnId) {
+      const list = segsByTurn.get(seg.turnId) ?? [];
+      list.push(seg);
+      segsByTurn.set(seg.turnId, list);
+    } else {
+      legacySegs.push(seg);
+    }
+  }
+
+  for (const [turnId, segs] of segsByTurn) {
+    pairSegsWithStepsInTurn(segs, turnId, stepToResponses, claimedEntries, entries);
+  }
+  if (legacySegs.length > 0) {
+    pairSegsGlobally(legacySegs, stepToResponses, claimedEntries, entries);
+  }
+}
+
+function pairSegsWithStepsInTurn(
+  segs: SegmentTokenData[],
+  turnId: string,
+  stepToResponses: Map<string, AgentActivityEntry[]>,
+  claimedEntries: Set<AgentActivityEntry>,
+  entries: AgentActivityEntry[],
+): void {
+  // Segments sorted by responseEndTs asc (model.response.completed order).
+  const sortedSegs = [...segs].sort((a, b) => a.responseEndTs - b.responseEndTs);
+
+  // Steps in this turn, sorted by numeric step number.
+  const turnStepIds = [...stepToResponses.keys()]
+    .filter(stepId => stepId.startsWith(`${turnId}:s`))
+    .sort((a, b) => {
+      const an = parseStepNumber(a);
+      const bn = parseStepNumber(b);
+      if (an !== bn) return an - bn;
+      return a.localeCompare(b);
+    });
+
+  let stepCursor = 0;
+  for (const seg of sortedSegs) {
+    while (stepCursor < turnStepIds.length) {
+      const stepId = turnStepIds[stepCursor];
+      const list = stepToResponses.get(stepId);
+      if (!list || list.length === 0) {
+        stepCursor++;
+        continue;
+      }
+      const entry = list.shift()!;
+      claimedEntries.add(entry);
+      applySegmentToMatch(entries, seg, [entry]);
+      if (list.length === 0) stepToResponses.delete(stepId);
+      stepCursor++;
+      break;
+    }
+    // If no step left in this turn, leave the seg unmatched (no regression).
+  }
+}
+
+function pairSegsGlobally(
+  segs: SegmentTokenData[],
+  stepToResponses: Map<string, AgentActivityEntry[]>,
+  claimedEntries: Set<AgentActivityEntry>,
+  entries: AgentActivityEntry[],
+): void {
+  // Legacy path: segments without turn_id. Pair by global step order
+  // (preserves b30a2ef6 behavior for older segment formats).
+  const sortedSegs = [...segs].sort((a, b) => a.responseEndTs - b.responseEndTs);
   const sortedStepIds = [...stepToResponses.keys()].sort((a, b) => {
     const an = parseStepNumber(a);
     const bn = parseStepNumber(b);
@@ -182,7 +253,6 @@ function applyOrderFallback(
 
   let stepCursor = 0;
   for (const seg of sortedSegs) {
-    // Advance to the next step that still has unclaimed responses.
     while (stepCursor < sortedStepIds.length) {
       const stepId = sortedStepIds[stepCursor];
       const list = stepToResponses.get(stepId);
@@ -193,10 +263,10 @@ function applyOrderFallback(
       const entry = list.shift()!;
       claimedEntries.add(entry);
       applySegmentToMatch(entries, seg, [entry]);
-      if (list.length === 0) stepCursor++;
+      if (list.length === 0) stepToResponses.delete(stepId);
+      stepCursor++;
       break;
     }
-    // If no step left, leave remaining segs unmatched (no regression).
   }
 }
 

--- a/tests/unit/inputs/qoder-trace/prod-shape-token-enricher.test.ts
+++ b/tests/unit/inputs/qoder-trace/prod-shape-token-enricher.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import { enrichCliTurn } from '../../../../src/inputs/qoder-trace/token-enricher.js';
+import type { AgentActivityEntry } from '../../../../src/types/index.js';
+import type { SegmentTokenData } from '../../../../src/inputs/qoder-trace/segment-token-reader.js';
+
+// Reproduces tester Round 6 E2E evidence (comment bdfe6f36):
+//   - OTLP gen_ai.session.id = 303593aa-... (the qoder-cli session ID)
+//   - OTLP gen_ai.turn.id   = 1df498c6-... (per-turn, hook-derived)
+//   - OTLP gen_ai.step.id   = `${turn.id}:s${i+1}` (1-indexed)
+//   - OTLP gen_ai.response.id = resp_xxx (Anthropic message.id format)
+//   - Segment turn_id       = 303593aa-... (T1; NOTE: ≠ OTLP turn.id)
+//   - Segment request_id    = UUID (e.g. c3be0573-...)
+// Tester evidence: T1 LLM #1 OTLP startUnixNano matches seg.completed (11ms diff),
+// NOT seg.started (6413ms diff) → duration = 0. Root cause: Pass 2 step.id filter
+// uses seg.turnId prefix, but OTLP step.id uses OTLP turn.id prefix — mismatch
+// breaks all pairing, llm.request.time_unix_nano stays at hook processor's
+// `group[0].timestamp` fallback (≈ completed time).
+// Fix: Pass 2 filters stepToResponses by OTLP turn.id (from entries), not seg.turnId.
+// Caller (QoderTraceInput.collect) scopes segs per OTLP turn by sequential order.
+
+const SESS = '303593aa-d7fb-44b7-a3fe-c6ca143be7bf';
+const OTLP_TURN_T1 = '1df498c6-0c7f-4fbc-ba71-64137c0e44e9';
+const SEG_TURN_T1 = '303593aa-d7fb-44b7-a3fe-c6ca143be7bf'; // segment turn_id for T1 = session ID
+
+function makeRequest(overrides: Partial<AgentActivityEntry> = {}): AgentActivityEntry {
+  return {
+    'event.id': 'e-0',
+    'event.name': 'llm.request',
+    'gen_ai.session.id': SESS,
+    'gen_ai.turn.id': OTLP_TURN_T1,
+    'gen_ai.step.id': `${OTLP_TURN_T1}:s1`,
+    'gen_ai.agent.type': 'qoder-cli',
+    time_unix_nano: '1788260390500000000',
+    'gen_ai.request.model': 'auto',
+    ...overrides,
+  } as AgentActivityEntry;
+}
+
+function makeResponse(overrides: Partial<AgentActivityEntry> = {}): AgentActivityEntry {
+  return {
+    'event.id': 'e-1',
+    'event.name': 'llm.response',
+    'gen_ai.session.id': SESS,
+    'gen_ai.turn.id': OTLP_TURN_T1,
+    'gen_ai.step.id': `${OTLP_TURN_T1}:s1`,
+    'gen_ai.agent.type': 'qoder-cli',
+    time_unix_nano: '1788260390500000000',
+    'gen_ai.response.id': 'resp_0bfdfd26719a749f016a9680cc7f6c8194a84682cf40d8499c',
+    ...overrides,
+  } as AgentActivityEntry;
+}
+
+function makeSeg(overrides: Partial<SegmentTokenData> = {}): SegmentTokenData {
+  return {
+    requestId: 'c3be0573-f0d4-4347-b6a0-d9f8ec6d00ae',
+    turnId: SEG_TURN_T1, // ≠ OTLP turn.id — this is the prod shape
+    inputTokens: 5000,
+    outputTokens: 200,
+    cacheReadTokens: 3000,
+    cacheCreationTokens: 0,
+    requestStartTs: 1788260390875, // 10:59:50.875 (started)
+    responseEndTs: 1788260397277,  // 10:59:57.277 (completed)
+    toolFinishedTs: 0,
+    stopReason: 'tool_use',
+    model: 'claude-sonnet-4-5',
+    ...overrides,
+  };
+}
+
+describe('token-enricher prod-shape (seg.turnId ≠ OTLP turn.id)', () => {
+  it('pairs seg.requestStartTs into llm.request.time_unix_nano despite turn.id mismatch', () => {
+    // Reproduces tester Round 6 T1 LLM #1 symptom. seg.turnId = session ID,
+    // OTLP turn.id = hook-derived UUID. Pass 1 (exact response.id) fails
+    // (resp_xxx vs UUID). Pass 2 must pair segs with OTLP steps using the
+    // OTLP turn.id prefix (from entries), NOT seg.turnId.
+    // Caller pre-scopes segs to the current OTLP turn (sequential order pairing
+    // in QoderTraceInput.collect), so all segs passed in belong to T1.
+    const entries: AgentActivityEntry[] = [
+      makeRequest({ 'gen_ai.step.id': `${OTLP_TURN_T1}:s1` }),
+      makeResponse({ 'gen_ai.step.id': `${OTLP_TURN_T1}:s1` }),
+    ];
+    const segments: SegmentTokenData[] = [
+      makeSeg({ requestId: 'uuid-t1-r0' }),
+    ];
+
+    enrichCliTurn(entries, segments);
+
+    // CRITICAL: llm.request.time_unix_nano must be seg.requestStartTs (started)
+    // NOT seg.responseEndTs (completed). If pairing fails, stays at hook
+    // processor's fallback (= completed time → duration 0).
+    const expected = String(BigInt(1788260390875) * 1_000_000n);
+    expect(entries[0].time_unix_nano).toBe(expected);
+    // llm.response gets seg.responseEndTs
+    const expectedResp = String(BigInt(1788260397277) * 1_000_000n);
+    expect(entries[1].time_unix_nano).toBe(expectedResp);
+  });
+
+  it('pairs multi-LLM turn (5 segs × 5 steps) by sequential order despite turn.id mismatch', () => {
+    // T1 has 5 LLM calls. All segs have turnId=SEG_TURN_T1, OTLP step.ids
+    // are ${OTLP_TURN_T1}:s1..s5. Pass 2 must pair seg[i] ↔ step :s(i+1)
+    // by sequential order (sort by responseEndTs asc ↔ sort by step number asc).
+    const entries: AgentActivityEntry[] = [];
+    for (let i = 0; i < 5; i++) {
+      const stepId = `${OTLP_TURN_T1}:s${i + 1}`;
+      entries.push({
+        'event.id': `e-req-${i}`,
+        'event.name': 'llm.request',
+        'gen_ai.session.id': SESS,
+        'gen_ai.turn.id': OTLP_TURN_T1,
+        'gen_ai.step.id': stepId,
+        'gen_ai.agent.type': 'qoder-cli',
+        time_unix_nano: '0',
+        'gen_ai.request.model': 'auto',
+      } as AgentActivityEntry);
+      entries.push({
+        'event.id': `e-resp-${i}`,
+        'event.name': 'llm.response',
+        'gen_ai.session.id': SESS,
+        'gen_ai.turn.id': OTLP_TURN_T1,
+        'gen_ai.step.id': stepId,
+        'gen_ai.agent.type': 'qoder-cli',
+        time_unix_nano: '0',
+        'gen_ai.response.id': `resp_t1_s${i + 1}`,
+      } as AgentActivityEntry);
+    }
+    const segments: SegmentTokenData[] = [];
+    for (let i = 0; i < 5; i++) {
+      segments.push(makeSeg({
+        requestId: `uuid-t1-r${i}`,
+        requestStartTs: 1788260390875 + i * 1000,
+        responseEndTs: 1788260397277 + i * 1000,
+      }));
+    }
+
+    enrichCliTurn(entries, segments);
+
+    for (let i = 0; i < 5; i++) {
+      const req = entries[i * 2];
+      const resp = entries[i * 2 + 1];
+      const expectedStart = String(BigInt(1788260390875 + i * 1000) * 1_000_000n);
+      const expectedEnd = String(BigInt(1788260397277 + i * 1000) * 1_000_000n);
+      expect(req.time_unix_nano).toBe(expectedStart);
+      expect(resp.time_unix_nano).toBe(expectedEnd);
+    }
+  });
+});

--- a/tests/unit/inputs/qoder-trace/prod-shape.test.ts
+++ b/tests/unit/inputs/qoder-trace/prod-shape.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { readSegmentTokensForSession } from '../../../../src/inputs/qoder-trace/segment-token-reader.js';
+
+// Inline mock to avoid path issues
+import { vi } from 'vitest';
+vi.mock('../../../../src/utils/fs-utils.js', () => ({
+  resolveHome: (p: string) => p.replace('~', '/tmp/test-prod-shape-home'),
+}));
+vi.mock('../../../../src/utils/logger.js', () => ({
+  createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+const TEST_HOME = '/tmp/test-prod-shape-home';
+const SESSIONS_DIR = path.join(TEST_HOME, '.qoder/logs/sessions');
+
+interface SegmentLine {
+  type: string;
+  ts: number;
+  request_id?: string;
+  turn_id?: string;
+  data?: Record<string, unknown>;
+}
+
+function segLine(line: SegmentLine): string {
+  return JSON.stringify(line);
+}
+
+// Each file = one turn (matches tester's "3 segment files per turn" evidence)
+async function writeTurnFile(sessionId: string, turnNum: number, lines: string[]): Promise<void> {
+  const segDir = path.join(SESSIONS_DIR, 'cwd-1', sessionId, 'segments');
+  await fs.mkdir(segDir, { recursive: true });
+  const file = path.join(segDir, `segment-${turnNum}.jsonl`);
+  await fs.writeFile(file, lines.join('\n') + '\n');
+}
+
+describe('production-shape: started lacks turn_id', () => {
+  beforeEach(async () => {
+    try { await fs.rm(TEST_HOME, { recursive: true, force: true }); } catch {}
+    await fs.mkdir(SESSIONS_DIR, { recursive: true });
+  });
+  afterEach(async () => {
+    try { await fs.rm(TEST_HOME, { recursive: true, force: true }); } catch {}
+  });
+
+  it('pairs correctly when started lacks turn_id but completed has it (3 turns x 2 LLM)', async () => {
+    // Hypothesis: in production, model.request.started events lack turn_id
+    // (only model.response.completed has it). My per-turn filter
+    // `if (turnId && startedList[i].turnId !== turnId) continue;` rejects
+    // started events with undefined turnId. startTs stays undefined.
+    // Fallback to evt.ts (completed) gives duration=0.
+    await writeTurnFile('sess-prod', 1, [
+      // T1 started: NO turn_id (hypothesis)
+      segLine({ type: 'model.request.started', ts: 1780000000000, request_id: 't1-r0-started', data: { request_index: 0 } }),
+      segLine({ type: 'model.response.completed', ts: 1780000001000, request_id: 't1-r0-completed', turn_id: 'turn-1', data: { request_index: 0, stop_reason: 'tool_use' } }),
+      segLine({ type: 'model.request.started', ts: 1780000002000, request_id: 't1-r1-started', data: { request_index: 1 } }),
+      segLine({ type: 'model.response.completed', ts: 1780000003000, request_id: 't1-r1-completed', turn_id: 'turn-1', data: { request_index: 1, stop_reason: 'end_turn' } }),
+    ]);
+    await writeTurnFile('sess-prod', 2, [
+      segLine({ type: 'model.request.started', ts: 1780000100000, request_id: 't2-r0-started', data: { request_index: 0 } }),
+      segLine({ type: 'model.response.completed', ts: 1780000101000, request_id: 't2-r0-completed', turn_id: 'turn-2', data: { request_index: 0, stop_reason: 'tool_use' } }),
+      segLine({ type: 'model.request.started', ts: 1780000102000, request_id: 't2-r1-started', data: { request_index: 1 } }),
+      segLine({ type: 'model.response.completed', ts: 1780000103000, request_id: 't2-r1-completed', turn_id: 'turn-2', data: { request_index: 1, stop_reason: 'end_turn' } }),
+    ]);
+    await writeTurnFile('sess-prod', 3, [
+      segLine({ type: 'model.request.started', ts: 1780000200000, request_id: 't3-r0-started', data: { request_index: 0 } }),
+      segLine({ type: 'model.response.completed', ts: 1780000201000, request_id: 't3-r0-completed', turn_id: 'turn-3', data: { request_index: 0, stop_reason: 'end_turn' } }),
+    ]);
+
+    const result = await readSegmentTokensForSession('sess-prod');
+    expect(result).toHaveLength(5);
+
+    // T1 r0: should have requestStartTs=1780000000000 (started.ts), NOT 1780000001000 (completed)
+    expect(result[0].turnId).toBe('turn-1');
+    expect(result[0].requestStartTs).toBe(1780000000000); // started, not completed
+    expect(result[0].responseEndTs).toBe(1780000001000);
+    // T1 r1
+    expect(result[1].turnId).toBe('turn-1');
+    expect(result[1].requestStartTs).toBe(1780000002000);
+    expect(result[1].responseEndTs).toBe(1780000003000);
+    // T2 r0
+    expect(result[2].turnId).toBe('turn-2');
+    expect(result[2].requestStartTs).toBe(1780000100000);
+    expect(result[2].responseEndTs).toBe(1780000101000);
+    // T3 r0
+    expect(result[4].turnId).toBe('turn-3');
+    expect(result[4].requestStartTs).toBe(1780000200000);
+    expect(result[4].responseEndTs).toBe(1780000201000);
+  });
+
+  it('matches tester r5 session d5afbece shape: 3 turns × 5 LLM, started lacks turn_id', async () => {
+    // Reproduces tester r5 evidence: T1/T2 swapped, T3 correct turn but
+    // start=completed. Root cause was per-turn filter rejecting started
+    // events that lack turn_id. Per-file pairing fixes both.
+    const turnTs = (turn: number, req: number, kind: 'start' | 'end') => {
+      const base = turn === 1 ? 1780000000000 : turn === 2 ? 1780000100000 : 1780000200000;
+      return base + req * 2000 + (kind === 'end' ? 1000 : 0);
+    };
+    for (let t = 1; t <= 3; t++) {
+      const lines: string[] = [];
+      for (let r = 0; r < 5; r++) {
+        // started: NO turn_id (production shape hypothesis)
+        lines.push(segLine({
+          type: 'model.request.started',
+          ts: turnTs(t, r, 'start'),
+          request_id: `t${t}-r${r}-started`,
+          data: { request_index: r, model: 'claude-sonnet-4-5' },
+        }));
+        lines.push(segLine({
+          type: 'model.response.completed',
+          ts: turnTs(t, r, 'end'),
+          request_id: `t${t}-r${r}-completed`,
+          turn_id: `turn-${t}`,
+          data: {
+            request_index: r,
+            model: 'claude-sonnet-4-5',
+            stop_reason: r === 4 ? 'end_turn' : 'tool_use',
+            input_tokens: 1000 + r * 100,
+            output_tokens: 50 + r,
+          },
+        }));
+      }
+      await writeTurnFile('sess-r5', t, lines);
+    }
+
+    const result = await readSegmentTokensForSession('sess-r5');
+    expect(result).toHaveLength(15);
+
+    for (let t = 1; t <= 3; t++) {
+      for (let r = 0; r < 5; r++) {
+        const idx = (t - 1) * 5 + r;
+        const seg = result[idx];
+        expect(seg.turnId).toBe(`turn-${t}`);
+        // CRITICAL: requestStartTs must be the started.ts, NOT completed.ts.
+        // If this fails, duration collapses to 0 (r5 regression #1).
+        expect(seg.requestStartTs).toBe(turnTs(t, r, 'start'));
+        expect(seg.responseEndTs).toBe(turnTs(t, r, 'end'));
+        // CRITICAL: cross-turn swap (r5 regression #2). T1 seg must have
+        // T1 started.ts, not T2's.
+        if (t === 1) {
+          expect(seg.requestStartTs).toBeLessThan(result[5].requestStartTs);
+        }
+      }
+    }
+  });
+});

--- a/tests/unit/inputs/qoder-trace/prod-shape.test.ts
+++ b/tests/unit/inputs/qoder-trace/prod-shape.test.ts
@@ -144,4 +144,65 @@ describe('production-shape: started lacks turn_id', () => {
       }
     }
   });
+
+  it('tester Round 6 shape: 5 started + 5 completed per turn file, response.id mismatches UUID request_id', async () => {
+    // Reproduces tester Round 6 T1 session 303593aa shape:
+    //   - 1 segment file per turn (file boundary = turn boundary)
+    //   - 5 model.request.started + 5 model.response.completed per file
+    //   - started events LACK turn_id (production shape)
+    //   - started.request_id ≠ completed.request_id (s5/s6 case — UUID diverges)
+    //   - completed has turn_id + data.request_index
+    // segment-token-reader layer 1 (exact requestId) fails for all 5 pairs.
+    // Layers 2/3 (composite turnId+requestIndex) fail because started lacks turnId.
+    // Layer 4 (same-file order fallback) must claim the i-th unclaimed started
+    // for the i-th completed — NOT wrong-prioritize by claiming started #5 for
+    // completed #1. This test asserts requestStartTs = started.ts for all 5
+    // pairs in the file, proving layer 4 sequential pairing is correct.
+    const lines: string[] = [];
+    for (let r = 0; r < 5; r++) {
+      const startedTs = 1788260000000 + r * 7000;       // 7s gap per call
+      const completedTs = startedTs + 6400;              // ~6.4s LLM duration
+      lines.push(segLine({
+        type: 'model.request.started',
+        ts: startedTs,
+        request_id: `started-uuid-r${r}`,                 // ≠ completed.request_id
+        data: { request_index: r, model: 'claude-sonnet-4-5' },
+      }));
+      lines.push(segLine({
+        type: 'model.response.completed',
+        ts: completedTs,
+        request_id: `completed-uuid-r${r}`,              // ≠ started.request_id
+        turn_id: '303593aa-d7fb-44b7-a3fe-c6ca143be7bf',
+        data: {
+          request_index: r,
+          model: 'claude-sonnet-4-5',
+          stop_reason: r === 4 ? 'end_turn' : 'tool_use',
+          input_tokens: 1000 + r * 100,
+          output_tokens: 50 + r,
+        },
+      }));
+    }
+    await writeTurnFile('sess-r6', 1, lines);
+
+    const result = await readSegmentTokensForSession('sess-r6');
+    expect(result).toHaveLength(5);
+
+    for (let r = 0; r < 5; r++) {
+      const seg = result[r];
+      const expectedStart = 1788260000000 + r * 7000;
+      const expectedEnd = expectedStart + 6400;
+      // CRITICAL: requestStartTs must be started.ts (NOT completed.ts).
+      // If layer 4 wrong-prioritizes (claims started #5 for completed #1),
+      // requestStartTs would be 1788260028000 (started #4) for completed #0
+      // (expected 1788260000000). The assertion catches this.
+      expect(seg.requestStartTs).toBe(expectedStart);
+      expect(seg.responseEndTs).toBe(expectedEnd);
+      // duration > 0 (the runtime symptom was duration = 0)
+      expect(seg.responseEndTs - seg.requestStartTs).toBe(6400);
+      // turnId propagated from completed event
+      expect(seg.turnId).toBe('303593aa-d7fb-44b7-a3fe-c6ca143be7bf');
+      // requestId from completed event (s5/s6 case — completed's UUID)
+      expect(seg.requestId).toBe(`completed-uuid-r${r}`);
+    }
+  });
 });

--- a/tests/unit/inputs/qoder-trace/prod-shape.test.ts
+++ b/tests/unit/inputs/qoder-trace/prod-shape.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { readSegmentTokensForSession } from '../../../../src/inputs/qoder-trace/segment-token-reader.js';
+import { groupSegmentsByTurn, pickSegGroupByTimeOverlap } from '../../../../src/inputs/qoder-trace/segment-turn-pairing.js';
+import type { SegmentTokenData } from '../../../../src/inputs/qoder-trace/segment-token-reader.js';
+import type { AgentActivityEntry } from '../../../../src/types/index.js';
 
 // Inline mock to avoid path issues
 import { vi } from 'vitest';
@@ -204,5 +207,160 @@ describe('production-shape: started lacks turn_id', () => {
       // requestId from completed event (s5/s6 case — completed's UUID)
       expect(seg.requestId).toBe(`completed-uuid-r${r}`);
     }
+  });
+});
+
+// Round 8 #2 regression: seg.turn_id ≠ OTLP turn.id (completely different UUID
+// systems). Round 7's sessionCliTurnIdx was local to collect(), so under
+// incremental collection (one new turn per collect() call) it always picked
+// segGroups[0] = T1's group → T2/T3 LLM spans got T1's timestamps. Fix:
+// pickSegGroupByTimeOverlap is stateless — picks by TS overlap with OTLP turn's
+// [min,max time_unix_nano] range, not by sequential index.
+describe('production-shape: seg.turn_id ≠ OTLP turn.id — TS overlap pairing (Round 8 #2)', () => {
+  // Round 7 evidence UUIDs (truncated for readability).
+  const SEG_TURN_IDS = [
+    '62f13c94-023b-4a98-af7b-a8ec90d342ce',
+    'ab7e9bc9-1111-4aaa-bbbb-c9aaaaaaa111',
+    'eba366eb-2222-4ccc-dddd-e2bbbbbbb222',
+  ];
+  const OTLP_TURN_IDS = [
+    '8c2cbc8b-3903-489e-aa11-f1e425745832',
+    'a570818f-4903-489e-aa22-f2e425745833',
+    '870166f2-5903-489e-aa33-f3e425745834',
+  ];
+  // Round 7 evidence timestamps (T1 started ~11:51:11, T2 ~11:52:07, T3 ~11:53:10).
+  const T1_BASE = 1780000000000;
+  const T2_BASE = T1_BASE + 56_000;
+  const T3_BASE = T1_BASE + 119_000;
+  const TURN_BASES = [T1_BASE, T2_BASE, T3_BASE];
+
+  function makeSegGroup(turnId: string, base: number): SegmentTokenData[] {
+    const segs: SegmentTokenData[] = [];
+    for (let r = 0; r < 5; r++) {
+      const startedTs = base + r * 7000;
+      const completedTs = startedTs + 6400;
+      segs.push({
+        requestId: `seg-${turnId.slice(0, 8)}-r${r}`,
+        turnId,
+        inputTokens: 1000 + r * 100,
+        outputTokens: 50 + r,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        requestStartTs: startedTs,
+        responseEndTs: completedTs,
+        toolFinishedTs: completedTs + 100,
+        stopReason: r === 4 ? 'end_turn' : 'tool_use',
+        model: 'claude-sonnet-4-5',
+      });
+    }
+    return segs;
+  }
+
+  function makeOtlpTurn(turnId: string, base: number): AgentActivityEntry[] {
+    const entries: AgentActivityEntry[] = [];
+    for (let r = 0; r < 5; r++) {
+      const startedTs = base + r * 7000;
+      const completedTs = startedTs + 6400;
+      entries.push({
+        'event.name': 'llm.request',
+        'gen_ai.turn.id': turnId,
+        'gen_ai.step.id': `${turnId}:s${r + 1}`,
+        time_unix_nano: String(BigInt(startedTs) * 1_000_000n),
+      } as AgentActivityEntry);
+      entries.push({
+        'event.name': 'llm.response',
+        'gen_ai.turn.id': turnId,
+        'gen_ai.step.id': `${turnId}:s${r + 1}`,
+        time_unix_nano: String(BigInt(completedTs) * 1_000_000n),
+      } as AgentActivityEntry);
+    }
+    return entries;
+  }
+
+  it('incremental collection: 3 separate collect() calls each pick own turn group', () => {
+    // Simulates the production regression scenario: each collect() call
+    // processes ONE new OTLP turn but re-reads ALL segments. Round 7's
+    // sessionCliTurnIdx reset per call → always picked segGroups[0] = T1.
+    // TS overlap pairing is stateless → picks correctly per call.
+    const allSegs = [
+      ...makeSegGroup(SEG_TURN_IDS[0], T1_BASE),
+      ...makeSegGroup(SEG_TURN_IDS[1], T2_BASE),
+      ...makeSegGroup(SEG_TURN_IDS[2], T3_BASE),
+    ];
+
+    for (let turn = 0; turn < 3; turn++) {
+      const segGroups = groupSegmentsByTurn(allSegs);
+      expect(segGroups).toHaveLength(3);
+      // Groups sorted by min responseEndTs asc → T1 < T2 < T3.
+      expect(segGroups[0][0].turnId).toBe(SEG_TURN_IDS[0]);
+      expect(segGroups[1][0].turnId).toBe(SEG_TURN_IDS[1]);
+      expect(segGroups[2][0].turnId).toBe(SEG_TURN_IDS[2]);
+
+      const otlpEntries = makeOtlpTurn(OTLP_TURN_IDS[turn], TURN_BASES[turn]);
+      const picked = pickSegGroupByTimeOverlap(segGroups, otlpEntries);
+
+      // CRITICAL #2 assertion: picked group must be THIS turn's, not T1's.
+      expect(picked).toHaveLength(5);
+      expect(picked[0].turnId).toBe(SEG_TURN_IDS[turn]);
+      // If this fails for turn ≥ 1, the regression is back (T1's group picked).
+
+      // CRITICAL #1 assertion: requestStartTs = started.ts (not completed.ts).
+      for (let r = 0; r < 5; r++) {
+        const expectedStart = TURN_BASES[turn] + r * 7000;
+        expect(picked[r].requestStartTs).toBe(expectedStart);
+        expect(picked[r].responseEndTs).toBe(expectedStart + 6400);
+        expect(picked[r].responseEndTs - picked[r].requestStartTs).toBe(6400);
+      }
+    }
+  });
+
+  it('batch collection: 3 turns in one collect() call — picked groups spliced out', () => {
+    // Simulates one collect() call that processes all 3 turns at once.
+    // pickSegGroupByTimeOverlap splices the picked group out of segGroups so
+    // the next turn in the same call doesn't re-pick it.
+    const allSegs = [
+      ...makeSegGroup(SEG_TURN_IDS[0], T1_BASE),
+      ...makeSegGroup(SEG_TURN_IDS[1], T2_BASE),
+      ...makeSegGroup(SEG_TURN_IDS[2], T3_BASE),
+    ];
+    const segGroups = groupSegmentsByTurn(allSegs);
+    expect(segGroups).toHaveLength(3);
+
+    const pickedTurnIds: string[] = [];
+    for (let turn = 0; turn < 3; turn++) {
+      const otlpEntries = makeOtlpTurn(OTLP_TURN_IDS[turn], TURN_BASES[turn]);
+      const picked = pickSegGroupByTimeOverlap(segGroups, otlpEntries);
+      expect(picked).toHaveLength(5);
+      expect(picked[0].turnId).toBe(SEG_TURN_IDS[turn]);
+      pickedTurnIds.push(picked[0].turnId);
+      // Each iteration shrinks segGroups by 1 (spliced out).
+      expect(segGroups.length).toBe(3 - turn - 1);
+    }
+    // All 3 unique turn IDs picked — no duplicates (T1 not picked 3×).
+    expect(new Set(pickedTurnIds).size).toBe(3);
+  });
+
+  it('no OTLP timestamps → falls back to first group (sequential order)', () => {
+    // Edge case: if OTLP entries lack time_unix_nano, pickSegGroupByTimeOverlap
+    // falls back to segGroups[0] (sorted by min responseEndTs asc = T1).
+    const allSegs = [
+      ...makeSegGroup(SEG_TURN_IDS[0], T1_BASE),
+      ...makeSegGroup(SEG_TURN_IDS[1], T2_BASE),
+    ];
+    const segGroups = groupSegmentsByTurn(allSegs);
+    const entriesWithoutTs: AgentActivityEntry[] = [
+      { 'event.name': 'llm.request', 'gen_ai.turn.id': OTLP_TURN_IDS[1] } as AgentActivityEntry,
+    ];
+    const picked = pickSegGroupByTimeOverlap(segGroups, entriesWithoutTs);
+    expect(picked[0].turnId).toBe(SEG_TURN_IDS[0]);
+  });
+
+  it('single group → returned without overlap check, segGroups emptied', () => {
+    const segGroups = groupSegmentsByTurn(makeSegGroup(SEG_TURN_IDS[0], T1_BASE));
+    expect(segGroups).toHaveLength(1);
+    const otlpEntries = makeOtlpTurn(OTLP_TURN_IDS[0], T1_BASE);
+    const picked = pickSegGroupByTimeOverlap(segGroups, otlpEntries);
+    expect(picked[0].turnId).toBe(SEG_TURN_IDS[0]);
+    expect(segGroups).toHaveLength(0);
   });
 });

--- a/tests/unit/inputs/qoder-trace/segment-token-reader.test.ts
+++ b/tests/unit/inputs/qoder-trace/segment-token-reader.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { readSegmentTokensForSession } from '../../../../src/inputs/qoder-trace/segment-token-reader.js';
+
+vi.mock('../../../../src/utils/fs-utils.js', () => ({
+  resolveHome: (p: string) => p.replace('~', '/tmp/test-segment-token-reader-home'),
+}));
+
+vi.mock('../../../../src/utils/logger.js', () => ({
+  createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+const TEST_HOME = '/tmp/test-segment-token-reader-home';
+const SESSIONS_DIR = path.join(TEST_HOME, '.qoder/logs/sessions');
+
+// Segment JSONL line shapes below are derived from the architect's NEEDS_REVISION
+// review (issue AGE-1730, comment a1656a71) which documents the real segment
+// event schema: { type, ts, request_id, data:{ request_index, model,
+// stop_reason, input_tokens, output_tokens, cache_read_input_tokens,
+// cache_creation_input_tokens } }. The request_id values are UUIDs (e.g.
+// c3be0573-f0d4-4347-b6a0-d9f8ec6d00ae), matching what qoder CLI emits.
+// History JSONL gen_ai.response.id uses Anthropic message.id format
+// (resp_0bfdfd26719a749f016a9680cc7f6c8194a84682cf40d8499c) — these IDs
+// intentionally diverge to exercise the order-fallback path.
+
+interface SegmentLine {
+  type: string;
+  ts: number;
+  request_id?: string;
+  data?: Record<string, unknown>;
+}
+
+function segLine(line: SegmentLine): string {
+  return JSON.stringify(line);
+}
+
+async function writeSession(sessionId: string, lines: string[]): Promise<void> {
+  // Place under a cwd dir → session → segments/ segment-N.jsonl, mirroring real layout.
+  const segDir = path.join(SESSIONS_DIR, 'cwd-1', sessionId, 'segments');
+  await fs.mkdir(segDir, { recursive: true });
+  const file = path.join(segDir, 'seg-1.jsonl');
+  await fs.writeFile(file, lines.join('\n') + '\n');
+}
+
+describe('segment-token-reader pairing', () => {
+  beforeEach(async () => {
+    try { await fs.rm(TEST_HOME, { recursive: true, force: true }); } catch {}
+    await fs.mkdir(SESSIONS_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    try { await fs.rm(TEST_HOME, { recursive: true, force: true }); } catch {}
+  });
+
+  it('pairs by exact request_id when started and completed match (regression)', async () => {
+    // Case 1: request_id matches between model.request.started and
+    // model.response.completed. requestStartTs should equal started.ts.
+    await writeSession('sess-t1', [
+      segLine({ type: 'model.request.started', ts: 1780000000000, request_id: 'c3be0573-f0d4-4347-b6a0-d9f8ec6d00ae', data: { request_index: 0, model: 'claude-sonnet-4-5' } }),
+      segLine({ type: 'model.response.completed', ts: 1780000002000, request_id: 'c3be0573-f0d4-4347-b6a0-d9f8ec6d00ae', data: { request_index: 0, model: 'claude-sonnet-4-5', stop_reason: 'end_turn', input_tokens: 100, output_tokens: 50 } }),
+    ]);
+
+    const result = await readSegmentTokensForSession('sess-t1');
+    expect(result).toHaveLength(1);
+    expect(result[0].requestId).toBe('c3be0573-f0d4-4347-b6a0-d9f8ec6d00ae');
+    expect(result[0].requestStartTs).toBe(1780000000000);
+    expect(result[0].responseEndTs).toBe(1780000002000);
+    expect(result[0].stopReason).toBe('end_turn');
+    expect(result[0].model).toBe('claude-sonnet-4-5');
+  });
+
+  it('pairs by request_index when request_id mismatches (s5/s6 case)', async () => {
+    // Case 2: real segment s5/s6 defect — model.request.started.request_id ≠
+    // model.response.completed.request_id, but both carry the same
+    // request_index. Pairing must use request_index so startTs != endTs.
+    await writeSession('sess-t2', [
+      // s1: exact match (request_id aligns) — control case, ensures the fix
+      // doesn't disturb exact-match path.
+      segLine({ type: 'model.request.started', ts: 1780000000000, request_id: 'aaaaaaaa-0000-0000-0000-000000000001', data: { request_index: 0 } }),
+      segLine({ type: 'model.response.completed', ts: 1780000001000, request_id: 'aaaaaaaa-0000-0000-0000-000000000001', data: { request_index: 0, stop_reason: 'end_turn' } }),
+      // s5: started.request_id = d29daeda, completed.request_id = 682d6fb0
+      // (per architect's review). Both carry request_index=4. Must pair by
+      // index → startTs=1780000004000, endTs=1780000005000.
+      segLine({ type: 'model.request.started', ts: 1780000004000, request_id: 'd29daeda-0000-0000-0000-000000000005', data: { request_index: 4 } }),
+      segLine({ type: 'model.response.completed', ts: 1780000005000, request_id: '682d6fb0-0000-0000-0000-000000000005', data: { request_index: 4, stop_reason: 'tool_use' } }),
+    ]);
+
+    const result = await readSegmentTokensForSession('sess-t2');
+    expect(result).toHaveLength(2);
+
+    // s1 (exact match)
+    expect(result[0].requestStartTs).toBe(1780000000000);
+    expect(result[0].responseEndTs).toBe(1780000001000);
+
+    // s5 (request_index fallback)
+    expect(result[1].requestId).toBe('682d6fb0-0000-0000-0000-000000000005');
+    expect(result[1].requestStartTs).toBe(1780000004000);
+    expect(result[1].responseEndTs).toBe(1780000005000);
+  });
+
+  it('falls back to order alignment when both request_id and request_index diverge', async () => {
+    // Case 3: neither request_id nor request_index lines up between started
+    // and completed (the most degraded case). The i-th completed event must
+    // pair with the i-th unclaimed started event in ts asc order. Without
+    // this fallback, requestStartTs would fall back to responseEndTs and
+    // produce 0-duration LLM spans.
+    await writeSession('sess-t3', [
+      // Two started events, two completed events, all with mismatched ids and
+      // no request_index field at all. Pure order pairing.
+      segLine({ type: 'model.request.started', ts: 1780000010000, request_id: 'started-A' }),
+      segLine({ type: 'model.request.started', ts: 1780000020000, request_id: 'started-B' }),
+      segLine({ type: 'model.response.completed', ts: 1780000015000, request_id: 'completed-X', data: { stop_reason: 'end_turn' } }),
+      segLine({ type: 'model.response.completed', ts: 1780000025000, request_id: 'completed-Y', data: { stop_reason: 'tool_use' } }),
+    ]);
+
+    const result = await readSegmentTokensForSession('sess-t3');
+    expect(result).toHaveLength(2);
+
+    // X (first completed by file order) ↔ started-A (first unclaimed started by ts asc)
+    expect(result[0].requestId).toBe('completed-X');
+    expect(result[0].requestStartTs).toBe(1780000010000);
+    expect(result[0].responseEndTs).toBe(1780000015000);
+
+    // Y (second completed) ↔ started-B (second unclaimed started)
+    expect(result[1].requestId).toBe('completed-Y');
+    expect(result[1].requestStartTs).toBe(1780000020000);
+    expect(result[1].responseEndTs).toBe(1780000025000);
+  });
+
+  it('skips tool.execution.finished events but uses them for toolFinishedTs', async () => {
+    // Regression: tool.execution.finished must not produce a result entry,
+    // but must contribute toolFinishedTs to the preceding LLM call.
+    await writeSession('sess-t4', [
+      segLine({ type: 'model.request.started', ts: 1780000000000, request_id: 'req-tool-1', data: { request_index: 0 } }),
+      segLine({ type: 'model.response.completed', ts: 1780000002000, request_id: 'req-tool-1', data: { request_index: 0, stop_reason: 'tool_use' } }),
+      segLine({ type: 'tool.execution.finished', ts: 1780000004000, request_id: 'req-tool-1', data: { tool_name: 'Bash' } }),
+    ]);
+
+    const result = await readSegmentTokensForSession('sess-t4');
+    expect(result).toHaveLength(1);
+    expect(result[0].toolFinishedTs).toBe(1780000004000);
+  });
+});

--- a/tests/unit/inputs/qoder-trace/segment-token-reader.test.ts
+++ b/tests/unit/inputs/qoder-trace/segment-token-reader.test.ts
@@ -28,6 +28,7 @@ interface SegmentLine {
   type: string;
   ts: number;
   request_id?: string;
+  turn_id?: string;
   data?: Record<string, unknown>;
 }
 
@@ -140,5 +141,69 @@ describe('segment-token-reader pairing', () => {
     const result = await readSegmentTokensForSession('sess-t4');
     expect(result).toHaveLength(1);
     expect(result[0].toolFinishedTs).toBe(1780000004000);
+  });
+
+  it('does not mismatch cross-turn timestamps when request_index resets per turn', async () => {
+    // Regression: AGE-1730 Step C. request_index resets per turn, so
+    // turn 1 and turn 2 both have request_index=0. The composite key
+    // (turnId, requestIndex) must keep them distinct — turn 2's s1
+    // start must be turn 2's started.ts, NOT turn 1's started.ts.
+    // Prior fix (b30a2ef6) used request_index alone as the map key,
+    // which collided across turns and caused turn 2/3 LLM span
+    // timestamps to be sourced from turn 1.
+    await writeSession('sess-mt1', [
+      // Turn 1: 2 LLM calls (request_index 0 and 1)
+      segLine({ type: 'model.request.started', ts: 1780000000000, request_id: 't1-r0-started', turn_id: 'turn-1', data: { request_index: 0 } }),
+      segLine({ type: 'model.response.completed', ts: 1780000001000, request_id: 't1-r0-completed', turn_id: 'turn-1', data: { request_index: 0, stop_reason: 'tool_use' } }),
+      segLine({ type: 'model.request.started', ts: 1780000002000, request_id: 't1-r1-started', turn_id: 'turn-1', data: { request_index: 1 } }),
+      segLine({ type: 'model.response.completed', ts: 1780000003000, request_id: 't1-r1-completed', turn_id: 'turn-1', data: { request_index: 1, stop_reason: 'end_turn' } }),
+      // Turn 2: 2 LLM calls (request_index 0 and 1) — SAME indices as turn 1
+      segLine({ type: 'model.request.started', ts: 1780000100000, request_id: 't2-r0-started', turn_id: 'turn-2', data: { request_index: 0 } }),
+      segLine({ type: 'model.response.completed', ts: 1780000101000, request_id: 't2-r0-completed', turn_id: 'turn-2', data: { request_index: 0, stop_reason: 'tool_use' } }),
+      segLine({ type: 'model.request.started', ts: 1780000102000, request_id: 't2-r1-started', turn_id: 'turn-2', data: { request_index: 1 } }),
+      segLine({ type: 'model.response.completed', ts: 1780000103000, request_id: 't2-r1-completed', turn_id: 'turn-2', data: { request_index: 1, stop_reason: 'end_turn' } }),
+    ]);
+
+    const result = await readSegmentTokensForSession('sess-mt1');
+    expect(result).toHaveLength(4);
+
+    // Turn 1 r0
+    expect(result[0].turnId).toBe('turn-1');
+    expect(result[0].requestStartTs).toBe(1780000000000);
+    expect(result[0].responseEndTs).toBe(1780000001000);
+    // Turn 1 r1
+    expect(result[1].turnId).toBe('turn-1');
+    expect(result[1].requestStartTs).toBe(1780000002000);
+    expect(result[1].responseEndTs).toBe(1780000003000);
+    // Turn 2 r0 — CRITICAL: must NOT be 1780000000000 (turn 1's start)
+    expect(result[2].turnId).toBe('turn-2');
+    expect(result[2].requestStartTs).toBe(1780000100000);
+    expect(result[2].responseEndTs).toBe(1780000101000);
+    // Turn 2 r1
+    expect(result[3].turnId).toBe('turn-2');
+    expect(result[3].requestStartTs).toBe(1780000102000);
+    expect(result[3].responseEndTs).toBe(1780000103000);
+  });
+
+  it('per-turn order fallback does not cross turns when turn_id present', async () => {
+    // When request_id mismatches AND no request_index, the order fallback
+    // must be scoped to the same turn. A turn-2 completed event must not
+    // claim a turn-1 started event (which is what the b30a2ef6 global
+    // order fallback would have done once turn-1's start was unclaimed).
+    await writeSession('sess-mt2', [
+      // Turn 1: started+completed with mismatched request_ids (forces order fallback)
+      segLine({ type: 'model.request.started', ts: 1780000000000, request_id: 't1-start', turn_id: 'turn-1' }),
+      segLine({ type: 'model.response.completed', ts: 1780000001000, request_id: 't1-end', turn_id: 'turn-1', data: { stop_reason: 'end_turn' } }),
+      // Turn 2: started+completed with mismatched request_ids
+      segLine({ type: 'model.request.started', ts: 1780000100000, request_id: 't2-start', turn_id: 'turn-2' }),
+      segLine({ type: 'model.response.completed', ts: 1780000101000, request_id: 't2-end', turn_id: 'turn-2', data: { stop_reason: 'end_turn' } }),
+    ]);
+
+    const result = await readSegmentTokensForSession('sess-mt2');
+    expect(result).toHaveLength(2);
+    expect(result[0].turnId).toBe('turn-1');
+    expect(result[0].requestStartTs).toBe(1780000000000);
+    expect(result[1].turnId).toBe('turn-2');
+    expect(result[1].requestStartTs).toBe(1780000100000);
   });
 });

--- a/tests/unit/inputs/qoder-trace/token-enricher.test.ts
+++ b/tests/unit/inputs/qoder-trace/token-enricher.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest';
+import { enrichCliTurn } from '../../../../src/inputs/qoder-trace/token-enricher.js';
+import type { AgentActivityEntry } from '../../../../src/types/index.js';
+import type { InterceptTokenData } from '../../../../src/inputs/qoder-trace/intercept-token-reader.js';
+import type { SegmentTokenData } from '../../../../src/inputs/qoder-trace/segment-token-reader.js';
+
+// Fixtures model the documented real-data shapes from architect NEEDS_REVISION
+// review (issue AGE-1730, comment a1656a71):
+//   - History JSONL gen_ai.response.id: Anthropic message.id format ("resp_...")
+//   - Segment request_id: UUID format (e.g. "c3be0573-f0d4-4347-b6a0-d9f8ec6d00ae")
+//   - gen_ai.step.id: `${turn_id}:s${request_index}` (e.g. "turn-1:s1")
+// The cases below intentionally mix the two ID formats to exercise the
+// order-fallback path the fix introduces.
+
+function makeResponse(overrides: Partial<AgentActivityEntry> = {}): AgentActivityEntry {
+  return {
+    'event.id': 'e-1',
+    'event.name': 'llm.response',
+    'gen_ai.session.id': 'sess-f287bf17',
+    'gen_ai.turn.id': 'turn-1',
+    'gen_ai.step.id': 'turn-1:s1',
+    'gen_ai.agent.type': 'qoder-cli',
+    time_unix_nano: '1780000000000000000',
+    ...overrides,
+  } as AgentActivityEntry;
+}
+
+function makeRequest(overrides: Partial<AgentActivityEntry> = {}): AgentActivityEntry {
+  return {
+    'event.id': 'e-0',
+    'event.name': 'llm.request',
+    'gen_ai.session.id': 'sess-f287bf17',
+    'gen_ai.turn.id': 'turn-1',
+    'gen_ai.step.id': 'turn-1:s1',
+    'gen_ai.agent.type': 'qoder-cli',
+    time_unix_nano: '1780000000000000000',
+    'gen_ai.request.model': 'auto',
+    ...overrides,
+  } as AgentActivityEntry;
+}
+
+function makeSeg(overrides: Partial<SegmentTokenData> = {}): SegmentTokenData {
+  return {
+    requestId: 'c3be0573-f0d4-4347-b6a0-d9f8ec6d00ae',
+    inputTokens: 5000,
+    outputTokens: 200,
+    cacheReadTokens: 3000,
+    cacheCreationTokens: 0,
+    requestStartTs: 1780000000000,
+    responseEndTs: 1780000002000,
+    toolFinishedTs: 0,
+    stopReason: 'end_turn',
+    model: 'claude-sonnet-4-5',
+    ...overrides,
+  };
+}
+
+function makeIntercept(overrides: Partial<InterceptTokenData> = {}): InterceptTokenData {
+  return {
+    id: 'resp_intercept_A',
+    ts: 1780000002000,
+    promptTokens: 1200,
+    completionTokens: 80,
+    cachedTokens: 900,
+    reasoningTokens: 0,
+    totalTokens: 1280,
+    ...overrides,
+  };
+}
+
+describe('token-enricher enrichCliTurn', () => {
+  describe('Case 1: exact response.id match (regression)', () => {
+    it('injects usage/timestamps/model when response.id === seg.requestId', () => {
+      const entries: AgentActivityEntry[] = [
+        makeRequest({ 'gen_ai.step.id': 'turn-1:s1' }),
+        makeResponse({ 'gen_ai.response.id': 'c3be0573-f0d4-4347-b6a0-d9f8ec6d00ae' }),
+      ];
+      const segments: SegmentTokenData[] = [
+        makeSeg({ requestId: 'c3be0573-f0d4-4347-b6a0-d9f8ec6d00ae' }),
+      ];
+
+      enrichCliTurn(entries, segments);
+
+      const resp = entries[1];
+      expect(resp['gen_ai.usage.input_tokens']).toBe(5000);
+      expect(resp['gen_ai.usage.output_tokens']).toBe(200);
+      expect(resp['gen_ai.response.model']).toBe('claude-sonnet-4-5');
+      expect(resp.time_unix_nano).toBe(String(BigInt(1780000002000) * 1_000_000n));
+      expect(entries[0].time_unix_nano).toBe(String(BigInt(1780000000000) * 1_000_000n));
+      expect(entries[0]['gen_ai.request.model']).toBe('claude-sonnet-4-5');
+    });
+  });
+
+  describe("Case 2: response.id mismatch (history resp_xxx vs segment UUID) — order fallback", () => {
+    it('pairs segment i-th with step s(i+1) by order when response.id diverges', () => {
+      // History gen_ai.response.id uses Anthropic message.id format ("resp_...")
+      // while segment request_id is a UUID. Exact match misses on both steps.
+      // Order fallback: seg[0] (sorted by responseEndTs asc) ↔ step s1, seg[1] ↔ step s2.
+      const entries: AgentActivityEntry[] = [
+        makeRequest({ 'gen_ai.step.id': 'turn-1:s1', time_unix_nano: '1780000000000000000' }),
+        makeResponse({
+          'gen_ai.response.id': 'resp_0bfdfd26719a749f016a9680cc7f6c8194a84682cf40d8499c',
+          'gen_ai.step.id': 'turn-1:s1',
+          time_unix_nano: '1780000000000000000',
+        }),
+        makeRequest({ 'gen_ai.step.id': 'turn-1:s2', time_unix_nano: '1780000010000000000' }),
+        makeResponse({
+          'gen_ai.response.id': 'resp_0bfdfd26719a749f016a9680e4182c8194ab162def90bfcd02',
+          'gen_ai.step.id': 'turn-1:s2',
+          time_unix_nano: '1780000010000000000',
+        }),
+      ];
+      const segments: SegmentTokenData[] = [
+        makeSeg({
+          requestId: 'c3be0573-f0d4-4347-b6a0-d9f8ec6d00ae',
+          requestStartTs: 1780000000000,
+          responseEndTs: 1780000002000,
+        }),
+        makeSeg({
+          requestId: 'af972b1e-61df-4b40-92a3-efa1521c8e8a',
+          requestStartTs: 1780000010000,
+          responseEndTs: 1780000012000,
+        }),
+      ];
+
+      enrichCliTurn(entries, segments);
+
+      // s1 response paired with seg[0]
+      const s1Resp = entries[1];
+      expect(s1Resp['gen_ai.response.model']).toBe('claude-sonnet-4-5');
+      expect(s1Resp.time_unix_nano).toBe(String(BigInt(1780000002000) * 1_000_000n));
+      expect(s1Resp['gen_ai.usage.input_tokens']).toBe(5000);
+      // s1 request timestamp injected from segment.requestStartTs
+      expect(entries[0].time_unix_nano).toBe(String(BigInt(1780000000000) * 1_000_000n));
+
+      // s2 response paired with seg[1]
+      const s2Resp = entries[3];
+      expect(s2Resp.time_unix_nano).toBe(String(BigInt(1780000012000) * 1_000_000n));
+      expect(s2Resp['gen_ai.usage.input_tokens']).toBe(5000);
+      expect(entries[2].time_unix_nano).toBe(String(BigInt(1780000010000) * 1_000_000n));
+    });
+
+    it('leaves unmatched segments alone when there are no unclaimed step responses', () => {
+      // One response, two segments, both with mismatched response.id. Only one
+      // entry can be claimed by order fallback; the second segment is left
+      // unmatched — no regression (entry stays at original values).
+      const entries: AgentActivityEntry[] = [
+        makeResponse({
+          'gen_ai.response.id': 'resp_history_1',
+          'gen_ai.step.id': 'turn-1:s1',
+          time_unix_nano: '1780000000000000000',
+        }),
+      ];
+      const segments: SegmentTokenData[] = [
+        makeSeg({ requestId: 'seg-uuid-1', responseEndTs: 1780000001000, requestStartTs: 1780000000000 }),
+        makeSeg({ requestId: 'seg-uuid-2', responseEndTs: 1780000002000, requestStartTs: 1780000001000 }),
+      ];
+
+      enrichCliTurn(entries, segments);
+
+      // Single entry paired with seg[0] (lower responseEndTs)
+      expect(entries[0]['gen_ai.usage.input_tokens']).toBe(5000);
+      expect(entries[0].time_unix_nano).toBe(String(BigInt(1780000001000) * 1_000_000n));
+    });
+  });
+
+  describe('Case 3: mixed exact + order fallback (exact match takes priority)', () => {
+    it('claims entries for exact response.id matches before order fallback runs', () => {
+      // s1 has matching response.id (exact match). s2 has mismatching
+      // response.id (order fallback). Order fallback must skip the entry
+      // claimed by exact match for s1, and pair s2's segment with the next
+      // unclaimed step response.
+      const entries: AgentActivityEntry[] = [
+        makeRequest({ 'gen_ai.step.id': 'turn-1:s1' }),
+        makeResponse({
+          'gen_ai.response.id': 'c3be0573-f0d4-4347-b6a0-d9f8ec6d00ae', // matches seg[0].requestId
+          'gen_ai.step.id': 'turn-1:s1',
+        }),
+        makeRequest({ 'gen_ai.step.id': 'turn-1:s2' }),
+        makeResponse({
+          'gen_ai.response.id': 'resp_anthropic_message_id', // mismatches seg[1].requestId
+          'gen_ai.step.id': 'turn-1:s2',
+        }),
+      ];
+      const segments: SegmentTokenData[] = [
+        makeSeg({
+          requestId: 'c3be0573-f0d4-4347-b6a0-d9f8ec6d00ae',
+          requestStartTs: 1780000000000,
+          responseEndTs: 1780000002000,
+        }),
+        makeSeg({
+          requestId: 'af972b1e-61df-4b40-92a3-efa1521c8e8a',
+          requestStartTs: 1780000010000,
+          responseEndTs: 1780000012000,
+        }),
+      ];
+
+      enrichCliTurn(entries, segments);
+
+      // s1 paired by exact match
+      expect(entries[1]['gen_ai.usage.input_tokens']).toBe(5000);
+      expect(entries[1].time_unix_nano).toBe(String(BigInt(1780000002000) * 1_000_000n));
+      // s2 paired by order fallback (skipped s1's claimed entry)
+      expect(entries[3]['gen_ai.usage.input_tokens']).toBe(5000);
+      expect(entries[3].time_unix_nano).toBe(String(BigInt(1780000012000) * 1_000_000n));
+      expect(entries[2].time_unix_nano).toBe(String(BigInt(1780000010000) * 1_000_000n));
+    });
+  });
+
+  describe('intercept overrides segment usage even when order fallback applied', () => {
+    it('applies intercept usage by response.id after segment order fallback', () => {
+      const entries: AgentActivityEntry[] = [
+        makeResponse({
+          'gen_ai.response.id': 'resp_intercept_A', // matches intercept id, mismatches seg.requestId
+          'gen_ai.step.id': 'turn-1:s1',
+        }),
+      ];
+      const segments: SegmentTokenData[] = [
+        makeSeg({
+          requestId: 'c3be0573-f0d4-4347-b6a0-d9f8ec6d00ae',
+          inputTokens: 9999, // would be applied by segment, but intercept should win
+          requestStartTs: 1780000000000,
+          responseEndTs: 1780000002000,
+        }),
+      ];
+
+      enrichCliTurn(entries, segments, undefined, [makeIntercept()]);
+
+      // Intercept overrides segment usage
+      expect(entries[0]['gen_ai.usage.input_tokens']).toBe(1200);
+      expect(entries[0]['gen_ai.usage.output_tokens']).toBe(80);
+      expect(entries[0]['gen_ai.usage.total_tokens']).toBe(1280);
+      // But segment-derived timestamp sticks (segment is the unified clock source)
+      expect(entries[0].time_unix_nano).toBe(String(BigInt(1780000002000) * 1_000_000n));
+    });
+  });
+});

--- a/tests/unit/inputs/qoder-trace/token-enricher.test.ts
+++ b/tests/unit/inputs/qoder-trace/token-enricher.test.ts
@@ -234,4 +234,56 @@ describe('token-enricher enrichCliTurn', () => {
       expect(entries[0].time_unix_nano).toBe(String(BigInt(1780000002000) * 1_000_000n));
     });
   });
+
+  describe('Case 4: multi-turn cross-turn collision (AGE-1730 Step C regression)', () => {
+    it('pairs segments per-turn so turn-2:s1 does not steal turn-1:s1 timestamps', () => {
+      // Regression: gen_ai.step.id is `${turn_id}:s${request_index}`. Both
+      // turn-1 and turn-2 have a `:s1` step. The b30a2ef6 global order
+      // fallback parsed step numbers without turn scoping, so turn-2:s1
+      // and turn-1:s1 both matched as step#1 — turn 2 responses could
+      // be paired with turn 1 segments. Per-turn scoping (filter by
+      // stepId.startsWith(`${turnId}:s`)) prevents the cross-turn leak.
+      const entries: AgentActivityEntry[] = [
+        makeRequest({ 'gen_ai.step.id': 'turn-1:s1', 'gen_ai.turn.id': 'turn-1', time_unix_nano: '1780000000000000000' }),
+        makeResponse({
+          'gen_ai.response.id': 'resp_t1_s1',
+          'gen_ai.step.id': 'turn-1:s1',
+          'gen_ai.turn.id': 'turn-1',
+          time_unix_nano: '1780000000000000000',
+        }),
+        makeRequest({ 'gen_ai.step.id': 'turn-2:s1', 'gen_ai.turn.id': 'turn-2', time_unix_nano: '1780000100000000000' }),
+        makeResponse({
+          'gen_ai.response.id': 'resp_t2_s1',
+          'gen_ai.step.id': 'turn-2:s1',
+          'gen_ai.turn.id': 'turn-2',
+          time_unix_nano: '1780000100000000000',
+        }),
+      ];
+      const segments: SegmentTokenData[] = [
+        makeSeg({
+          requestId: 'uuid-t1-s1',
+          turnId: 'turn-1',
+          requestStartTs: 1780000000000,
+          responseEndTs: 1780000002000,
+        }),
+        makeSeg({
+          requestId: 'uuid-t2-s1',
+          turnId: 'turn-2',
+          requestStartTs: 1780000100000,
+          responseEndTs: 1780000102000,
+        }),
+      ];
+
+      enrichCliTurn(entries, segments);
+
+      // turn-1:s1 paired with seg[0] (turn-1)
+      expect(entries[1]['gen_ai.usage.input_tokens']).toBe(5000);
+      expect(entries[1].time_unix_nano).toBe(String(BigInt(1780000002000) * 1_000_000n));
+      expect(entries[0].time_unix_nano).toBe(String(BigInt(1780000000000) * 1_000_000n));
+      // turn-2:s1 paired with seg[1] (turn-2), NOT seg[0]
+      expect(entries[3]['gen_ai.usage.input_tokens']).toBe(5000);
+      expect(entries[3].time_unix_nano).toBe(String(BigInt(1780000102000) * 1_000_000n));
+      expect(entries[2].time_unix_nano).toBe(String(BigInt(1780000100000) * 1_000_000n));
+    });
+  });
 });


### PR DESCRIPTION
## 背景

qoder-trace 路径下 LLM span 普遍 0-duration，根因在 token-enricher 配对逻辑：segment `request_id`（UUID 格式）与 history `gen_ai.response.id`（Anthropic `resp_xxx` 格式）不匹配 → token-enricher 静默跳过 → 0-duration。后续轮次迭代发现更深根因：segment `turn_id` ≠ OTLP `turn.id`（前者为 segment 端 ID，后者为 pilot 端 UUID），且 `request_index` 跨 turn 配对会引发 cross-turn swap。本 PR 通过多轮迭代修复 3 类核心问题：LLM duration=0、cross-turn swap、step.id passthrough。

## 修法（5 commit 叠加）

### commit `b30a2ef6` — Round 1：order fallback（精确匹配优先）
`src/inputs/qoder-trace/token-enricher.ts` 新增 `applyOrderFallback`：response.id 精确匹配优先（保留原逻辑），失败时按 `step.id` 顺序（`s1`/`s2`/...）配对 request → response。`segment-token-reader.ts` 新增 `request_index` 配对 fallback。不破坏精确匹配路径，纯 additive。

### commit `ad34e14f` — Round 5：scope segment pairing per turn
将 segment 配对范围从全局改为按 turn 作用域，防止跨 turn timestamp mismatch。

### commit `dd99eb65` — Round 6：scope segment pairing per file
进一步将配对作用域改为按 segment 文件（same-file segment pairing），修复 #1 dur=0 + #2 cross-turn swap（#1 在 runtime 未完全生效，需下一轮真根因修复）。

### commit `e857cc1c` — Round 7：真根因修复 + step.id passthrough
- 真根因：segment `turn_id` ≠ OTLP `turn.id`（segment 端 ID vs pilot 端 UUID）→ `otlpTurnIds` prefix fallback（按 turn.id 前缀匹配 segment turn_id）
- #4 step.id passthrough：将 segment 端 `step.id` 透传到 OTLP span（`<turnId>:s<N>` 格式）

### commit `6c741f05` — Round 8：stateless TS overlap pairing
替换 `sessionCliTurnIdx` 局部变量为 stateless 时间戳重叠配对（pair seg groups with OTLP turns by TS overlap, not stateful index），修复 #2 cross-turn swap 回归。

## 修改文件

| 文件 | 改动 | 类型 |
|------|------|------|
| `src/inputs/qoder-trace/token-enricher.ts` | `applyOrderFallback` + `otlpTurnIds` prefix fallback + step.id passthrough + stateless TS overlap | src |
| `src/inputs/qoder-trace/segment-token-reader.ts` | `request_index` 配对 fallback + same-file scoping | src |
| `src/inputs/qoder-trace/segment-turn-pairing.ts` | 新文件：turn 配对辅助逻辑 | src |
| `src/inputs/qoder-trace/qoder-trace-input.ts` | input 侧配合 segment scoping | src |
| `src/flushers/otlp-trace-flusher.ts` | flusher 侧配合 step.id passthrough | src |
| `tests/unit/inputs/qoder-trace/token-enricher.test.ts` | 单测覆盖 order fallback + 各轮 fix | test |
| `tests/unit/inputs/qoder-trace/segment-token-reader.test.ts` | 单测覆盖 request_index fallback | test |
| `tests/unit/inputs/qoder-trace/prod-shape.test.ts` | 真实 shape 集成测试 | test |
| `tests/unit/inputs/qoder-trace/prod-shape-token-enricher.test.ts` | 真实 shape token-enricher 测试 | test |

改动规模：5 src + 4 test，+1568 / -95 行（相对 base `1643cea1`）。

## 验证

### 单测 + 类型检查
- ✅ 单测 3840/3844 PASS（4 pre-existing flaky，非本 PR 引入）
- ✅ typecheck PASS（`tsc --noEmit` 0 error）
- ✅ 新增单测覆盖 order fallback / request_index fallback / same-file scoping / otlpTurnIds prefix / step.id passthrough / stateless TS overlap

### tester Round 8 真实 E2E（CP5 溯源）
- ✅ 真实 qoder-cli 1.1.4 触发对话产出 trace
- ✅ **#1（dur=0）PASS**：34/34 LLM span duration > 0（6.6s ~ 74.4s）
- ✅ **#2（cross-turn swap）PASS**：T1/T2/T3 LLM s1 start = 本 turn seg req1（diff 0ms × 3，无跨 turn 错位）
- ✅ **#4（step.id）PASS**：34/34 = 100% 非空（`<turnId>:s<N>` 格式）
- ⚠️ **#3（duplication）仍 2× fan-out**：researcher 确认为 PR #248 dual-backend 正常行为，非 bug；P2 可选修复（见已知遗留）

### validate-trace（26 ERROR，全部归因 #3 fan-out）
- 17 no_step_overlap
- 3 single_entry
- 3 single_agent
- 3 agent_token_sum
- #1/#2/#4 相关 ERROR 已清零 ✅

## 时序对照（tester Round 8）

| 维度 | Round 1 基线 | Round 8 实测 |
|------|------|------|
| LLM dur=0 占比 | 87% | 0/34 ✅ |
| cross-turn swap（T1/T2/T3 s1 start diff） | 错位 | 0ms × 3 ✅ |
| step.id 非空率 | 0% | 100% ✅ |
| LLM duration 范围 | 0s | 6.6s ~ 74.4s ✅ |

## FINAL_HEAD

`6c741f050df7f3c2b61e7633ae3f014f19dfc948`（5 commit 叠加：`b30a2ef6` → `ad34e14f` → `dd99eb65` → `e857cc1c` → `6c741f05`）

## 基线

`1643cea1e9dbee99d15da5498e2864ce5d15362c`（PR #342 合并后的 main HEAD）

## 已知遗留

- **#3 2× fan-out**（researcher 确认 PR #248 dual-backend 正常行为，非 bug；P2 可选修复：把 `writeDebugLog` 从 `doConvertAndExport` 提到 `convertAndExport`，仅影响 debug 文件视图，不影响实际 backend 发送；留作后续 iteration）
- 26 validate-trace ERROR 全部归因 #3 fan-out，非本 PR 修复范围
- 4 pre-existing flaky 单测，非本 PR 引入

## caveat

- 本 PR 与 #342（qoder-cli-session fallback 路径防御性修复）正交
- order fallback / otlpTurnIds prefix / stateless TS overlap 均为防御性补丁，不替代精确匹配；当 qoder 后续统一 ID 格式后 fallback 路径自然失效
- 真实采集，无手工构造

## Co-Authored-By

Co-Authored-By: pilot-developer-v2 <pilot-developer-v2@loongsuite.local>
