### PR TITLE
fix(installer): hold updater during overlay install so GC cannot delete the candidate dir

### DIFF
--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -1831,6 +1831,67 @@ function Stop-PilotService {
     }
 }
 
+# >>> pilot-hold-tasks-during-deploy >>>
+# Stop-PilotService only ends the current task instance. The updater task has a
+# repeating trigger every 5 minutes plus RestartCount, so it comes back while
+# Deploy-Package is still filling a versions/ directory that neither current nor
+# previous names. gcOldVersions then deletes that directory. Disable-ScheduledTask
+# writes Enabled=false on the task definition and actually holds that relaunch;
+# Stop-ScheduledTask does not.
+#
+# Disable is a write, so it can fail with Access is denied: a -RunLevel Limited
+# task grants its own principal only Read, Synchronize, and an elevated first
+# install leaves the tasks owned by Administrators (same ACL that makes uninstall
+# fail to delete them). A failed disable must not abort the install. Track only
+# names we actually disabled so Enable cannot turn on a task we never held.
+#
+# Enable lives in finally and is idempotent. Start stays on the success path: a
+# failed postinstall must not launch a collector whose hooks were never written.
+# Keep this block byte-identical across the three .ps1 installers.
+$script:PILOT_HELD_TASK_NAMES = @()
+
+function Get-PilotDeployTaskNames {
+    $tag = Get-PilotUserTag
+    @("LoongsuitePilot-$tag", "LoongsuitePilotUpdater-$tag")
+}
+
+function Disable-PilotScheduledTasksDuringDeploy {
+    $script:PILOT_HELD_TASK_NAMES = @()
+    $taskFolder = "\LoongsuitePilot\"
+    foreach ($taskName in (Get-PilotDeployTaskNames)) {
+        $task = Get-ScheduledTask -TaskName $taskName -TaskPath $taskFolder -ErrorAction SilentlyContinue
+        if (-not $task) { continue }
+        $enabled = $true
+        try { $enabled = [bool]$task.Settings.Enabled } catch { $enabled = $true }
+        if (-not $enabled) { continue }
+        try {
+            Disable-ScheduledTask -TaskName $taskName -TaskPath $taskFolder -ErrorAction Stop | Out-Null
+            $script:PILOT_HELD_TASK_NAMES += $taskName
+        } catch {
+            Msg "    ⚠️  无法禁用计划任务 ${taskName}: $($_.Exception.Message)" `
+                "    ⚠️  Could not disable scheduled task ${taskName}: $($_.Exception.Message)"
+        }
+    }
+    if (@($script:PILOT_HELD_TASK_NAMES).Count -gt 0) {
+        Msg "    已禁用计划任务（部署期间）: $($script:PILOT_HELD_TASK_NAMES -join ', ')" `
+            "    Disabled scheduled tasks for the deploy: $($script:PILOT_HELD_TASK_NAMES -join ', ')"
+    }
+}
+
+function Enable-PilotScheduledTasksAfterDeploy {
+    $taskFolder = "\LoongsuitePilot\"
+    foreach ($taskName in @($script:PILOT_HELD_TASK_NAMES)) {
+        try {
+            Enable-ScheduledTask -TaskName $taskName -TaskPath $taskFolder -ErrorAction Stop | Out-Null
+        } catch {
+            Msg "    ⚠️  无法重新启用计划任务 ${taskName}: $($_.Exception.Message)" `
+                "    ⚠️  Could not re-enable scheduled task ${taskName}: $($_.Exception.Message)"
+        }
+    }
+    $script:PILOT_HELD_TASK_NAMES = @()
+}
+# <<< pilot-hold-tasks-during-deploy <<<
+
 # ============================================================
 # GC old versions
 # ============================================================
@@ -2477,6 +2538,7 @@ function Cmd-Install {
     }
 
     Stop-PilotService
+    Disable-PilotScheduledTasksDuringDeploy
 
     try {
         Download-AndExtract
@@ -2498,6 +2560,7 @@ function Cmd-Install {
         Install-Command
         Inject-QoderworkRuntimeWrapper
 
+        Enable-PilotScheduledTasksAfterDeploy
         Msg "==> 启动服务..." "==> Starting service..."
         $ps1Path = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot-service.ps1"
         $started = Start-PilotAndWait -ScriptPath $ps1Path -PriorVersion $curVer
@@ -2516,6 +2579,7 @@ function Cmd-Install {
         Write-Host ""
         Print-Summary "install"
     } finally {
+        Enable-PilotScheduledTasksAfterDeploy
         Remove-PilotPathQuietly $script:TMP_DIR
     }
 }
@@ -2560,11 +2624,13 @@ function Cmd-Upgrade {
         Msg "==> 停止服务..." "==> Stopping service..."
         Stop-PilotService
         Write-Host ""
+        Disable-PilotScheduledTasksDuringDeploy
 
         Deploy-Package $script:INSTALL_SRC
         Install-Command
         Inject-QoderworkRuntimeWrapper
 
+        Enable-PilotScheduledTasksAfterDeploy
         Msg "==> 启动新版本..." "==> Starting new version..."
         $ps1Path = Join-Path $env:USERPROFILE ".local\bin\loongsuite-pilot-service.ps1"
         # A failed postinstall is a failed upgrade: no point starting the new version, and the
@@ -2597,6 +2663,7 @@ function Cmd-Upgrade {
             exit 1
         }
     } finally {
+        Enable-PilotScheduledTasksAfterDeploy
         Remove-PilotPathQuietly $script:TMP_DIR
     }
 }

--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -1880,15 +1880,19 @@ function Disable-PilotScheduledTasksDuringDeploy {
 
 function Enable-PilotScheduledTasksAfterDeploy {
     $taskFolder = "\LoongsuitePilot\"
+    $stillHeld = @()
     foreach ($taskName in @($script:PILOT_HELD_TASK_NAMES)) {
         try {
             Enable-ScheduledTask -TaskName $taskName -TaskPath $taskFolder -ErrorAction Stop | Out-Null
         } catch {
             Msg "    ⚠️  无法重新启用计划任务 ${taskName}: $($_.Exception.Message)" `
                 "    ⚠️  Could not re-enable scheduled task ${taskName}: $($_.Exception.Message)"
+            # Keep the name so finally can retry. Wiping the list here would
+            # make a failed success-path Enable a no-op on the way out.
+            $stillHeld += $taskName
         }
     }
-    $script:PILOT_HELD_TASK_NAMES = @()
+    $script:PILOT_HELD_TASK_NAMES = @($stillHeld)
 }
 # <<< pilot-hold-tasks-during-deploy <<<
 
@@ -2537,10 +2541,10 @@ function Cmd-Install {
         Write-Host ""
     }
 
-    Stop-PilotService
-    Disable-PilotScheduledTasksDuringDeploy
-
     try {
+        Stop-PilotService
+        Disable-PilotScheduledTasksDuringDeploy
+
         Download-AndExtract
         Probe-Agents
         Select-Agents

--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -1850,8 +1850,9 @@ run_pilot_cli() {
     local cli
     cli="$(resolve_pilot_cli)"
     [ -n "$cli" ] || return 1
+    # deploy_package writes versions/current under $HOME/.loongsuite-pilot
+    # (the CLI cache default). Do not point CACHE_DIR at DATA_DIR.
     LOONGSUITE_PILOT_DATA_DIR="$DATA_DIR" \
-        LOONGSUITE_PILOT_CACHE_DIR="$DATA_DIR" \
         "$cli" "$@"
 }
 
@@ -1887,8 +1888,8 @@ stop_pilot_for_deploy() {
 
     msg "==> 停止服务..." "==> Stopping service..."
     if [ -n "$cli" ]; then
-        run_pilot_cli stop 2>/dev/null || true
         PILOT_HELD_FOR_DEPLOY=1
+        run_pilot_cli stop 2>/dev/null || true
     fi
     # Leftovers: no CLI on PATH, or an updater the CLI did not track.
     stop_one_pilot_pid_file "$DATA_DIR/loongsuite-pilot.pid"
@@ -1900,7 +1901,10 @@ restore_pilot_after_deploy() {
     [ "${PILOT_HELD_FOR_DEPLOY:-0}" -eq 1 ] || return 0
     [ "${INSTALL_MODE:-host}" = "container" ] && return 0
     PILOT_HELD_FOR_DEPLOY=0
-    run_pilot_cli start >/dev/null 2>&1 || true
+    if ! run_pilot_cli start; then
+        msg "    ⚠️  无法恢复自启，请手动运行: loongsuite-pilot start" \
+            "    ⚠️  Could not restore autostart, run manually: loongsuite-pilot start"
+    fi
 }
 # <<< pilot-stop-for-deploy <<<
 
@@ -1928,9 +1932,10 @@ cmd_install() {
 
     # Stop collector AND updater, and unload launchd / disable systemd so GC
     # cannot delete the in-flight versions dir. See stop_pilot_for_deploy.
-    stop_pilot_for_deploy
-
+    # Arm restore before stop: autostart_remove is not reversible if we die
+    # between stop and trap.
     trap 'restore_pilot_after_deploy; rm -rf "${TMP_DIR:-}"' EXIT
+    stop_pilot_for_deploy
     download_and_extract
     probe_agents
     select_agents
@@ -1955,6 +1960,7 @@ cmd_install() {
         local _status_out
         _status_out="$(run_pilot_cli status 2>/dev/null || true)"
         if echo "$_status_out" | grep -q "is running"; then
+            PILOT_HELD_FOR_DEPLOY=0
             msg "    ✅ 服务已启动" "    ✅ Service started"
         else
             msg "    ⚠️  服务可能尚未就绪，请检查: loongsuite-pilot status" \
@@ -2023,7 +2029,11 @@ cmd_upgrade() {
         local _rollback_ok=1
         run_pilot_cli rollback 2>/dev/null || _rollback_ok=0
         if [ "$_rollback_ok" -eq 1 ]; then
-            run_pilot_cli start 2>/dev/null || _rollback_ok=0
+            if run_pilot_cli start; then
+                PILOT_HELD_FOR_DEPLOY=0
+            else
+                _rollback_ok=0
+            fi
         fi
         if [ "$_rollback_ok" -eq 1 ]; then
             msg "❌ 升级失败（部署/依赖安装出错），已回滚到 v${old_ver:-unknown} 并重启服务" \
@@ -2045,6 +2055,7 @@ cmd_upgrade() {
         local _status_out
         _status_out="$(run_pilot_cli status 2>/dev/null || true)"
         if echo "$_status_out" | grep -q "is running"; then
+            PILOT_HELD_FOR_DEPLOY=0
             msg "    ✅ 新版本启动成功" "    ✅ New version started successfully"
             echo ""
 
@@ -2067,9 +2078,17 @@ cmd_upgrade() {
     run_pilot_cli rollback 2>/dev/null || _rb_ok=0
 
     if [ "$_rb_ok" -eq 1 ]; then
-        msg "❌ 升级失败，已回滚到 v${old_ver:-unknown}" \
-            "❌ Upgrade failed, rolled back to v${old_ver:-unknown}"
-        msg "   请检查日志: loongsuite-pilot log" "   Check logs: loongsuite-pilot log"
+        if run_pilot_cli start; then
+            PILOT_HELD_FOR_DEPLOY=0
+            msg "❌ 升级失败，已回滚到 v${old_ver:-unknown}" \
+                "❌ Upgrade failed, rolled back to v${old_ver:-unknown}"
+            msg "   请检查日志: loongsuite-pilot log" "   Check logs: loongsuite-pilot log"
+        else
+            msg "❌ 升级失败，已回滚但未能重启服务" \
+                "❌ Upgrade failed, rolled back but could not restart"
+            msg "   请手动运行: loongsuite-pilot start" \
+                "   Run manually: loongsuite-pilot start"
+        fi
     else
         msg "❌ 升级失败且回滚未成功，请手动恢复:" \
             "❌ Upgrade failed and rollback did not succeed. Manual recovery:"

--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -1820,6 +1820,90 @@ print_summary() {
     echo "============================================================"
 }
 
+# >>> pilot-stop-for-deploy >>>
+# Overlay `install` used to SIGTERM only the collector pid file. The updater
+# stayed up, and gcOldVersions() deletes any versions/<dir> that is not
+# current/previous -- including the directory this deploy just copied, before
+# current is published. installer-opensource.sh writes current after
+# node_modules + postinstall, so that window is minutes. `loongsuite-pilot stop`
+# unloads LaunchAgent / disables systemd (autostart_remove) so neither process
+# comes back mid-deploy. That is the Unix counterpart of Disable-ScheduledTask.
+#
+# stop deletes the unit files. restore_pilot_after_deploy (EXIT trap) is the
+# counterpart of Enable-ScheduledTask in finally: it re-registers autostart
+# via start. Container installs must not start a daemon in the build layer.
+#
+# Fresh install has no CLI yet. Fall back to both pid files so a leftover
+# collector or updater still goes down.
+# All CLI after stop must go through run_pilot_cli so --data-dir matches.
+PILOT_HELD_FOR_DEPLOY=0
+
+resolve_pilot_cli() {
+    if command -v loongsuite-pilot &>/dev/null; then
+        command -v loongsuite-pilot
+    elif [ -f "$HOME/.local/bin/loongsuite-pilot" ]; then
+        printf '%s\n' "$HOME/.local/bin/loongsuite-pilot"
+    fi
+}
+
+run_pilot_cli() {
+    local cli
+    cli="$(resolve_pilot_cli)"
+    [ -n "$cli" ] || return 1
+    LOONGSUITE_PILOT_DATA_DIR="$DATA_DIR" \
+        LOONGSUITE_PILOT_CACHE_DIR="$DATA_DIR" \
+        "$cli" "$@"
+}
+
+stop_one_pilot_pid_file() {
+    local pid_file="$1"
+    [ -f "$pid_file" ] || return 0
+    local old_pid
+    old_pid=$(cat "$pid_file")
+    if kill -0 "$old_pid" 2>/dev/null; then
+        kill "$old_pid" 2>/dev/null || true
+        local count=0
+        while kill -0 "$old_pid" 2>/dev/null && [ $count -lt 10 ]; do
+            sleep 1
+            count=$((count + 1))
+        done
+        if kill -0 "$old_pid" 2>/dev/null; then
+            kill -9 "$old_pid" 2>/dev/null || true
+        fi
+        rm -f "$pid_file"
+    else
+        rm -f "$pid_file"
+    fi
+}
+
+stop_pilot_for_deploy() {
+    PILOT_HELD_FOR_DEPLOY=0
+    local cli
+    cli="$(resolve_pilot_cli)"
+
+    if [ -z "$cli" ] && [ ! -f "$DATA_DIR/loongsuite-pilot.pid" ] && [ ! -f "$DATA_DIR/loongsuite-pilot-updater.pid" ]; then
+        return 0
+    fi
+
+    msg "==> 停止服务..." "==> Stopping service..."
+    if [ -n "$cli" ]; then
+        run_pilot_cli stop 2>/dev/null || true
+        PILOT_HELD_FOR_DEPLOY=1
+    fi
+    # Leftovers: no CLI on PATH, or an updater the CLI did not track.
+    stop_one_pilot_pid_file "$DATA_DIR/loongsuite-pilot.pid"
+    stop_one_pilot_pid_file "$DATA_DIR/loongsuite-pilot-updater.pid"
+    echo ""
+}
+
+restore_pilot_after_deploy() {
+    [ "${PILOT_HELD_FOR_DEPLOY:-0}" -eq 1 ] || return 0
+    [ "${INSTALL_MODE:-host}" = "container" ] && return 0
+    PILOT_HELD_FOR_DEPLOY=0
+    run_pilot_cli start >/dev/null 2>&1 || true
+}
+# <<< pilot-stop-for-deploy <<<
+
 # ============================================================
 # CMD: install
 # ============================================================
@@ -1842,32 +1926,11 @@ cmd_install() {
         echo ""
     fi
 
-    # Stop running service before re-install
-    local pid_file="$DATA_DIR/loongsuite-pilot.pid"
-    if [ -f "$pid_file" ]; then
-        local old_pid
-        old_pid=$(cat "$pid_file")
-        if kill -0 "$old_pid" 2>/dev/null; then
-            msg "==> 停止运行中的服务 (PID $old_pid)..." \
-                "==> Stopping running service (PID $old_pid)..."
-            kill "$old_pid" 2>/dev/null || true
-            local count=0
-            while kill -0 "$old_pid" 2>/dev/null && [ $count -lt 10 ]; do
-                sleep 1
-                count=$((count + 1))
-            done
-            if kill -0 "$old_pid" 2>/dev/null; then
-                kill -9 "$old_pid" 2>/dev/null || true
-            fi
-            rm -f "$pid_file"
-            msg "    ✅ 已停止" "    ✅ Stopped"
-            echo ""
-        else
-            rm -f "$pid_file"
-        fi
-    fi
+    # Stop collector AND updater, and unload launchd / disable systemd so GC
+    # cannot delete the in-flight versions dir. See stop_pilot_for_deploy.
+    stop_pilot_for_deploy
 
-    trap 'rm -rf "${TMP_DIR:-}"' EXIT
+    trap 'restore_pilot_after_deploy; rm -rf "${TMP_DIR:-}"' EXIT
     download_and_extract
     probe_agents
     select_agents
@@ -1887,10 +1950,10 @@ cmd_install() {
     inject_claude_code_fetch_intercept
 
     msg "==> 启动服务..." "==> Starting service..."
-    if loongsuite-pilot start; then
+    if run_pilot_cli start; then
         sleep 2
         local _status_out
-        _status_out="$(loongsuite-pilot status 2>/dev/null || true)"
+        _status_out="$(run_pilot_cli status 2>/dev/null || true)"
         if echo "$_status_out" | grep -q "is running"; then
             msg "    ✅ 服务已启动" "    ✅ Service started"
         else
@@ -1932,7 +1995,7 @@ cmd_upgrade() {
 
     check_deps
 
-    trap 'rm -rf "${TMP_DIR:-}"' EXIT
+    trap 'restore_pilot_after_deploy; rm -rf "${TMP_DIR:-}"' EXIT
     download_and_extract
 
     local new_ver; new_ver=$(get_version_from_dir "$INSTALL_SRC")
@@ -1949,14 +2012,7 @@ cmd_upgrade() {
         "   New version: ${new_ver:-unknown} (${new_commit:-unknown})"
     echo ""
 
-    # Stop the running service
-    msg "==> 停止服务..." "==> Stopping service..."
-    if command -v loongsuite-pilot &>/dev/null; then
-        loongsuite-pilot stop 2>/dev/null || true
-    elif [ -f "$HOME/.local/bin/loongsuite-pilot" ]; then
-        "$HOME/.local/bin/loongsuite-pilot" stop 2>/dev/null || true
-    fi
-    echo ""
+    stop_pilot_for_deploy
 
     # Deploy new version to versions/<ver>_<commit>/
     # Old version stays untouched; deploy_package writes current/previous pointers
@@ -1965,17 +2021,9 @@ cmd_upgrade() {
         msg "⚠️  部署失败，正在回滚到旧版本..." \
             "⚠️  Deployment failed, rolling back to old version..."
         local _rollback_ok=1
-        if command -v loongsuite-pilot &>/dev/null; then
-            loongsuite-pilot rollback 2>/dev/null || _rollback_ok=0
-        elif [ -f "$HOME/.local/bin/loongsuite-pilot" ]; then
-            "$HOME/.local/bin/loongsuite-pilot" rollback 2>/dev/null || _rollback_ok=0
-        fi
+        run_pilot_cli rollback 2>/dev/null || _rollback_ok=0
         if [ "$_rollback_ok" -eq 1 ]; then
-            if command -v loongsuite-pilot &>/dev/null; then
-                loongsuite-pilot start 2>/dev/null || _rollback_ok=0
-            elif [ -f "$HOME/.local/bin/loongsuite-pilot" ]; then
-                "$HOME/.local/bin/loongsuite-pilot" start 2>/dev/null || _rollback_ok=0
-            fi
+            run_pilot_cli start 2>/dev/null || _rollback_ok=0
         fi
         if [ "$_rollback_ok" -eq 1 ]; then
             msg "❌ 升级失败（部署/依赖安装出错），已回滚到 v${old_ver:-unknown} 并重启服务" \
@@ -1992,10 +2040,10 @@ cmd_upgrade() {
 
     # Start the new version
     msg "==> 启动新版本..." "==> Starting new version..."
-    if loongsuite-pilot start; then
+    if run_pilot_cli start; then
         sleep 2
         local _status_out
-        _status_out="$(loongsuite-pilot status 2>/dev/null || true)"
+        _status_out="$(run_pilot_cli status 2>/dev/null || true)"
         if echo "$_status_out" | grep -q "is running"; then
             msg "    ✅ 新版本启动成功" "    ✅ New version started successfully"
             echo ""
@@ -2013,14 +2061,10 @@ cmd_upgrade() {
     msg "⚠️  新版本启动失败，正在回滚..." \
         "⚠️  New version failed to start, rolling back..."
 
-    loongsuite-pilot stop 2>/dev/null || true
+    run_pilot_cli stop 2>/dev/null || true
 
     local _rb_ok=1
-    if command -v loongsuite-pilot &>/dev/null; then
-        loongsuite-pilot rollback 2>/dev/null || _rb_ok=0
-    else
-        "$HOME/.local/bin/loongsuite-pilot" rollback 2>/dev/null || _rb_ok=0
-    fi
+    run_pilot_cli rollback 2>/dev/null || _rb_ok=0
 
     if [ "$_rb_ok" -eq 1 ]; then
         msg "❌ 升级失败，已回滚到 v${old_ver:-unknown}" \

--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -1889,7 +1889,10 @@ stop_pilot_for_deploy() {
     msg "==> 停止服务..." "==> Stopping service..."
     if [ -n "$cli" ]; then
         PILOT_HELD_FOR_DEPLOY=1
-        run_pilot_cli stop 2>/dev/null || true
+        if ! run_pilot_cli stop; then
+            msg "    ⚠️  无法停止服务，覆盖安装期间 updater 可能仍会 GC" \
+                "    ⚠️  Could not stop the service; updater may still GC during this overlay"
+        fi
     fi
     # Leftovers: no CLI on PATH, or an updater the CLI did not track.
     stop_one_pilot_pid_file "$DATA_DIR/loongsuite-pilot.pid"

--- a/tests/unit/deploy/installer-hold-tasks-during-deploy.test.mjs
+++ b/tests/unit/deploy/installer-hold-tasks-during-deploy.test.mjs
@@ -1,0 +1,152 @@
+// Stop-PilotService only ends the current task instance. The updater task's 5-minute
+// repeating trigger (and RestartCount) relaunches it while Deploy-Package is still
+// filling in a versions/ directory that neither `current` nor `previous` names, and
+// gcOldVersions deletes that directory. Disable-ScheduledTask is a write to the task
+// definition, so it actually holds the watchdog for the rest of the deploy.
+//
+// Only the .ps1 installers are pinned here: the relaunch is a Task Scheduler artefact,
+// and the .sh installers unload launchd / disable systemd in `loongsuite-pilot stop`.
+import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+
+const INTERNAL_PS1 = [
+  'deploy/installer.ps1',
+  'deploy/installer-inner.ps1',
+];
+const OPENSOURCE_PS1 = 'deploy/installer-opensource.ps1';
+const PS1_INSTALLERS = [...INTERNAL_PS1, OPENSOURCE_PS1];
+
+const TAG = 'pilot-hold-tasks-during-deploy';
+
+const read = (f) => readFileSync(f, 'utf-8');
+
+const blockOf = (text, tag) => {
+  const re = new RegExp(`^\\s*# >>> ${tag} >>>\\n[\\s\\S]*?^\\s*# <<< ${tag} <<<\\n`, 'm');
+  const m = text.match(re);
+  return m ? m[0] : null;
+};
+
+const codeOf = (text) => text
+  .split('\n')
+  .filter(line => !/^\s*#/.test(line))
+  .join('\n');
+
+const functionBody = (text, name) => {
+  const start = text.indexOf(`function ${name} {`);
+  expect(start, `${name} not found`).toBeGreaterThan(-1);
+  const rest = text.slice(start);
+  const end = rest.search(/\nfunction \S+ \{/);
+  return rest.slice(0, end === -1 ? rest.length : end);
+};
+
+const present = PS1_INSTALLERS.filter(existsSync);
+const patched = present.filter(f => blockOf(read(f), TAG));
+
+describe('installers disable scheduled tasks for the duration of a deploy', () => {
+  it('defines the hold/restore helpers', () => {
+    expect(patched.length).toBeGreaterThanOrEqual(1);
+    for (const file of INTERNAL_PS1.filter(existsSync)) {
+      expect(blockOf(read(file), TAG), `${file}: ${TAG} block missing`).toBeTruthy();
+    }
+    for (const file of patched) {
+      const code = codeOf(blockOf(read(file), TAG));
+      expect(code, file).toMatch(/function Disable-PilotScheduledTasksDuringDeploy/);
+      expect(code, file).toMatch(/function Enable-PilotScheduledTasksAfterDeploy/);
+      expect(code, file).toMatch(/Disable-ScheduledTask/);
+      expect(code, file).toMatch(/Enable-ScheduledTask/);
+    }
+  });
+
+  it('the block is byte-identical across the patched .ps1 installers', () => {
+    const blocks = patched.map(f => blockOf(read(f), TAG));
+    expect(blocks.filter(b => !b)).toEqual([]);
+    expect(new Set(blocks).size).toBe(1);
+  });
+
+  it('disables both the collector and the updater task', () => {
+    const code = codeOf(blockOf(read(patched[0]), TAG));
+    expect(code).toMatch(/LoongsuitePilot-\$tag/);
+    expect(code).toMatch(/LoongsuitePilotUpdater-\$tag/);
+  });
+
+  it('does not abort the install when Disable is denied', () => {
+    // Elevated first installs leave the tasks owned by Administrators; the same
+    // Access is denied that blocks schtasks /Delete would also block Disable.
+    // Swallowing that is required -- a denied hold must not turn a working reinstall
+    // into a failed one. Restart-StaleCollector still covers that machine.
+    const code = codeOf(blockOf(read(patched[0]), TAG));
+    expect(code).toMatch(/Disable-ScheduledTask[\s\S]*catch/);
+    expect(code).not.toMatch(/Disable-ScheduledTask[\s\S]*exit 1/);
+  });
+
+  it('re-enables only the tasks this deploy actually disabled', () => {
+    // Enabling a task we never held would turn on something the user had disabled,
+    // or a task whose Disable failed (and is therefore still enabled).
+    const code = codeOf(blockOf(read(patched[0]), TAG));
+    expect(code).toMatch(/PILOT_HELD_TASK_NAMES/);
+    expect(code).toMatch(/Enable-PilotScheduledTasksAfterDeploy[\s\S]*PILOT_HELD_TASK_NAMES = @\(\)/);
+  });
+
+  it('Cmd-Install stops, then disables, then deploys', () => {
+    for (const file of patched) {
+      const body = functionBody(read(file), 'Cmd-Install');
+      const stopAt = body.indexOf('Stop-PilotService');
+      const disableAt = body.indexOf('Disable-PilotScheduledTasksDuringDeploy');
+      const deployAt = body.indexOf('Deploy-Package');
+      expect(stopAt, `${file}: Stop-PilotService missing from Cmd-Install`).toBeGreaterThan(-1);
+      expect(disableAt, `${file}: Disable missing from Cmd-Install`).toBeGreaterThan(-1);
+      expect(deployAt, `${file}: Deploy-Package missing from Cmd-Install`).toBeGreaterThan(-1);
+      expect(stopAt).toBeLessThan(disableAt);
+      expect(disableAt).toBeLessThan(deployAt);
+    }
+  });
+
+  it('Cmd-Upgrade stops, then disables, then deploys', () => {
+    for (const file of patched) {
+      const body = functionBody(read(file), 'Cmd-Upgrade');
+      const stopAt = body.indexOf('Stop-PilotService');
+      const disableAt = body.indexOf('Disable-PilotScheduledTasksDuringDeploy');
+      const deployAt = body.indexOf('Deploy-Package');
+      expect(stopAt, `${file}: Stop-PilotService missing from Cmd-Upgrade`).toBeGreaterThan(-1);
+      expect(disableAt, `${file}: Disable missing from Cmd-Upgrade`).toBeGreaterThan(-1);
+      expect(deployAt, `${file}: Deploy-Package missing from Cmd-Upgrade`).toBeGreaterThan(-1);
+      expect(stopAt).toBeLessThan(disableAt);
+      expect(disableAt).toBeLessThan(deployAt);
+    }
+  });
+
+  it('enables before start, and again in finally', () => {
+    // Enable must precede Start-ScheduledTask: a disabled task will not start.
+    // finally must also Enable so Ctrl+C / exit 1 cannot leave the tasks disabled.
+    // Start itself stays on the success path -- a failed postinstall must not launch
+    // a collector whose hooks were never written.
+    for (const file of patched) {
+      for (const fn of ['Cmd-Install', 'Cmd-Upgrade']) {
+        const body = functionBody(read(file), fn);
+        const enables = [];
+        let from = 0;
+        while (true) {
+          const at = body.indexOf('Enable-PilotScheduledTasksAfterDeploy', from);
+          if (at === -1) break;
+          enables.push(at);
+          from = at + 1;
+        }
+        expect(enables.length, `${file} ${fn}: expected Enable twice (before start + finally)`).toBeGreaterThanOrEqual(2);
+        expect(body).toMatch(/finally[\s\S]*Enable-PilotScheduledTasksAfterDeploy/);
+        const startAt = body.search(/启动服务|启动新版本/);
+        expect(startAt, `${file} ${fn}: start prompt missing`).toBeGreaterThan(-1);
+        expect(enables[0]).toBeLessThan(startAt);
+      }
+    }
+  });
+
+  it('does not hold tasks during uninstall', () => {
+    // Uninstall deletes the tasks. Re-enabling them in a finally would fight
+    // Remove-PilotScheduledTasks.
+    for (const file of patched) {
+      const body = functionBody(read(file), 'Cmd-Uninstall');
+      expect(body, file).not.toMatch(/Disable-PilotScheduledTasksDuringDeploy/);
+      expect(body, file).not.toMatch(/Enable-PilotScheduledTasksAfterDeploy/);
+    }
+  });
+});

--- a/tests/unit/deploy/installer-hold-tasks-during-deploy.test.mjs
+++ b/tests/unit/deploy/installer-hold-tasks-during-deploy.test.mjs
@@ -73,7 +73,7 @@ describe('installers disable scheduled tasks for the duration of a deploy', () =
     // Elevated first installs leave the tasks owned by Administrators; the same
     // Access is denied that blocks schtasks /Delete would also block Disable.
     // Swallowing that is required -- a denied hold must not turn a working reinstall
-    // into a failed one. Restart-StaleCollector still covers that machine.
+    // into a failed one.
     const code = codeOf(blockOf(read(patched[0]), TAG));
     expect(code).toMatch(/Disable-ScheduledTask[\s\S]*catch/);
     expect(code).not.toMatch(/Disable-ScheduledTask[\s\S]*exit 1/);

--- a/tests/unit/deploy/installer-hold-tasks-during-deploy.test.mjs
+++ b/tests/unit/deploy/installer-hold-tasks-during-deploy.test.mjs
@@ -84,20 +84,37 @@ describe('installers disable scheduled tasks for the duration of a deploy', () =
     // or a task whose Disable failed (and is therefore still enabled).
     const code = codeOf(blockOf(read(patched[0]), TAG));
     expect(code).toMatch(/PILOT_HELD_TASK_NAMES/);
-    expect(code).toMatch(/Enable-PilotScheduledTasksAfterDeploy[\s\S]*PILOT_HELD_TASK_NAMES = @\(\)/);
+    expect(code).toMatch(/PILOT_HELD_TASK_NAMES \+= \$taskName/);
+  });
+
+  it('keeps failed Enable names on the list for finally to retry', () => {
+    // Unconditional wipe after the loop makes a failed success-path Enable a
+    // no-op in finally: the names are already gone.
+    const code = codeOf(blockOf(read(patched[0]), TAG));
+    const enableFn = code.slice(code.indexOf('function Enable-PilotScheduledTasksAfterDeploy'));
+    expect(enableFn).not.toMatch(/PILOT_HELD_TASK_NAMES = @\(\)/);
+    expect(enableFn).toMatch(/stillHeld/);
+    expect(enableFn).toMatch(/PILOT_HELD_TASK_NAMES = @\(\$stillHeld\)/);
   });
 
   it('Cmd-Install stops, then disables, then deploys', () => {
     for (const file of patched) {
       const body = functionBody(read(file), 'Cmd-Install');
+      const tryAt = body.indexOf('try {');
       const stopAt = body.indexOf('Stop-PilotService');
       const disableAt = body.indexOf('Disable-PilotScheduledTasksDuringDeploy');
       const deployAt = body.indexOf('Deploy-Package');
+      const finallyAt = body.indexOf('} finally {');
       expect(stopAt, `${file}: Stop-PilotService missing from Cmd-Install`).toBeGreaterThan(-1);
       expect(disableAt, `${file}: Disable missing from Cmd-Install`).toBeGreaterThan(-1);
       expect(deployAt, `${file}: Deploy-Package missing from Cmd-Install`).toBeGreaterThan(-1);
       expect(stopAt).toBeLessThan(disableAt);
       expect(disableAt).toBeLessThan(deployAt);
+      // Ctrl+C during Disable must still hit Enable in finally.
+      expect(tryAt, `${file}: Cmd-Install try missing`).toBeGreaterThan(-1);
+      expect(finallyAt, `${file}: Cmd-Install finally missing`).toBeGreaterThan(-1);
+      expect(tryAt, `${file}: Disable must be inside try`).toBeLessThan(disableAt);
+      expect(disableAt, `${file}: Disable must be before finally`).toBeLessThan(finallyAt);
     }
   });
 

--- a/tests/unit/deploy/installer-stop-for-deploy.test.mjs
+++ b/tests/unit/deploy/installer-stop-for-deploy.test.mjs
@@ -65,6 +65,9 @@ describe('sh overlay install stops updater, not just the collector pid', () => {
     // The CLI is how autostart_remove happens. Pid fallback is for a missing CLI,
     // not the overlay path.
     expect(code).toMatch(/command -v loongsuite-pilot/);
+    // Unix hold IS this stop. Swallowing it hides a still-live updater/GC window.
+    expect(code).not.toMatch(/run_pilot_cli stop\s+2>\/dev\/null/);
+    expect(code).toMatch(/Could not stop the service/);
   });
 
   it('passes the installer data dir into every CLI verb after stop', () => {
@@ -92,9 +95,11 @@ describe('sh overlay install stops updater, not just the collector pid', () => {
   });
 
   it('restores autostart after a failed overlay, except in container mode', () => {
-    // stop deletes LaunchAgent/systemd unit files. Windows Enable-in-finally is
-    // reversible; Unix restore is `start`, which re-registers autostart. A
-    // docker build layer must not launch a daemon.
+    // stop deletes LaunchAgent/systemd unit files. Unix restore is `start`,
+    // which re-registers autostart. That is safe because deploy_package
+    // publishes `current` only after node_modules + postinstall: abort still
+    // points at the previous complete version (or nothing, on a fresh install).
+    // A docker build layer must not launch a daemon.
     const code = codeOf(blockOf(read(patched[0]), 'pilot-stop-for-deploy'));
     expect(code).toMatch(/restore_pilot_after_deploy\(\)/);
     expect(code).toMatch(/INSTALL_MODE:-host/);
@@ -102,6 +107,26 @@ describe('sh overlay install stops updater, not just the collector pid', () => {
     // Swallowing start hides the only signal that autostart did not come back.
     expect(code).not.toMatch(/run_pilot_cli start\s+>\/dev\/null/);
     expect(code).toMatch(/Could not restore autostart/);
+  });
+
+  it('deploy_package publishes current only after postinstall', () => {
+    // Overlay restore is `start`. If current already named the new dir, abort
+    // would launch a collector with no hooks / no node_modules.
+    for (const file of SH_INSTALLERS.filter(existsSync)) {
+      const fn = fnOf(read(file), 'deploy_package');
+      const writeAt = fn.indexOf('echo "$dir_name" > "$current_file.tmp"');
+      const postAt = fn.indexOf('scripts/postinstall.js');
+      const npmFailAt = fn.indexOf('Dependency installation failed');
+      expect(writeAt, `${file}: current pointer write missing`).toBeGreaterThan(-1);
+      expect(postAt, `${file}: postinstall missing`).toBeGreaterThan(-1);
+      expect(npmFailAt, `${file}: npm failure path missing`).toBeGreaterThan(-1);
+      expect(writeAt, `${file}: current published before postinstall`).toBeGreaterThan(postAt);
+      expect(writeAt, `${file}: current published before npm install`).toBeGreaterThan(npmFailAt);
+      expect(fn.slice(npmFailAt, writeAt), `${file}: npm failure does not return before current write`)
+        .toMatch(/return 1/);
+      expect(fn.slice(postAt, writeAt), `${file}: postinstall failure does not return before current write`)
+        .toMatch(/return 1/);
+    }
   });
 
   it('cmd_install and cmd_upgrade both call it before deploy_package', () => {

--- a/tests/unit/deploy/installer-stop-for-deploy.test.mjs
+++ b/tests/unit/deploy/installer-stop-for-deploy.test.mjs
@@ -73,6 +73,22 @@ describe('sh overlay install stops updater, not just the collector pid', () => {
     const code = codeOf(blockOf(read(patched[0]), 'pilot-stop-for-deploy'));
     expect(code).toMatch(/run_pilot_cli\(\)/);
     expect(code).toMatch(/LOONGSUITE_PILOT_DATA_DIR="\$DATA_DIR"/);
+    // deploy_package writes versions/current under $HOME/.loongsuite-pilot.
+    // Pointing the CLI cache at DATA_DIR would start/rollback a different tree.
+    expect(code).not.toMatch(/LOONGSUITE_PILOT_CACHE_DIR=/);
+  });
+
+  it('sets PILOT_HELD_FOR_DEPLOY before stop, so a killed stop still restores', () => {
+    const code = codeOf(blockOf(read(patched[0]), 'pilot-stop-for-deploy'));
+    const stopFn = code.slice(
+      code.indexOf('stop_pilot_for_deploy() {'),
+      code.indexOf('restore_pilot_after_deploy() {'),
+    );
+    const heldAt = stopFn.lastIndexOf('PILOT_HELD_FOR_DEPLOY=1');
+    const cliStopAt = stopFn.indexOf('run_pilot_cli stop');
+    expect(heldAt).toBeGreaterThan(-1);
+    expect(cliStopAt).toBeGreaterThan(-1);
+    expect(heldAt).toBeLessThan(cliStopAt);
   });
 
   it('restores autostart after a failed overlay, except in container mode', () => {
@@ -83,6 +99,9 @@ describe('sh overlay install stops updater, not just the collector pid', () => {
     expect(code).toMatch(/restore_pilot_after_deploy\(\)/);
     expect(code).toMatch(/INSTALL_MODE:-host/);
     expect(code).toMatch(/run_pilot_cli start/);
+    // Swallowing start hides the only signal that autostart did not come back.
+    expect(code).not.toMatch(/run_pilot_cli start\s+>\/dev\/null/);
+    expect(code).toMatch(/Could not restore autostart/);
   });
 
   it('cmd_install and cmd_upgrade both call it before deploy_package', () => {
@@ -124,6 +143,22 @@ describe('sh overlay install stops updater, not just the collector pid', () => {
         .toMatch(/run_pilot_cli start/);
       expect(upgrade, `${file}: cmd_upgrade rollback is not DATA_DIR-aware`)
         .toMatch(/run_pilot_cli rollback/);
+
+      const trapAt = (fn) => fn.indexOf("trap 'restore_pilot_after_deploy");
+      const stopCall = (fn) => fn.search(/^\s*stop_pilot_for_deploy$/m);
+      expect(trapAt(install), `${file}: cmd_install restore trap missing`).toBeGreaterThan(-1);
+      expect(stopCall(install), `${file}: cmd_install stop call missing`).toBeGreaterThan(-1);
+      expect(trapAt(install), `${file}: cmd_install trap must be armed before stop`)
+        .toBeLessThan(stopCall(install));
+      expect(trapAt(upgrade), `${file}: cmd_upgrade restore trap missing`).toBeGreaterThan(-1);
+      expect(stopCall(upgrade), `${file}: cmd_upgrade stop call missing`).toBeGreaterThan(-1);
+      expect(trapAt(upgrade), `${file}: cmd_upgrade trap must be armed before stop`)
+        .toBeLessThan(stopCall(upgrade));
+
+      const failAt = upgrade.indexOf('New version failed to start');
+      expect(failAt, `${file}: cmd_upgrade start-failure path missing`).toBeGreaterThan(-1);
+      expect(upgrade.slice(failAt), `${file}: start-failure path never starts after rollback`)
+        .toMatch(/run_pilot_cli start/);
     }
   });
 

--- a/tests/unit/deploy/installer-stop-for-deploy.test.mjs
+++ b/tests/unit/deploy/installer-stop-for-deploy.test.mjs
@@ -1,0 +1,135 @@
+// Overlay `install` used to SIGTERM only the collector pid file. The updater
+// stayed up, and gcOldVersions() deletes any versions/<dir> that is not
+// current/previous -- including the directory this deploy just copied, before
+// current is published. installer-opensource.sh writes current after
+// node_modules + postinstall, so that window is minutes (same class of bug as
+// Windows Stop-ScheduledTask without Disable).
+//
+// Unix stop already unloads LaunchAgent / disables systemd (autostart_remove).
+// Overlay install has to call that, the same way `cmd_upgrade` always did; a
+// collector-only pid kill does not close the GC race.
+import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+
+const INTERNAL_SH = [
+  'deploy/installer.sh',
+  'deploy/installer-inner.sh',
+];
+const OPENSOURCE_SH = 'deploy/installer-opensource.sh';
+const SH_INSTALLERS = [...INTERNAL_SH, OPENSOURCE_SH];
+
+const read = (f) => readFileSync(f, 'utf-8');
+
+const blockOf = (text, tag) => {
+  const re = new RegExp(`^\\s*# >>> ${tag} >>>\\n[\\s\\S]*?^\\s*# <<< ${tag} <<<\\n`, 'm');
+  const m = text.match(re);
+  return m ? m[0] : null;
+};
+
+const codeOf = (text) => text
+  .split('\n')
+  .filter(line => !/^\s*#/.test(line))
+  .join('\n');
+
+const fnOf = (text, name) => {
+  const start = text.indexOf(`${name}() {`);
+  if (start < 0) return '';
+  const end = text.indexOf('\n# ============================================================', start + 1);
+  return end > start ? text.slice(start, end) : text.slice(start);
+};
+
+const present = SH_INSTALLERS.filter(existsSync);
+const patched = present.filter(f => blockOf(read(f), 'pilot-stop-for-deploy'));
+
+describe('sh overlay install stops updater, not just the collector pid', () => {
+  it('defines stop_pilot_for_deploy', () => {
+    expect(patched.length).toBeGreaterThanOrEqual(1);
+    for (const file of INTERNAL_SH.filter(existsSync)) {
+      expect(blockOf(read(file), 'pilot-stop-for-deploy'), `${file}: pilot-stop-for-deploy block missing`).toBeTruthy();
+    }
+    for (const file of patched) {
+      expect(codeOf(blockOf(read(file), 'pilot-stop-for-deploy')), file).toMatch(/stop_pilot_for_deploy\(\) \{/);
+    }
+  });
+
+  it('the block is byte-identical across the patched .sh installers', () => {
+    const blocks = patched.map(f => blockOf(read(f), 'pilot-stop-for-deploy'));
+    expect(blocks.filter(b => !b)).toEqual([]);
+    expect(new Set(blocks).size).toBe(1);
+  });
+
+  it('calls loongsuite-pilot stop, not a collector-only kill', () => {
+    const code = codeOf(blockOf(read(patched[0]), 'pilot-stop-for-deploy'));
+    expect(code).toMatch(/run_pilot_cli stop/);
+    expect(code).toMatch(/loongsuite-pilot-updater\.pid/);
+    // The CLI is how autostart_remove happens. Pid fallback is for a missing CLI,
+    // not the overlay path.
+    expect(code).toMatch(/command -v loongsuite-pilot/);
+  });
+
+  it('passes the installer data dir into every CLI verb after stop', () => {
+    // Without this, --data-dir overlay would stop the custom instance and then
+    // start/status/rollback the default ~/.loongsuite-pilot one.
+    const code = codeOf(blockOf(read(patched[0]), 'pilot-stop-for-deploy'));
+    expect(code).toMatch(/run_pilot_cli\(\)/);
+    expect(code).toMatch(/LOONGSUITE_PILOT_DATA_DIR="\$DATA_DIR"/);
+  });
+
+  it('restores autostart after a failed overlay, except in container mode', () => {
+    // stop deletes LaunchAgent/systemd unit files. Windows Enable-in-finally is
+    // reversible; Unix restore is `start`, which re-registers autostart. A
+    // docker build layer must not launch a daemon.
+    const code = codeOf(blockOf(read(patched[0]), 'pilot-stop-for-deploy'));
+    expect(code).toMatch(/restore_pilot_after_deploy\(\)/);
+    expect(code).toMatch(/INSTALL_MODE:-host/);
+    expect(code).toMatch(/run_pilot_cli start/);
+  });
+
+  it('cmd_install and cmd_upgrade both call it before deploy_package', () => {
+    for (const file of patched) {
+      const text = read(file);
+      expect(text.match(/stop_pilot_for_deploy/g)?.length, `${file}: expected helper + two call sites`)
+        .toBeGreaterThanOrEqual(3);
+
+      const install = fnOf(text, 'cmd_install');
+      const upgrade = fnOf(text, 'cmd_upgrade');
+      expect(install, `${file}: cmd_install missing`).toContain('stop_pilot_for_deploy');
+      expect(upgrade, `${file}: cmd_upgrade missing`).toContain('stop_pilot_for_deploy');
+
+      const stopAt = install.indexOf('stop_pilot_for_deploy');
+      const deployAt = install.indexOf('deploy_package');
+      expect(stopAt, `${file}: cmd_install never calls stop_pilot_for_deploy`).toBeGreaterThan(-1);
+      expect(deployAt, `${file}: cmd_install never calls deploy_package`).toBeGreaterThan(-1);
+      expect(stopAt, `${file}: cmd_install stops after deploy_package`).toBeLessThan(deployAt);
+
+      const upStopAt = upgrade.indexOf('stop_pilot_for_deploy');
+      const upDeployAt = upgrade.indexOf('deploy_package');
+      expect(upStopAt, file).toBeGreaterThan(-1);
+      expect(upDeployAt, file).toBeGreaterThan(-1);
+      expect(upStopAt, `${file}: cmd_upgrade stops after deploy_package`).toBeLessThan(upDeployAt);
+
+      // The old overlay path printed this and killed only the collector pid.
+      expect(install, `${file}: cmd_install still uses the collector-only pid kill`)
+        .not.toMatch(/Stopping running service \(PID/);
+
+      expect(install, `${file}: cmd_install EXIT trap does not restore autostart`)
+        .toMatch(/restore_pilot_after_deploy/);
+      expect(upgrade, `${file}: cmd_upgrade EXIT trap does not restore autostart`)
+        .toMatch(/restore_pilot_after_deploy/);
+
+      // start/status/rollback after stop must go through run_pilot_cli so --data-dir matches.
+      expect(install, `${file}: cmd_install start is not DATA_DIR-aware`)
+        .toMatch(/run_pilot_cli start/);
+      expect(upgrade, `${file}: cmd_upgrade start is not DATA_DIR-aware`)
+        .toMatch(/run_pilot_cli start/);
+      expect(upgrade, `${file}: cmd_upgrade rollback is not DATA_DIR-aware`)
+        .toMatch(/run_pilot_cli rollback/);
+    }
+  });
+
+  it('AGENTS.md still names the helper when this repo documents the rule', () => {
+    const agents = read('AGENTS.md');
+    if (!agents.includes('pilot-stop-for-deploy')) return;
+    expect(agents).toContain('tests/unit/deploy/installer-stop-for-deploy.test.mjs');
+  });
+});


### PR DESCRIPTION
## Summary
- Windows overlay install/upgrade `Disable-ScheduledTask`s the collector and updater tasks after stop, so the 5-minute watchdog cannot `gcOldVersions()` the in-flight `versions/<ver>_<commit>` directory before `current` is published. `finally` re-enables only the tasks this deploy actually disabled.
- Unix overlay install now calls `loongsuite-pilot stop` like upgrade (`autostart_remove` + stop both processes) instead of SIGTERM-ing only the collector pid. EXIT trap restores autostart via `start`. `stop`/`start`/`status`/`rollback` all pass `LOONGSUITE_PILOT_DATA_DIR`.
- Internal `installer.sh` / `installer.ps1` counterparts land in a separate internal MR; this PR is the opensource copies only.

## Test plan
- [x] `tests/unit/deploy/installer-hold-tasks-during-deploy.test.mjs`
- [x] `tests/unit/deploy/installer-stop-for-deploy.test.mjs`
- [ ] Overlay reinstall: updater does not delete the candidate version dir
- [ ] Failed overlay restores autostart (`loongsuite-pilot start` / scheduled tasks Enabled)


Made with [Cursor](https://cursor.com)