### PR TITLE
fix(installer): survive 8.3 short %TEMP% on Windows

### DIFF
--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -270,6 +270,89 @@ function Get-ManagedNodePlatform {
     }
 }
 
+# >>> pilot-short-path >>>
+# 8.3 short paths: why every delete and move below goes through a helper.
+#
+# Windows hands out %TEMP% in 8.3 short form whenever the profile name does not fit 8.3,
+# which a dot in an account name is often enough to do: C:\Users\zhang.wang becomes
+# C:\Users\ZHANG~1.WAN, the four characters after the dot being one too many for an 8.3
+# extension. %USERPROFILE% stays long, so a single install sees both forms. Reading such a
+# path works everywhere (Test-Path, Get-Item, Get-ChildItem, Get-Content, Set-Content,
+# Add-Content, New-Item, Out-File and Copy-Item all resolve it, and so does a Move-Item
+# destination), but Remove-Item, Move-Item, Rename-Item, Set-Location and Push-Location
+# fail with
+#
+#     An object at the specified path C:\Users\ZHANG~1.WAN does not exist.
+#
+# naming the prefix their walk broke on rather than the path that was passed in.
+#
+# It is one guard in FileSystemProvider.NormalizeThePath, which is what the .NET stack
+# trace on the PSArgumentException names. That walk accumulates currentPath in the form you
+# typed it and, for each segment, compares the resolved item against it:
+#
+#     if (fsinfo.FullName.Length < currentPath.Length)
+#         throw NewArgumentException("path", ItemDoesNotExist, currentPath);
+#     if (fsinfo.Name.Length >= childName.Length)
+#         childName = fsinfo.Name;          // "Expand the short file name"
+#
+# The guard is aimed at a child name of two or more dots, which .NET resolves to the parent
+# and so hands back shorter. An 8.3 name longer than the name it stands for is the other way
+# to make resolved shorter than typed, and the guard cannot tell the two apart -- note that
+# the very next line expands a short name only when doing so would not shorten it.
+#
+# So the trigger is not "a segment is in 8.3 form". Measured on 5.1.26100 over 13 profile
+# names and 7 nesting cases, it is a length comparison on every prefix:
+#
+#     zhang.wang     -> ZHANG~1.WAN    11 > 10   throws
+#     abcd.wang      -> ABCD~1.WAN     10 >  9   throws
+#     ab.wang        -> ABxxxx~1.WAN   12 >  7   throws (<=2 chars of base get a hash)
+#     wang.zhang     -> WANG~1.ZHA     10 = 10   works
+#     zhangsan.wang  -> ZHANGS~1.WAN   12 < 13   works
+#     zhang.san      -> no short name at all     works
+#
+# It takes a short base with an over-long extension, which is why it looks rare in the
+# field. Depth is not irrelevant either: the first prefix whose typed length exceeds its
+# resolved length is the one that throws, so an earlier segment resolving much longer masks
+# a later offender (VERYLO~1\ZHANG~1.WAN is fine) while those same two segments in the other
+# order still throw (ZHANG~1.WAN\VERYLO~1 breaks on the first one). -LiteralPath behaves
+# identically to -Path, so quoting is not the fix, and neither is Convert-Path or
+# Resolve-Path -- both hand the short form straight back. Get-Item .FullName expands it.
+function Get-PilotLongPath {
+    param([string]$Path)
+    if (-not $Path) { return $Path }
+    try {
+        $item = Get-Item -LiteralPath $Path -Force -ErrorAction Stop
+        if ($item.FullName) { return $item.FullName }
+    } catch {
+        # Not there, or not there yet -- a Move-Item destination is the common case. Only
+        # an existing directory can carry a short name, so expanding the parent is enough.
+        try {
+            $parent = Split-Path -Parent $Path
+            $leaf = Split-Path -Leaf $Path
+            if ($parent -and $leaf) {
+                $parentItem = Get-Item -LiteralPath $parent -Force -ErrorAction Stop
+                if ($parentItem.FullName) { return (Join-Path $parentItem.FullName $leaf) }
+            }
+        } catch {}
+    }
+    return $Path
+}
+
+# Best-effort delete, for cleanup only. Every caller is a catch or a finally, where an
+# exception is not merely unhelpful but destructive, so this has to be incapable of
+# raising one: -ErrorAction SilentlyContinue covers the ordinary non-terminating half (a
+# file a virus scanner still holds open) and the catch covers everything else, the
+# binding failure above included. Deliberately returns nothing -- a caller that needs to
+# know whether the path is gone asks Test-Path.
+function Remove-PilotPathQuietly {
+    param([string]$Path)
+    if (-not $Path) { return }
+    try {
+        Remove-Item -LiteralPath (Get-PilotLongPath $Path) -Recurse -Force -ErrorAction SilentlyContinue
+    } catch {}
+}
+# <<< pilot-short-path <<<
+
 # >>> pilot-ascii-temp >>>
 # Temp root guaranteed to be ASCII, for the two tar.exe staging dirs only.
 #
@@ -302,6 +385,9 @@ function Get-PilotAsciiTempRoot {
     elseif ($env:TMP) { $root = $env:TMP }
     elseif ($env:SystemRoot) { $root = (Join-Path $env:SystemRoot "Temp") }
     if ($root -notmatch '[^\x20-\x7E]') {
+        # 8.3 TEMP (ZHANG~1.WAN) is ASCII, so this branch used to return it as-is
+        # and skip the long-name expand that Remove-Item / Move-Item need.
+        $root = Get-PilotLongPath $root
         $script:PILOT_ASCII_TEMP_ROOT = $root
         return $root
     }
@@ -325,6 +411,8 @@ function Get-PilotAsciiTempRoot {
         } catch {}
     }
     # Nothing writable: keep the old behaviour rather than failing outright.
+    # Same $root as the ASCII early return, so the same 8.3 expand applies.
+    $root = Get-PilotLongPath $root
     $script:PILOT_ASCII_TEMP_ROOT = $root
     return $root
 }
@@ -517,21 +605,21 @@ function Ensure-ManagedNode {
         if (-not (Invoke-ManagedNodeDownload "$base/SHASUMS256.txt" $shasumsPath)) { return $null }
         if (-not (Test-ManagedNodeChecksum $archivePath $shasumsPath $archive)) { return $null }
 
-        if (Test-Path $nodeDir) { Remove-Item $nodeDir -Recurse -Force }
+        if (Test-Path $nodeDir) { Remove-Item -LiteralPath (Get-PilotLongPath $nodeDir) -Recurse -Force }
         if (-not (Test-Path $runtimeDir)) { New-Item -ItemType Directory -Path $runtimeDir -Force | Out-Null }
         Expand-Archive -Path $archivePath -DestinationPath $runtimeDir -Force
         $nodeBin = Resolve-ManagedNodeBin $nodeDir
         if (-not $nodeBin) {
             Msg "    ❌ 解压产物中未找到 node.exe（bin\ 或根目录布局）" "    ❌ No node.exe found in extracted archive (bin\ or root layout)"
-            Remove-Item $nodeDir -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-PilotPathQuietly $nodeDir
             return $null
         }
         return $nodeBin
     } catch {
-        Remove-Item $nodeDir -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-PilotPathQuietly $nodeDir
         return $null
     } finally {
-        Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-PilotPathQuietly $tmp
     }
 }
 
@@ -582,8 +670,11 @@ function Ensure-NodeModules {
         }
 
         Set-Content -Path (Join-Path $stagedModules ".pilot-modules-version") -Value $stamp
-        if (Test-Path $modulesDir) { Remove-Item $modulesDir -Recurse -Force }
-        Move-Item $stagedModules $modulesDir
+        if (Test-Path $modulesDir) { Remove-Item -LiteralPath (Get-PilotLongPath $modulesDir) -Recurse -Force }
+        # $stagedModules sits under the ASCII temp root, i.e. under whatever %TEMP%
+        # gave us, and Move-Item cannot see an 8.3 segment either -- without this the
+        # prebuilt tree silently lost every install on such a profile to npm install.
+        Move-Item (Get-PilotLongPath $stagedModules) $modulesDir
         # The move brought the ASCII root's ACL with it, which can leave the tree
         # unreadable to the non-elevated scheduled task -- see Reset-PilotInheritedAcl.
         # If that cannot be repaired, throw the prebuilt tree away rather than deploy
@@ -592,14 +683,14 @@ function Ensure-NodeModules {
         if (-not (Reset-PilotInheritedAcl $modulesDir)) {
             Msg "    ⚠️  预编译 node_modules 权限修复失败: $script:PILOT_LAST_ACL_ERR" `
                 "    ⚠️  Could not reset permissions on prebuilt node_modules: $script:PILOT_LAST_ACL_ERR"
-            Remove-Item $modulesDir -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-PilotPathQuietly $modulesDir
             return $false
         }
         return $true
     } catch {
         return $false
     } finally {
-        Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-PilotPathQuietly $tmp
     }
 }
 # <<< managed-node-runtime <<<
@@ -1306,7 +1397,7 @@ if (opts.selectedAgents) {
 fs.writeFileSync(opts.configPath, JSON.stringify(config, null, 2) + '\n');
 '@ $cfgTmp
     $ErrorActionPreference = $prevEAP
-    Remove-Item -LiteralPath $cfgTmp -Force -ErrorAction SilentlyContinue
+    Remove-PilotPathQuietly $cfgTmp
 
     Msg "    ✅ 配置已写入" "    ✅ Config written"
     Write-Host ""
@@ -2425,9 +2516,7 @@ function Cmd-Install {
         Write-Host ""
         Print-Summary "install"
     } finally {
-        if ($script:TMP_DIR -and (Test-Path $script:TMP_DIR)) {
-            Remove-Item $script:TMP_DIR -Recurse -Force -ErrorAction SilentlyContinue
-        }
+        Remove-PilotPathQuietly $script:TMP_DIR
     }
 }
 
@@ -2508,9 +2597,7 @@ function Cmd-Upgrade {
             exit 1
         }
     } finally {
-        if ($script:TMP_DIR -and (Test-Path $script:TMP_DIR)) {
-            Remove-Item $script:TMP_DIR -Recurse -Force -ErrorAction SilentlyContinue
-        }
+        Remove-PilotPathQuietly $script:TMP_DIR
     }
 }
 
@@ -2547,7 +2634,7 @@ fs.writeFileSync(process.argv[2], content);
         $rewriteExit = $LASTEXITCODE
     } finally {
         $ErrorActionPreference = $prevEAP
-        Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+        Remove-PilotPathQuietly $tmp
     }
     if ($rewriteExit -ne 0) { throw "Failed to write UTF-8 file: $Path" }
 }

--- a/tests/unit/deploy/installer-short-path.test.mjs
+++ b/tests/unit/deploy/installer-short-path.test.mjs
@@ -1,0 +1,277 @@
+// Windows hands out %TEMP% in 8.3 short form whenever the profile name does not fit 8.3,
+// which a dot in an account name is often enough to do: C:\Users\zhang.wang gives
+// %TEMP% = C:\Users\ZHANG~1.WAN\AppData\Local\Temp while %USERPROFILE% stays long.
+// Reading such a path works everywhere, but Remove-Item, Move-Item (source), Rename-Item,
+// Set-Location and Push-Location fail with
+//
+//     An object at the specified path C:\Users\ZHANG~1.WAN does not exist.
+//
+// naming the prefix their walk broke on rather than the path that was passed in.
+//
+// It is one guard in FileSystemProvider.NormalizeThePath, which the .NET stack trace on the
+// PSArgumentException names. The walk accumulates currentPath in the form it was typed and,
+// per segment, throws when `fsinfo.FullName.Length < currentPath.Length` -- a check aimed at
+// a child name of two or more dots (.NET resolves that to the parent, so it comes back
+// shorter), which an 8.3 name longer than the name it stands for trips in exactly the same
+// way. The very next line only expands a short name when doing so would not shorten it.
+//
+// So the trigger is narrower than "a segment is in 8.3 form", and reproducing with the wrong
+// name proves nothing. Measured on 5.1.26100 over 13 profile names and 7 nesting cases:
+// zhang.wang -> ZHANG~1.WAN (11 > 10) throws, abcd.wang -> ABCD~1.WAN (10 > 9) throws,
+// wang.zhang -> WANG~1.ZHA (10 = 10) works, zhangsan.wang -> ZHANGS~1.WAN (12 < 13) works,
+// zhang.san gets no short name at all. It takes a short base with an over-long extension.
+// Depth is not irrelevant either: the guard runs per prefix, so deltas prefix-sum and order
+// matters -- VERYLO~1\ZHANG~1.WAN is fine (-11 masks +1) while ZHANG~1.WAN\VERYLO~1 throws
+// on its first segment, and wrapping the offender in a long outer directory does not help.
+// -LiteralPath behaves identically to -Path (file, empty directory and -Recurse tree
+// alike), so this is not the globbing hazard that -LiteralPath fixes, and Convert-Path /
+// Resolve-Path are not the fix either -- both hand the short form straight back.
+//
+// It cost one real install twice over. Move-Item could not land the prebuilt
+// node_modules, so that degraded to npm install; then the cleanup in the finally raised
+// the error above, and because it arrives during parameter binding as a
+// PSArgumentException rather than as an error record, -ErrorAction SilentlyContinue did
+// not suppress it. Thrown from inside a finally it replaced the exception in flight and
+// aborted the run, leaving no config, no command shim and no service.
+//
+// The reasoning is the rule; this file is the ratchet. Two invariants carry it:
+// nothing that could be a temp path reaches Remove-Item or Move-Item unnormalised, and
+// no finally deletes a file at all -- cleanup there goes through a helper that cannot
+// raise.
+import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const VARIANTS = ['installer.ps1', 'installer-inner.ps1', 'installer-opensource.ps1'];
+const present = VARIANTS.filter(f => existsSync(resolve('deploy', f)));
+const read = (f) => readFileSync(resolve('deploy', f), 'utf-8');
+
+const blockOf = (text, tag) => {
+  const re = new RegExp(`^# >>> ${tag} >>>\\n[\\s\\S]*?^# <<< ${tag} <<<\\n`, 'm');
+  const m = text.match(re);
+  return m ? m[0] : null;
+};
+
+// installer-opensource.ps1 is landed on GitHub separately from the internal
+// variants, so the internal tree may still have the file without the block
+// until the next opensource sync. Sweep helpers only on copies that have it.
+const withBlock = present.filter(f => blockOf(read(f), 'pilot-short-path'));
+
+const functionOf = (text, name) => {
+  const start = text.indexOf(`function ${name} {`);
+  if (start < 0) return '';
+  const next = text.indexOf('\nfunction ', start + 1);
+  return text.slice(start, next < 0 ? text.length : next);
+};
+
+// Here-strings carry the JS payloads that patch config.json, and that JS has its own
+// `} finally {` and its own braces. Blank their bodies (keeping the line count) before
+// anything counts a brace or greps for a cmdlet. A here-string opens at the end of a
+// line and can only close with "@ / '@ at the start of one.
+const stripHereStrings = (text) => {
+  const out = [];
+  let closer = null;
+  for (const line of text.split('\n')) {
+    if (closer) {
+      if (line.startsWith(closer)) { closer = null; out.push(''); } else out.push('');
+      continue;
+    }
+    const open = line.match(/@("|')\s*$/);
+    if (open) { closer = open[1] === '"' ? '"@' : "'@"; out.push(''); continue; }
+    out.push(line);
+  }
+  return out;
+};
+
+// Full-line comments only: enough to keep a brace in prose out of the counting, while
+// leaving code untouched.
+const codeOnly = (lines) => lines.map(l => (/^\s*#/.test(l) ? '' : l));
+
+// Bodies of every finally block, by brace matching from the `finally {`.
+const finallyBodies = (text) => {
+  const src = codeOnly(stripHereStrings(text)).join('\n');
+  const out = [];
+  const re = /\bfinally\s*\{/g;
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    let depth = 1;
+    let i = m.index + m[0].length;
+    for (; i < src.length && depth > 0; i++) {
+      if (src[i] === '{') depth++;
+      else if (src[i] === '}') depth--;
+    }
+    out.push(src.slice(m.index + m[0].length, i - 1));
+  }
+  return out;
+};
+
+// Paths that could carry an 8.3 segment: anything rooted in a temp dir, plus anything
+// derived from one via Join-Path / Split-Path / Get-ChildItem, plus plain aliases.
+// Seeded from the two temp-root helpers and from $env:TEMP / $env:TMP directly, then
+// run to a fixpoint -- `$tmp` -> `$stage` -> `$stagedModules` is the chain that broke
+// the real install. Get-ChildItem is how the 7-Zip fallback's `$tarFile` is born.
+const taintedVars = (text) => {
+  const lines = codeOnly(stripHereStrings(text));
+  const bindings = [];
+  for (const line of lines) {
+    const assign = line.match(/\$(?:script:)?([A-Za-z_]\w*)\s*=\s*(.*)$/);
+    if (assign) bindings.push([assign[1], assign[2]]);
+  }
+  // GetTempPath() is not CLM-safe and installer-opensource.ps1 should be using the
+  // shared helper, but it is still a temp root, so it is seeded here all the same.
+  const seed = /Get-PilotTempRoot|Get-PilotAsciiTempRoot|\$env:TEMP\b|\$env:TMP\b|GetTempPath/;
+  const vars = new Set();
+  for (const [name, rhs] of bindings) if (seed.test(rhs)) vars.add(name);
+  for (let pass = 0; pass < 8; pass++) {
+    const before = vars.size;
+    for (const [name, rhs] of bindings) {
+      const derived = /\b(Join-Path|Split-Path|Get-ChildItem)\b/.test(rhs) || /^\$(?:script:)?[A-Za-z_]\w*\s*$/.test(rhs);
+      if (!derived) continue;
+      if ([...vars].some(v => new RegExp(`\\$(?:script:)?${v}\\b`).test(rhs))) vars.add(name);
+    }
+    if (vars.size === before) break;
+  }
+  return vars;
+};
+
+// Every delete or move of a possibly-short path, the helper calls included -- counting
+// those too is what keeps the sweep from going quiet the moment a site is converted.
+const hazardSites = (text) => {
+  const names = [...taintedVars(text)];
+  const out = [];
+  const lines = stripHereStrings(text);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^\s*#/.test(line)) continue;
+    // Every cmdlet measured to go through NormalizeThePath, not just the two that broke
+    // the real install -- Rename-Item, Set-Location and Push-Location throw the identical
+    // PSArgumentException, so a future `Push-Location $tmp` has to be caught here too.
+    if (!/\b(Remove-Item|Move-Item|Rename-Item|Set-Location|Push-Location|Remove-PilotPathQuietly)\b/.test(line)) continue;
+    if (!names.some(v => new RegExp(`\\$(?:script:)?${v}\\b`).test(line))) continue;
+    out.push({ n: i + 1, line: line.trim() });
+  }
+  return out;
+};
+
+describe('installers survive an 8.3 short %TEMP%', () => {
+  it('finds the installers to check', () => {
+    // Guards against a silently empty sweep. The GitHub tree only has
+    // installer-opensource.ps1; the internal tree always has installer.ps1.
+    expect(present.length).toBeGreaterThan(0);
+    if (present.includes('installer.ps1')) {
+      expect(present).toContain('installer.ps1');
+    } else {
+      expect(present).toContain('installer-opensource.ps1');
+    }
+  });
+
+  it('every present internal installer carries the short-path block', () => {
+    for (const f of ['installer.ps1', 'installer-inner.ps1']) {
+      if (!present.includes(f)) continue;
+      expect(blockOf(read(f), 'pilot-short-path'), f).toBeTruthy();
+    }
+  });
+
+  it('the public installer carries the block when it is the only variant', () => {
+    // GitHub: this file is the whole tree. Internal: it may lag until sync.
+    if (!present.includes('installer.ps1') && present.includes('installer-opensource.ps1')) {
+      expect(blockOf(read('installer-opensource.ps1'), 'pilot-short-path')).toBeTruthy();
+    }
+  });
+
+  it('all variants that carry the helper share one byte-identical block', () => {
+    // Three copies of the same reasoning is how the bare Remove-Item survived in the
+    // first place. One implementation, or the next fix reaches only one file.
+    expect(withBlock.length).toBeGreaterThan(0);
+    const blocks = withBlock.map(f => blockOf(read(f), 'pilot-short-path'));
+    expect(new Set(blocks).size).toBe(1);
+  });
+
+  for (const f of withBlock) {
+    const ps1 = read(f);
+
+    it(`${f} normalises short paths through Get-Item .FullName`, () => {
+      const fn = functionOf(ps1, 'Get-PilotLongPath');
+      expect(fn, 'Get-PilotLongPath must exist').not.toBe('');
+      expect(fn).toContain('Get-Item -LiteralPath $Path -Force -ErrorAction Stop');
+      expect(fn).toContain('$item.FullName');
+      // A Move-Item destination does not exist yet; only an existing directory can
+      // carry a short name, so the parent has to be expanded instead of giving up.
+      expect(fn).toContain('Split-Path -Parent $Path');
+      expect(fn).toContain('$parentItem.FullName');
+      // Measured non-fixes. Keeping them out is the point of the helper.
+      expect(fn).not.toMatch(/Convert-Path|Resolve-Path/);
+      // CLM/WDAC: a property read off the DirectoryInfo is allowed, a type call is not.
+      expect(fn).not.toMatch(/\[(System\.)?IO\.|New-Object|Add-Type/);
+    });
+
+    it(`${f} cleanup deletes cannot raise`, () => {
+      const fn = functionOf(ps1, 'Remove-PilotPathQuietly');
+      expect(fn, 'Remove-PilotPathQuietly must exist').not.toBe('');
+      expect(fn).toContain('Remove-Item -LiteralPath (Get-PilotLongPath $Path) -Recurse -Force -ErrorAction SilentlyContinue');
+      // -ErrorAction covers the non-terminating half (a file a scanner holds open); the
+      // catch covers the binding failure, which -ErrorAction cannot reach.
+      expect(fn).toMatch(/try \{[\s\S]*\} catch \{/);
+    });
+
+    it(`${f} deletes nothing on disk from inside a finally`, () => {
+      // A throw here replaces the exception in flight, so the caller never learns why
+      // it failed and, under $ErrorActionPreference = "Stop", the run aborts. Env:
+      // entries are in-process and cannot be short, so they stay allowed.
+      const offenders = [];
+      for (const body of finallyBodies(ps1)) {
+        for (const line of body.split('\n')) {
+          if (!/\b(Remove-Item|Move-Item)\b/.test(line)) continue;
+          if (/\bEnv:/.test(line)) continue;
+          offenders.push(line.trim());
+        }
+      }
+      expect(offenders, 'use Remove-PilotPathQuietly').toEqual([]);
+    });
+
+    it(`${f} never hands a possibly-short path to Remove-Item or Move-Item raw`, () => {
+      const sites = hazardSites(ps1);
+      // Non-vacuity: the temp-root taint has to actually reach the cleanup sites. Six
+      // of them today -- two staging dirs, the staged node_modules move, both command
+      // finallys and the npm log.
+      expect(sites.length).toBeGreaterThanOrEqual(4);
+      const offenders = sites
+        .filter(({ line }) => !/Get-PilotLongPath|Remove-PilotPathQuietly/.test(line))
+        .map(({ n, line }) => `${n}: ${line}`);
+      expect(offenders, 'wrap in Get-PilotLongPath or call Remove-PilotPathQuietly').toEqual([]);
+    });
+
+    it(`${f} keeps no bare best-effort recursive delete`, () => {
+      // `Remove-Item $x -Recurse -Force -ErrorAction SilentlyContinue` is the exact
+      // shape that failed: it reads as "cannot fail" and is not.
+      const offenders = stripHereStrings(ps1)
+        .map((line, i) => [i + 1, line])
+        .filter(([, line]) => !/^\s*#/.test(line))
+        .filter(([, line]) => /Remove-Item\s+[^-\n]/.test(line) && /-Recurse/.test(line) && /SilentlyContinue/.test(line))
+        .map(([n, line]) => `${n}: ${line.trim()}`);
+      expect(offenders, 'use Remove-PilotPathQuietly').toEqual([]);
+    });
+
+    it(`${f} Get-PilotAsciiTempRoot expands an ASCII 8.3 TEMP`, () => {
+      const fn = functionOf(ps1, 'Get-PilotAsciiTempRoot');
+      expect(fn, 'Get-PilotAsciiTempRoot must exist').not.toBe('');
+      // Pure-ASCII 8.3 TEMP used to skip expand because the charset check passed.
+      // Both the early return and the nothing-writable fallback start from that
+      // same $root, so both must expand.
+      const hits = fn.match(/Get-PilotLongPath \$root/g) || [];
+      expect(hits.length).toBeGreaterThanOrEqual(2);
+    });
+
+    if (f !== 'installer-opensource.ps1') {
+      it(`${f} 7-Zip fallback cleans the intermediate .tar quietly`, () => {
+        const fn = functionOf(ps1, 'Download-AndExtract');
+        expect(fn, 'Download-AndExtract must exist').not.toBe('');
+        expect(fn).toMatch(/Remove-PilotPathQuietly \$(?:tarFile|tarPath)/);
+        const bare = fn.split('\n')
+          .filter((line) => !/^\s*#/.test(line))
+          .filter((line) => /\bRemove-Item\b/.test(line) && /\$(?:tarFile|tarPath)\b/.test(line));
+        expect(bare, 'intermediate .tar delete must go through Remove-PilotPathQuietly').toEqual([]);
+      });
+    }
+  }
+});

--- a/tests/unit/deploy/managed-node-wiring.test.mjs
+++ b/tests/unit/deploy/managed-node-wiring.test.mjs
@@ -121,7 +121,12 @@ describe('ps1 installer variants wire the managed node runtime', () => {
       expect(ps1).toMatch(/function Resolve-ManagedNodeBin\s*\{/);
       expect(ps1).toContain('Join-Path $NodeDir "node.exe"');
       const ensure = ps1.slice(ps1.indexOf('function Ensure-ManagedNode'), ps1.indexOf('function Ensure-NodeModules'));
-      expect(ensure.split('Remove-Item $nodeDir').length - 1).toBeGreaterThanOrEqual(3);
+      // Three wipes: the pre-extract one, the "archive held no node.exe" bail-out and the
+      // catch. None of them says `Remove-Item $nodeDir` any more -- that shape throws on
+      // an 8.3 path, see the pilot-short-path block and installer-short-path.test.mjs.
+      const wipes = (ensure.match(/Remove-PilotPathQuietly \$nodeDir\b/g) ?? []).length
+        + (ensure.match(/Remove-Item -LiteralPath \(Get-PilotLongPath \$nodeDir\)/g) ?? []).length;
+      expect(wipes).toBeGreaterThanOrEqual(3);
     });
   }
 });

--- a/tests/unit/scripts/ps1-json-encoding.test.mjs
+++ b/tests/unit/scripts/ps1-json-encoding.test.mjs
@@ -216,8 +216,11 @@ describe('ps1 <-> node JSON interchange is explicitly UTF-8', () => {
       // Each staged payload must be handed to node as argv[1] and then deleted: it
       // carries the SLS AccessKeySecret and the CMS license key.
       const consumed = text.match(/^'@ \$cfgTmp$/gm) || [];
+      // installer-opensource.ps1 stages under $env:TEMP, which Windows may hand out as an
+      // 8.3 short path that Remove-Item then refuses to walk, so there the delete goes
+      // through the helper (see installer-short-path.test.mjs).
       const removed = text.match(
-        /Remove-Item -LiteralPath \$cfgTmp -Force -ErrorAction SilentlyContinue/g) || [];
+        /Remove-Item -LiteralPath \$cfgTmp -Force -ErrorAction SilentlyContinue|Remove-PilotPathQuietly \$cfgTmp\b/g) || [];
       expect(staged.length).toBeGreaterThanOrEqual(floor);
       expect(consumed.length).toBe(staged.length);
       expect(removed.length).toBe(staged.length);


### PR DESCRIPTION
## Summary
- When `%TEMP%` is an 8.3 short path (e.g. `zhang.wang` → `ZHANG~1.WAN`), `Remove-Item` / `Move-Item` throw `PSArgumentException` at parameter binding. `-ErrorAction SilentlyContinue` does not catch it, and a `finally` cleanup then replaces the real error and aborts install.
- Expand short paths with `Get-Item -LiteralPath ... .FullName` (`Get-PilotLongPath`) and delete through `Remove-PilotPathQuietly`, which cannot raise.
- Pin the helpers with `installer-short-path.test.mjs`, and update the managed-node wipe / `$cfgTmp` delete ratchets to match.

Internal `installer.ps1` / `installer-inner.ps1` stay on the GitLab CR: https://code.alibaba-inc.com/sls/loongsuite-pilot/codereview/29536114

## Test plan
- [ ] `npx vitest run tests/unit/deploy/installer-short-path.test.mjs tests/unit/deploy/managed-node-wiring.test.mjs tests/unit/scripts/ps1-json-encoding.test.mjs tests/unit/scripts/ps1-clm-safe.test.mjs`
- [ ] Confirm this PR does not touch `installer.ps1` / `installer-inner.ps1` (GitHub tree only has the public installer)


Made with [Cursor](https://cursor.com)