### PR TITLE
feat(hermes): support AGENTTEAMS_WORKER_NAME

### DIFF
--- a/assets/plugins/hermes-agent/loongsuite-pilot/__init__.py
+++ b/assets/plugins/hermes-agent/loongsuite-pilot/__init__.py
@@ -34,6 +34,7 @@ MAX_PARTS = 64
 MAX_COLLECTION_ITEMS = 128
 MAX_CONTENT_CHARS = 32 * 1024
 MAX_VALUE_DEPTH = 8
+MAX_RESOURCE_FIELD_VALUE_LENGTH = 512
 LOG_RETENTION_SECONDS = 7 * 24 * 60 * 60
 MANAGED_MARKER_FILE = ".loongsuite-pilot-managed.json"
 
@@ -140,6 +141,16 @@ def _resolve_user_id(sender_id: Any, config: Dict[str, Any]) -> str:
     if isinstance(config_user, str) and config_user:
         return config_user
     return _hostname()
+
+
+def _worker_name() -> Optional[str]:
+    raw = os.environ.get("AGENTTEAMS_WORKER_NAME")
+    if raw is None:
+        return None
+    value = raw.strip()
+    if not value or len(value) > MAX_RESOURCE_FIELD_VALUE_LENGTH:
+        return None
+    return value
 
 
 def _truncate(value: str) -> str:
@@ -428,7 +439,7 @@ def _common_fields(
     span_id: str,
 ) -> Dict[str, Any]:
     platform = session_state.get("platform") or "cli"
-    return {
+    fields: Dict[str, Any] = {
         "time_unix_nano": str(timestamp_ns),
         "observed_time_unix_nano": str(timestamp_ns),
         "event.id": _new_event_id(),
@@ -444,6 +455,13 @@ def _common_fields(
         "gen_ai.step.id": step_id,
         "gen_ai.agent.type": AGENT_TYPE,
     }
+    worker_name = _worker_name()
+    if worker_name:
+        fields["gen_ai.agent.name"] = worker_name
+        fields["resourceAttributes"] = {
+            "agentteams.worker.name": worker_name,
+        }
+    return fields
 
 
 def _usage_fields(payload: Dict[str, Any]) -> Dict[str, int]:

--- a/docs/output-event-schema.md
+++ b/docs/output-event-schema.md
@@ -133,7 +133,7 @@ When a supported agent process starts with the following environment variables, 
 | `AGENTTEAMS_WORKER_NAME` | `gen_ai.agent.name`, `resourceAttributes["agentteams.worker.name"]` | Logical worker name; takes precedence over the native name for a main agent. |
 | `AGENTTEAMS_INSTANCE_ID` | `resourceAttributes["agentteams.instance.id"]` | Concrete worker instance; never overwrites `gen_ai.agent.id`. |
 
-This is currently supported for Claude Code, Qoder, Codex, OpenCode, Pi Coding Agent, MiMo Code, Qwen Code CLI, and Cursor CLI. Cursor Desktop does not consume these variables. Existing event fields and name fallbacks remain unchanged when the variables are absent. Pilot collects only the two fixed allowlisted variables above; other `AGENTTEAMS_*` variables are never written to events or OTLP resources.
+Claude Code, Qoder, Codex, OpenCode, Pi Coding Agent, MiMo Code, Qwen Code CLI, and Cursor CLI support both variables. OpenClaw and Hermes Agent support only `AGENTTEAMS_WORKER_NAME` and do not currently consume `AGENTTEAMS_INSTANCE_ID`. Cursor Desktop does not consume these variables. Existing event fields and name fallbacks remain unchanged when the variables are absent. Pilot collects only the two fixed allowlisted variables above; other `AGENTTEAMS_*` variables are never written to events or OTLP resources.
 
 ## Provider Names
 

--- a/docs/zh-CN/custom-agent-identity.md
+++ b/docs/zh-CN/custom-agent-identity.md
@@ -15,12 +15,13 @@
 | Qwen Code CLI | `qwen-code-cli` | `qwen` |
 | Cursor CLI | `cursor-cli` | `cursor-agent` |
 | OpenClaw | `openclaw` | `openclaw` |
+| Hermes Agent | `hermes` | `hermes` |
 
 Cursor Desktop 不支持这组变量。
 
-OpenClaw 当前仅支持 `AGENTTEAMS_WORKER_NAME`，暂不支持
-`AGENTTEAMS_INSTANCE_ID`。如果 OpenClaw 运行在容器中，环境变量必须注入
-OpenClaw Gateway 所在的容器和进程；修改变量后需要重启或重建容器。
+OpenClaw 和 Hermes Agent 当前仅支持 `AGENTTEAMS_WORKER_NAME`，暂不支持
+`AGENTTEAMS_INSTANCE_ID`。如果它们运行在容器中，环境变量必须注入对应的
+Agent 容器和进程；修改变量后需要重启或重建容器。
 
 ## 设置环境变量
 
@@ -29,7 +30,7 @@ OpenClaw Gateway 所在的容器和进程；修改变量后需要重启或重建
 | `AGENTTEAMS_WORKER_NAME` | 设置 `gen_ai.agent.name`，并写入 Resource 属性 `agentteams.worker.name`。 |
 | `AGENTTEAMS_INSTANCE_ID` | 写入 Resource 属性 `agentteams.instance.id`，用于区分同一 Worker 的不同运行实例。 |
 
-建议两个变量一起设置：
+除 OpenClaw 和 Hermes Agent 外，建议两个变量一起设置：
 
 ```bash
 export AGENTTEAMS_WORKER_NAME=planner

--- a/docs/zh-CN/output-event-schema.md
+++ b/docs/zh-CN/output-event-schema.md
@@ -128,7 +128,7 @@ LoongSuite Pilot 会将采集到的活动归一化为 GenAI 遥测事件。Pilot
 | `AGENTTEAMS_WORKER_NAME` | `gen_ai.agent.name`、`resourceAttributes["agentteams.worker.name"]` | 逻辑 Worker 名称；主 Agent 上优先于 Agent 原生名称。 |
 | `AGENTTEAMS_INSTANCE_ID` | `resourceAttributes["agentteams.instance.id"]` | 当前 Worker 运行实例；不会覆盖 `gen_ai.agent.id`。 |
 
-当前支持 Claude Code、Qoder、Codex、OpenCode、Pi Coding Agent、MiMo Code、Qwen Code CLI 和 Cursor CLI。Cursor Desktop 不读取这组变量。未设置变量时，现有事件字段和名称回退行为不变。Pilot 只采集上述固定白名单字段；其他 `AGENTTEAMS_*` 变量不会进入事件或 OTLP Resource。
+Claude Code、Qoder、Codex、OpenCode、Pi Coding Agent、MiMo Code、Qwen Code CLI 和 Cursor CLI 支持上述两个变量。OpenClaw 和 Hermes Agent 仅支持 `AGENTTEAMS_WORKER_NAME`，暂不读取 `AGENTTEAMS_INSTANCE_ID`。Cursor Desktop 不读取这组变量。未设置变量时，现有事件字段和名称回退行为不变。Pilot 只采集上述固定白名单字段；其他 `AGENTTEAMS_*` 变量不会进入事件或 OTLP Resource。
 
 ## Provider Names
 

--- a/tests/unit/hooks/hermes-agent-plugin.test.mjs
+++ b/tests/unit/hooks/hermes-agent-plugin.test.mjs
@@ -248,6 +248,7 @@ function skillViewTurn() {
 
 function replay(events, {
   captureMessageContent = true,
+  agentTeamsWorkerName,
   pilotEnvUser,
   legacyEnvUser,
   configUser = 'pilot-config-user',
@@ -318,6 +319,8 @@ print(json.dumps(sorted(ctx.hooks)))
   else env.LOONGSUITE_PILOT_USER_ID = pilotEnvUser;
   if (legacyEnvUser === undefined) delete env.LOONGSUITE_USER_ID;
   else env.LOONGSUITE_USER_ID = legacyEnvUser;
+  if (agentTeamsWorkerName === undefined) delete env.AGENTTEAMS_WORKER_NAME;
+  else env.AGENTTEAMS_WORKER_NAME = agentTeamsWorkerName;
   const run = spawnSync('python3', ['-c', driver, pluginPath, path.join(root, 'events.jsonl')], {
     cwd: root,
     env,
@@ -428,6 +431,30 @@ describe('Hermes Agent native plugin', () => {
     expect(partTypes(requestTwo['gen_ai.input.messages'])).toEqual(expect.arrayContaining(['tool_call', 'tool_call_response']));
     expect(partTypes(responseTwo['gen_ai.output.messages'])).toContain('text');
     expect(responseTwo['gen_ai.response.finish_reasons']).toEqual(['stop']);
+  });
+
+  it('uses AGENTTEAMS_WORKER_NAME as the agent name and Resource marker', () => {
+    const { records } = replay(firstTurn(), {
+      agentTeamsWorkerName: ' planner ',
+    });
+
+    expect(records).not.toHaveLength(0);
+    expect(records.every(record => record['gen_ai.agent.name'] === 'planner')).toBe(true);
+    expect(records.every(record =>
+      record.resourceAttributes?.['agentteams.worker.name'] === 'planner')).toBe(true);
+    expect(new Set(records.map(record => record['event.name']))).toEqual(new Set([
+      'llm.request', 'llm.response', 'tool.call', 'tool.result',
+    ]));
+  });
+
+  it.each([
+    ['blank', '   '],
+    ['overlong', 'x'.repeat(513)],
+  ])('ignores a %s AGENTTEAMS_WORKER_NAME value', (_label, agentTeamsWorkerName) => {
+    const { records } = replay(firstTurn(), { agentTeamsWorkerName });
+
+    expect(records.every(record => !('gen_ai.agent.name' in record))).toBe(true);
+    expect(records.every(record => !('resourceAttributes' in record))).toBe(true);
   });
 
   it('emits an error response when a provider request fails before post_llm_call', () => {

--- a/tests/unit/inputs/hermes-log-input.test.ts
+++ b/tests/unit/inputs/hermes-log-input.test.ts
@@ -118,6 +118,23 @@ describe('HermesLogInput', () => {
     expect(entry?.['gen_ai.skill.version']).toBe('1.2.3');
   });
 
+  it('preserves the custom Hermes worker identity and Resource marker', async () => {
+    await writeRecords('hermes-agent-101.jsonl', [{
+      ...makeRecord('worker-event'),
+      'gen_ai.agent.name': 'planner',
+      resourceAttributes: {
+        'agentteams.worker.name': 'planner',
+      },
+    }]);
+
+    const [entry] = await makeInput().collectOnce();
+
+    expect(entry?.['gen_ai.agent.name']).toBe('planner');
+    expect(entry?.resourceAttributes).toEqual({
+      'agentteams.worker.name': 'planner',
+    });
+  });
+
   it('waits for an incomplete UTF-8 JSONL line before advancing its byte offset', async () => {
     const file = path.join(tmpDir, 'hermes-agent-101.jsonl');
     const outputMessages = [


### PR DESCRIPTION
## Summary

- read and validate `AGENTTEAMS_WORKER_NAME` in the native Hermes plugin
- write the trimmed value to `gen_ai.agent.name` and Resource attribute `agentteams.worker.name` on every Hermes LLM and tool record
- preserve the worker identity through `HermesLogInput` and document Hermes support
- keep existing behavior for missing, blank, or values longer than 512 characters

## Validation

- `npm test -- tests/unit/hooks/hermes-agent-plugin.test.mjs tests/unit/inputs/hermes-log-input.test.ts tests/unit/inputs/base/hook-record-transform.test.ts tests/unit/flushers/otlp-trace-flusher/conversion.test.ts` (51 passed)
- `npm test` (3915 passed, 56 skipped)
- `npm run typecheck`
- `npm run build`

Closes #354