### PR TITLE
fix(qoder-trace): pair segments by request id so LLM spans carry real durations

### DIFF
--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -1146,6 +1146,7 @@ export function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, 
     const outputParts = [];
     const toolCalls = [];
     let responseId = undefined;
+    let clientRequestId = undefined;
     let lastAssistantTs = null;
     let firstAssistantTs = null;
 
@@ -1154,6 +1155,13 @@ export function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, 
         const msg = row.message || {};
         const blocks = Array.isArray(msg.content) ? msg.content : [];
         if (msg.id && !responseId) responseId = msg.id;
+        // The CLI's own request id, carried on the usage object of the row that
+        // closes a streamed response (msg.id lands on the first row instead, so
+        // the two cannot be read from the same row).
+        if (!clientRequestId && msg.usage && typeof msg.usage === 'object' &&
+            typeof msg.usage.request_id === 'string' && msg.usage.request_id) {
+          clientRequestId = msg.usage.request_id;
+        }
         if (row.timestamp) lastAssistantTs = row.timestamp;
         if (row.timestamp && !firstAssistantTs) firstAssistantTs = row.timestamp;
         for (const block of blocks) {
@@ -1234,6 +1242,13 @@ export function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, 
         // with dropAgentScopedFields: true, so an `agent.qoder.stop_reason`
         // spelling would reach neither sink.
         'agent.stop_reason': lastStopReason,
+        // The CLI's own request id for this response, taken from the transcript's
+        // usage object. It shares a namespace with a segment record's request_id
+        // (gen_ai.response.id does not: that one is the provider's id), so the
+        // token-enricher joins segments on this field and only falls back to
+        // timestamp proximity when it is absent. Single segment after `agent.`
+        // on purpose, same reason as agent.stop_reason above.
+        'agent.client_request_id': clientRequestId,
         // Accurate per-response timestamp from the transcript's first assistant record
         // (≈ SQLite gmt_create). Used only for token-enricher matching; dropped from
         // SLS/JSONL output as an agent-scoped field. Absent for CLI (no firstAssistantTs).

--- a/src/inputs/qoder-trace/segment-token-reader.ts
+++ b/src/inputs/qoder-trace/segment-token-reader.ts
@@ -2,6 +2,9 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import type { Dirent } from 'node:fs';
 import { resolveHome } from '../../utils/fs-utils.js';
+import { createLogger } from '../../utils/logger.js';
+
+const logger = createLogger('SegmentTokenReader');
 
 function getSessionsDir(): string {
   return resolveHome('~/.qoder/logs/sessions');
@@ -12,6 +15,9 @@ const sessionCache = new Map<string, { data: SegmentTokenData[]; fingerprint: st
 // decides whether the cached data is still valid.
 const CACHE_IDLE_MS = 60_000;
 const CACHE_MAX_SIZE = 50;
+// An unreadable segment file is reported once per on-disk state, so a sustained
+// failure does not emit one line per poll cycle.
+const warnedScans = new Map<string, string>();
 
 interface SegmentFileScan {
   files: string[];
@@ -51,16 +57,26 @@ export async function readSegmentTokensForSession(sessionId: string): Promise<Se
   const files = scan.files;
 
   const requestStarts = new Map<string, number>();
+  // loop_id is 1:1 with a CLI loop iteration, so it joins a completion back to
+  // the iteration that issued it without any time-proximity guessing.
+  const loopStarts = new Map<string, number>();
+  const attemptFailures = new Map<string, number>();
   const results: SegmentTokenData[] = [];
 
+  // A file we could not open leaves this scan missing whole requests, which must
+  // not be cached behind a fingerprint that claims the data is current.
+  let complete = true;
+
   // Collect all events in order to properly associate tool.execution.finished with LLM calls
-  const allEvents: Array<{ type: string; ts: number; requestId?: string; data?: Record<string, unknown> }> = [];
+  const allEvents: Array<{ type: string; ts: number; requestId?: string; loopId?: string; data?: Record<string, unknown> }> = [];
 
   for (const filePath of files) {
     let content: string;
     try {
       content = await fs.readFile(filePath, 'utf-8');
-    } catch {
+    } catch (err) {
+      complete = false;
+      warnUnreadableOnce(sessionId, scan.fingerprint, filePath, err);
       continue;
     }
 
@@ -77,12 +93,19 @@ export async function readSegmentTokensForSession(sessionId: string): Promise<Se
       if (!type) continue;
 
       const ts = parseTs(record.ts);
-      if (type === 'model.request.started' || type === 'model.response.completed' || type === 'tool.execution.finished') {
+      if (
+        type === 'model.request.started'
+        || type === 'model.response.completed'
+        || type === 'tool.execution.finished'
+        || type === 'loop.iteration.started'
+        || type === 'model.request.attempt_failed'
+      ) {
         const requestId = record.request_id as string | undefined;
+        const loopId = record.loop_id as string | undefined;
         const data = (record.data && typeof record.data === 'object' && !Array.isArray(record.data))
           ? record.data as Record<string, unknown>
           : undefined;
-        allEvents.push({ type, ts, requestId: requestId || undefined, data });
+        allEvents.push({ type, ts, requestId: requestId || undefined, loopId: loopId || undefined, data });
       }
     }
   }
@@ -93,9 +116,19 @@ export async function readSegmentTokensForSession(sessionId: string): Promise<Se
       requestStarts.set(evt.requestId, evt.ts);
     }
 
+    if (evt.type === 'loop.iteration.started' && evt.loopId && evt.ts > 0) {
+      loopStarts.set(evt.loopId, evt.ts);
+    }
+
+    // A retry reaches the model under a fresh request id, so the failure of the
+    // attempt it replaces is the closest thing to that retry's own start.
+    if (evt.type === 'model.request.attempt_failed' && evt.loopId && evt.ts > 0) {
+      attemptFailures.set(evt.loopId, evt.ts);
+    }
+
     if (evt.type === 'model.response.completed' && evt.requestId) {
       const data = evt.data || {};
-      const startTs = requestStarts.get(evt.requestId) ?? evt.ts;
+      const startTs = resolveRequestStart(evt, requestStarts, attemptFailures, loopStarts);
 
       results.push({
         requestId: evt.requestId,
@@ -116,7 +149,12 @@ export async function readSegmentTokensForSession(sessionId: string): Promise<Se
   // The last tool.execution.finished before the next model.request.started belongs to that step.
   for (let i = 0; i < results.length; i++) {
     const currentEnd = results[i].responseEndTs;
-    const nextStart = i + 1 < results.length ? results[i + 1].requestStartTs : Infinity;
+    const next = i + 1 < results.length ? results[i + 1] : undefined;
+    // An unresolved start would collapse the window to nothing and drop the tool
+    // timings that belong to this step.
+    const nextStart = next
+      ? (next.requestStartTs > 0 ? next.requestStartTs : next.responseEndTs)
+      : Infinity;
 
     let lastToolFinish = 0;
     for (const evt of allEvents) {
@@ -130,15 +168,82 @@ export async function readSegmentTokensForSession(sessionId: string): Promise<Se
   // Evict idle entries and enforce max size
   const now = Date.now();
   for (const [key, entry] of sessionCache) {
-    if (key !== sessionId && now - entry.ts > CACHE_IDLE_MS) sessionCache.delete(key);
+    if (key !== sessionId && now - entry.ts > CACHE_IDLE_MS) {
+      sessionCache.delete(key);
+      warnedScans.delete(key);
+    }
   }
   if (sessionCache.size >= CACHE_MAX_SIZE && !sessionCache.has(sessionId)) {
     const oldest = [...sessionCache.entries()].sort((a, b) => a[1].ts - b[1].ts)[0];
     if (oldest) sessionCache.delete(oldest[0]);
   }
 
-  sessionCache.set(sessionId, { data: results, fingerprint: scan.fingerprint, ts: now });
+  // An incomplete parse is still returned, but never cached: the fingerprint
+  // describes the current on-disk state, so caching it would serve the same gap
+  // to every remaining turn of this batch instead of retrying the read.
+  if (complete) {
+    sessionCache.set(sessionId, { data: results, fingerprint: scan.fingerprint, ts: now });
+  }
   return results;
+}
+
+/**
+ * Resolve the instant a completed request began.
+ *
+ * A retried request emits model.response.completed under a fresh request id but
+ * no matching model.request.started, so the exact lookup misses. Falling back to
+ * the completion instant made requestStartTs === responseEndTs - a zero-width
+ * LLM span manufactured by enrichment rather than one merely left un-enriched.
+ *
+ * Anchors are tried tightest first. 0 means "unknown" and is returned instead of
+ * a degenerate value so the enricher leaves the hook clock in place.
+ */
+function resolveRequestStart(
+  evt: { requestId?: string; loopId?: string; ts: number },
+  requestStarts: Map<string, number>,
+  attemptFailures: Map<string, number>,
+  loopStarts: Map<string, number>,
+): number {
+  if (evt.requestId) {
+    const exact = requestStarts.get(evt.requestId);
+    if (exact !== undefined) return exact;
+  }
+
+  if (!evt.loopId) {
+    logger.warn('segment completion carries no loop_id to anchor its start', {
+      requestId: evt.requestId,
+    });
+    return 0;
+  }
+
+  const failedAttempt = attemptFailures.get(evt.loopId);
+  if (failedAttempt !== undefined) {
+    logger.debug('anchored a retried request on the attempt it replaced', {
+      requestId: evt.requestId, loopId: evt.loopId,
+    });
+    return failedAttempt;
+  }
+
+  const loopStart = loopStarts.get(evt.loopId);
+  if (loopStart !== undefined) {
+    logger.debug('anchored a request on its loop iteration', {
+      requestId: evt.requestId, loopId: evt.loopId,
+    });
+    return loopStart;
+  }
+
+  logger.warn('segment completion has no start anchor; leaving its span on the hook clock', {
+    requestId: evt.requestId, loopId: evt.loopId,
+  });
+  return 0;
+}
+
+function warnUnreadableOnce(sessionId: string, fingerprint: string, filePath: string, err: unknown): void {
+  if (warnedScans.get(sessionId) === fingerprint) return;
+  warnedScans.set(sessionId, fingerprint);
+  logger.warn('segment file unreadable; affected turns keep the hook clock', {
+    sessionId, filePath, error: String(err),
+  });
 }
 
 async function findSegmentFilesForSession(sessionId: string): Promise<SegmentFileScan> {

--- a/src/inputs/qoder-trace/segment-token-reader.ts
+++ b/src/inputs/qoder-trace/segment-token-reader.ts
@@ -7,9 +7,16 @@ function getSessionsDir(): string {
   return resolveHome('~/.qoder/logs/sessions');
 }
 
-const sessionCache = new Map<string, { data: SegmentTokenData[]; ts: number }>();
-const CACHE_TTL_MS = 60_000;
+const sessionCache = new Map<string, { data: SegmentTokenData[]; fingerprint: string; ts: number }>();
+// `ts` only drives eviction of sessions nobody touches any more - it never
+// decides whether the cached data is still valid.
+const CACHE_IDLE_MS = 60_000;
 const CACHE_MAX_SIZE = 50;
+
+interface SegmentFileScan {
+  files: string[];
+  fingerprint: string;
+}
 
 export interface SegmentTokenData {
   requestId: string;
@@ -25,11 +32,23 @@ export interface SegmentTokenData {
 }
 
 export async function readSegmentTokensForSession(sessionId: string): Promise<SegmentTokenData[]> {
-  const cached = sessionCache.get(sessionId);
-  if (cached && Date.now() - cached.ts < CACHE_TTL_MS) return cached.data;
+  const scan = await findSegmentFilesForSession(sessionId);
+  if (scan.files.length === 0) return [];
 
-  const files = await findSegmentFilesForSession(sessionId);
-  if (files.length === 0) return [];
+  // Freshness is decided by what is on disk, never by elapsed time. The CLI
+  // keeps appending to these files while pilot is already processing earlier
+  // turns of the same session, so an age-based cache would serve a snapshot
+  // taken before the current turn's own segments were written. The exact-id
+  // join would then find nothing for that turn and its llm.request /
+  // llm.response would keep the hook's identical timestamps - a zero-width
+  // LLM span. Re-scanning is cheap next to re-parsing every file.
+  const cached = sessionCache.get(sessionId);
+  if (cached && cached.fingerprint === scan.fingerprint) {
+    cached.ts = Date.now();
+    return cached.data;
+  }
+
+  const files = scan.files;
 
   const requestStarts = new Map<string, number>();
   const results: SegmentTokenData[] = [];
@@ -108,27 +127,27 @@ export async function readSegmentTokensForSession(sessionId: string): Promise<Se
     results[i].toolFinishedTs = lastToolFinish;
   }
 
-  // Evict expired entries and enforce max size
+  // Evict idle entries and enforce max size
   const now = Date.now();
   for (const [key, entry] of sessionCache) {
-    if (now - entry.ts > CACHE_TTL_MS) sessionCache.delete(key);
+    if (key !== sessionId && now - entry.ts > CACHE_IDLE_MS) sessionCache.delete(key);
   }
-  if (sessionCache.size >= CACHE_MAX_SIZE) {
+  if (sessionCache.size >= CACHE_MAX_SIZE && !sessionCache.has(sessionId)) {
     const oldest = [...sessionCache.entries()].sort((a, b) => a[1].ts - b[1].ts)[0];
     if (oldest) sessionCache.delete(oldest[0]);
   }
 
-  sessionCache.set(sessionId, { data: results, ts: now });
+  sessionCache.set(sessionId, { data: results, fingerprint: scan.fingerprint, ts: now });
   return results;
 }
 
-async function findSegmentFilesForSession(sessionId: string): Promise<string[]> {
+async function findSegmentFilesForSession(sessionId: string): Promise<SegmentFileScan> {
   const files: string[] = [];
   let cwdDirs: Dirent[];
   try {
     cwdDirs = await fs.readdir(getSessionsDir(), { withFileTypes: true });
   } catch {
-    return [];
+    return { files: [], fingerprint: '' };
   }
 
   for (const cwdDir of cwdDirs) {
@@ -147,7 +166,30 @@ async function findSegmentFilesForSession(sessionId: string): Promise<string[]> 
     }
   }
 
-  return files.sort();
+  files.sort();
+
+  // size + mtime per file: an append always grows the file, and a rewrite that
+  // happens to land on the same size still moves mtime. A file that disappeared
+  // between readdir and stat is dropped from both lists so they stay in step.
+  const stamps = await Promise.all(files.map(async filePath => {
+    try {
+      const stat = await fs.stat(filePath);
+      return `${filePath}:${stat.size}:${stat.mtimeMs}`;
+    } catch {
+      return undefined;
+    }
+  }));
+
+  const readable: string[] = [];
+  const parts: string[] = [];
+  for (let i = 0; i < files.length; i++) {
+    const stamp = stamps[i];
+    if (stamp === undefined) continue;
+    readable.push(files[i]);
+    parts.push(stamp);
+  }
+
+  return { files: readable, fingerprint: parts.join('|') };
 }
 
 function parseTs(value: unknown): number {

--- a/src/inputs/qoder-trace/token-enricher.ts
+++ b/src/inputs/qoder-trace/token-enricher.ts
@@ -1,5 +1,6 @@
 import * as crypto from 'node:crypto';
 import type { AgentActivityEntry } from '../../types/index.js';
+import { normalizeFinishReason } from '../../normalization/finish-reason.js';
 import type { InterceptTokenData } from './intercept-token-reader.js';
 import type { SegmentTokenData } from './segment-token-reader.js';
 import type { SqliteTokenData } from './sqlite-token-reader.js';
@@ -9,6 +10,15 @@ import type { SqliteTokenData } from './sqlite-token-reader.js';
 // llm.response time (hook progress clock) drifts from SQLite gmt_create by up to
 // ~1.4s; the accurate agent.qoder.match_ts (when present) matches within a few ms.
 const TIMESTAMP_THRESHOLD_MS = 5000;
+
+// Fallback bound for pairing a segment with the llm.response it describes when
+// the hook did not record agent.client_request_id (older JSONL). gen_ai.response.id
+// is the provider's id while a segment request_id is the CLI's own uuid, so those
+// two never compare equal and the response completion instant is used instead.
+// The hook fires just after the response lands, trailing the segment by 0-32ms on
+// observed data, and 50ms is where the match rate saturates - widening it further
+// pairs nothing extra.
+const SEGMENT_JOIN_TOLERANCE_MS = 50;
 
 export function enrichCliTurn(
   entries: AgentActivityEntry[],
@@ -27,13 +37,7 @@ export function enrichCliTurn(
     }
   }
 
-  for (const seg of segments) {
-    const matches = entries.filter(e =>
-      e['gen_ai.response.id'] === seg.requestId && e['event.name'] === 'llm.response',
-    );
-
-    if (matches.length === 0) continue;
-
+  for (const { seg, matches } of pairSegmentsWithResponses(entries, segments)) {
     // Segment usage is a compatibility fallback only. New qodercli releases
     // emit zero token fields in segments, while intercept observes the actual
     // provider usage. Preserve any native usage already present on the entry.
@@ -54,7 +58,15 @@ export function enrichCliTurn(
     }
 
     if (seg.stopReason && !matches[0]['gen_ai.response.finish_reasons']) {
-      matches[0]['gen_ai.response.finish_reasons'] = [seg.stopReason];
+      // seg.stopReason is Anthropic's native spelling; finish_reasons is the OTel
+      // GenAI enum. Writing it through raw is how tool_use / stop_sequence /
+      // model_context_window_exceeded reached the validator as illegal values.
+      // Unmappable values are left absent rather than guessed, matching the
+      // transcript hook.
+      const normalized = normalizeFinishReason(seg.stopReason);
+      if (normalized) {
+        matches[0]['gen_ai.response.finish_reasons'] = [normalized];
+      }
     }
 
     // Inject segment-derived timestamps and model for the entire step (unified clock source)
@@ -70,46 +82,50 @@ export function enrichCliTurn(
       if (req) req['gen_ai.request.model'] = seg.model;
     }
 
-    // llm.request: use segment requestStartTs
-    if (seg.requestStartTs > 0) {
-      const req = entries.find(e =>
-        e['event.name'] === 'llm.request' && e['gen_ai.step.id'] === stepId,
-      );
-      if (req) {
-        req.time_unix_nano = String(BigInt(seg.requestStartTs) * 1_000_000n);
-      }
-    }
-
-    // llm.response: use segment responseEndTs
+    // Timestamps are injected as a set, never piecemeal. A segment whose
+    // responseEndTs failed to parse would otherwise move llm.request onto the
+    // segment clock while llm.response stayed on the hook clock - inverting the
+    // two into a negative-duration span - and would stamp tool.call with
+    // BigInt(0), i.e. 1970. Exact-id pairing accepts such a segment for its
+    // usage, so this is reachable; the timestamp pass rejects it outright.
     if (seg.responseEndTs > 0) {
-      matches[0].time_unix_nano = String(BigInt(seg.responseEndTs) * 1_000_000n);
-    }
-
-    // Preserve per-tool hook timestamps when available. Segment timing has no
-    // tool ID, so it is only a fallback for legacy hook records.
-    if (stepId && seg.toolFinishedTs > 0) {
-      const toolCalls = entries.filter(e =>
-        e['event.name'] === 'tool.call' && e['gen_ai.step.id'] === stepId,
-      );
-      const toolResults = entries.filter(e =>
-        e['event.name'] === 'tool.result' && e['gen_ai.step.id'] === stepId,
-      );
-      const toolCallTs = String(BigInt(seg.responseEndTs) * 1_000_000n);
-      const toolResultTs = String(BigInt(seg.toolFinishedTs) * 1_000_000n);
-      const toolDurationMs = seg.responseEndTs > 0
-        ? seg.toolFinishedTs - seg.responseEndTs
-        : 0;
-      for (const tc of toolCalls) {
-        if (parseUnixNanos(tc.time_unix_nano) === undefined) {
-          tc.time_unix_nano = toolCallTs;
+      // llm.request: use segment requestStartTs
+      if (seg.requestStartTs > 0) {
+        const req = entries.find(e =>
+          e['event.name'] === 'llm.request' && e['gen_ai.step.id'] === stepId,
+        );
+        if (req) {
+          req.time_unix_nano = String(BigInt(seg.requestStartTs) * 1_000_000n);
         }
       }
-      for (const tr of toolResults) {
-        if (parseUnixNanos(tr.time_unix_nano) === undefined) {
-          tr.time_unix_nano = toolResultTs;
+
+      // llm.response: use segment responseEndTs
+      matches[0].time_unix_nano = String(BigInt(seg.responseEndTs) * 1_000_000n);
+
+      // Preserve per-tool hook timestamps when available. Segment timing has no
+      // tool ID, so it is only a fallback for legacy hook records.
+      if (stepId && seg.toolFinishedTs > 0) {
+        const toolCalls = entries.filter(e =>
+          e['event.name'] === 'tool.call' && e['gen_ai.step.id'] === stepId,
+        );
+        const toolResults = entries.filter(e =>
+          e['event.name'] === 'tool.result' && e['gen_ai.step.id'] === stepId,
+        );
+        const toolCallTs = String(BigInt(seg.responseEndTs) * 1_000_000n);
+        const toolResultTs = String(BigInt(seg.toolFinishedTs) * 1_000_000n);
+        const toolDurationMs = seg.toolFinishedTs - seg.responseEndTs;
+        for (const tc of toolCalls) {
+          if (parseUnixNanos(tc.time_unix_nano) === undefined) {
+            tc.time_unix_nano = toolCallTs;
+          }
         }
-        if (tr['gen_ai.tool.call.duration'] === undefined && toolDurationMs > 0) {
-          (tr as Record<string, unknown>)['gen_ai.tool.call.duration'] = toolDurationMs;
+        for (const tr of toolResults) {
+          if (parseUnixNanos(tr.time_unix_nano) === undefined) {
+            tr.time_unix_nano = toolResultTs;
+          }
+          if (tr['gen_ai.tool.call.duration'] === undefined && toolDurationMs > 0) {
+            (tr as Record<string, unknown>)['gen_ai.tool.call.duration'] = toolDurationMs;
+          }
         }
       }
     }
@@ -119,6 +135,108 @@ export function enrichCliTurn(
   // exact response-id match overrides native/legacy segment usage, but never
   // guesses by order or timestamp when ids differ.
   applyInterceptUsage(entries, interceptTokens);
+}
+
+/**
+ * Pair segments with the llm.response entries they describe.
+ *
+ * The hook copies the CLI's own request id onto agent.client_request_id, which
+ * is the same id a segment records, so that pairing is exact. Records written
+ * before the hook carried that field fall back to the response completion
+ * instant.
+ */
+function pairSegmentsWithResponses(
+  entries: AgentActivityEntry[],
+  segments: SegmentTokenData[],
+): { seg: SegmentTokenData; matches: AgentActivityEntry[] }[] {
+  // One provider response can be represented by several llm.response entries
+  // (separate thinking/text parts, or one hook row observed twice). Group them
+  // so a segment enriches every entry of the response it belongs to, and so a
+  // group consumes only one segment.
+  const groups = new Map<string, ResponseGroup>();
+  for (const entry of entries) {
+    if (entry['event.name'] !== 'llm.response') continue;
+    const nanos = parseUnixNanos(entry.time_unix_nano);
+    if (nanos === undefined) continue;
+    const responseId = entry['gen_ai.response.id'];
+    const key = typeof responseId === 'string' && responseId
+      ? `id:${responseId}`
+      : `step:${String(entry['gen_ai.step.id'] ?? '')}`;
+    const clientRequestId = readClientRequestId(entry);
+    const group = groups.get(key);
+    if (group) {
+      group.matches.push(entry);
+      if (!group.clientRequestId && clientRequestId) group.clientRequestId = clientRequestId;
+    } else {
+      groups.set(key, { matches: [entry], ms: Number(nanos / 1_000_000n), clientRequestId });
+    }
+  }
+  if (groups.size === 0) return [];
+
+  const usedSegments = new Set<SegmentTokenData>();
+  const usedKeys = new Set<string>();
+  const paired: { seg: SegmentTokenData; matches: AgentActivityEntry[] }[] = [];
+
+  // Pass A: exact id join. Deliberately not gated on responseEndTs, unlike the
+  // timestamp pass which cannot work without it - a segment that only carries
+  // usage still enriches tokens here.
+  const segmentsByRequestId = new Map<string, SegmentTokenData[]>();
+  for (const seg of segments) {
+    if (!seg.requestId) continue;
+    const list = segmentsByRequestId.get(seg.requestId);
+    if (list) list.push(seg);
+    else segmentsByRequestId.set(seg.requestId, [seg]);
+  }
+  for (const [key, group] of groups) {
+    if (!group.clientRequestId) continue;
+    const seg = segmentsByRequestId.get(group.clientRequestId)?.find(s => !usedSegments.has(s));
+    if (!seg) continue;
+    usedKeys.add(key);
+    usedSegments.add(seg);
+    paired.push({ seg, matches: group.matches });
+  }
+
+  // Pass B: whatever is left is matched on the response completion instant.
+  // Only records without the exact key take part. Every segment carries a
+  // request_id from the same namespace as agent.client_request_id, so a segment
+  // that Pass A did not claim for this group describes a different request -
+  // pairing it by proximity would copy another call's usage and clock onto this
+  // response. Segments with no counterpart in the batch (the CLI's own internal
+  // calls) are exactly what would be grabbed here.
+  const candidates: { key: string; seg: SegmentTokenData; delta: number }[] = [];
+  for (const [key, group] of groups) {
+    if (usedKeys.has(key) || group.clientRequestId) continue;
+    for (const seg of segments) {
+      if (seg.responseEndTs <= 0 || usedSegments.has(seg)) continue;
+      const delta = Math.abs(group.ms - seg.responseEndTs);
+      if (delta <= SEGMENT_JOIN_TOLERANCE_MS) candidates.push({ key, seg, delta });
+    }
+  }
+
+  // Closest pair wins globally and each side is consumed once, so a burst of
+  // near-simultaneous calls cannot collapse onto a single segment. Matching
+  // greedily in entry order would instead reject pairs a later entry owns.
+  candidates.sort((a, b) => a.delta - b.delta);
+  for (const candidate of candidates) {
+    if (usedKeys.has(candidate.key) || usedSegments.has(candidate.seg)) continue;
+    usedKeys.add(candidate.key);
+    usedSegments.add(candidate.seg);
+    paired.push({ seg: candidate.seg, matches: groups.get(candidate.key)!.matches });
+  }
+  return paired;
+}
+
+interface ResponseGroup {
+  matches: AgentActivityEntry[];
+  ms: number;
+  clientRequestId?: string;
+}
+
+// The CLI's own request id, written by the hook from the transcript's usage
+// object. Absent on records collected before the hook carried it.
+function readClientRequestId(entry: AgentActivityEntry): string | undefined {
+  const raw = (entry as Record<string, unknown>)['agent.client_request_id'];
+  return typeof raw === 'string' && raw ? raw : undefined;
 }
 
 function applyInterceptUsage(

--- a/src/inputs/qoder-trace/token-enricher.ts
+++ b/src/inputs/qoder-trace/token-enricher.ts
@@ -88,15 +88,18 @@ export function enrichCliTurn(
     // two into a negative-duration span - and would stamp tool.call with
     // BigInt(0), i.e. 1970. Exact-id pairing accepts such a segment for its
     // usage, so this is reachable; the timestamp pass rejects it outright.
-    if (seg.responseEndTs > 0) {
+    //
+    // requestStartTs === responseEndTs is rejected for the same reason: a
+    // request whose start could not be anchored would otherwise be published as
+    // an instantaneous span, which is worse than leaving it on the hook clock
+    // because it looks like a measurement rather than a gap.
+    if (seg.responseEndTs > 0 && seg.requestStartTs > 0 && seg.requestStartTs < seg.responseEndTs) {
       // llm.request: use segment requestStartTs
-      if (seg.requestStartTs > 0) {
-        const req = entries.find(e =>
-          e['event.name'] === 'llm.request' && e['gen_ai.step.id'] === stepId,
-        );
-        if (req) {
-          req.time_unix_nano = String(BigInt(seg.requestStartTs) * 1_000_000n);
-        }
+      const req = entries.find(e =>
+        e['event.name'] === 'llm.request' && e['gen_ai.step.id'] === stepId,
+      );
+      if (req) {
+        req.time_unix_nano = String(BigInt(seg.requestStartTs) * 1_000_000n);
       }
 
       // llm.response: use segment responseEndTs

--- a/src/normalization/finish-reason.ts
+++ b/src/normalization/finish-reason.ts
@@ -1,0 +1,42 @@
+// Segment records carry Anthropic's native stop_reason, but
+// gen_ai.response.finish_reasons is the normalized OTel GenAI enum — the same
+// one the transcript hook emits, so both collection paths must agree, including
+// on which values are dropped. The raw value stays reachable through
+// attributes.stop_reason, which entry-builder prefixes to agent.stop_reason.
+// Duplicated rather than imported from scripts/validate-trace.mjs: that is a dev
+// validator, not a runtime dependency of the collector. A unit test asserts the
+// two sets stay equal, so the copy cannot drift the way `cancelled` did.
+//
+// Lives here rather than next to one collection path because every producer that
+// stamps finish_reasons has to agree on the enum: the transcript hook, the
+// segment token enricher on the qoder-trace path, and any future input. A
+// per-input copy is how token-enricher ended up writing the raw stop_reason
+// straight through while the neighbouring path normalized it.
+export const VALID_FINISH_REASONS = new Set([
+  'stop',
+  'length',
+  'content_filter',
+  'tool_call',
+  'tool_calls',
+  'error',
+  'end_turn',
+  'max_tokens',
+  // Terminal in otlp-trace-flusher's TERMINAL_FINISH_REASONS and already emitted
+  // by the Codex and WorkBuddy paths, so it belongs in the enum.
+  'cancelled',
+]);
+
+const FINISH_REASON_ALIASES: Record<string, string> = {
+  tool_use: 'tool_call',
+  stop_sequence: 'stop',
+  refusal: 'stop',
+  model_context_window_exceeded: 'length',
+};
+
+export function normalizeFinishReason(reason: string): string | undefined {
+  const mapped = FINISH_REASON_ALIASES[reason] ?? reason;
+  // Unknown values are dropped, never coerced to `stop`: a mid-turn value such
+  // as pause_turn would then read as terminal and Signal A would flush the turn
+  // buffer early, trading a validator error for a fragmented trace.
+  return VALID_FINISH_REASONS.has(mapped) ? mapped : undefined;
+}

--- a/tests/integration/qoder-cli-segment-span-timing.test.ts
+++ b/tests/integration/qoder-cli-segment-span-timing.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { convertEventLogToReadableSpans, type EventLogRecord } from '@loongsuite/otel-util-genai';
+import type { AgentActivityEntry } from '../../src/types/index.js';
+
+let tmpHome: string = os.tmpdir();
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return {
+    ...actual,
+    homedir: () => tmpHome,
+    default: { ...actual, homedir: () => tmpHome },
+  };
+});
+
+const { readSegmentTokensForSession } = await import('../../src/inputs/qoder-trace/segment-token-reader.js');
+const { enrichCliTurn } = await import('../../src/inputs/qoder-trace/token-enricher.js');
+
+const SESSION = 'session-span-timing';
+const BASE = 1_780_000_000_000;
+
+function ns(ms: number): string {
+  return String(BigInt(ms) * 1_000_000n);
+}
+
+async function writeSegments(lines: object[]): Promise<void> {
+  const dir = path.join(tmpHome, '.qoder', 'logs', 'sessions', 'Users-someone-project', SESSION, 'segments');
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    path.join(dir, 'segment-0.jsonl'),
+    lines.map(l => JSON.stringify(l)).join('\n') + '\n',
+    'utf-8',
+  );
+}
+
+const base = {
+  trace_id: '1234567890abcdef1234567890abcdef',
+  'gen_ai.session.id': SESSION,
+  'gen_ai.turn.id': `${SESSION}:turn-1`,
+  'gen_ai.agent.type': 'qoder-cli',
+  'gen_ai.agent.id': SESSION,
+  'gen_ai.provider.name': 'anthropic',
+  'gen_ai.request.model': 'auto',
+};
+
+/**
+ * A qoder CLI step as the hook emits it: with no usable progress event the turn
+ * boundary collapses onto the assistant row, so llm.request and llm.response
+ * carry the *same* instant. Enrichment is the only thing that can give these
+ * spans a real width, which is exactly what this test pins down.
+ */
+function hookStep(stepId: string, clientRequestId: string, hookMs: number): AgentActivityEntry[] {
+  return [
+    { ...base, 'event.name': 'llm.request', time_unix_nano: ns(hookMs), 'gen_ai.step.id': stepId },
+    {
+      ...base,
+      'event.name': 'llm.response',
+      time_unix_nano: ns(hookMs),
+      'gen_ai.step.id': stepId,
+      'agent.client_request_id': clientRequestId,
+      'gen_ai.response.finish_reasons': ['stop'],
+    },
+  ] as unknown as AgentActivityEntry[];
+}
+
+function llmSpans(spans: readonly { attributes: Record<string, unknown>; startTime: [number, number]; endTime: [number, number] }[]) {
+  return spans.filter(s => s.attributes['gen_ai.step.id'] !== undefined || s.attributes['gen_ai.operation.name'] === 'chat');
+}
+
+function toMs(hr: [number, number]): number {
+  return hr[0] * 1_000 + Math.round(hr[1] / 1_000_000);
+}
+
+beforeEach(async () => {
+  tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'span-timing-'));
+  process.env.OTEL_SEMCONV_STABILITY_OPT_IN ??= 'gen_ai_latest_experimental';
+  process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT ??= 'SPAN_ONLY';
+});
+
+describe('qoder-cli segment span timing', () => {
+  // The whole point of joining segments: an LLM span must be as wide as the
+  // request the CLI actually measured, and a step whose start had to be
+  // reconstructed must not be published as an instant.
+  it('gives each LLM span the width its segment measured', async () => {
+    await writeSegments([
+      // step 1: ordinary request, exact start available
+      { type: 'loop.iteration.started', loop_id: 'turn-1:1', ts: BASE },
+      { type: 'model.request.started', request_id: 'req-1', loop_id: 'turn-1:1', ts: BASE + 4 },
+      {
+        type: 'model.response.completed', request_id: 'req-1', loop_id: 'turn-1:1', ts: BASE + 9_000,
+        data: { input_tokens: 100, output_tokens: 20, model: 'claude-sonnet-4' },
+      },
+      // step 2: first attempt times out, the retry never emits its own start
+      { type: 'loop.iteration.started', loop_id: 'turn-1:2', ts: BASE + 20_000 },
+      { type: 'model.request.started', request_id: 'req-2a', loop_id: 'turn-1:2', ts: BASE + 20_002 },
+      { type: 'model.request.attempt_failed', request_id: 'req-2a', loop_id: 'turn-1:2', ts: BASE + 80_028 },
+      {
+        type: 'model.response.completed', request_id: 'req-2b', loop_id: 'turn-1:2', ts: BASE + 88_127,
+        data: { input_tokens: 300, output_tokens: 40, model: 'claude-sonnet-4' },
+      },
+    ]);
+
+    const segments = await readSegmentTokensForSession(SESSION);
+    expect(segments.map(s => s.requestId)).toEqual(['req-1', 'req-2b']);
+
+    const entries = [
+      ...hookStep(`${SESSION}:turn-1:s1`, 'req-1', BASE + 9_000),
+      ...hookStep(`${SESSION}:turn-1:s2`, 'req-2b', BASE + 88_127),
+    ];
+    enrichCliTurn(entries, segments);
+
+    const result = await convertEventLogToReadableSpans(entries as unknown as EventLogRecord[], {
+      strict: false,
+      passthroughKeys: ['gen_ai.agent.id', 'agent.client_request_id'],
+    });
+
+    const spans = llmSpans(result.spans as never);
+    expect(spans.length).toBeGreaterThanOrEqual(2);
+
+    const durations = spans.map(s => toMs(s.endTime) - toMs(s.startTime)).sort((a, b) => a - b);
+    // exact start for step 1; attempt_failed anchor for the step 2 retry
+    expect(durations).toEqual([8_099, 8_996]);
+    for (const d of durations) expect(d).toBeGreaterThan(0);
+  });
+
+  // Publishing the completion instant as the start would look like a measured
+  // zero-length request. Leaving the hook clock in place keeps it an obvious gap.
+  it('leaves a step whose start cannot be anchored on the hook clock', async () => {
+    await writeSegments([
+      {
+        type: 'model.response.completed', request_id: 'req-orphan', ts: BASE + 5_000,
+        data: { input_tokens: 100, output_tokens: 20, model: 'claude-sonnet-4' },
+      },
+    ]);
+
+    const segments = await readSegmentTokensForSession(SESSION);
+    expect(segments[0].requestStartTs).toBe(0);
+
+    const entries = hookStep(`${SESSION}:turn-1:s1`, 'req-orphan', BASE + 1_234);
+    enrichCliTurn(entries, segments);
+
+    // usage still lands, only the timestamps are refused
+    expect(entries[1]['gen_ai.usage.input_tokens']).toBe(100);
+    for (const entry of entries) {
+      expect(entry.time_unix_nano).toBe(ns(BASE + 1_234));
+    }
+  });
+});

--- a/tests/unit/hooks/qoder-client-request-id.test.mjs
+++ b/tests/unit/hooks/qoder-client-request-id.test.mjs
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildLlmBoundaries,
+  buildEventsFromBoundaries,
+} from '../../../assets/hooks/qoder-hook-processor.mjs';
+import { projectLogEntry } from '../../../src/normalization/entry-builder.ts';
+
+// gen_ai.response.id carries the provider's response id, whose spelling changes
+// per provider (32-hex, uuid, chatcmpl-*, resp_*) and only coincidentally equals
+// a segment's request_id. message.usage.request_id is the CLI's own id and is
+// the same value a segment records, so the hook lifts it onto
+// agent.client_request_id for the token-enricher to join on.
+function userRow(text) {
+  return {
+    type: 'user',
+    timestamp: '2026-08-03T09:22:25.100000Z',
+    message: { role: 'user', content: text },
+  };
+}
+
+/** Streaming writes msg.id on the opening row and usage on the closing one. */
+function assistantRow(timestamp, message) {
+  return { type: 'assistant', timestamp, message: { role: 'assistant', ...message } };
+}
+
+function buildFrom(rows, progress = []) {
+  const boundaries = buildLlmBoundaries(progress, rows);
+  return buildEventsFromBoundaries(
+    boundaries, rows, rows, 'turn-1', 'session-1', 'qoder', {}, undefined,
+  );
+}
+
+function responses(records) {
+  return records.filter(record => record['event.name'] === 'llm.response');
+}
+
+describe('qoder hook agent.client_request_id', () => {
+  it('lifts usage.request_id off the row that closes the response', () => {
+    const records = buildFrom([
+      userRow('explain spans'),
+      assistantRow('2026-08-03T09:22:26.000000Z', {
+        id: 'resp_074f8158b56ee638016a968589ddb48193',
+        model: 'qwen-max',
+        content: [{ type: 'text', content: 'partial' , text: 'partial' }],
+      }),
+      assistantRow('2026-08-03T09:22:27.000000Z', {
+        model: 'qwen-max',
+        content: [{ type: 'text', text: 'done' }],
+        stop_reason: 'end_turn',
+        usage: {
+          input_tokens: 29194,
+          output_tokens: 43,
+          request_id: 'f2a2d7da-9bd0-4dd8-b144-195adc8ffc32',
+        },
+      }),
+    ]);
+
+    const [response] = responses(records);
+    expect(response['agent.client_request_id']).toBe('f2a2d7da-9bd0-4dd8-b144-195adc8ffc32');
+    // The provider id is still reported separately; the two are not interchangeable.
+    expect(response['gen_ai.response.id']).toBe('resp_074f8158b56ee638016a968589ddb48193');
+  });
+
+  it('reads the id when it shares a row with message.id', () => {
+    const records = buildFrom([
+      userRow('explain spans'),
+      assistantRow('2026-08-03T09:22:26.000000Z', {
+        id: '06e5b7b833c1b4c47d515d39c2acff8c',
+        model: 'qwen-max',
+        content: [{ type: 'text', text: 'done' }],
+        stop_reason: 'end_turn',
+        usage: { request_id: 'c034d35f-d7d1-41a8-9a14-d9681a0e2505' },
+      }),
+    ]);
+
+    expect(responses(records)[0]['agent.client_request_id'])
+      .toBe('c034d35f-d7d1-41a8-9a14-d9681a0e2505');
+  });
+
+  it('leaves the field absent when the transcript has no usage', () => {
+    const records = buildFrom([
+      userRow('explain spans'),
+      assistantRow('2026-08-03T09:22:26.000000Z', {
+        id: 'message-1',
+        model: 'qwen-max',
+        content: [{ type: 'text', text: 'done' }],
+        stop_reason: 'end_turn',
+      }),
+    ]);
+
+    expect(responses(records)[0]['agent.client_request_id']).toBeUndefined();
+  });
+
+  it('ignores a usage object without a usable request_id', () => {
+    for (const usage of [
+      { input_tokens: 10, output_tokens: 2 },
+      { request_id: '' },
+      { request_id: 42 },
+    ]) {
+      const records = buildFrom([
+        userRow('explain spans'),
+        assistantRow('2026-08-03T09:22:26.000000Z', {
+          id: 'message-1',
+          model: 'qwen-max',
+          content: [{ type: 'text', text: 'done' }],
+          stop_reason: 'end_turn',
+          usage,
+        }),
+      ]);
+      expect(responses(records)[0]['agent.client_request_id']).toBeUndefined();
+    }
+  });
+
+  it('gives each step of a turn its own client request id', () => {
+    const rows = [
+      userRow('run a tool then answer'),
+      assistantRow('2026-08-03T09:22:25.555446Z', {
+        id: 'resp_step_one',
+        model: 'qwen-max',
+        content: [{ type: 'tool_use', id: 'tool-b', name: 'Read', input: {} }],
+        stop_reason: 'tool_use',
+        usage: { request_id: 'cli-req-step-1' },
+      }),
+      {
+        type: 'user',
+        timestamp: '2026-08-03T09:22:26.668419Z',
+        message: {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'tool-b', content: 'ok' }],
+        },
+      },
+      assistantRow('2026-08-03T09:22:26.999890Z', {
+        id: 'resp_step_two',
+        model: 'qwen-max',
+        content: [{ type: 'text', text: 'done' }],
+        stop_reason: 'end_turn',
+        usage: { request_id: 'cli-req-step-2' },
+      }),
+    ];
+    const progress = [
+      { hookEvent: 'UserPromptSubmit', ts: '2026-08-03T09:22:25.000000Z' },
+      { hookEvent: 'PreToolUse', ts: '2026-08-03T09:22:25.996439Z' },
+      { hookEvent: 'PostToolUse', ts: '2026-08-03T09:22:26.999176Z' },
+      { hookEvent: 'Stop', ts: '2026-08-03T09:22:28.000000Z' },
+    ];
+
+    const found = responses(buildFrom(rows, progress))
+      .map(record => record['agent.client_request_id']);
+    expect(found).toEqual(['cli-req-step-1', 'cli-req-step-2']);
+  });
+
+  // AGENT_SCOPED_FIELD_RE in entry-builder.ts is /^agent\.[^.]+\..+$/ and both
+  // sls-flusher and jsonl-flusher serialise with dropAgentScopedFields: true, so
+  // an `agent.qoder.client_request_id` spelling would reach neither sink. Driven
+  // through the real serialiser rather than a copied regex, because a copied
+  // predicate is exactly what stops catching the divergence it guards.
+  it('spells the field so it survives flusher serialisation', () => {
+    const records = buildFrom([
+      userRow('explain spans'),
+      assistantRow('2026-08-03T09:22:26.000000Z', {
+        id: 'message-1',
+        model: 'qwen-max',
+        content: [{ type: 'text', text: 'done' }],
+        stop_reason: 'end_turn',
+        usage: { request_id: 'cli-req-A' },
+      }),
+    ]);
+    const response = responses(records)[0];
+    // Guards the assertion below: a sibling agent-scoped field has to be present
+    // on this very record for its absence after projection to mean anything.
+    expect(response['agent.qoder.match_ts']).toBeTypeOf('number');
+
+    const projected = projectLogEntry(response, { dropAgentScopedFields: true });
+    expect(projected['agent.client_request_id']).toBe('cli-req-A');
+    expect(projected['agent.qoder.match_ts']).toBeUndefined();
+  });
+});

--- a/tests/unit/inputs/qoder-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-trace-input.test.ts
@@ -27,6 +27,9 @@ import {
   type SqliteTokenData,
 } from '../../../src/inputs/qoder-trace/sqlite-token-reader.js';
 import { getTodayDateString } from '../../../src/utils/fs-utils.js';
+// The dev validator's enum, imported so a drift in the runtime copy fails here
+// rather than at collection time.
+import { VALID_FINISH_REASONS as VALIDATOR_FINISH_REASONS } from '../../../scripts/validate-trace.mjs';
 import { MockStateStore } from '../../helpers/mock-state-store.js';
 
 vi.mock('../../../src/inputs/qoder-trace/sqlite-token-reader.js', async (importOriginal) => {
@@ -65,15 +68,34 @@ function makeIntercept(overrides: Partial<InterceptTokenData> = {}): InterceptTo
   };
 }
 
+function makeSegment(overrides: Partial<SegmentTokenData> = {}): SegmentTokenData {
+  return {
+    requestId: 'req-A',
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    requestStartTs: 1780000000000,
+    responseEndTs: 1780000001000,
+    toolFinishedTs: 0,
+    stopReason: '',
+    model: '',
+    ...overrides,
+  };
+}
+
 describe('QoderTraceInput token-enricher', () => {
-  describe('enrichCliTurn (precise response_id match)', () => {
+  // Segments are paired with llm.response by completion instant, so a fixture's
+  // response time must sit within the join tolerance of its responseEndTs - the
+  // hook fires just after the response lands, 0-32ms later on real data.
+  describe('enrichCliTurn (segment paired by response completion time)', () => {
     it('injects tokens from segment into matching hook events', () => {
       // Simulate old processor output (time == observed → enricher overwrites timestamp)
       const entries: AgentActivityEntry[] = [
         makeEntry({
           'gen_ai.response.id': 'req-A',
           'event.name': 'llm.response',
-          time_unix_nano: '1780000001000000000',
+          time_unix_nano: '1780000002030000000',
           observed_time_unix_nano: '1780000001000000000',
         } as any),
       ];
@@ -103,7 +125,7 @@ describe('QoderTraceInput token-enricher', () => {
         makeEntry({
           'gen_ai.response.id': 'req-A',
           'event.name': 'llm.response',
-          time_unix_nano: '1780000005000000000',
+          time_unix_nano: '1780000002030000000',
           observed_time_unix_nano: '1780000009000000000',
         } as any),
       ];
@@ -129,8 +151,8 @@ describe('QoderTraceInput token-enricher', () => {
 
     it('only writes tokens to first response of same response.id (thinking+text)', () => {
       const entries: AgentActivityEntry[] = [
-        makeEntry({ 'gen_ai.response.id': 'req-A', 'event.name': 'llm.response', time_unix_nano: '1780000001000000000' }),
-        makeEntry({ 'gen_ai.response.id': 'req-A', 'event.name': 'llm.response', time_unix_nano: '1780000001500000000' }),
+        makeEntry({ 'gen_ai.response.id': 'req-A', 'event.name': 'llm.response', time_unix_nano: '1780000002000000000' }),
+        makeEntry({ 'gen_ai.response.id': 'req-A', 'event.name': 'llm.response', time_unix_nano: '1780000002010000000' }),
       ];
       const segments: SegmentTokenData[] = [{
         requestId: 'req-A',
@@ -156,7 +178,7 @@ describe('QoderTraceInput token-enricher', () => {
     it('injects real model name from segment into llm.request and llm.response', () => {
       const entries: AgentActivityEntry[] = [
         makeEntry({ 'gen_ai.response.id': 'req-A', 'event.name': 'llm.request', 'gen_ai.step.id': 'turn-1:s1', 'gen_ai.request.model': 'auto' } as any),
-        makeEntry({ 'gen_ai.response.id': 'req-A', 'event.name': 'llm.response', 'gen_ai.step.id': 'turn-1:s1', 'gen_ai.request.model': 'auto', 'gen_ai.response.model': 'auto' } as any),
+        makeEntry({ 'gen_ai.response.id': 'req-A', 'event.name': 'llm.response', 'gen_ai.step.id': 'turn-1:s1', 'gen_ai.request.model': 'auto', 'gen_ai.response.model': 'auto', time_unix_nano: '1780000002000000000' } as any),
       ];
       const segments: SegmentTokenData[] = [{
         requestId: 'req-A',
@@ -164,8 +186,9 @@ describe('QoderTraceInput token-enricher', () => {
         outputTokens: 200,
         cacheReadTokens: 0,
         cacheCreationTokens: 0,
+        // Left at 0 so no request timestamp is backfilled, isolating the model assertion.
         requestStartTs: 0,
-        responseEndTs: 0,
+        responseEndTs: 1780000002000,
         toolFinishedTs: 0,
         stopReason: '',
         model: 'ultimate',
@@ -180,7 +203,7 @@ describe('QoderTraceInput token-enricher', () => {
 
     it('does not override model when segment model is empty or unknown', () => {
       const entries: AgentActivityEntry[] = [
-        makeEntry({ 'gen_ai.response.id': 'req-A', 'event.name': 'llm.response', 'gen_ai.request.model': 'auto' } as any),
+        makeEntry({ 'gen_ai.response.id': 'req-A', 'event.name': 'llm.response', 'gen_ai.request.model': 'auto', time_unix_nano: '1780000002000000000' } as any),
       ];
       const segments: SegmentTokenData[] = [{
         requestId: 'req-A',
@@ -189,7 +212,7 @@ describe('QoderTraceInput token-enricher', () => {
         cacheReadTokens: 0,
         cacheCreationTokens: 0,
         requestStartTs: 0,
-        responseEndTs: 0,
+        responseEndTs: 1780000002000,
         toolFinishedTs: 0,
         stopReason: '',
         model: '',
@@ -242,6 +265,7 @@ describe('QoderTraceInput token-enricher', () => {
           'gen_ai.usage.input_tokens': 10,
           'gen_ai.usage.output_tokens': 1,
           'gen_ai.usage.total_tokens': 11,
+          time_unix_nano: '1780000002000000000',
         }),
       ];
       const segments: SegmentTokenData[] = [{
@@ -251,7 +275,7 @@ describe('QoderTraceInput token-enricher', () => {
         cacheReadTokens: 3000,
         cacheCreationTokens: 100,
         requestStartTs: 0,
-        responseEndTs: 0,
+        responseEndTs: 1780000002000,
         toolFinishedTs: 0,
         stopReason: '',
         model: '',
@@ -272,6 +296,7 @@ describe('QoderTraceInput token-enricher', () => {
           'gen_ai.usage.input_tokens': 700,
           'gen_ai.usage.output_tokens': 30,
           'gen_ai.usage.total_tokens': 730,
+          time_unix_nano: '1780000002000000000',
         }),
       ];
       const segments: SegmentTokenData[] = [{
@@ -281,7 +306,7 @@ describe('QoderTraceInput token-enricher', () => {
         cacheReadTokens: 3000,
         cacheCreationTokens: 0,
         requestStartTs: 0,
-        responseEndTs: 0,
+        responseEndTs: 1780000002000,
         toolFinishedTs: 0,
         stopReason: '',
         model: '',
@@ -352,6 +377,272 @@ describe('QoderTraceInput token-enricher', () => {
       expect(entries[1].time_unix_nano).toBe(ms(base + 201));
       expect(entries[2].time_unix_nano).toBe(ms(base + 4201));
       expect(entries[2]['gen_ai.tool.call.duration']).toBe(4000);
+    });
+
+    // Segments carry Anthropic's native stop_reason, but finish_reasons is the
+    // OTel GenAI enum. This path used to write the raw value through, so a
+    // segment could put tool_use / stop_sequence on a span while the transcript
+    // hook normalized the very same reason.
+    it('maps vendor stop_reason spellings onto the OTel finish_reason enum', () => {
+      const cases: Array<[string, string]> = [
+        ['tool_use', 'tool_call'],
+        ['stop_sequence', 'stop'],
+        ['refusal', 'stop'],
+        ['model_context_window_exceeded', 'length'],
+      ];
+
+      for (const [raw, expected] of cases) {
+        const entries: AgentActivityEntry[] = [
+          makeEntry({ 'gen_ai.response.id': 'req-A', 'event.name': 'llm.response' } as any),
+        ];
+        enrichCliTurn(entries, [makeSegment({ stopReason: raw })]);
+        expect(entries[0]['gen_ai.response.finish_reasons']).toEqual([expected]);
+      }
+    });
+
+    // Dropped rather than coerced to `stop`: pause_turn is mid-turn, and reading
+    // it as terminal would make Signal A flush the turn buffer early, trading a
+    // validator error for a fragmented trace.
+    it('leaves finish_reasons absent for stop_reasons outside the enum', () => {
+      for (const raw of ['pause_turn', 'some_future_reason']) {
+        const entries: AgentActivityEntry[] = [
+          makeEntry({ 'gen_ai.response.id': 'req-A', 'event.name': 'llm.response' } as any),
+        ];
+        enrichCliTurn(entries, [makeSegment({ stopReason: raw })]);
+        expect(entries[0]['gen_ai.response.finish_reasons']).toBeUndefined();
+      }
+    });
+
+    it('never emits a finish_reason the trace validator rejects', () => {
+      const entries: AgentActivityEntry[] = [
+        makeEntry({ 'gen_ai.response.id': 'req-A', 'event.name': 'llm.response' } as any),
+      ];
+      enrichCliTurn(entries, [makeSegment({ stopReason: 'tool_use' })]);
+      const reasons = entries[0]['gen_ai.response.finish_reasons'] as string[];
+      for (const reason of reasons) {
+        expect(VALIDATOR_FINISH_REASONS).toContain(reason);
+      }
+    });
+  });
+
+  // agent.client_request_id carries the CLI's own request id, the same id a
+  // segment records, so pairing no longer depends on the two clocks agreeing.
+  // The timestamp pass above stays for JSONL written before the hook had it.
+  describe('enrichCliTurn (segment paired by agent.client_request_id)', () => {
+    it('pairs on the client request id even when the clocks are far apart', () => {
+      const entries: AgentActivityEntry[] = [
+        makeEntry({
+          'gen_ai.response.id': 'resp_provider_A',
+          'event.name': 'llm.response',
+          'agent.client_request_id': 'cli-req-A',
+          // 30s away: the timestamp pass would reject this outright.
+          time_unix_nano: '1780000032000000000',
+        } as any),
+      ];
+      const segments = [makeSegment({
+        requestId: 'cli-req-A',
+        inputTokens: 5000,
+        outputTokens: 200,
+        cacheReadTokens: 3000,
+        requestStartTs: 1780000000000,
+        responseEndTs: 1780000002000,
+      })];
+
+      enrichCliTurn(entries, segments);
+
+      expect(entries[0]['gen_ai.usage.input_tokens']).toBe(5000);
+      expect(entries[0].time_unix_nano).toBe(String(BigInt(1780000002000) * 1_000_000n));
+    });
+
+    // The whole point of the exact key: a burst of calls closer together than
+    // the tolerance can no longer be attributed to the wrong segment.
+    it('keeps near-simultaneous responses on their own segments', () => {
+      const ms = (value: number) => String(BigInt(value) * 1_000_000n);
+      const base = 1_780_000_000_000;
+      const entries: AgentActivityEntry[] = [
+        makeEntry({
+          'gen_ai.response.id': 'resp_A',
+          'gen_ai.step.id': 'turn-1:s1',
+          'agent.client_request_id': 'cli-req-A',
+          time_unix_nano: ms(base + 10),
+        } as any),
+        makeEntry({
+          'gen_ai.response.id': 'resp_B',
+          'gen_ai.step.id': 'turn-1:s2',
+          'agent.client_request_id': 'cli-req-B',
+          time_unix_nano: ms(base + 12),
+        } as any),
+      ];
+      // Deliberately inverted: B's segment is nearer to A's response time, so a
+      // purely temporal match would swap the two.
+      const segments = [
+        makeSegment({ requestId: 'cli-req-A', inputTokens: 100, outputTokens: 1, responseEndTs: base + 40 }),
+        makeSegment({ requestId: 'cli-req-B', inputTokens: 200, outputTokens: 2, responseEndTs: base + 11 }),
+      ];
+
+      enrichCliTurn(entries, segments);
+
+      expect(entries[0]['gen_ai.usage.input_tokens']).toBe(100);
+      expect(entries[1]['gen_ai.usage.input_tokens']).toBe(200);
+      expect(entries[0].time_unix_nano).toBe(ms(base + 40));
+      expect(entries[1].time_unix_nano).toBe(ms(base + 11));
+    });
+
+    it('falls back to the timestamp pass for entries without the id', () => {
+      const ms = (value: number) => String(BigInt(value) * 1_000_000n);
+      const base = 1_780_000_000_000;
+      const entries: AgentActivityEntry[] = [
+        makeEntry({
+          'gen_ai.response.id': 'resp_A',
+          'gen_ai.step.id': 'turn-1:s1',
+          'agent.client_request_id': 'cli-req-A',
+          time_unix_nano: ms(base + 5000),
+        } as any),
+        makeEntry({
+          'gen_ai.response.id': 'resp_legacy',
+          'gen_ai.step.id': 'turn-1:s2',
+          time_unix_nano: ms(base + 20),
+        } as any),
+      ];
+      const segments = [
+        makeSegment({ requestId: 'cli-req-A', inputTokens: 100, outputTokens: 1, responseEndTs: base + 9000 }),
+        makeSegment({ requestId: 'cli-req-legacy', inputTokens: 200, outputTokens: 2, responseEndTs: base + 30 }),
+      ];
+
+      enrichCliTurn(entries, segments);
+
+      expect(entries[0]['gen_ai.usage.input_tokens']).toBe(100);
+      expect(entries[1]['gen_ai.usage.input_tokens']).toBe(200);
+    });
+
+    // A segment already claimed by an exact match must not be reused by the
+    // fallback, otherwise one provider call's usage lands on two spans.
+    it('does not let the timestamp pass re-consume an exactly matched segment', () => {
+      const ms = (value: number) => String(BigInt(value) * 1_000_000n);
+      const base = 1_780_000_000_000;
+      const entries: AgentActivityEntry[] = [
+        makeEntry({
+          'gen_ai.response.id': 'resp_A',
+          'gen_ai.step.id': 'turn-1:s1',
+          'agent.client_request_id': 'cli-req-A',
+          time_unix_nano: ms(base + 5000),
+        } as any),
+        makeEntry({
+          'gen_ai.response.id': 'resp_legacy',
+          'gen_ai.step.id': 'turn-1:s2',
+          time_unix_nano: ms(base + 20),
+        } as any),
+      ];
+      const segments = [makeSegment({
+        requestId: 'cli-req-A',
+        inputTokens: 100,
+        outputTokens: 1,
+        responseEndTs: base + 20,
+      })];
+
+      enrichCliTurn(entries, segments);
+
+      expect(entries[0]['gen_ai.usage.input_tokens']).toBe(100);
+      expect(entries[1]['gen_ai.usage.input_tokens']).toBeUndefined();
+      expect(entries[1].time_unix_nano).toBe(ms(base + 20));
+    });
+
+    // Both ids come from the CLI's own namespace, so a segment carrying a
+    // different one provably belongs to another request. The CLI makes internal
+    // calls (title generation) whose segments have no response in the batch, and
+    // proximity alone would happily attribute one of those to this response.
+    it('does not fall back to proximity when the exact key found no segment', () => {
+      const entries: AgentActivityEntry[] = [
+        makeEntry({
+          'gen_ai.response.id': 'resp_A',
+          'agent.client_request_id': 'cli-req-missing',
+          time_unix_nano: '1780000002000000000',
+        } as any),
+      ];
+      const segments = [makeSegment({
+        requestId: 'cli-req-other',
+        inputTokens: 100,
+        outputTokens: 1,
+        responseEndTs: 1780000002000,
+      })];
+
+      enrichCliTurn(entries, segments);
+
+      expect(entries[0]['gen_ai.usage.input_tokens']).toBeUndefined();
+      expect(entries[0].time_unix_nano).toBe('1780000002000000000');
+    });
+
+    // Exact pairing accepts a segment whose timestamps failed to parse, so the
+    // timestamp injection has to stand on its own guard: moving llm.response onto
+    // a zero clock would put it before its llm.request (negative-duration span)
+    // and stamp tool.call at 1970.
+    it('takes usage from a segment with unparseable timestamps without moving any clock', () => {
+      const hookTs = '1780000099000000000';
+      const entries: AgentActivityEntry[] = [
+        makeEntry({
+          'event.name': 'llm.request',
+          'gen_ai.step.id': 'turn-1:s1',
+          time_unix_nano: hookTs,
+        } as any),
+        makeEntry({
+          'gen_ai.response.id': 'resp_A',
+          'gen_ai.step.id': 'turn-1:s1',
+          'agent.client_request_id': 'cli-req-A',
+          time_unix_nano: hookTs,
+        } as any),
+        makeEntry({
+          'event.name': 'tool.call',
+          'gen_ai.step.id': 'turn-1:s1',
+          time_unix_nano: hookTs,
+        } as any),
+      ];
+      const segments = [makeSegment({
+        requestId: 'cli-req-A',
+        inputTokens: 5000,
+        outputTokens: 200,
+        requestStartTs: 0,
+        responseEndTs: 0,
+        toolFinishedTs: 0,
+      })];
+
+      enrichCliTurn(entries, segments);
+
+      expect(entries[1]['gen_ai.usage.input_tokens']).toBe(5000);
+      for (const entry of entries) {
+        expect(entry.time_unix_nano).toBe(hookTs);
+      }
+    });
+
+    // Segment usage is zero on current qodercli releases; timestamps are the
+    // reason to pair at all, so an all-zero segment must still be joined.
+    it('joins a zero-usage segment for its timestamps', () => {
+      const entries: AgentActivityEntry[] = [
+        makeEntry({
+          'gen_ai.response.id': 'resp_A',
+          'gen_ai.step.id': 'turn-1:s1',
+          'agent.client_request_id': 'cli-req-A',
+          'gen_ai.usage.input_tokens': 700,
+          'gen_ai.usage.output_tokens': 30,
+          time_unix_nano: '1780000099000000000',
+        } as any),
+        makeEntry({
+          'event.name': 'llm.request',
+          'gen_ai.step.id': 'turn-1:s1',
+          time_unix_nano: '1780000099000000000',
+        } as any),
+      ];
+      const segments = [makeSegment({
+        requestId: 'cli-req-A',
+        requestStartTs: 1780000000000,
+        responseEndTs: 1780000002000,
+      })];
+
+      enrichCliTurn(entries, segments);
+
+      // Native usage is preserved, timing comes from the segment.
+      expect(entries[0]['gen_ai.usage.input_tokens']).toBe(700);
+      expect(entries[0].time_unix_nano).toBe(String(BigInt(1780000002000) * 1_000_000n));
+      expect(entries[1].time_unix_nano).toBe(String(BigInt(1780000000000) * 1_000_000n));
     });
   });
 

--- a/tests/unit/inputs/segment-token-reader-cache.test.ts
+++ b/tests/unit/inputs/segment-token-reader-cache.test.ts
@@ -105,4 +105,30 @@ describe('readSegmentTokensForSession cache invalidation', () => {
   it('returns nothing when the session has no segments directory', async () => {
     expect(await readSegmentTokensForSession(nextSessionId())).toEqual([]);
   });
+
+  // A file we could not open still has a valid size+mtime stamp, so caching that
+  // parse would pin the gap behind a fingerprint claiming the data is current.
+  // collect() calls this once per turn, so every remaining turn of the batch
+  // would inherit the same missing requests until the CLI happened to append.
+  // root ignores file modes, so the denial cannot be staged there.
+  it.skipIf(process.getuid?.() === 0)(
+    'does not cache a parse that could not read every file',
+    async () => {
+      const sessionId = nextSessionId();
+      await writeSegments(sessionId, requestPair('req-a', 1_780_000_000_000, 1_780_000_005_000, 100));
+      const blocked = await writeSegments(
+        sessionId,
+        requestPair('req-b', 1_780_000_010_000, 1_780_000_016_000, 250),
+        'segment-1.jsonl',
+      );
+
+      await fs.chmod(blocked, 0o000);
+      const during = await readSegmentTokensForSession(sessionId);
+      expect(during.map(s => s.requestId)).toEqual(['req-a']);
+
+      await fs.chmod(blocked, 0o644);
+      const after = await readSegmentTokensForSession(sessionId);
+      expect(after.map(s => s.requestId)).toEqual(['req-a', 'req-b']);
+    },
+  );
 });

--- a/tests/unit/inputs/segment-token-reader-cache.test.ts
+++ b/tests/unit/inputs/segment-token-reader-cache.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+let tmpHome: string = os.tmpdir();
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return {
+    ...actual,
+    homedir: () => tmpHome,
+    default: { ...actual, homedir: () => tmpHome },
+  };
+});
+
+const { readSegmentTokensForSession } = await import('../../../src/inputs/qoder-trace/segment-token-reader.js');
+
+let sessionCounter = 0;
+
+/** ~/.qoder/logs/sessions/<cwd>/<sessionId>/segments/ */
+function segmentsDir(sessionId: string, cwd = 'Users-someone-project'): string {
+  return path.join(tmpHome, '.qoder', 'logs', 'sessions', cwd, sessionId, 'segments');
+}
+
+function requestPair(requestId: string, startTs: number, endTs: number, inputTokens: number): string {
+  return [
+    JSON.stringify({ type: 'model.request.started', request_id: requestId, ts: startTs }),
+    JSON.stringify({
+      type: 'model.response.completed',
+      request_id: requestId,
+      ts: endTs,
+      data: { input_tokens: inputTokens, output_tokens: 20, model: 'claude-sonnet-4' },
+    }),
+  ].join('\n') + '\n';
+}
+
+async function writeSegments(sessionId: string, body: string, name = 'segment-0.jsonl'): Promise<string> {
+  const dir = segmentsDir(sessionId);
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, name);
+  await fs.writeFile(filePath, body, 'utf-8');
+  return filePath;
+}
+
+beforeEach(async () => {
+  tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'segment-cache-'));
+  sessionCounter += 1;
+});
+
+function nextSessionId(): string {
+  return `session-${sessionCounter}-${Math.random().toString(16).slice(2)}`;
+}
+
+describe('readSegmentTokensForSession cache invalidation', () => {
+  // The regression this guards: the CLI appends a turn's segments while pilot is
+  // already polling, so a cache keyed on elapsed time hands back a snapshot that
+  // predates those records. Every request id of that turn then finds no segment,
+  // and its LLM span keeps the hook's identical start/end - a zero-width span.
+  it('sees records appended right after a previous read', async () => {
+    const sessionId = nextSessionId();
+    const filePath = await writeSegments(sessionId, requestPair('req-turn-1', 1_780_000_000_000, 1_780_000_005_000, 100));
+
+    const first = await readSegmentTokensForSession(sessionId);
+    expect(first.map(s => s.requestId)).toEqual(['req-turn-1']);
+
+    await fs.appendFile(filePath, requestPair('req-turn-2', 1_780_000_020_000, 1_780_000_029_000, 700), 'utf-8');
+
+    const second = await readSegmentTokensForSession(sessionId);
+    expect(second.map(s => s.requestId)).toEqual(['req-turn-1', 'req-turn-2']);
+    const turn2 = second.find(s => s.requestId === 'req-turn-2');
+    expect(turn2?.inputTokens).toBe(700);
+    expect(turn2?.requestStartTs).toBe(1_780_000_020_000);
+    expect(turn2?.responseEndTs).toBe(1_780_000_029_000);
+  });
+
+  it('picks up a segment file added after a previous read', async () => {
+    const sessionId = nextSessionId();
+    await writeSegments(sessionId, requestPair('req-a', 1_780_000_000_000, 1_780_000_005_000, 100));
+
+    await readSegmentTokensForSession(sessionId);
+
+    await writeSegments(
+      sessionId,
+      requestPair('req-b', 1_780_000_040_000, 1_780_000_046_000, 250),
+      'segment-1.jsonl',
+    );
+
+    const second = await readSegmentTokensForSession(sessionId);
+    expect(second.map(s => s.requestId)).toEqual(['req-a', 'req-b']);
+  });
+
+  // Reuse still matters: a single poll cycle calls this once per turn, and
+  // re-parsing every file each time would be wasted work.
+  it('reuses the parsed result while the files are untouched', async () => {
+    const sessionId = nextSessionId();
+    await writeSegments(sessionId, requestPair('req-a', 1_780_000_000_000, 1_780_000_005_000, 100));
+
+    const first = await readSegmentTokensForSession(sessionId);
+    const second = await readSegmentTokensForSession(sessionId);
+
+    expect(second).toBe(first);
+  });
+
+  it('returns nothing when the session has no segments directory', async () => {
+    expect(await readSegmentTokensForSession(nextSessionId())).toEqual([]);
+  });
+});

--- a/tests/unit/inputs/segment-token-reader-request-start.test.ts
+++ b/tests/unit/inputs/segment-token-reader-request-start.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+let tmpHome: string = os.tmpdir();
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return {
+    ...actual,
+    homedir: () => tmpHome,
+    default: { ...actual, homedir: () => tmpHome },
+  };
+});
+
+const { readSegmentTokensForSession } = await import('../../../src/inputs/qoder-trace/segment-token-reader.js');
+
+let sessionCounter = 0;
+
+function nextSessionId(): string {
+  return `session-${sessionCounter}-${Math.random().toString(16).slice(2)}`;
+}
+
+async function writeSegments(sessionId: string, lines: object[]): Promise<void> {
+  const dir = path.join(tmpHome, '.qoder', 'logs', 'sessions', 'Users-someone-project', sessionId, 'segments');
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    path.join(dir, 'segment-0.jsonl'),
+    lines.map(l => JSON.stringify(l)).join('\n') + '\n',
+    'utf-8',
+  );
+}
+
+const completed = (requestId: string, loopId: string | undefined, ts: number) => ({
+  type: 'model.response.completed',
+  request_id: requestId,
+  ...(loopId ? { loop_id: loopId } : {}),
+  ts,
+  data: { input_tokens: 100, output_tokens: 20, model: 'claude-sonnet-4' },
+});
+
+beforeEach(async () => {
+  tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'segment-start-'));
+  sessionCounter += 1;
+});
+
+// A CLI request that times out is retried under a brand new request_id, and the
+// retry emits model.response.completed without its own model.request.started.
+// The old fallback used the completion instant as the start, so enrichment itself
+// manufactured requestStartTs === responseEndTs - a zero-width LLM span that
+// looks like a measured instant rather than a missing measurement.
+describe('readSegmentTokensForSession request start anchoring', () => {
+  it('prefers the exact model.request.started for the same request id', async () => {
+    const sessionId = nextSessionId();
+    await writeSegments(sessionId, [
+      { type: 'loop.iteration.started', loop_id: 'turn-1:1', ts: 1_780_000_000_000 },
+      { type: 'model.request.started', request_id: 'req-a', loop_id: 'turn-1:1', ts: 1_780_000_000_004 },
+      completed('req-a', 'turn-1:1', 1_780_000_009_000),
+    ]);
+
+    const [seg] = await readSegmentTokensForSession(sessionId);
+    expect(seg.requestStartTs).toBe(1_780_000_000_004);
+    expect(seg.responseEndTs).toBe(1_780_000_009_000);
+  });
+
+  // The failure of the attempt being replaced is the tightest available bound on
+  // the retry's own start: anchoring on the iteration instead would swallow the
+  // whole timeout of the attempt that never returned.
+  it('anchors a retry on the attempt_failed it replaces, not on the iteration', async () => {
+    const sessionId = nextSessionId();
+    await writeSegments(sessionId, [
+      { type: 'loop.iteration.started', loop_id: 'turn-1:1', ts: 1_780_000_000_000 },
+      { type: 'model.request.started', request_id: 'req-first', loop_id: 'turn-1:1', ts: 1_780_000_000_002 },
+      { type: 'model.request.attempt_failed', request_id: 'req-first', loop_id: 'turn-1:1', ts: 1_780_000_060_026 },
+      // the retry never emits model.request.started
+      completed('req-retry', 'turn-1:1', 1_780_000_068_125),
+    ]);
+
+    const [seg] = await readSegmentTokensForSession(sessionId);
+    expect(seg.requestId).toBe('req-retry');
+    expect(seg.requestStartTs).toBe(1_780_000_060_026);
+    expect(seg.responseEndTs - seg.requestStartTs).toBe(8_099);
+  });
+
+  it('falls back to the loop iteration when nothing failed before it', async () => {
+    const sessionId = nextSessionId();
+    await writeSegments(sessionId, [
+      { type: 'loop.iteration.started', loop_id: 'turn-1:1', ts: 1_780_000_000_000 },
+      completed('req-orphan', 'turn-1:1', 1_780_000_007_500),
+    ]);
+
+    const [seg] = await readSegmentTokensForSession(sessionId);
+    expect(seg.requestStartTs).toBe(1_780_000_000_000);
+    expect(seg.responseEndTs - seg.requestStartTs).toBe(7_500);
+  });
+
+  // Each iteration owns exactly one loop_id, so an anchor is never borrowed from
+  // a neighbouring request.
+  it('anchors each completion on its own iteration', async () => {
+    const sessionId = nextSessionId();
+    await writeSegments(sessionId, [
+      { type: 'loop.iteration.started', loop_id: 'turn-1:1', ts: 1_780_000_000_000 },
+      completed('req-1', 'turn-1:1', 1_780_000_003_000),
+      { type: 'loop.iteration.started', loop_id: 'turn-1:2', ts: 1_780_000_020_000 },
+      completed('req-2', 'turn-1:2', 1_780_000_024_000),
+    ]);
+
+    const segs = await readSegmentTokensForSession(sessionId);
+    expect(segs.map(s => s.requestStartTs)).toEqual([1_780_000_000_000, 1_780_000_020_000]);
+  });
+
+  // Reporting "unknown" lets the enricher leave the hook clock alone; reporting
+  // the completion instant would publish an instantaneous span instead.
+  it('reports an unknown start rather than a degenerate one', async () => {
+    const sessionId = nextSessionId();
+    await writeSegments(sessionId, [completed('req-no-anchor', undefined, 1_780_000_005_000)]);
+
+    const [seg] = await readSegmentTokensForSession(sessionId);
+    expect(seg.requestStartTs).toBe(0);
+    expect(seg.requestStartTs).not.toBe(seg.responseEndTs);
+  });
+
+  it('never returns a start equal to its own end', async () => {
+    const sessionId = nextSessionId();
+    await writeSegments(sessionId, [
+      { type: 'loop.iteration.started', loop_id: 'turn-1:1', ts: 1_780_000_000_000 },
+      completed('req-a', 'turn-1:1', 1_780_000_004_000),
+      completed('req-b', 'turn-2:1', 1_780_000_008_000),
+      completed('req-c', undefined, 1_780_000_012_000),
+    ]);
+
+    for (const seg of await readSegmentTokensForSession(sessionId)) {
+      expect(seg.requestStartTs).not.toBe(seg.responseEndTs);
+    }
+  });
+});

--- a/tests/unit/normalization/finish-reason.test.ts
+++ b/tests/unit/normalization/finish-reason.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { VALID_FINISH_REASONS, normalizeFinishReason } from '../../../src/normalization/finish-reason.js';
+import { VALID_FINISH_REASONS as VALIDATOR_FINISH_REASONS } from '../../../scripts/validate-trace.mjs';
+
+describe('normalizeFinishReason', () => {
+  it('keeps its finish-reason allowlist equal to the trace validator\'s', () => {
+    // The collector must not depend on scripts/validate-trace.mjs at runtime, so
+    // the set is duplicated. This asserts the duplicate cannot drift: an allowlist
+    // narrower than the validator's silently drops valid finish reasons, and a
+    // wider one emits values the validator rejects.
+    expect([...VALID_FINISH_REASONS].sort()).toEqual([...VALIDATOR_FINISH_REASONS].sort());
+  });
+
+  it('maps vendor spellings onto the OTel GenAI enum', () => {
+    expect(normalizeFinishReason('tool_use')).toBe('tool_call');
+    expect(normalizeFinishReason('stop_sequence')).toBe('stop');
+    expect(normalizeFinishReason('refusal')).toBe('stop');
+    expect(normalizeFinishReason('model_context_window_exceeded')).toBe('length');
+  });
+
+  it('passes through values already in the enum', () => {
+    for (const reason of VALID_FINISH_REASONS) {
+      expect(normalizeFinishReason(reason as string)).toBe(reason);
+    }
+  });
+
+  it('drops unknown values instead of coercing them to a terminal reason', () => {
+    // pause_turn is mid-turn. Coercing it to `stop` would read as terminal and
+    // flush the turn buffer early, trading a validator error for a split trace.
+    expect(normalizeFinishReason('pause_turn')).toBeUndefined();
+    expect(normalizeFinishReason('some_future_reason')).toBeUndefined();
+    expect(normalizeFinishReason('')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

93% of the LLM spans produced for Qoder CLI were zero-width (`start == end`, 1ms).

The Stop hook replays a whole turn at once, so every entry it writes shares one
timestamp, and an LLM span takes its start/end straight from the `llm.request` /
`llm.response` pair. Real timing only exists in the CLI's own segment files
(`model.request.started` / `model.response.completed`), so the span durations can
only be recovered if entries and segments can be joined reliably.

Two layers were in the way:

1. The hook never read `msg.usage.request_id`, so the only join key available was
   `gen_ai.response.id` — the provider's id, a different namespace from a
   segment's `request_id`. Pairing could therefore only guess by timestamp.
2. `segment-token-reader` invalidated its cache on a 60s time TTL while the input
   polls every 30s, so a poll would reuse a snapshot taken before the newest
   segment existed.

Layer 2 is the one that is easy to miss: fixing only layer 1 still left ~40% of
the LLM spans zero-width.

## Fix

- **hook** — read the CLI's own request id from `msg.usage.request_id` on the row
  that closes a streamed response (`msg.id` lands on the first row, so the two
  cannot come from the same row) and emit it as `agent.client_request_id`.
  Single segment after `agent.` on purpose: `AGENT_SCOPED_FIELD_RE` drops
  three-segment `agent.*` fields in both the SLS and JSONL flushers.
- **token-enricher** — join on that id first, and fall back to the ±50ms window
  only for records that carry no id.
- **segment-token-reader** — invalidate the cache on a content fingerprint
  instead of a wall-clock TTL, so a snapshot can never outlive the file it
  describes.
- **finish-reason** — extract `normalizeFinishReason` into
  `src/normalization/finish-reason.ts`, sharing one allowlist with
  `scripts/validate-trace.mjs`. Unknown values are dropped rather than coerced to
  `stop`, so a mid-turn value such as `pause_turn` cannot read as terminal and
  make Signal A flush the turn buffer early.

## Validation

Built from this branch and deployed, then exercised with real `qodercli` runs —
48 LLM calls across 5 traces:

| span kind | n | zero-width | ms min/med/max |
|---|---|---|---|
| AGENT | 5 | 0 (0%) | 6078 / 16792 / 249436 |
| ENTRY | 5 | 0 (0%) | 6078 / 16792 / 249436 |
| LLM | 48 | 0 (0%) | 1493 / 2294 / 14456 |
| STEP | 48 | 0 (0%) | 2263 / 6167 / 21427 |
| TOOL | 66 | 0 (0%) | 517 / 2890 / 11930 |

- **Injected duration equals segment truth 48/48**, to the millisecond
  (`model.response.completed` − `model.request.started` per request id). This
  rules out timestamps that merely look plausible.
- **`agent.client_request_id` matches a segment `request_id` 48/48**, a bijection
  with no unmatched id on either side, and all 48 have a `model.request.started`.
- Segment responses and `llm.response` entries agree exactly (48 ↔ 48): no loss,
  no duplication. The turns span three separate 30s poll cycles, so the
  fingerprint invalidation is genuinely exercised.
- Both export service names carry identical timing (172 matching span keys, no
  divergence), 0 parent/child window violations, 0 duplicate span ids.
- `agent.client_request_id` never reaches span attributes — it stays an internal
  join key.
- No ERROR or WARN after deployment and no new `otlp-failed` entries, so the data
  comes from the normal path rather than a fallback.

## Cross-agent impact

`qoder-hook-processor.mjs` is also delegated to by the Qoder CN hook, so the
15 added lines do run on that path. They are inert there:

- CN only imports `enrichIdeTurn` and `injectTraceId` from `token-enricher`, and
  both function bodies are byte-identical to `main` (verified by hash).
- The IDE/CN transcript format has no `usage` object at all — 0 occurrences
  across ~15,000 assistant rows on disk — so the guard's first condition fails,
  `clientRequestId` stays `undefined`, and `JSON.stringify` omits the key.
- Measured after deployment: `agent.client_request_id` is absent (not even as a
  key) from every `qoder`, `qoder-work` and `codex` record.

`tests/unit/{hooks,inputs,normalization,flushers}`: 1782 passed, 0 failures,
covering codex / claude-code / cursor / kiro / qwen / qwen-work-cn / qoderwork /
opencode / mimo / hermes / openclaw / pi-coding-agent / workbuddy / dsh.
