### PR TITLE
feat(genai): preserve OpenClaw and Hermes sender identity

### DIFF
--- a/assets/plugins/hermes-agent/loongsuite-pilot/__init__.py
+++ b/assets/plugins/hermes-agent/loongsuite-pilot/__init__.py
@@ -37,6 +37,7 @@ MAX_VALUE_DEPTH = 8
 MAX_RESOURCE_FIELD_VALUE_LENGTH = 512
 LOG_RETENTION_SECONDS = 7 * 24 * 60 * 60
 MANAGED_MARKER_FILE = ".loongsuite-pilot-managed.json"
+INVOCATION_USER_ID_FIELD = "agent.pilot.invocation.user.id"
 
 _PROCESS_FILE_TOKEN = "%s-%s-%s" % (
     os.getpid(),
@@ -128,20 +129,47 @@ def _hostname() -> str:
         return "unknown"
 
 
-def _resolve_user_id(sender_id: Any, config: Dict[str, Any]) -> str:
+def _normalized_identity(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if not normalized or len(normalized) > MAX_RESOURCE_FIELD_VALUE_LENGTH:
+        return None
+    return normalized
+
+
+def _invocation_user_id() -> Optional[str]:
+    raw = os.environ.get("LOONGSUITE_PILOT_SPAN_ATTRIBUTES")
+    if not isinstance(raw, str) or not raw:
+        return None
+    resolved = None
+    for pair in raw.split(","):
+        key, separator, value = pair.partition("=")
+        if separator and key.strip() == "gen_ai.user.id":
+            candidate = _normalized_identity(value)
+            if candidate:
+                resolved = candidate
+    return resolved
+
+
+def _resolve_user_identity(sender_id: Any, config: Dict[str, Any]) -> Dict[str, str]:
+    invocation_user = _invocation_user_id()
+    if invocation_user:
+        return {"user_id": invocation_user, "source": "invocation"}
     env_user = (
         os.environ.get("LOONGSUITE_PILOT_USER_ID")
         or os.environ.get("LOONGSUITE_USER_ID")
     )
-    if env_user:
-        return env_user
-    if isinstance(sender_id, str) and sender_id:
-        return sender_id
-    config_user = config.get("userId")
-    if isinstance(config_user, str) and config_user:
-        return config_user
-    return _hostname()
-
+    normalized_env_user = _normalized_identity(env_user)
+    if normalized_env_user:
+        return {"user_id": normalized_env_user, "source": "environment"}
+    normalized_sender_id = _normalized_identity(sender_id)
+    if normalized_sender_id:
+        return {"user_id": normalized_sender_id, "source": "sender"}
+    config_user = _normalized_identity(config.get("userId"))
+    if config_user:
+        return {"user_id": config_user, "source": "config"}
+    return {"user_id": _hostname(), "source": "hostname"}
 
 def _worker_name() -> Optional[str]:
     raw = os.environ.get("AGENTTEAMS_WORKER_NAME")
@@ -289,6 +317,8 @@ def _new_turn(
     observer_turn_id: Any = "",
 ) -> Dict[str, Any]:
     config = _config()
+    normalized_sender_id = _normalized_identity(sender_id)
+    user_identity = _resolve_user_identity(normalized_sender_id, config)
     return {
         "session_id": session_id,
         "task_id": None,
@@ -297,7 +327,9 @@ def _new_turn(
         ),
         "fallback_turn_id": "%s:%s" % (session_id, uuid.uuid4()),
         "trace_id": _new_trace_id(),
-        "user_id": _resolve_user_id(sender_id, config),
+        "user_id": user_identity["user_id"],
+        "user_id_source": user_identity["source"],
+        "sender_id": normalized_sender_id,
         "capture_content": _capture_message_content(config),
         "user_message": user_message if isinstance(user_message, str) else str(user_message or ""),
         "history_length": max(1, history_length),
@@ -455,6 +487,10 @@ def _common_fields(
         "gen_ai.step.id": step_id,
         "gen_ai.agent.type": AGENT_TYPE,
     }
+    if turn.get("user_id_source") in ("invocation", "environment", "sender"):
+        fields[INVOCATION_USER_ID_FIELD] = turn["user_id"]
+    if turn.get("sender_id"):
+        fields["agent.hermes.sender.id"] = turn["sender_id"]
     worker_name = _worker_name()
     if worker_name:
         fields["gen_ai.agent.name"] = worker_name

--- a/assets/plugins/openclaw/plugin.mjs
+++ b/assets/plugins/openclaw/plugin.mjs
@@ -71,9 +71,10 @@ const SPAN_ATTR_RESERVED_PREFIXES = [
 const SPAN_ATTR_MAX_VALUE_LENGTH = 512;
 const SPAN_ATTR_SENSITIVE_RE =
   /(^|[_.-])(TOKEN|SECRET|PASSWORD|CREDENTIAL|COOKIE)([_.-]|$)|^(API_KEY|API_HEADER)$/i;
+const INVOCATION_USER_ID_FIELD = "agent.pilot.invocation.user.id";
 const INVOCATION_IDENTITY_FIELD_MAP = {
   "gen_ai.session.id": "agent.pilot.invocation.session.id",
-  "gen_ai.user.id": "agent.pilot.invocation.user.id",
+  "gen_ai.user.id": INVOCATION_USER_ID_FIELD,
 };
 
 function parseSpanAttributesFromEnv(env = process.env) {
@@ -239,15 +240,45 @@ function loadPilotConfig() {
   return value;
 }
 
-function resolveUserId(cfg) {
-  return (
-    process.env.LOONGSUITE_USER_ID ||
-    process.env.LOONGSUITE_PILOT_USER_ID ||
-    cfg.userId ||
-    cfg["user.id"] ||
-    os.hostname() ||
-    "unknown"
+function normalizeIdentityValue(value) {
+  if (typeof value !== "string" && typeof value !== "number" && typeof value !== "bigint") {
+    return undefined;
+  }
+  const normalized = String(value).trim();
+  return normalized.length > 0 && normalized.length <= SPAN_ATTR_MAX_VALUE_LENGTH
+    ? normalized
+    : undefined;
+}
+
+function resolveSenderId(event, ctx) {
+  return normalizeIdentityValue(event?.senderId)
+    || normalizeIdentityValue(ctx?.senderId)
+    || normalizeIdentityValue(ctx?.channelContext?.sender?.id);
+}
+
+function resolveUserIdentity(cfg, senderId) {
+  const invocationUserId = normalizeIdentityValue(SPAN_ATTRIBUTES[INVOCATION_USER_ID_FIELD]);
+  if (invocationUserId) return { userId: invocationUserId, source: "invocation" };
+
+  const environmentUserId = normalizeIdentityValue(
+    process.env.LOONGSUITE_PILOT_USER_ID || process.env.LOONGSUITE_USER_ID,
   );
+  if (environmentUserId) return { userId: environmentUserId, source: "environment" };
+
+  const nativeSenderId = normalizeIdentityValue(senderId);
+  if (nativeSenderId) return { userId: nativeSenderId, source: "sender" };
+
+  const configuredUserId = normalizeIdentityValue(cfg.userId || cfg["user.id"]);
+  if (configuredUserId) return { userId: configuredUserId, source: "config" };
+
+  return {
+    userId: normalizeIdentityValue(os.hostname()) || "unknown",
+    source: "hostname",
+  };
+}
+
+function resolveUserId(cfg) {
+  return resolveUserIdentity(cfg).userId;
 }
 
 function isExplicitlyFalse(value) {
@@ -425,6 +456,21 @@ function getRun(runId, event, ctx) {
   return r;
 }
 
+function updateRunUserIdentity(run, event, ctx, cfg) {
+  if (!run) return;
+  const senderId = resolveSenderId(event, ctx) || run.senderId;
+
+  const identity = resolveUserIdentity(cfg, senderId);
+  run.userId = identity.userId;
+  run.userIdSource = identity.source;
+  if (senderId) {
+    run.senderId = senderId;
+    run.channel = normalizeIdentityValue(ctx?.channel || event?.channel) || run.channel;
+    run.accountId = normalizeIdentityValue(event?.accountId || ctx?.accountId) || run.accountId;
+    run.channelId = normalizeIdentityValue(event?.channelId || ctx?.channelId) || run.channelId;
+  }
+}
+
 function resolveContextRun(event, ctx) {
   const directRunId = event?.runId || ctx?.runId;
   if (directRunId) return getRun(directRunId, event, ctx);
@@ -503,14 +549,23 @@ function getSession(sessionId) {
 // ---------------------------------------------------------------------------
 
 function buildCommonFields(run, sessionId, userId) {
+  const resolvedUserId = run?.userId || userId;
   const base = {
     time_unix_nano: nowNanos(),
     observed_time_unix_nano: nowNanos(),
     "event.id": crypto.randomUUID(),
     "gen_ai.agent.type": AGENT_TYPE,
     "gen_ai.agent.name": AGENT_TYPE,
-    "user.id": userId,
+    "user.id": resolvedUserId,
     ...(agentCwd ? { "agent.openclaw.cwd": agentCwd } : {}),
+    ...(run?.senderId ? { "agent.openclaw.sender.id": run.senderId } : {}),
+    ...(run?.channel ? { "agent.openclaw.channel": run.channel } : {}),
+    ...(run?.accountId ? { "agent.openclaw.account.id": run.accountId } : {}),
+    ...(run?.channelId ? { "agent.openclaw.channel.id": run.channelId } : {}),
+    ...(run?.userIdSource ? { "agent.openclaw.user.id.source": run.userIdSource } : {}),
+    ...(["invocation", "environment", "sender"].includes(run?.userIdSource)
+      ? { [INVOCATION_USER_ID_FIELD]: resolvedUserId }
+      : {}),
     ...SPAN_ATTRIBUTES,
     ...RESOURCE_BASE_FIELD_PATCH,
     ...RESOURCE_ATTRIBUTE_FIELDS,
@@ -762,10 +817,11 @@ function handleSessionEnd(event, ctx, userId, emit) {
   if (s.sessionKey) sessionRunIds.delete(s.sessionKey);
 }
 
-function handleBeforeModelResolve(event, ctx, userId, emit) {
+function handleBeforeModelResolve(event, ctx, userId, emit, cfg) {
   const runId = ctx?.runId;
   if (!runId) return;
   const run = getRun(runId, event, ctx);
+  updateRunUserIdentity(run, event, ctx, cfg);
   const record = {
     ...buildCommonFields(run, ctx?.sessionId, userId),
     "event.name": "other",
@@ -777,18 +833,20 @@ function handleBeforeModelResolve(event, ctx, userId, emit) {
   emit(record);
 }
 
-function handleBeforePromptBuild(event, ctx, userId) {
+function handleBeforePromptBuild(event, ctx, userId, emit, cfg) {
   const runId = ctx?.runId;
   if (!runId) return;
   const run = getRun(runId, event, ctx);
+  updateRunUserIdentity(run, event, ctx, cfg);
   if (event?.prompt) run.userPromptText = event.prompt;
   // No emission — redundant with before_agent_run which has richer fields.
 }
 
-function handleBeforeAgentRun(event, ctx, userId, emit) {
+function handleBeforeAgentRun(event, ctx, userId, emit, cfg) {
   const runId = ctx?.runId || event?.runId;
   if (!runId) return;
   const run = getRun(runId, event, ctx);
+  updateRunUserIdentity(run, event, ctx, cfg);
   if (event?.prompt) run.userPromptText = event.prompt;
   if (event?.systemPrompt) run.systemPrompt = event.systemPrompt;
   if (ctx?.sessionId) run.sessionId = ctx.sessionId;
@@ -820,10 +878,11 @@ function handleBeforeAgentReply(event, ctx, userId, emit) {
   emit(record);
 }
 
-function handleLlmInput(event, ctx, userId) {
+function handleLlmInput(event, ctx, userId, emit, cfg) {
   const runId = event?.runId || ctx?.runId;
   if (!runId) return;
   const run = getRun(runId, event, ctx);
+  updateRunUserIdentity(run, event, ctx, cfg);
   // OpenClaw v2026.6.10 can reuse a runId for a provider fallback after the
   // first agent cycle has already emitted llm_output. A fresh llm_input is the
   // unambiguous start of that next cycle; late terminal hooks must not revive
@@ -1244,7 +1303,7 @@ function makeHandler(fn) {
       const cfg = loadPilotConfig();
       const userId = resolveUserId(cfg);
       const emit = (record) => writeRecord(record, shouldCaptureContent(cfg));
-      fn(event, ctx, userId, emit);
+      fn(event, ctx, userId, emit, cfg);
     } catch (err) {
       writeError(fn.name || "handler", err);
     }

--- a/docs/trace-output.md
+++ b/docs/trace-output.md
@@ -327,9 +327,10 @@ Notes:
   ```
 
 - The values become the canonical event-log identity fields (`gen_ai.session.id` and `user.id`) and the standard trace-span attributes (`gen_ai.session.id` and `gen_ai.user.id`) on every span kind. No `spanAttributePassthroughPrefixes` entry is required.
-- Invocation identity wins over the configured user id and agent-native identity. Native turn and step ids are not changed.
+- Explicit per-invocation identity wins over the configured user id and agent-native identity. Native turn and step ids are not changed.
 - Phase-one support covers OpenCode, Claude Code, Qoder/Qoder-CN, and OpenClaw. Codex and Qwen Code CLI continue to reject these reserved keys.
-- Hermes additionally supports per-invocation `gen_ai.user.id`. When no explicit invocation identity or Pilot user environment variable is present, OpenClaw and Hermes use the channel-native `senderId` / `sender_id`, then fall back to plugin configuration and the hostname.
+- Hermes additionally supports per-invocation `gen_ai.user.id`. For OpenClaw and Hermes, the final user-id precedence is: explicit `gen_ai.user.id` in `LOONGSUITE_PILOT_SPAN_ATTRIBUTES` → `LOONGSUITE_PILOT_USER_ID` / `LOONGSUITE_USER_ID` → channel-native `senderId` / `sender_id` (carried through the invocation transport field, so it wins over the collector-configured user id) → collector-configured user id → producer plugin configuration / hostname fallback. In a standard installation, the collector and plugin fallbacks normally read the same `config.json`.
+- Other supported agents retain the generic precedence and do not promote an agent-native identity above the collector-configured user id.
 - All other `gen_ai.*` and `user.*` keys remain reserved and are dropped.
 
 **Built-in OpenCode attribute (`opencode.message.id`).** The OpenCode plugin always stamps `opencode.message.id` (the opencode assistant-message id) on its `llm.request`, `llm.response`, `tool.call` and `tool.result` records — no launcher env var required. To surface it on spans, just list the `opencode.` prefix; it then appears on ENTRY / AGENT / STEP / LLM / TOOL spans (LLM and TOOL take the value from their own records; ENTRY / AGENT / STEP take the turn-level value):

--- a/docs/trace-output.md
+++ b/docs/trace-output.md
@@ -329,6 +329,7 @@ Notes:
 - The values become the canonical event-log identity fields (`gen_ai.session.id` and `user.id`) and the standard trace-span attributes (`gen_ai.session.id` and `gen_ai.user.id`) on every span kind. No `spanAttributePassthroughPrefixes` entry is required.
 - Invocation identity wins over the configured user id and agent-native identity. Native turn and step ids are not changed.
 - Phase-one support covers OpenCode, Claude Code, Qoder/Qoder-CN, and OpenClaw. Codex and Qwen Code CLI continue to reject these reserved keys.
+- Hermes additionally supports per-invocation `gen_ai.user.id`. When no explicit invocation identity or Pilot user environment variable is present, OpenClaw and Hermes use the channel-native `senderId` / `sender_id`, then fall back to plugin configuration and the hostname.
 - All other `gen_ai.*` and `user.*` keys remain reserved and are dropped.
 
 **Built-in OpenCode attribute (`opencode.message.id`).** The OpenCode plugin always stamps `opencode.message.id` (the opencode assistant-message id) on its `llm.request`, `llm.response`, `tool.call` and `tool.result` records — no launcher env var required. To surface it on spans, just list the `opencode.` prefix; it then appears on ENTRY / AGENT / STEP / LLM / TOOL spans (LLM and TOOL take the value from their own records; ENTRY / AGENT / STEP take the turn-level value):

--- a/docs/zh-CN/trace-output.md
+++ b/docs/zh-CN/trace-output.md
@@ -329,6 +329,7 @@ Pilot 会在 OTLP Trace 的两个层级上记录 Token 用量：
 - 它们会转换为 event log 中的标准身份字段（`gen_ai.session.id` 和 `user.id`），并成为所有类型 trace span 上的标准属性（`gen_ai.session.id` 和 `gen_ai.user.id`）。无需配置 `spanAttributePassthroughPrefixes`。
 - 按次调用身份的优先级高于已配置的 user id 和 agent 原生身份；原生 turn id 和 step id 不变。
 - 一期支持 OpenCode、Claude Code、Qoder/Qoder-CN 和 OpenClaw。Codex 和 Qwen Code CLI 仍会拒绝这两个保留 key。
+- Hermes 额外支持按次调用的 `gen_ai.user.id`。OpenClaw 与 Hermes 在没有显式按次身份和 Pilot 用户环境变量时，会使用 channel 原生 `senderId` / `sender_id`；随后才回退到插件配置和 hostname。
 - 除这两个精确 key 之外，其他 `gen_ai.*` 和 `user.*` 字段仍为保留字段并会被丢弃。
 
 **OpenCode 内置属性（`opencode.message.id`）。** OpenCode 插件会在其 `llm.request`、`llm.response`、`tool.call`、`tool.result` 记录上自动打上 `opencode.message.id`（opencode 的 assistant 消息 id）——无需启动器 env 变量。要让它出现在 span 上，只需列出 `opencode.` 前缀；随后它会出现在 ENTRY / AGENT / STEP / LLM / TOOL span 上（LLM、TOOL 取各自记录的值，ENTRY / AGENT / STEP 取 turn 级值）：

--- a/docs/zh-CN/trace-output.md
+++ b/docs/zh-CN/trace-output.md
@@ -327,9 +327,10 @@ Pilot 会在 OTLP Trace 的两个层级上记录 Token 用量：
   ```
 
 - 它们会转换为 event log 中的标准身份字段（`gen_ai.session.id` 和 `user.id`），并成为所有类型 trace span 上的标准属性（`gen_ai.session.id` 和 `gen_ai.user.id`）。无需配置 `spanAttributePassthroughPrefixes`。
-- 按次调用身份的优先级高于已配置的 user id 和 agent 原生身份；原生 turn id 和 step id 不变。
+- 显式按次调用身份的优先级高于已配置的 user id 和 agent 原生身份；原生 turn id 和 step id 不变。
 - 一期支持 OpenCode、Claude Code、Qoder/Qoder-CN 和 OpenClaw。Codex 和 Qwen Code CLI 仍会拒绝这两个保留 key。
-- Hermes 额外支持按次调用的 `gen_ai.user.id`。OpenClaw 与 Hermes 在没有显式按次身份和 Pilot 用户环境变量时，会使用 channel 原生 `senderId` / `sender_id`；随后才回退到插件配置和 hostname。
+- Hermes 额外支持按次调用的 `gen_ai.user.id`。对于 OpenClaw 和 Hermes，最终 user id 的优先级为：`LOONGSUITE_PILOT_SPAN_ATTRIBUTES` 中显式配置的 `gen_ai.user.id` → `LOONGSUITE_PILOT_USER_ID` / `LOONGSUITE_USER_ID` → channel 原生 `senderId` / `sender_id`（通过 invocation transport field 传递，因此高于 collector 配置的 user id）→ collector 配置的 user id → producer 插件配置 / hostname fallback。标准安装中，collector 与插件 fallback 通常读取同一份 `config.json`。
+- 其他已支持 Agent 保持通用优先级，不会将 Agent 原生身份提升到 collector 配置的 user id 之前。
 - 除这两个精确 key 之外，其他 `gen_ai.*` 和 `user.*` 字段仍为保留字段并会被丢弃。
 
 **OpenCode 内置属性（`opencode.message.id`）。** OpenCode 插件会在其 `llm.request`、`llm.response`、`tool.call`、`tool.result` 记录上自动打上 `opencode.message.id`（opencode 的 assistant 消息 id）——无需启动器 env 变量。要让它出现在 span 上，只需列出 `opencode.` 前缀；随后它会出现在 ENTRY / AGENT / STEP / LLM / TOOL span 上（LLM、TOOL 取各自记录的值，ENTRY / AGENT / STEP 取 turn 级值）：

--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -84,6 +84,54 @@ interface GrokConversionMetadata {
   dataSourceId?: string;
 }
 
+interface OpenClawIdentityMetadata {
+  senderId?: string;
+  channel?: string;
+  accountId?: string;
+  channelId?: string;
+  userIdSource?: string;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/**
+ * OpenClaw's before_model_resolve hook can emit before before_agent_run exposes
+ * senderId. Reconcile record copies at the full-turn boundary so the converter
+ * cannot select the earlier collector fallback as the trace-wide user ID.
+ */
+function prepareOpenClawIdentityRecords(records: AgentActivityEntry[]): {
+  records: AgentActivityEntry[];
+  metadata: OpenClawIdentityMetadata;
+} {
+  const metadata: OpenClawIdentityMetadata = {};
+  let senderUserId: string | undefined;
+
+  for (const record of records) {
+    metadata.senderId ??= nonEmptyString(record['agent.openclaw.sender.id']);
+    metadata.channel ??= nonEmptyString(record['agent.openclaw.channel']);
+    metadata.accountId ??= nonEmptyString(record['agent.openclaw.account.id']);
+    metadata.channelId ??= nonEmptyString(record['agent.openclaw.channel.id']);
+    metadata.userIdSource ??= nonEmptyString(record['agent.openclaw.user.id.source']);
+    if (
+      record['agent.openclaw.user.id.source'] === 'sender'
+      && typeof record['agent.openclaw.sender.id'] === 'string'
+      && record['agent.openclaw.sender.id'].length > 0
+    ) {
+      senderUserId = record['agent.openclaw.sender.id'];
+    }
+  }
+
+  if (!senderUserId) return { records, metadata };
+  return {
+    records: records.map(record => record['user.id'] === senderUserId
+      ? record
+      : { ...record, 'user.id': senderUserId }),
+    metadata,
+  };
+}
+
 function parseGrokSystemInstructions(value: unknown): unknown[] {
   if (Array.isArray(value)) return value;
   if (typeof value !== 'string' || value.length === 0) return [];
@@ -786,6 +834,7 @@ export class OtlpTraceFlusher extends BaseFlusher {
     const { handler, provider, inMem, toolSpanIds } = convertState;
     convertState.active += 1;
     let grokMetadata: GrokConversionMetadata = { systemInstructions: [] };
+    let openClawIdentity: OpenClawIdentityMetadata = {};
 
     try {
       try {
@@ -828,6 +877,11 @@ export class OtlpTraceFlusher extends BaseFlusher {
               }
               return copy;
             });
+        if (agentType === 'openclaw') {
+          const prepared = prepareOpenClawIdentityRecords(recordsForConversion);
+          recordsForConversion = prepared.records;
+          openClawIdentity = prepared.metadata;
+        }
         if (agentType === 'grok-build') {
           const prepared = prepareGrokConversionRecords(recordsForConversion);
           recordsForConversion = prepared.records;
@@ -883,6 +937,7 @@ export class OtlpTraceFlusher extends BaseFlusher {
       applyQoderWorkStepTiming(records, spans);
       this.enrichToolSkillAttributes(records, spans);
       if (agentType === 'openclaw') {
+        this.enrichOpenClawIdentityAttributes(openClawIdentity, spans);
         this.enrichOpenClawToolAttributes(records, spans);
         this.enrichOpenClawLlmAttributes(records, spans);
       }
@@ -1110,6 +1165,23 @@ export class OtlpTraceFlusher extends BaseFlusher {
         }
       }
     }
+  }
+
+  private enrichOpenClawIdentityAttributes(
+    identity: OpenClawIdentityMetadata,
+    spans: ReadableSpan[],
+  ): void {
+    const attributes = {
+      ...(identity.senderId ? { 'agent.openclaw.sender.id': identity.senderId } : {}),
+      ...(identity.channel ? { 'agent.openclaw.channel': identity.channel } : {}),
+      ...(identity.accountId ? { 'agent.openclaw.account.id': identity.accountId } : {}),
+      ...(identity.channelId ? { 'agent.openclaw.channel.id': identity.channelId } : {}),
+      ...(identity.userIdSource
+        ? { 'agent.openclaw.user.id.source': identity.userIdSource }
+        : {}),
+    };
+    if (Object.keys(attributes).length === 0) return;
+    for (const span of spans) Object.assign(span.attributes, attributes);
   }
 
   private enrichGrokBuildSpans(

--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -106,29 +106,55 @@ function prepareOpenClawIdentityRecords(records: AgentActivityEntry[]): {
   metadata: OpenClawIdentityMetadata;
 } {
   const metadata: OpenClawIdentityMetadata = {};
-  let senderUserId: string | undefined;
+  let senderIdentity: OpenClawIdentityMetadata | undefined;
 
   for (const record of records) {
-    metadata.senderId ??= nonEmptyString(record['agent.openclaw.sender.id']);
+    const recordSenderId = nonEmptyString(record['agent.openclaw.sender.id']);
+    metadata.senderId ??= recordSenderId;
     metadata.channel ??= nonEmptyString(record['agent.openclaw.channel']);
     metadata.accountId ??= nonEmptyString(record['agent.openclaw.account.id']);
     metadata.channelId ??= nonEmptyString(record['agent.openclaw.channel.id']);
     metadata.userIdSource ??= nonEmptyString(record['agent.openclaw.user.id.source']);
-    if (
-      record['agent.openclaw.user.id.source'] === 'sender'
-      && typeof record['agent.openclaw.sender.id'] === 'string'
-      && record['agent.openclaw.sender.id'].length > 0
-    ) {
-      senderUserId = record['agent.openclaw.sender.id'];
+    if (record['agent.openclaw.user.id.source'] === 'sender' && recordSenderId) {
+      // Keep the selected sender and its provenance metadata atomic. Otherwise
+      // an earlier config/hostname fallback can survive as the turn-wide source
+      // even after user.id has been reconciled to a later sender.
+      senderIdentity = {
+        senderId: recordSenderId,
+        channel: nonEmptyString(record['agent.openclaw.channel']),
+        accountId: nonEmptyString(record['agent.openclaw.account.id']),
+        channelId: nonEmptyString(record['agent.openclaw.channel.id']),
+        userIdSource: 'sender',
+      };
     }
   }
 
-  if (!senderUserId) return { records, metadata };
+  if (!senderIdentity?.senderId) return { records, metadata };
+  const senderUserId = senderIdentity.senderId;
+  const reconciledMetadata: OpenClawIdentityMetadata = {
+    senderId: senderUserId,
+    channel: senderIdentity.channel ?? metadata.channel,
+    accountId: senderIdentity.accountId ?? metadata.accountId,
+    channelId: senderIdentity.channelId ?? metadata.channelId,
+    userIdSource: 'sender',
+  };
+  const reconciledFields = {
+    'user.id': senderUserId,
+    'agent.openclaw.sender.id': senderUserId,
+    ...(reconciledMetadata.channel
+      ? { 'agent.openclaw.channel': reconciledMetadata.channel }
+      : {}),
+    ...(reconciledMetadata.accountId
+      ? { 'agent.openclaw.account.id': reconciledMetadata.accountId }
+      : {}),
+    ...(reconciledMetadata.channelId
+      ? { 'agent.openclaw.channel.id': reconciledMetadata.channelId }
+      : {}),
+    'agent.openclaw.user.id.source': 'sender',
+  };
   return {
-    records: records.map(record => record['user.id'] === senderUserId
-      ? record
-      : { ...record, 'user.id': senderUserId }),
-    metadata,
+    records: records.map(record => ({ ...record, ...reconciledFields })),
+    metadata: reconciledMetadata,
   };
 }
 

--- a/tests/integration/hermes-agent-event-log-flow.test.ts
+++ b/tests/integration/hermes-agent-event-log-flow.test.ts
@@ -5,7 +5,10 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { convertEventLogToReadableSpans, type EventLogRecord } from '@loongsuite/otel-util-genai';
 import { HermesLogInput } from '../../src/inputs/hermes-log/hermes-log-input.js';
+import { InputManager } from '../../src/core/input-manager.js';
+import { ClientType } from '../../src/types/index.js';
 import type { AgentActivityEntry } from '../../src/types/index.js';
+import { MockFlusher } from '../helpers/mock-flusher.js';
 import { MockStateStore } from '../helpers/mock-state-store.js';
 
 const PLUGIN_PATH = path.resolve('assets/plugins/hermes-agent/loongsuite-pilot/__init__.py');
@@ -30,7 +33,7 @@ describe('Hermes Agent plugin to trace flow', () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'pilot-hermes-flow-'));
     temporaryDirectories.push(root);
     await fs.writeFile(path.join(root, 'config.json'), JSON.stringify({
-      userId: 'fixture-user',
+      userId: 'plugin-config-user',
       agents: { 'hermes-agent': { captureMessageContent: true } },
     }));
 
@@ -62,6 +65,9 @@ for line in fixture_path.read_text(encoding="utf-8").splitlines():
       env: {
         ...process.env,
         LOONGSUITE_PILOT_DATA_DIR: root,
+        LOONGSUITE_PILOT_USER_ID: '',
+        LOONGSUITE_USER_ID: '',
+        LOONGSUITE_PILOT_SPAN_ATTRIBUTES: '',
         PYTHONDONTWRITEBYTECODE: '1',
       },
       encoding: 'utf8',
@@ -73,7 +79,18 @@ for line in fixture_path.read_text(encoding="utf-8").splitlines():
       sessionDir: path.join(root, 'logs', 'hermes-agent'),
       pollIntervalMs: 60_000,
     });
-    const records = await input.collectOnce();
+    const flusher = new MockFlusher();
+    const manager = new InputManager();
+    manager.setAgentsConfig({ [ClientType.Hermes]: { captureMessageContent: true } });
+    manager.setConfiguredUserId('collector-config-user');
+    manager.setUserId('collector-fallback-user');
+    manager.setFlusher(flusher);
+    manager.registerInput(input);
+    await manager.startInput(input.id);
+    await manager.stopInput(input.id);
+
+    expect(flusher.batchCalls).toHaveLength(1);
+    const records = flusher.batchCalls[0];
     expect(records.map(record => record['event.name'])).toEqual([
       'llm.request',
       'llm.response',
@@ -82,6 +99,9 @@ for line in fixture_path.read_text(encoding="utf-8").splitlines():
       'llm.request',
       'llm.response',
     ]);
+    expect(records.every(record => record['user.id'] === 'fixture-user')).toBe(true);
+    expect(records.every(record =>
+      !('agent.pilot.invocation.user.id' in record))).toBe(true);
 
     const previousStability = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
     const previousCapture = process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT;
@@ -115,6 +135,8 @@ for line in fixture_path.read_text(encoding="utf-8").splitlines():
       expect(parents.filter(item => item.kind === 'LLM').every(item => item.parent === 'STEP')).toBe(true);
       expect(parents).toContainEqual({ kind: 'TOOL', parent: 'STEP' });
       expect(new Set(converted.spans.map(span => span.spanContext().traceId)).size).toBe(1);
+      expect(converted.spans.every(span =>
+        span.attributes['gen_ai.user.id'] === 'fixture-user')).toBe(true);
     } finally {
       if (previousStability === undefined) delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
       else process.env.OTEL_SEMCONV_STABILITY_OPT_IN = previousStability;

--- a/tests/integration/openclaw-plugin-event-log-flow.test.ts
+++ b/tests/integration/openclaw-plugin-event-log-flow.test.ts
@@ -25,14 +25,18 @@ describe('OpenClaw plugin to InputManager trace flow', () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), 'pilot-openclaw-flow-'));
     temporaryDirectories.push(root);
     await fs.writeFile(path.join(root, 'config.json'), JSON.stringify({
-      userId: 'fixture-user',
+      userId: 'plugin-config-user',
       agents: { openclaw: { captureMessageContent: true } },
     }));
 
     const previousDataDir = process.env.LOONGSUITE_PILOT_DATA_DIR;
     const previousUserId = process.env.LOONGSUITE_USER_ID;
+    const previousPilotUserId = process.env.LOONGSUITE_PILOT_USER_ID;
+    const previousSpanAttributes = process.env.LOONGSUITE_PILOT_SPAN_ATTRIBUTES;
     process.env.LOONGSUITE_PILOT_DATA_DIR = root;
-    process.env.LOONGSUITE_USER_ID = 'fixture-user';
+    delete process.env.LOONGSUITE_USER_ID;
+    delete process.env.LOONGSUITE_PILOT_USER_ID;
+    delete process.env.LOONGSUITE_PILOT_SPAN_ATTRIBUTES;
     try {
       const plugin = (await import(`${PLUGIN_PATH}?integration=${Date.now()}`)).default;
       const fixture = await fs.readFile(FIXTURE_PATH, 'utf8');
@@ -52,6 +56,14 @@ describe('OpenClaw plugin to InputManager trace flow', () => {
       for (const envelope of envelopes) {
         const handler = handlers[envelope.hook];
         if (!handler) continue;
+        const event = envelope.hook === 'before_agent_run'
+          ? {
+              ...envelope.event,
+              senderId: 'channel-sender',
+              accountId: 'channel-account',
+              channelId: 'channel-conversation',
+            }
+          : envelope.event;
         const ctx = syncHooks.has(envelope.hook)
           ? { agentId: 'main', sessionKey: envelope.event?.sessionKey || knownSessionKey }
           : {
@@ -59,14 +71,19 @@ describe('OpenClaw plugin to InputManager trace flow', () => {
               runId: envelope.event?.runId || knownRun,
               sessionId: envelope.event?.sessionId || knownSession,
               sessionKey: envelope.event?.sessionKey || knownSessionKey,
+              channel: 'telegram',
             };
-        await Promise.resolve(handler(envelope.event, ctx));
+        await Promise.resolve(handler(event, ctx));
       }
     } finally {
       if (previousDataDir === undefined) delete process.env.LOONGSUITE_PILOT_DATA_DIR;
       else process.env.LOONGSUITE_PILOT_DATA_DIR = previousDataDir;
       if (previousUserId === undefined) delete process.env.LOONGSUITE_USER_ID;
       else process.env.LOONGSUITE_USER_ID = previousUserId;
+      if (previousPilotUserId === undefined) delete process.env.LOONGSUITE_PILOT_USER_ID;
+      else process.env.LOONGSUITE_PILOT_USER_ID = previousPilotUserId;
+      if (previousSpanAttributes === undefined) delete process.env.LOONGSUITE_PILOT_SPAN_ATTRIBUTES;
+      else process.env.LOONGSUITE_PILOT_SPAN_ATTRIBUTES = previousSpanAttributes;
     }
 
     const input = new OpenClawPluginInput({
@@ -77,6 +94,8 @@ describe('OpenClaw plugin to InputManager trace flow', () => {
     const flusher = new MockFlusher();
     const manager = new InputManager();
     manager.setAgentsConfig({ [ClientType.OpenClaw]: { captureMessageContent: true } });
+    manager.setConfiguredUserId('collector-config-user');
+    manager.setUserId('collector-fallback-user');
     manager.setFlusher(flusher);
     manager.registerInput(input);
 
@@ -87,6 +106,9 @@ describe('OpenClaw plugin to InputManager trace flow', () => {
     const records = flusher.batchCalls[0];
     expect(records.length).toBeGreaterThan(10);
     expect(records.every(record => record['gen_ai.agent.type'] === ClientType.OpenClaw)).toBe(true);
+    expect(records.every(record => record['user.id'] === 'channel-sender')).toBe(true);
+    expect(records.every(record =>
+      !('agent.pilot.invocation.user.id' in record))).toBe(true);
     const terminal = records.find(record => record['agent.openclaw.hook'] === 'llm_output');
     expect(terminal).toMatchObject({
       'event.name': 'other',
@@ -129,6 +151,8 @@ describe('OpenClaw plugin to InputManager trace flow', () => {
       }, {});
       expect(kindCounts).toEqual({ ENTRY: 1, AGENT: 1, STEP: 2, LLM: 2, TOOL: 2 });
       expect(new Set(converted.spans.map(span => span.spanContext().traceId)).size).toBe(1);
+      expect(converted.spans.every(span =>
+        span.attributes['gen_ai.user.id'] === 'channel-sender')).toBe(true);
 
       const llmSpans = converted.spans.filter(span => span.attributes['gen_ai.span.kind'] === 'LLM');
       expect(llmSpans.map(span => [

--- a/tests/unit/flushers/otlp-trace-flusher/conversion.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/conversion.test.ts
@@ -61,6 +61,7 @@ describe('OtlpTraceFlusher - conversion', () => {
       'gen_ai.turn.id': 'openclaw-turn',
       'user.id': 'collector-user',
       'agent.openclaw.hook': 'before_model_resolve',
+      'agent.openclaw.user.id.source': 'hostname',
       'gen_ai.input.messages_delta': [],
     } as unknown as AgentActivityEntry;
     const senderKnown = {
@@ -69,6 +70,9 @@ describe('OtlpTraceFlusher - conversion', () => {
       'user.id': 'channel-sender',
       'agent.openclaw.hook': 'before_agent_run',
       'agent.openclaw.sender.id': 'channel-sender',
+      'agent.openclaw.channel': 'telegram',
+      'agent.openclaw.account.id': 'channel-account',
+      'agent.openclaw.channel.id': 'channel-conversation',
       'agent.openclaw.user.id.source': 'sender',
     } as unknown as AgentActivityEntry;
     const terminal = {
@@ -81,7 +85,14 @@ describe('OtlpTraceFlusher - conversion', () => {
 
     const convertedRecords = vi.mocked(convertEventLogToTrace).mock.calls[0][0] as AgentActivityEntry[];
     expect(convertedRecords.every(record => record['user.id'] === 'channel-sender')).toBe(true);
+    expect(convertedRecords.every(record =>
+      record['agent.openclaw.user.id.source'] === 'sender')).toBe(true);
+    expect(convertedRecords.every(record =>
+      record['agent.openclaw.sender.id'] === 'channel-sender')).toBe(true);
+    expect(convertedRecords.every(record =>
+      record['agent.openclaw.channel'] === 'telegram')).toBe(true);
     expect(early['user.id']).toBe('collector-user');
+    expect(early['agent.openclaw.user.id.source']).toBe('hostname');
   });
 
   it('does not replace an explicit OpenClaw environment identity with sender metadata', async () => {

--- a/tests/unit/flushers/otlp-trace-flusher/conversion.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/conversion.test.ts
@@ -54,6 +54,59 @@ describe('OtlpTraceFlusher - conversion', () => {
     expect(callArgs[1]).toMatchObject({ strict: false });
   });
 
+  it('reconciles an early OpenClaw fallback to the sender identity at turn conversion', async () => {
+    const early = {
+      'event.name': 'other',
+      'gen_ai.agent.type': 'openclaw',
+      'gen_ai.turn.id': 'openclaw-turn',
+      'user.id': 'collector-user',
+      'agent.openclaw.hook': 'before_model_resolve',
+      'gen_ai.input.messages_delta': [],
+    } as unknown as AgentActivityEntry;
+    const senderKnown = {
+      ...early,
+      'event.id': 'sender-known',
+      'user.id': 'channel-sender',
+      'agent.openclaw.hook': 'before_agent_run',
+      'agent.openclaw.sender.id': 'channel-sender',
+      'agent.openclaw.user.id.source': 'sender',
+    } as unknown as AgentActivityEntry;
+    const terminal = {
+      ...senderKnown,
+      'event.id': 'terminal',
+      'agent.openclaw.hook': 'llm_output',
+    } as unknown as AgentActivityEntry;
+
+    await flusher.sendBatch([early, senderKnown, terminal]);
+
+    const convertedRecords = vi.mocked(convertEventLogToTrace).mock.calls[0][0] as AgentActivityEntry[];
+    expect(convertedRecords.every(record => record['user.id'] === 'channel-sender')).toBe(true);
+    expect(early['user.id']).toBe('collector-user');
+  });
+
+  it('does not replace an explicit OpenClaw environment identity with sender metadata', async () => {
+    const early = {
+      'event.name': 'other',
+      'gen_ai.agent.type': 'openclaw',
+      'gen_ai.turn.id': 'openclaw-env-turn',
+      'user.id': 'environment-user',
+      'agent.openclaw.hook': 'before_model_resolve',
+      'gen_ai.input.messages_delta': [],
+    } as unknown as AgentActivityEntry;
+    const terminal = {
+      ...early,
+      'event.id': 'terminal',
+      'agent.openclaw.hook': 'llm_output',
+      'agent.openclaw.sender.id': 'channel-sender',
+      'agent.openclaw.user.id.source': 'environment',
+    } as unknown as AgentActivityEntry;
+
+    await flusher.sendBatch([early, terminal]);
+
+    const convertedRecords = vi.mocked(convertEventLogToTrace).mock.calls[0][0] as AgentActivityEntry[];
+    expect(convertedRecords.every(record => record['user.id'] === 'environment-user')).toBe(true);
+  });
+
   it('excludes agent.input only at the EventLog-to-Trace boundary', async () => {
     const inputOther = {
       time_unix_nano: '1700000000000000000',

--- a/tests/unit/hooks/hermes-agent-plugin.test.mjs
+++ b/tests/unit/hooks/hermes-agent-plugin.test.mjs
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { INVOCATION_USER_ID_FIELD } from '../../../assets/hooks/shared/resource-context.mjs';
 
 const PLUGIN = path.resolve(
   fileURLToPath(import.meta.url),
@@ -251,6 +252,7 @@ function replay(events, {
   agentTeamsWorkerName,
   pilotEnvUser,
   legacyEnvUser,
+  spanAttributes,
   configUser = 'pilot-config-user',
   dataDirSource = 'env',
   beforeSpawn,
@@ -319,6 +321,8 @@ print(json.dumps(sorted(ctx.hooks)))
   else env.LOONGSUITE_PILOT_USER_ID = pilotEnvUser;
   if (legacyEnvUser === undefined) delete env.LOONGSUITE_USER_ID;
   else env.LOONGSUITE_USER_ID = legacyEnvUser;
+  if (spanAttributes === undefined) delete env.LOONGSUITE_PILOT_SPAN_ATTRIBUTES;
+  else env.LOONGSUITE_PILOT_SPAN_ATTRIBUTES = spanAttributes;
   if (agentTeamsWorkerName === undefined) delete env.AGENTTEAMS_WORKER_NAME;
   else env.AGENTTEAMS_WORKER_NAME = agentTeamsWorkerName;
   const run = spawnSync('python3', ['-c', driver, pluginPath, path.join(root, 'events.jsonl')], {
@@ -411,6 +415,8 @@ describe('Hermes Agent native plugin', () => {
     expect(new Set(records.map(record => record['gen_ai.turn.id']))).toEqual(new Set([TURN_ONE]));
     expect(records.every(record => record['gen_ai.session.id'] === SESSION_ID)).toBe(true);
     expect(records.every(record => record['user.id'] === 'pilot-env-user')).toBe(true);
+    expect(records.every(record =>
+      record[INVOCATION_USER_ID_FIELD] === 'pilot-env-user')).toBe(true);
     expect(records.every(record => record['gen_ai.agent.type'] === 'hermes')).toBe(true);
     expect(records.every(record => record['gen_ai.provider.name'] === 'qwen')).toBe(true);
 
@@ -536,6 +542,19 @@ describe('Hermes Agent native plugin', () => {
     expect(records.every(record => record['user.id'] === 'legacy-env-user')).toBe(true);
   });
 
+  it('gives invocation-scoped identity precedence over env and sender identity', () => {
+    const { records } = replay(firstTurn({ senderId: 'sender-user' }), {
+      pilotEnvUser: 'pilot-env-user',
+      spanAttributes: 'gen_ai.user.id=invocation-user,gen_ai.agent.name=blocked',
+    });
+
+    expect(records.every(record => record['user.id'] === 'invocation-user')).toBe(true);
+    expect(records.every(record =>
+      record[INVOCATION_USER_ID_FIELD] === 'invocation-user')).toBe(true);
+    expect(records.every(record =>
+      record['agent.hermes.sender.id'] === 'sender-user')).toBe(true);
+  });
+
   it('pairs two sequential tools with three unique API steps', () => {
     const { records } = replay(secondTurn(), { configUser: 'config-fallback-user' });
     expect(records.map(record => record['event.name'])).toEqual([
@@ -561,6 +580,10 @@ describe('Hermes Agent native plugin', () => {
   it('keeps message and correlation structure while removing captured content', () => {
     const { records, raw } = replay(firstTurn({ senderId: 'sender-user' }), { captureMessageContent: false });
     expect(records.every(record => record['user.id'] === 'sender-user')).toBe(true);
+    expect(records.every(record =>
+      record[INVOCATION_USER_ID_FIELD] === 'sender-user')).toBe(true);
+    expect(records.every(record =>
+      record['agent.hermes.sender.id'] === 'sender-user')).toBe(true);
     expect(raw).not.toContain('approved files');
     expect(raw).not.toContain('wc -l /etc/hosts');
     expect(raw).not.toContain('17 /etc/hosts');

--- a/tests/unit/hooks/openclaw/plugin.test.mjs
+++ b/tests/unit/hooks/openclaw/plugin.test.mjs
@@ -88,7 +88,7 @@ function readOutputRecords() {
   return text.split('\n').filter((l) => l.trim().length > 0).map((l) => JSON.parse(l));
 }
 
-async function replay(plugin, envelopes, { pluginConfig = {} } = {}) {
+async function replay(plugin, envelopes, { pluginConfig = {}, contextPatch } = {}) {
   const handlers = registerPlugin(plugin, pluginConfig);
 
   // Agent/model/tool hooks receive PluginHookAgentContext with the run/session
@@ -113,6 +113,7 @@ async function replay(plugin, envelopes, { pluginConfig = {} } = {}) {
       runId: env.event?.runId || knownRun,
       sessionKey: env.event?.sessionKey || knownSessionKey,
     };
+    if (contextPatch) Object.assign(ctx, contextPatch(env) || {});
     await h(env.event, ctx);
   }
   return readOutputRecords();
@@ -290,6 +291,82 @@ describe('OpenClaw plugin stateful pipeline', () => {
       expect(record['gen_ai.session.id']).not.toBe('env-session');
       expect(record['gen_ai.agent.name']).not.toBe('blocked');
     }
+  });
+
+  it('uses before_agent_run senderId as the invocation user identity', async () => {
+    delete process.env.LOONGSUITE_USER_ID;
+    fs.writeFileSync(path.join(pilotDataDir, 'config.json'), JSON.stringify({
+      userId: 'configured-user',
+    }));
+    const envelopes = readJsonl('pilot-probe-events-smoke.jsonl').map(envelope =>
+      envelope.hook === 'before_agent_run'
+        ? {
+            ...envelope,
+            event: {
+              ...envelope.event,
+              senderId: 'telegram-user-42',
+              accountId: 'telegram-account',
+              channelId: 'telegram-chat',
+            },
+          }
+        : envelope);
+
+    const plugin = await loadPlugin();
+    const records = await replay(plugin, envelopes, {
+      contextPatch: envelope => envelope.hook === 'before_agent_run'
+        ? { channel: 'telegram' }
+        : {},
+    });
+
+    expect(records.length).toBeGreaterThan(0);
+    expect(records.every(record => record['user.id'] === 'telegram-user-42')).toBe(true);
+    expect(records.every(record =>
+      record[INVOCATION_USER_ID_FIELD] === 'telegram-user-42')).toBe(true);
+    expect(records.every(record =>
+      record['agent.openclaw.sender.id'] === 'telegram-user-42')).toBe(true);
+    expect(records.every(record =>
+      record['agent.openclaw.user.id.source'] === 'sender')).toBe(true);
+    expect(records[0]).toMatchObject({
+      'agent.openclaw.channel': 'telegram',
+      'agent.openclaw.account.id': 'telegram-account',
+      'agent.openclaw.channel.id': 'telegram-chat',
+    });
+  });
+
+  it.each([
+    ['ctx.senderId', { senderId: 'context-sender' }, 'context-sender'],
+    ['ctx.channelContext.sender.id', { channelContext: { sender: { id: 'channel-context-sender' } } }, 'channel-context-sender'],
+  ])('falls back to %s on newer OpenClaw contexts', async (_label, contextIdentity, expected) => {
+    delete process.env.LOONGSUITE_USER_ID;
+    fs.writeFileSync(path.join(pilotDataDir, 'config.json'), JSON.stringify({
+      userId: 'configured-user',
+    }));
+    const plugin = await loadPlugin();
+    const records = await replay(plugin, readJsonl('pilot-probe-events-smoke.jsonl'), {
+      contextPatch: envelope => envelope.hook === 'before_agent_run'
+        ? contextIdentity
+        : {},
+    });
+
+    expect(records.every(record => record['user.id'] === expected)).toBe(true);
+    expect(records.every(record => record[INVOCATION_USER_ID_FIELD] === expected)).toBe(true);
+  });
+
+  it('keeps an explicit Pilot user ID above the native sender', async () => {
+    const envelopes = readJsonl('pilot-probe-events-smoke.jsonl').map(envelope =>
+      envelope.hook === 'before_agent_run'
+        ? { ...envelope, event: { ...envelope.event, senderId: 'native-sender' } }
+        : envelope);
+    const plugin = await loadPlugin();
+    const records = await replay(plugin, envelopes);
+
+    expect(records.every(record => record['user.id'] === 'test-user')).toBe(true);
+    expect(records.every(record =>
+      record['agent.openclaw.sender.id'] === 'native-sender')).toBe(true);
+    expect(records.every(record =>
+      record['agent.openclaw.user.id.source'] === 'environment')).toBe(true);
+    expect(records.every(record =>
+      record[INVOCATION_USER_ID_FIELD] === 'test-user')).toBe(true);
   });
 
   it('uses AGENTTEAMS_WORKER_NAME as the agent name and Resource marker', async () => {


### PR DESCRIPTION
Closes #359

## Summary

- resolve OpenClaw native sender identity from hook event/context and snapshot it for the full run
- propagate Hermes sender identity through the shared invocation identity path so collector fallback does not overwrite it
- reconcile early OpenClaw records when sender metadata arrives later, and attach channel/account metadata to converted spans
- document the identity precedence and add unit/integration coverage

## Identity precedence

Explicit per-invocation gen_ai.user.id > Pilot user-id environment variable > native sender identity > plugin configuration > hostname.

## Testing

- npm run typecheck
- Python py_compile for the Hermes plugin
- OpenClaw and Hermes plugin test suites: 72 tests passed
- TypeScript integration/conversion coverage added; full execution is delegated to GitHub CI because the local host security policy terminates the Vite/esbuild transform service.