### PR TITLE
fix(qoder): preserve per-invocation custom span attributes

### DIFF
--- a/src/inputs/base/canonical-hook-record.ts
+++ b/src/inputs/base/canonical-hook-record.ts
@@ -1,5 +1,10 @@
 import type { AgentActivityEntry, JsonValue } from '../../types/index.js';
 import { buildAgentActivityEntry } from '../../normalization/entry-builder.js';
+import { isReservedKey } from '../../normalization/global-attributes.js';
+
+const MAX_CUSTOM_FIELD_VALUE_LENGTH = 512;
+const SENSITIVE_FIELD_NAME_RE =
+  /(^|[_.-])(TOKEN|SECRET|PASSWORD|CREDENTIAL|COOKIE)([_.-]|$)|^(API_KEY|API_HEADER)$/i;
 
 const CANONICAL_PREFIXES = [
   'agent.',
@@ -24,10 +29,21 @@ const CANONICAL_KEYS = new Set([
   'user.id',
 ]);
 
+export interface CanonicalHookRecordOptions {
+  /**
+   * Preserve caller-supplied string fields after canonical normalization.
+   * This is opt-in because most canonical adapters intentionally expose only
+   * the managed schema. Reserved, sensitive, malformed, and unsafe values are
+   * still discarded.
+   */
+  preserveSafeCustomTopLevelFields?: boolean;
+}
+
 export function buildCanonicalHookEntry(
   record: Record<string, unknown>,
   fallbackAgentType: string,
   attributes?: Record<string, unknown>,
+  options?: CanonicalHookRecordOptions,
 ): AgentActivityEntry | null {
   if (!isCanonicalHookRecord(record)) return null;
 
@@ -50,7 +66,31 @@ export function buildCanonicalHookEntry(
     attributes: toJsonObject(attributes ?? {}),
   });
 
+  if (options?.preserveSafeCustomTopLevelFields) {
+    attachSafeCustomTopLevelFields(entry, record);
+  }
+
   return entry;
+}
+
+function attachSafeCustomTopLevelFields(
+  entry: AgentActivityEntry,
+  record: Record<string, unknown>,
+): void {
+  for (const [rawKey, rawValue] of Object.entries(record)) {
+    if (isCanonicalKey(rawKey)) continue;
+
+    const key = rawKey.trim();
+    if (!key || key.includes(',') || key.includes('=') || isReservedKey(key)) continue;
+    if (SENSITIVE_FIELD_NAME_RE.test(key)) continue;
+    if (typeof rawValue !== 'string') continue;
+
+    const value = rawValue.trim();
+    if (!value || value.length > MAX_CUSTOM_FIELD_VALUE_LENGTH || value.includes(',')) continue;
+
+    // Fill only: custom fields must never overwrite the normalized schema.
+    if (entry[key] === undefined) entry[key] = value;
+  }
 }
 
 function isCanonicalHookRecord(record: Record<string, unknown>): boolean {

--- a/src/inputs/qoder-cli/qoder-cli-input.ts
+++ b/src/inputs/qoder-cli/qoder-cli-input.ts
@@ -50,7 +50,12 @@ export class QoderCliInput extends BaseHookInput {
     const ver = record['agent.qoder.version'] ?? record.version;
     if (typeof ver === 'string' && ver) this.lastAgentVersion = ver;
 
-    const canonicalEntry = buildCanonicalHookEntry(record, ClientType.QoderCli);
+    const canonicalEntry = buildCanonicalHookEntry(
+      record,
+      ClientType.QoderCli,
+      undefined,
+      { preserveSafeCustomTopLevelFields: true },
+    );
     if (canonicalEntry) {
       await enrichCanonicalEntryWithGit(canonicalEntry, record, 'qoder');
       delete (canonicalEntry as Record<string, unknown>)['agent.qoder.attachments'];

--- a/src/inputs/qoder-cn-trace/qoder-cn-trace-input.ts
+++ b/src/inputs/qoder-cn-trace/qoder-cn-trace-input.ts
@@ -247,7 +247,12 @@ export class QoderCnTraceInput extends BaseInput {
   // ─── Record transformation ──────────────────────────────────────────────────
 
   private async transformRecord(record: Record<string, unknown>): Promise<AgentActivityEntry | null> {
-    const canonicalEntry = buildCanonicalHookEntry(record, ClientType.QoderCn);
+    const canonicalEntry = buildCanonicalHookEntry(
+      record,
+      ClientType.QoderCn,
+      undefined,
+      { preserveSafeCustomTopLevelFields: true },
+    );
     if (canonicalEntry) {
       await enrichCanonicalEntryWithGit(canonicalEntry, record, 'qoder-cn');
       return canonicalEntry;

--- a/src/inputs/qoder-trace/qoder-trace-input.ts
+++ b/src/inputs/qoder-trace/qoder-trace-input.ts
@@ -282,7 +282,12 @@ export class QoderTraceInput extends BaseInput {
   // ─── Record transformation (canonical passthrough) ──────────────────────────
 
   private async transformRecord(record: Record<string, unknown>): Promise<AgentActivityEntry | null> {
-    const canonicalEntry = buildCanonicalHookEntry(record, ClientType.QoderCli);
+    const canonicalEntry = buildCanonicalHookEntry(
+      record,
+      ClientType.QoderCli,
+      undefined,
+      { preserveSafeCustomTopLevelFields: true },
+    );
     if (canonicalEntry) {
       await enrichCanonicalEntryWithGit(canonicalEntry, record, 'qoder');
       return canonicalEntry;

--- a/tests/unit/hooks/qoder-hook-processor-cold-start.test.mjs
+++ b/tests/unit/hooks/qoder-hook-processor-cold-start.test.mjs
@@ -162,6 +162,27 @@ describe('qoder-hook-processor cold-start recovery', () => {
     }
   });
 
+  it('stamps safe invocation attributes from env onto every hook record', () => {
+    fs.writeFileSync(transcriptPath, [
+      ...turnRows(1, 'custom attribute prompt'),
+      lastPrompt(1),
+    ].map(row => JSON.stringify(row)).join('\n') + '\n');
+
+    const result = runProcessor('session-custom-attributes', {
+      LOONGSUITE_PILOT_SPAN_ATTRIBUTES:
+        'multica.issue.id=AGE-992,multica.user.id=staff-1,multica.api_token=blocked',
+    });
+
+    expect(result.status).toBe(0);
+    const records = readHistory();
+    expect(records.length).toBeGreaterThan(0);
+    for (const record of records) {
+      expect(record['multica.issue.id']).toBe('AGE-992');
+      expect(record['multica.user.id']).toBe('staff-1');
+      expect(record['multica.api_token']).toBeUndefined();
+    }
+  });
+
   it('does not replay old turns when each old session first appears after redeployment', () => {
     fs.writeFileSync(transcriptPath, [
       ...turnRows(1, 'historical prompt 1'),

--- a/tests/unit/inputs/base/hook-record-transform.test.ts
+++ b/tests/unit/inputs/base/hook-record-transform.test.ts
@@ -45,3 +45,66 @@ describe('hook record resource attribute passthrough', () => {
     });
   });
 });
+
+describe('canonical hook custom top-level field passthrough', () => {
+  const canonicalRecord = {
+    'event.id': 'event-custom-1',
+    'event.name': 'llm.response',
+    'gen_ai.session.id': 'session-custom-1',
+    'gen_ai.agent.type': 'qoder-cli',
+  };
+
+  it('keeps strict canonical behavior by default', () => {
+    const entry = buildCanonicalHookEntry({
+      ...canonicalRecord,
+      'multica.issue.id': 'AGE-992',
+    }, ClientType.QoderCli);
+
+    expect(entry).not.toHaveProperty('multica.issue.id');
+  });
+
+  it('preserves safe string fields when explicitly enabled', () => {
+    const entry = buildCanonicalHookEntry(
+      {
+        ...canonicalRecord,
+        'multica.issue.id': 'AGE-992',
+        'multica.user.id': ' staff-1 ',
+      },
+      ClientType.QoderCli,
+      undefined,
+      { preserveSafeCustomTopLevelFields: true },
+    );
+
+    expect(entry).toMatchObject({
+      'event.name': 'llm.response',
+      'multica.issue.id': 'AGE-992',
+      'multica.user.id': 'staff-1',
+    });
+  });
+
+  it('drops unsafe custom fields when passthrough is enabled', () => {
+    const entry = buildCanonicalHookEntry(
+      {
+        ...canonicalRecord,
+        'multica.api_token': 'secret',
+        'multica.count': 42,
+        'multica.empty': ' ',
+        'multica.comma': 'one,two',
+        'multica.too_long': 'x'.repeat(513),
+        cost_custom: 'reserved',
+        'event.custom': 'reserved',
+      },
+      ClientType.QoderCli,
+      undefined,
+      { preserveSafeCustomTopLevelFields: true },
+    );
+
+    expect(entry).not.toHaveProperty('multica.api_token');
+    expect(entry).not.toHaveProperty('multica.count');
+    expect(entry).not.toHaveProperty('multica.empty');
+    expect(entry).not.toHaveProperty('multica.comma');
+    expect(entry).not.toHaveProperty('multica.too_long');
+    expect(entry).not.toHaveProperty('cost_custom');
+    expect(entry).not.toHaveProperty('event.custom');
+  });
+});

--- a/tests/unit/inputs/qoder-cli-input.test.ts
+++ b/tests/unit/inputs/qoder-cli-input.test.ts
@@ -89,6 +89,9 @@ describe('QoderCliInput', () => {
       'gen_ai.output.messages': [{ type: 'text', content: 'hello' }],
       'agent.source': 'qoder-transcript-hook',
       'agent.qoder.cwd': '/workspace/qoder-project',
+      'multica.issue.id': 'AGE-992',
+      'multica.user.id': 'staff-1',
+      'multica.api_token': 'blocked',
     }]);
 
     expect(entries).toHaveLength(1);
@@ -103,7 +106,10 @@ describe('QoderCliInput', () => {
       'gen_ai.output.messages': [{ role: 'assistant', parts: [{ type: 'text', content: 'hello' }] }],
       'agent.source': 'qoder-transcript-hook',
       'workspace.path': '/workspace/qoder-project',
+      'multica.issue.id': 'AGE-992',
+      'multica.user.id': 'staff-1',
     });
+    expect(entries[0]).not.toHaveProperty('multica.api_token');
   });
 
   it('maps IDE user rows to qoder llm.request entries', async () => {

--- a/tests/unit/inputs/qoder-cn-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-cn-trace-input.test.ts
@@ -285,6 +285,28 @@ describe('QoderCnTraceInput.collect (session-level enrich)', () => {
     // No tokens were enriched (no session id to look up)
     expect(entries[0]['gen_ai.usage.input_tokens']).toBeUndefined();
   });
+
+  it('preserves safe invocation attributes on canonical Qoder CN records', async () => {
+    const record = buildEntry({
+      event: 'llm.response',
+      turn: 'custom-attribute-turn',
+      step: 'custom-attribute-turn:s1',
+      session: '',
+      ts: 1_780_000_021_000,
+    });
+    record['multica.issue.id'] = 'AGE-992';
+    record['multica.user.id'] = 'staff-1';
+    record['multica.api_token'] = 'blocked';
+    await writeHookJsonl(logDir, [record]);
+
+    const entries = await collectOnce();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      'multica.issue.id': 'AGE-992',
+      'multica.user.id': 'staff-1',
+    });
+    expect(entries[0]).not.toHaveProperty('multica.api_token');
+  });
 });
 
 // --- Test helpers ---

--- a/tests/unit/inputs/qoder-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-trace-input.test.ts
@@ -1517,7 +1517,7 @@ describe('QoderTraceInput multimodal', () => {
   });
 
   describe('IDE gate via collect', () => {
-    it('converts IDE and CLI tool Image file paths independently', async () => {
+    it('converts IDE and CLI tool Image file paths and preserves invocation attributes', async () => {
       const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'qoder-trace-mm-'));
       const imgPath = path.join(tmpDir, 'shot.png');
       await fs.writeFile(imgPath, Buffer.from('shot'));
@@ -1531,6 +1531,7 @@ describe('QoderTraceInput multimodal', () => {
           'gen_ai.session.id': 'ide-sess',
           'gen_ai.turn.id': 'ide-turn',
           'gen_ai.tool.call.result': `Image file: ${imgPath}`,
+          'multica.issue.id': 'IDE-992',
           time_unix_nano: '1780000000000000000',
         };
         const cliTool = {
@@ -1540,6 +1541,7 @@ describe('QoderTraceInput multimodal', () => {
           'gen_ai.session.id': 'cli-sess',
           'gen_ai.turn.id': 'cli-turn',
           'gen_ai.tool.call.result': `Image file: ${imgPath}`,
+          'multica.issue.id': 'CLI-992',
           time_unix_nano: '1780000000000000000',
         };
         await fs.writeFile(
@@ -1571,6 +1573,8 @@ describe('QoderTraceInput multimodal', () => {
         const cli = entries.find(e => e['event.id'] === 'cli-tool')!;
         expect(Array.isArray(ide['gen_ai.tool.call.result'])).toBe(true);
         expect(Array.isArray(cli['gen_ai.tool.call.result'])).toBe(true);
+        expect(ide['multica.issue.id']).toBe('IDE-992');
+        expect(cli['multica.issue.id']).toBe('CLI-992');
       } finally {
         await fs.rm(tmpDir, { recursive: true, force: true });
       }


### PR DESCRIPTION
## Summary

- add an explicit, default-off safe custom top-level field passthrough option to canonical hook normalization
- enable it only for Qoder Trace, Qoder CN Trace, and the Qoder CLI fallback input
- preserve caller-supplied string attributes after canonical entry construction so they cannot alter structural normalization
- keep reserved, sensitive, malformed, non-string, empty, comma-containing, and overlong values filtered
- leave OTLP prefix selection and all non-Qoder canonical adapters unchanged

## Why

The Qoder hook already stamps LOONGSUITE_PILOT_SPAN_ATTRIBUTES onto every hook record, but the canonical Qoder inputs projected only managed keys. As a result, arbitrary invocation attributes such as multica.issue.id were discarded before spanAttributePassthroughPrefixes could discover them.

## Verification

- targeted Qoder/custom-attribute tests: 118 passed
- full test suite: 3920 passed, 56 skipped
- npm run typecheck
- npm run build
- git diff --check

Fixes #357