### PR TITLE
fix(qoder): support managed QoderCN SDK runtime

### DIFF
--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -546,17 +546,16 @@ async function processTranscript(agentId, logPrefix, transcriptPath, sessionId, 
     // session_meta, other types: ignored
   }
 
-  // --- Phase 2.5 (qoder-cn only): Skip processing if transcript hasn't reached Stop ---
-  // For qoder-cn, only process the transcript when the Stop progress event has been
-  // written. A PostToolUse retry (which runs before Stop is written) would see an
-  // incomplete ReAct chain and produce partial events. The Stop retry (fired after
-  // the final assistant text is written) sees the complete chain and can correctly
-  // generate all llm.request events with proper input.messages_delta (including
-  // tool_result as input delta for step 2).
+  // --- Phase 2.5 (qoder-cn only): Skip processing until the transcript is terminal ---
+  // QoderCN does not guarantee that its progress Stop row is visible when the Stop
+  // hook process runs. In SDK --print mode the terminal assistant row and
+  // last-prompt marker can already be durable while progress Stop is appended only
+  // after the hook returns. Accept all terminal forms understood by the retry path;
+  // otherwise a complete managed-runtime turn is silently dropped forever.
   if (agentId === 'qoder-cn') {
-    const hasStop = progressEvents.some(pe => pe.hookEvent === 'Stop');
-    if (!hasStop) {
-      logDebug(agentId, `Transcript not yet complete (no Stop event in progress). Skipping processing.`);
+    const hasTerminalMarker = hasQoderCnTerminalMarker(progressEvents, parsed);
+    if (!hasTerminalMarker) {
+      logDebug(agentId, `Transcript not yet complete (no terminal marker). Skipping processing.`);
       return;
     }
     // A precise retry snapshot already contains the complete target Turn. Only
@@ -753,6 +752,15 @@ const TERMINAL_STOP_REASONS = new Set([
 
 function isTerminalStopReason(reason) {
   return typeof reason === 'string' && TERMINAL_STOP_REASONS.has(reason);
+}
+
+export function hasQoderCnTerminalMarker(progressEvents, rows) {
+  return progressEvents.some(event => event?.hookEvent === 'Stop')
+    || rows.some(row => row?.type === 'last-prompt')
+    || rows.some(row => (
+      row?.type === 'assistant'
+      && isTerminalStopReason(row?.message?.stop_reason)
+    ));
 }
 
 export function findTriggeredTurnWindow(snapshot, triggerEndLine) {

--- a/assets/hooks/qodercli-runtime-wrapper.sh
+++ b/assets/hooks/qodercli-runtime-wrapper.sh
@@ -2,10 +2,10 @@
 #
 # Launch qodercli with the token intercept scoped to this process only.
 #
-# npm qodercli distributions are Node.js entrypoints and require NODE_OPTIONS
-# --import. Native qodercli distributions are Bun executables and require
-# BUN_OPTIONS --preload. Set LOONGSUITE_QODERCLI_RUNTIME=node|bun to override
-# auto-detection, or LOONGSUITE_QODERCLI_BIN to provide the real executable.
+# npm and bundled SDK qodercli distributions are Node.js entrypoints and require
+# NODE_OPTIONS --import. Native qodercli distributions are Bun executables and
+# require BUN_OPTIONS --preload. Set LOONGSUITE_QODERCLI_RUNTIME=node|bun to
+# override auto-detection, or LOONGSUITE_QODERCLI_BIN to provide the real entry.
 
 SCRIPT_DIR=$(CDPATH= cd "$(dirname "$0")" 2>/dev/null && pwd)
 INTERCEPT_SCRIPT="$SCRIPT_DIR/qodercli-token-intercept.mjs"
@@ -20,18 +20,38 @@ if [ -z "$QODERCLI_BIN" ]; then
   exit 127
 fi
 
-# Missing hook assets must never prevent qodercli from starting.
-if [ ! -f "$INTERCEPT_SCRIPT" ]; then
-  exec "$QODERCLI_BIN" "$@"
-fi
-
 QODERCLI_RUNTIME="${LOONGSUITE_QODERCLI_RUNTIME:-}"
 if [ -z "$QODERCLI_RUNTIME" ]; then
-  if LC_ALL=C head -c 128 "$QODERCLI_BIN" 2>/dev/null | grep -aq '^#!.*node'; then
-    QODERCLI_RUNTIME=node
-  else
-    QODERCLI_RUNTIME=bun
+  case "$QODERCLI_BIN" in
+    *.js|*.cjs|*.mjs) QODERCLI_RUNTIME=node ;;
+    *)
+      if LC_ALL=C head -c 128 "$QODERCLI_BIN" 2>/dev/null | grep -aq '^#!.*node'; then
+        QODERCLI_RUNTIME=node
+      else
+        QODERCLI_RUNTIME=bun
+      fi
+      ;;
+  esac
+fi
+
+launch_qodercli() {
+  if [ "$QODERCLI_RUNTIME" = "node" ]; then
+    QODERCLI_NODE_BIN="${LOONGSUITE_QODERCLI_NODE_BIN:-}"
+    if [ -z "$QODERCLI_NODE_BIN" ]; then
+      QODERCLI_NODE_BIN=$(command -v node 2>/dev/null || true)
+    fi
+    if [ -z "$QODERCLI_NODE_BIN" ]; then
+      echo "loongsuite-pilot: node executable not found for qodercli entry" >&2
+      exit 127
+    fi
+    exec "$QODERCLI_NODE_BIN" "$QODERCLI_BIN" "$@"
   fi
+  exec "$QODERCLI_BIN" "$@"
+}
+
+# Missing hook assets must never prevent qodercli from starting.
+if [ ! -f "$INTERCEPT_SCRIPT" ]; then
+  launch_qodercli "$@"
 fi
 
 if [ "$QODERCLI_RUNTIME" = "node" ]; then
@@ -50,4 +70,4 @@ else
   export BUN_OPTIONS
 fi
 
-exec "$QODERCLI_BIN" "$@"
+launch_qodercli "$@"

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -987,6 +987,7 @@ export class Orchestrator extends EventEmitter {
     const qoderCnTraceInput = new QoderCnTraceInput({
       stateStore: this.stateStore,
       logDir: qoderCnLogDir,
+      pollIntervalMs: listenerCfg['qoder-cn-trace']?.pollInterval,
     });
     this.inputManager.registerInput(qoderCnTraceInput);
     entries.push(

--- a/tests/unit/core/orchestrator.test.ts
+++ b/tests/unit/core/orchestrator.test.ts
@@ -404,6 +404,20 @@ describe('Orchestrator', () => {
       await orch.stop();
     });
 
+    it('passes the configured QoderCN trace poll interval to the input', async () => {
+      const config = makeConfig();
+      config.listeners['qoder-cn-trace'] = { enabled: true, pollInterval: 1000 };
+
+      const orch = new Orchestrator(config);
+      await orch.start();
+
+      const input = (orch as any).inputManager.getInput('qoder-cn-trace');
+      expect(input).toBeDefined();
+      expect(input.pollIntervalMs).toBe(1000);
+
+      await orch.stop();
+    });
+
     it('uses the configured dataDir for all QwenWorkCN Hook and intercept paths', async () => {
       const dataDir = '/tmp/custom-pilot-data';
       const orch = new Orchestrator(makeConfig({ dataDir }));

--- a/tests/unit/hooks/qoder-control-message-turns.test.mjs
+++ b/tests/unit/hooks/qoder-control-message-turns.test.mjs
@@ -247,4 +247,31 @@ describe('qoder slash-command control rows', () => {
     expect(partsOf(records.find(r => r['event.name'] === 'other'))).toEqual(['杭州天气']);
     expect(partsOf(records.find(r => r['event.name'] === 'llm.request'))).toEqual(['杭州天气']);
   });
+
+  it('applies the shared CLI control-row filtering to QoderCN SDK transcripts', () => {
+    const prompt = promptRow('杭州天气');
+    const assistant = assistantRow('杭州今天多云。');
+    const turns = splitContentEventsIntoTurns([
+      caveatRow(), commandRow(), stdoutRow(), prompt, assistant,
+    ]);
+
+    expect(turns).toHaveLength(1);
+    const records = buildEventsFromBoundaries(
+      buildLlmBoundaries(progress, turns[0]),
+      turns[0],
+      turns[0],
+      'turn-qoder-cn-sdk',
+      'session-qoder-cn-sdk',
+      'qoder-cn',
+      {},
+      '/tmp/cwd',
+    );
+
+    expect(records.every(r => r['gen_ai.agent.type'] === 'qoder-cn')).toBe(true);
+    for (const record of records) {
+      for (const part of partsOf(record)) {
+        expect(part).not.toMatch(/command-message|command-name|local-command/u);
+      }
+    }
+  });
 });

--- a/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
+++ b/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
@@ -10,6 +10,7 @@ import {
   buildEventsFromBoundaries,
   findIncrementalTurnEndLine,
   findTriggeredTurnWindow,
+  hasQoderCnTerminalMarker,
   isRetryLockStale,
   readRetryLock,
   releaseRetryLock,
@@ -664,6 +665,26 @@ describe('findTriggeredTurnWindow stop source variants (B3 P0)', () => {
       stopLine: null,
       endLine: null,
     });
+  });
+});
+
+describe('hasQoderCnTerminalMarker', () => {
+  it('accepts the traditional progress Stop marker', () => {
+    expect(hasQoderCnTerminalMarker([{ hookEvent: 'Stop' }], [])).toBe(true);
+  });
+
+  it('accepts SDK print-mode terminal rows before progress Stop is appended', () => {
+    expect(hasQoderCnTerminalMarker([], [
+      { type: 'assistant', message: { stop_reason: 'end_turn' } },
+      { type: 'last-prompt', lastPrompt: 'summarize the file' },
+    ])).toBe(true);
+  });
+
+  it('rejects a mid-tool snapshot', () => {
+    expect(hasQoderCnTerminalMarker([], [
+      { type: 'assistant', message: { stop_reason: 'tool_use' } },
+      { type: 'user', message: { content: [{ type: 'tool_result' }] } },
+    ])).toBe(false);
   });
 });
 

--- a/tests/unit/hooks/qodercli-runtime-wrapper.test.mjs
+++ b/tests/unit/hooks/qodercli-runtime-wrapper.test.mjs
@@ -13,7 +13,7 @@ afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
 });
 
-async function makeFixture(qodercliSource, withIntercept = true) {
+async function makeFixture(qodercliSource, withIntercept = true, qodercliName = 'qodercli') {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), 'pilot-qoder-wrapper-'));
   tempDirs.push(root);
   const hooks = path.join(root, 'hooks');
@@ -27,12 +27,13 @@ async function makeFixture(qodercliSource, withIntercept = true) {
   if (withIntercept) {
     await fs.writeFile(path.join(hooks, 'qodercli-token-intercept.mjs'), 'export {};\n');
   }
-  const qodercli = path.join(bin, 'qodercli');
+  const qodercli = path.join(bin, qodercliName);
   await fs.writeFile(qodercli, qodercliSource, { mode: 0o755 });
   return {
     root,
     wrapper: path.join(hooks, 'qodercli-runtime-wrapper.sh'),
     bin,
+    qodercli,
   };
 }
 
@@ -82,6 +83,31 @@ printf '{"nodeOptions":"%s","bunOptions":"%s","arg":"%s"}\\n' "$NODE_OPTIONS" "$
     expect(output.bunOptions).toContain('qodercli-token-intercept.mjs');
     expect(output.bunOptions).toContain('/user/own.mjs');
     expect(output.arg).toBe('hello');
+  });
+
+  it('runs a bundled SDK .mjs entry through Node without requiring a shebang', async () => {
+    const fixture = await makeFixture(`
+console.log(JSON.stringify({
+  nodeOptions: process.env.NODE_OPTIONS,
+  bunOptions: process.env.BUN_OPTIONS || '',
+  args: process.argv.slice(2)
+}));
+`, true, 'qoder-worker-runtime.obf.mjs');
+    const result = spawnSync('sh', [fixture.wrapper, 'hello'], {
+      env: {
+        ...process.env,
+        LOONGSUITE_QODERCLI_BIN: fixture.qodercli,
+        NODE_OPTIONS: '',
+        BUN_OPTIONS: '',
+      },
+      encoding: 'utf-8',
+    });
+    expect(result.status, result.stderr).toBe(0);
+    const output = JSON.parse(result.stdout.trim());
+    expect(output.nodeOptions).toContain('--import=');
+    expect(output.nodeOptions).toContain('qodercli-token-intercept.mjs');
+    expect(output.bunOptions).toBe('');
+    expect(output.args).toEqual(['hello']);
   });
 
   it('fails open when the intercept asset is missing', async () => {

--- a/tests/unit/inputs/qoder-cn-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-cn-trace-input.test.ts
@@ -297,6 +297,8 @@ describe('QoderCnTraceInput.collect (session-level enrich)', () => {
     record['multica.issue.id'] = 'AGE-992';
     record['multica.user.id'] = 'staff-1';
     record['multica.api_token'] = 'blocked';
+    record['agentcore.task_id'] = 'task-managed-runtime';
+    record['agentcore.subtask_id'] = 'subtask-managed-runtime';
     await writeHookJsonl(logDir, [record]);
 
     const entries = await collectOnce();
@@ -304,6 +306,8 @@ describe('QoderCnTraceInput.collect (session-level enrich)', () => {
     expect(entries[0]).toMatchObject({
       'multica.issue.id': 'AGE-992',
       'multica.user.id': 'staff-1',
+      'agentcore.task_id': 'task-managed-runtime',
+      'agentcore.subtask_id': 'subtask-managed-runtime',
     });
     expect(entries[0]).not.toHaveProperty('multica.api_token');
   });

--- a/tests/unit/inputs/qoder-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-trace-input.test.ts
@@ -1532,6 +1532,7 @@ describe('QoderTraceInput multimodal', () => {
           'gen_ai.turn.id': 'ide-turn',
           'gen_ai.tool.call.result': `Image file: ${imgPath}`,
           'multica.issue.id': 'IDE-992',
+          'agentcore.task_id': 'task-ide-runtime',
           time_unix_nano: '1780000000000000000',
         };
         const cliTool = {
@@ -1542,6 +1543,7 @@ describe('QoderTraceInput multimodal', () => {
           'gen_ai.turn.id': 'cli-turn',
           'gen_ai.tool.call.result': `Image file: ${imgPath}`,
           'multica.issue.id': 'CLI-992',
+          'agentcore.task_id': 'task-cli-runtime',
           time_unix_nano: '1780000000000000000',
         };
         await fs.writeFile(
@@ -1575,6 +1577,8 @@ describe('QoderTraceInput multimodal', () => {
         expect(Array.isArray(cli['gen_ai.tool.call.result'])).toBe(true);
         expect(ide['multica.issue.id']).toBe('IDE-992');
         expect(cli['multica.issue.id']).toBe('CLI-992');
+        expect(ide['agentcore.task_id']).toBe('task-ide-runtime');
+        expect(cli['agentcore.task_id']).toBe('task-cli-runtime');
       } finally {
         await fs.rm(tmpDir, { recursive: true, force: true });
       }


### PR DESCRIPTION
Builds on #358, now merged into main.

## Issue

Managed Qoder runtimes can provide the real CLI as a bundled JavaScript module rather than a self-executable binary. The QoderCN SDK currently bundles a qoder-worker-runtime.obf.mjs entry without a shebang. The Pilot wrapper directly execs the target, so this entry can be treated as a shell script and fail with a syntax error before the SDK starts.

QoderCN SDK print mode also has a transcript ordering difference: the terminal assistant row or last-prompt marker may be durable before the progress Stop row is appended. Requiring progress Stop alone can drop an otherwise complete turn. The configured QoderCN trace polling interval was also not passed to the input instance.

Managed Runtime Task attributes use the safe opt-in Qoder passthrough introduced by #358. This PR deliberately does not add agentcore fields to the canonical schema; it adds Qoder and QoderCN coverage proving that agentcore.task_id and agentcore.subtask_id follow the generic per-invocation attribute path. Runtime configuration selects agentcore. through spanAttributePassthroughPrefixes when those fields are required on spans.

## Changes

- Detect .js, .cjs, and .mjs CLI entries and launch them explicitly with Node while preserving the scoped token/system-prompt preload.
- Preserve native/Bun launcher behavior and the fail-open path when the intercept asset is unavailable.
- Accept QoderCN terminal assistant and last-prompt markers in addition to progress Stop, while keeping tool_use and pause_turn non-terminal.
- Pass the configured qoder-cn-trace polling interval to QoderCnTraceInput.
- Add regression coverage for bundled modules, terminal-marker timing, control-row filtering, Task attributes through #358, and polling configuration.

## Validation

- TypeScript typecheck passed.
- Focused suite: 7 files, 167 tests passed.
- Real managed QoderCN SDK flow passed with SDK 1.0.30 and bundled CLI 1.1.35 through the Pilot wrapper, including Task attributes, token usage, and system-prompt capture.
- #358 has its own full-suite, build, typecheck, and security validation.

## Scope

Credential selection and account management remain owned by the runtime/SDK and are unchanged. A separate SDK session-resume retry observed in the global Runtime integration is reproducible when bypassing this wrapper, so it is outside this Pilot fix.