### PR TITLE
feat(logs): rotate and retain local observability logs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -210,7 +210,9 @@ Pilot can clean up local runtime logs on a schedule.
     "hookErrorDays": 7,
     "hookDebugDays": 7,
     "outputDays": 7,
-    "slsFailedDays": 7
+    "slsFailedDays": 7,
+    "otlpFailedDays": 7,
+    "metricAlarmDays": 7
   }
 }
 ```
@@ -220,6 +222,17 @@ Pilot can clean up local runtime logs on a schedule.
 | `LOONGSUITE_PILOT_LOG_RETENTION_ENABLED` | Enables or disables retention cleanup. |
 | `LOONGSUITE_PILOT_LOG_RETENTION_DAYS` | Applies one retention period to all log categories. |
 | `LOONGSUITE_PILOT_LOG_RETENTION_INTERVAL_MS` | Cleanup interval. |
+
+`otlpFailedDays` controls managed files under `logs/otlp-failed`; `metricAlarmDays`
+controls managed metrics, alarms, and updater-event files under `logs/metric_alarm`.
+Both default to 7 days. These streams write one file per local calendar day; there
+is no per-file size rotation. During scheduled cleanup, Pilot also tries to reduce
+managed OTLP failure logs to 512 MiB and managed metric/alarm logs to 256 MiB by
+deleting the oldest files while always retaining today and yesterday. These are
+soft cleanup targets: current files can grow beyond them between cleanup runs.
+Legacy undated files use their modification date for cleanup. When scheduled
+retention is disabled, neither age nor size cleanup runs. `token-usage-state.json`
+remains an overwrite state file and is excluded from this policy.
 
 ## Verify Changes
 

--- a/docs/trace-output.md
+++ b/docs/trace-output.md
@@ -89,7 +89,7 @@ Shared vs. per-backend settings (spans are converted once per distinct `service.
 - **Shared across all backends:** `resourceAttributes`, `captureMessageContent`, `resourceAttributeKeys`, `spanAttributePassthroughPrefixes`, `maxExportBatchBytes`, `turnIdleTimeoutMs`.
 - **Per-backend:** endpoint URL, headers, compression, and `service.name` (see below — user vs. managed backends can differ).
 
-A failing backend is isolated — it does not block the healthy backends, and its failed spans are persisted separately under `~/.loongsuite-pilot/logs/otlp-failed/<service>-<agent>__<backend-name>.jsonl`.
+A failing backend is isolated — it does not block the healthy backends, and its failed spans are persisted separately under `~/.loongsuite-pilot/logs/otlp-failed/<service>-<agent>__<backend-name>-YYYY-MM-DD.jsonl`.
 
 ### Managed backends (`configs/inner/data_config.json`)
 
@@ -363,3 +363,11 @@ Failed trace export data may be persisted under:
 ```text
 ~/.loongsuite-pilot/logs/otlp-failed/
 ```
+
+Each JSONL record keeps the existing full span payload plus `_error`. Files use
+the local calendar date and are not split by size. Scheduled retention defaults to
+7 days. If managed files exceed the 512 MiB soft cleanup target, Pilot removes the
+oldest files while always retaining today and yesterday. The directory may exceed
+that target between cleanup runs. Legacy undated JSONL files are no longer appended
+and use their modification date for the same age and pressure cleanup. This lifecycle
+does not change OTLP retry, exporter, or healthy-backend behavior.

--- a/docs/zh-CN/configuration.md
+++ b/docs/zh-CN/configuration.md
@@ -210,7 +210,9 @@ Pilot 可以定期清理本地运行日志。
     "hookErrorDays": 7,
     "hookDebugDays": 7,
     "outputDays": 7,
-    "slsFailedDays": 7
+    "slsFailedDays": 7,
+    "otlpFailedDays": 7,
+    "metricAlarmDays": 7
   }
 }
 ```
@@ -220,6 +222,15 @@ Pilot 可以定期清理本地运行日志。
 | `LOONGSUITE_PILOT_LOG_RETENTION_ENABLED` | 开启或关闭保留清理。 |
 | `LOONGSUITE_PILOT_LOG_RETENTION_DAYS` | 对所有日志类别使用统一保留天数。 |
 | `LOONGSUITE_PILOT_LOG_RETENTION_INTERVAL_MS` | 清理间隔。 |
+
+`otlpFailedDays` 控制 `logs/otlp-failed` 中受管文件的保留天数；
+`metricAlarmDays` 控制 `logs/metric_alarm` 中指标、告警和 Updater 事件文件的
+保留天数，二者默认都是 7 天。这些日志按本地日期每天写一个文件，不按单文件
+大小轮转。后台定时清理时，如果受管 OTLP 失败日志超过 512 MiB，或受管指标
+告警日志超过 256 MiB，Pilot 会从最旧文件开始删除，但始终保留当天和昨天。
+这些容量值是软清理目标，两次清理之间或当天文件持续增长时可以暂时超过。
+旧的无日期文件按修改日期参与清理；关闭定时保留后，按天数和容量的清理都不
+执行。`token-usage-state.json` 仍是覆盖写状态文件，不参与这项清理。
 
 ## 验证配置
 

--- a/docs/zh-CN/input-runtime-metrics.md
+++ b/docs/zh-CN/input-runtime-metrics.md
@@ -8,7 +8,7 @@ Pilot 会对 Input 的主数据源做低开销窗口统计，用于比较“实�
 - 正常运行时每 10 分钟上报一次；
 - 正常退出时在 Input 停止并排空事件队列后上报最后一个短窗口；
 - 远端仍使用 `pilot_pipeline`，Input 行的 `type` 为 `input`；
-- 本地镜像位于 `logs/metric_alarm/pilot-input-metrics.jsonl`。
+- 本地镜像按本地日期写入 `logs/metric_alarm/pilot-input-metrics-YYYY-MM-DD.jsonl`。
 
 当前窗口维度是固定的 `agent + input_name + source_kind + collection_method`。不包含 `session_id`、`turn_id`、`trace_id`、动态文件名或文件路径，因此上报行数和常驻内存不会随源记录数增长。
 

--- a/docs/zh-CN/trace-output.md
+++ b/docs/zh-CN/trace-output.md
@@ -89,7 +89,7 @@ Trace 导出会把**同一批**转换后的 span **同时**发往**所有**已�
 - **所有后端共享:** `resourceAttributes`、`captureMessageContent`、`resourceAttributeKeys`、`spanAttributePassthroughPrefixes`、`maxExportBatchBytes`、`turnIdleTimeoutMs`。
 - **每后端独立:** endpoint URL、headers、compression,以及 `service.name`(见下文——用户后端与托管后端可不同)。
 
-某个后端失败会被隔离——不会阻塞健康后端,其失败 span 会单独落盘到 `~/.loongsuite-pilot/logs/otlp-failed/<service>-<agent>__<后端名>.jsonl`。
+某个后端失败会被隔离——不会阻塞健康后端,其失败 span 会单独落盘到 `~/.loongsuite-pilot/logs/otlp-failed/<服务>-<Agent>__<后端名>-YYYY-MM-DD.jsonl`。
 
 ### 托管后端(`configs/inner/data_config.json`)
 
@@ -363,3 +363,9 @@ Trace 导出失败的数据可能会持久化到：
 ```text
 ~/.loongsuite-pilot/logs/otlp-failed/
 ```
+
+每条 JSONL 仍保留现有完整 span 和 `_error`。文件按本地日期每天写一个，不按
+大小分片，默认保留 7 天。后台清理时，如果受管文件超过 512 MiB 的软目标，
+Pilot 会从最旧文件开始删除，但始终保留当天和昨天，因此目录可能在两次清理
+之间暂时超过目标。新版本不再追加旧的无日期 JSONL；旧文件按修改日期参与
+相同的保留和容量清理。该变化不影响 OTLP 重试、导出和健康后端行为。

--- a/src/core/config-loader.ts
+++ b/src/core/config-loader.ts
@@ -117,6 +117,8 @@ export interface ConfigFile {
     hookDebugDays?: number;
     outputDays?: number;
     slsFailedDays?: number;
+    otlpFailedDays?: number;
+    metricAlarmDays?: number;
   };
 
   hookWatchdog?: {
@@ -651,6 +653,8 @@ function buildRetentionConfig(file: ConfigFile | null): LogRetentionConfig {
     hookDebugDays: resolve(file?.retention?.hookDebugDays, 7),
     outputDays: resolve(file?.retention?.outputDays, 7),
     slsFailedDays: resolve(file?.retention?.slsFailedDays, 7),
+    otlpFailedDays: resolve(file?.retention?.otlpFailedDays, 7),
+    metricAlarmDays: resolve(file?.retention?.metricAlarmDays, 7),
   };
 }
 

--- a/src/core/log-retention-service.ts
+++ b/src/core/log-retention-service.ts
@@ -15,14 +15,35 @@ export const OUTPUT_RETENTION_LARGE_FILE_THRESHOLD_BYTES = 512 * MEBIBYTE;
 export const OUTPUT_RETENTION_LARGE_FILE_DAYS = 2;
 export const OUTPUT_RETENTION_PRESSURE_MIN_KEEP_DAYS = 1;
 export const SLS_FAILURE_RETENTION_MAX_TOTAL_BYTES = SLS_FAILURE_LOG_MAX_TOTAL_BYTES;
+export const OTLP_FAILED_RETENTION_MAX_TOTAL_BYTES = 512 * MEBIBYTE;
+export const METRIC_ALARM_RETENTION_MAX_TOTAL_BYTES = 256 * MEBIBYTE;
+export const LOCAL_OBSERVABILITY_PRESSURE_MIN_KEEP_DAYS = 1;
 
-type Category = 'history' | 'errors' | 'debug' | 'output' | 'sls-failed-logs';
+const METRIC_ALARM_STREAM_NAMES = new Set([
+  'pilot-metrics',
+  'pilot-agent-metrics',
+  'pilot-flusher-metrics',
+  'pilot-input-metrics',
+  'pilot-alarm-metrics',
+  'pilot-alarms',
+  'pilot-updater-events',
+]);
+
+type Category =
+  | 'history'
+  | 'errors'
+  | 'debug'
+  | 'output'
+  | 'sls-failed-logs'
+  | 'otlp-failed'
+  | 'metric_alarm';
 
 interface DatedLogFile {
   file: string;
   fullPath: string;
   dateStr: string;
   size: number;
+  mtimeMs: number;
 }
 
 const CATEGORY_DIR_MAP: Record<string, Category> = {
@@ -31,6 +52,8 @@ const CATEGORY_DIR_MAP: Record<string, Category> = {
   debug: 'debug',
   output: 'output',
   'sls-failed-logs': 'sls-failed-logs',
+  'otlp-failed': 'otlp-failed',
+  metric_alarm: 'metric_alarm',
 };
 
 export class LogRetentionService {
@@ -56,11 +79,16 @@ export class LogRetentionService {
       hookDebugDays: this.config.hookDebugDays,
       outputDays: this.config.outputDays,
       slsFailedDays: this.config.slsFailedDays,
+      otlpFailedDays: this.config.otlpFailedDays,
+      metricAlarmDays: this.config.metricAlarmDays,
       outputMaxTotalBytes: OUTPUT_RETENTION_MAX_TOTAL_BYTES,
       outputLargeFileThresholdBytes: OUTPUT_RETENTION_LARGE_FILE_THRESHOLD_BYTES,
       outputLargeFileDays: OUTPUT_RETENTION_LARGE_FILE_DAYS,
       outputPressureMinKeepDays: OUTPUT_RETENTION_PRESSURE_MIN_KEEP_DAYS,
       slsFailedMaxTotalBytes: SLS_FAILURE_RETENTION_MAX_TOTAL_BYTES,
+      otlpFailedMaxTotalBytes: OTLP_FAILED_RETENTION_MAX_TOTAL_BYTES,
+      metricAlarmMaxTotalBytes: METRIC_ALARM_RETENTION_MAX_TOTAL_BYTES,
+      localObservabilityPressureMinKeepDays: LOCAL_OBSERVABILITY_PRESSURE_MIN_KEEP_DAYS,
     });
 
     this.startupTimer = setTimeout(() => {
@@ -156,6 +184,9 @@ export class LogRetentionService {
     if (category === 'sls-failed-logs') {
       return this.cleanSlsFailedDirectory(dir, files, today);
     }
+    if (category === 'otlp-failed' || category === 'metric_alarm') {
+      return this.cleanLocalObservabilityDirectory(dir, files, category);
+    }
 
     const retentionDays = this.getRetentionDays(category);
     const cutoff = dateCutoff(retentionDays);
@@ -217,6 +248,100 @@ export class LogRetentionService {
     return { deleted, errors };
   }
 
+  private async cleanLocalObservabilityDirectory(
+    dir: string,
+    files: string[],
+    category: 'otlp-failed' | 'metric_alarm',
+  ): Promise<{ deleted: number; errors: number }> {
+    let deleted = 0;
+    let errors = 0;
+    let remaining = await this.collectLocalObservabilityFiles(dir, files, category);
+
+    const retentionCutoff = dateCutoff(this.getRetentionDays(category));
+    // Both age and pressure cleanup protect the two most recent local dates.
+    const protectedFrom = dateCutoff(LOCAL_OBSERVABILITY_PRESSURE_MIN_KEEP_DAYS);
+    const expired = await this.deleteDatedFiles(
+      remaining,
+      file => file.dateStr < protectedFrom && file.dateStr < retentionCutoff,
+    );
+    deleted += expired.deleted;
+    errors += expired.errors;
+
+    // Re-read after deletion so a failed unlink still contributes to pressure.
+    remaining = await this.collectLocalObservabilityFiles(dir, await readdir(dir), category);
+    let totalBytes = remaining.reduce((sum, file) => sum + file.size, 0);
+    const maxTotalBytes = category === 'otlp-failed'
+      ? OTLP_FAILED_RETENTION_MAX_TOTAL_BYTES
+      : METRIC_ALARM_RETENTION_MAX_TOTAL_BYTES;
+    if (totalBytes <= maxTotalBytes) return { deleted, errors };
+
+    // protectedFrom is yesterday. Only strictly older files are eligible.
+    const candidates = remaining
+      .filter(file => file.dateStr < protectedFrom)
+      .sort((a, b) => a.dateStr.localeCompare(b.dateStr)
+        || a.mtimeMs - b.mtimeMs
+        || a.file.localeCompare(b.file));
+
+    for (const file of candidates) {
+      if (totalBytes <= maxTotalBytes) break;
+      if (await this.deleteFile(file.fullPath)) {
+        deleted++;
+        totalBytes -= file.size;
+      } else {
+        errors++;
+      }
+    }
+
+    return { deleted, errors };
+  }
+
+  private async collectLocalObservabilityFiles(
+    dir: string,
+    files: string[],
+    category: 'otlp-failed' | 'metric_alarm',
+  ): Promise<DatedLogFile[]> {
+    const result: DatedLogFile[] = [];
+    for (const file of files) {
+      if (file.startsWith('.') || !file.endsWith('.jsonl')) continue;
+
+      const extractedDate = extractDate(file);
+      const dated = extractedDate !== null && this.isManagedDatedFile(file, extractedDate, category);
+      const legacy = extractedDate === null && this.isManagedLegacyFile(file, category);
+      if (!dated && !legacy) continue;
+
+      const fullPath = path.join(dir, file);
+      const stat = await safeLstat(fullPath);
+      if (!stat?.isFile()) continue;
+      result.push({
+        file,
+        fullPath,
+        dateStr: extractedDate ?? localDateString(new Date(stat.mtimeMs)),
+        size: stat.size,
+        mtimeMs: stat.mtimeMs,
+      });
+    }
+    return result;
+  }
+
+  private isManagedDatedFile(
+    file: string,
+    dateStr: string,
+    category: 'otlp-failed' | 'metric_alarm',
+  ): boolean {
+    if (category === 'otlp-failed') return true;
+    const suffix = `-${dateStr}.jsonl`;
+    if (!file.endsWith(suffix)) return false;
+    return METRIC_ALARM_STREAM_NAMES.has(file.slice(0, -suffix.length));
+  }
+
+  private isManagedLegacyFile(
+    file: string,
+    category: 'otlp-failed' | 'metric_alarm',
+  ): boolean {
+    if (category === 'otlp-failed') return true;
+    return METRIC_ALARM_STREAM_NAMES.has(file.slice(0, -'.jsonl'.length));
+  }
+
   private async cleanOutputDirectory(
     dir: string,
     files: string[],
@@ -268,6 +393,7 @@ export class LogRetentionService {
         fullPath,
         dateStr,
         size: stat.size,
+        mtimeMs: stat.mtimeMs,
       });
     }
     return result;
@@ -344,6 +470,8 @@ export class LogRetentionService {
       case 'debug': return this.config.hookDebugDays;
       case 'output': return this.config.outputDays;
       case 'sls-failed-logs': return this.config.slsFailedDays;
+      case 'otlp-failed': return this.config.otlpFailedDays;
+      case 'metric_alarm': return this.config.metricAlarmDays;
     }
   }
 }
@@ -383,6 +511,14 @@ async function readdir(dir: string): Promise<string[]> {
 async function safeStat(p: string) {
   try {
     return await fs.stat(p);
+  } catch {
+    return null;
+  }
+}
+
+async function safeLstat(p: string) {
+  try {
+    return await fs.lstat(p);
   } catch {
     return null;
   }

--- a/src/flushers/otlp-trace-flusher.ts
+++ b/src/flushers/otlp-trace-flusher.ts
@@ -1536,7 +1536,7 @@ export class OtlpTraceFlusher extends BaseFlusher {
       const svcName = `${this.cfg.serviceName}-${agentType}__${safeEndpoint}`;
       const dir = this.failedDir;
       await ensureDir(dir);
-      const filepath = path.join(dir, `${svcName}.jsonl`);
+      const filepath = path.join(dir, `${svcName}-${getTodayDateString()}.jsonl`);
       const jsonLines = createReadableSpanToOtlpSpanJsonArray(spans);
       for (const line of jsonLines) {
         const obj = JSON.parse(line);

--- a/src/metrics/metrics-writer.ts
+++ b/src/metrics/metrics-writer.ts
@@ -1,5 +1,5 @@
 import * as path from 'node:path';
-import { appendLine, ensureDir } from '../utils/fs-utils.js';
+import { appendLine, ensureDir, getTodayDateString } from '../utils/fs-utils.js';
 import { createLogger } from '../utils/logger.js';
 import { flattenToStrings } from '../utils/record-utils.js';
 import { sendAlarm, sendRunningStatus, sendStatus } from '../internal/sender.js';
@@ -172,7 +172,7 @@ export class MetricsWriter {
       sendStatus('pilot_status', flattenToStrings(metrics));
       sendRunningStatus(flattenToStrings(metrics));
 
-      const filePath = path.join(this.logsDir, 'pilot-metrics.jsonl');
+      const filePath = path.join(this.logsDir, `pilot-metrics-${getTodayDateString()}.jsonl`);
       await appendLine(filePath, JSON.stringify(metrics));
     } catch (err) {
       logger.warn('L1 metrics write failed', { error: String(err) });
@@ -441,13 +441,22 @@ export class MetricsWriter {
         for (const row of l2.flushers) sendStatus('pilot_pipeline', flattenToStrings(row));
 
         for (const row of l2.agents) {
-          await appendLine(path.join(this.logsDir, 'pilot-agent-metrics.jsonl'), JSON.stringify(row));
+          await appendLine(
+            path.join(this.logsDir, `pilot-agent-metrics-${getTodayDateString()}.jsonl`),
+            JSON.stringify(row),
+          );
         }
         for (const row of l2.inputs) {
-          await appendLine(path.join(this.logsDir, 'pilot-input-metrics.jsonl'), JSON.stringify(row));
+          await appendLine(
+            path.join(this.logsDir, `pilot-input-metrics-${getTodayDateString()}.jsonl`),
+            JSON.stringify(row),
+          );
         }
         for (const row of l2.flushers) {
-          await appendLine(path.join(this.logsDir, 'pilot-flusher-metrics.jsonl'), JSON.stringify(row));
+          await appendLine(
+            path.join(this.logsDir, `pilot-flusher-metrics-${getTodayDateString()}.jsonl`),
+            JSON.stringify(row),
+          );
         }
       }
     } catch (err) {
@@ -460,11 +469,11 @@ export class MetricsWriter {
     try {
       const entries = this.alarmManager.serialize();
       if (entries.length === 0) return;
-      const filePath = path.join(this.logsDir, 'pilot-alarms.jsonl');
       // Invoke the existing sender before local IO, so ENOSPC cannot block it.
       for (const entry of entries) {
         sendAlarm('pilot_alarm', flattenToStrings(entry));
       }
+      const filePath = path.join(this.logsDir, `pilot-alarms-${getTodayDateString()}.jsonl`);
       for (const entry of entries) {
         await appendLine(filePath, JSON.stringify(entry));
       }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -379,6 +379,8 @@ export interface LogRetentionConfig {
   hookDebugDays: number;
   outputDays: number;
   slsFailedDays: number;
+  otlpFailedDays: number;
+  metricAlarmDays: number;
 }
 
 export interface HookWatchdogConfig {

--- a/src/updater/updater-metrics.ts
+++ b/src/updater/updater-metrics.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { appendLine, ensureDir } from '../utils/fs-utils.js';
+import { appendLine, ensureDir, getTodayDateString } from '../utils/fs-utils.js';
 import { createLogger } from '../utils/logger.js';
 import { resolveLocalIp } from '../utils/network-utils.js';
 import { flattenToStrings } from '../utils/record-utils.js';
@@ -150,9 +150,12 @@ export class UpdaterMetrics {
 
     if (events.length > 0) {
       try {
-        const filePath = path.join(this.logsDir, 'pilot-updater-events.jsonl');
-        for (const ev of events) {
-          await appendLine(filePath, JSON.stringify(ev));
+        const filePath = path.join(
+          this.logsDir,
+          `pilot-updater-events-${getTodayDateString()}.jsonl`,
+        );
+        for (const event of events) {
+          await appendLine(filePath, JSON.stringify(event));
         }
       } catch (err) {
         logger.warn('updater event write failed', { error: String(err) });
@@ -165,15 +168,18 @@ export class UpdaterMetrics {
 
     if (alarms.length > 0) {
       try {
-        const filePath = path.join(this.logsDir, 'pilot-alarms.jsonl');
-        for (const al of alarms) {
-          await appendLine(filePath, JSON.stringify(al));
+        const filePath = path.join(
+          this.logsDir,
+          `pilot-alarms-${getTodayDateString()}.jsonl`,
+        );
+        for (const alarm of alarms) {
+          await appendLine(filePath, JSON.stringify(alarm));
         }
       } catch (err) {
         logger.warn('updater alarm write failed', { error: String(err) });
       }
-      for (const al of alarms) {
-        sendAlarm('pilot_alarm', flattenToStrings(al));
+      for (const alarm of alarms) {
+        sendAlarm('pilot_alarm', flattenToStrings(alarm));
       }
     }
   }
@@ -225,4 +231,3 @@ export class UpdaterMetrics {
     return `${base} | cause=${reason} detail="${detailHead}" phase=${breadcrumb.phase} version=${breadcrumb.version}`;
   }
 }
-

--- a/tests/integration/disk-usage-monitor.test.ts
+++ b/tests/integration/disk-usage-monitor.test.ts
@@ -58,8 +58,13 @@ describe('Directory usage: real files to reported metrics', () => {
       disk_dir_status: 'ok', disk_data_bytes: '8', disk_logs_bytes: '5',
       disk_dir_sampled_at: new Date(snapshot.sampledAt!).toISOString(),
     });
+    const metricDir = path.join(dataDir, 'logs', 'metric_alarm');
+    const metricFile = fs.readdirSync(metricDir).find(name => (
+      name.startsWith('pilot-metrics-') && name.endsWith('.jsonl')
+    ));
+    expect(metricFile).toBeDefined();
     const localRow = JSON.parse(fs.readFileSync(
-      path.join(dataDir, 'logs', 'metric_alarm', 'pilot-metrics.jsonl'), 'utf8',
+      path.join(metricDir, metricFile!), 'utf8',
     ).trim().split('\n')[0]);
     expect(localRow.metric_json.disk_data_bytes).toBe('8');
     expect(sent.runningStatus).toHaveBeenCalledOnce();

--- a/tests/unit/core/config-loader.test.ts
+++ b/tests/unit/core/config-loader.test.ts
@@ -338,6 +338,8 @@ describe('ConfigLoader', () => {
       expect(config.retention.hookDebugDays).toBe(7);
       expect(config.retention.outputDays).toBe(7);
       expect(config.retention.slsFailedDays).toBe(7);
+      expect(config.retention.otlpFailedDays).toBe(7);
+      expect(config.retention.metricAlarmDays).toBe(7);
     });
 
     it('uses config file values over defaults', async () => {
@@ -345,6 +347,8 @@ describe('ConfigLoader', () => {
         retention: {
           hookHistoryDays: 60,
           hookDebugDays: 14,
+          otlpFailedDays: 3,
+          metricAlarmDays: 14,
         },
       });
 
@@ -352,6 +356,8 @@ describe('ConfigLoader', () => {
       expect(config.retention.hookHistoryDays).toBe(60);
       expect(config.retention.hookDebugDays).toBe(14);
       expect(config.retention.hookErrorDays).toBe(7);
+      expect(config.retention.otlpFailedDays).toBe(3);
+      expect(config.retention.metricAlarmDays).toBe(14);
     });
 
     it('LOONGSUITE_PILOT_LOG_RETENTION_DAYS overrides all defaults', async () => {
@@ -364,6 +370,8 @@ describe('ConfigLoader', () => {
       expect(config.retention.hookDebugDays).toBe(10);
       expect(config.retention.outputDays).toBe(10);
       expect(config.retention.slsFailedDays).toBe(10);
+      expect(config.retention.otlpFailedDays).toBe(10);
+      expect(config.retention.metricAlarmDays).toBe(10);
     });
 
     it('config file values take precedence over unified env var', async () => {
@@ -375,6 +383,8 @@ describe('ConfigLoader', () => {
       const config = await loadConfig();
       expect(config.retention.hookHistoryDays).toBe(90);
       expect(config.retention.hookErrorDays).toBe(10);
+      expect(config.retention.otlpFailedDays).toBe(10);
+      expect(config.retention.metricAlarmDays).toBe(10);
     });
 
     it('LOONGSUITE_PILOT_LOG_RETENTION_ENABLED disables retention', async () => {

--- a/tests/unit/core/log-retention-service.test.ts
+++ b/tests/unit/core/log-retention-service.test.ts
@@ -6,6 +6,8 @@ import {
   LogRetentionService,
   OUTPUT_RETENTION_LARGE_FILE_THRESHOLD_BYTES,
   OUTPUT_RETENTION_MAX_TOTAL_BYTES,
+  METRIC_ALARM_RETENTION_MAX_TOTAL_BYTES,
+  OTLP_FAILED_RETENTION_MAX_TOTAL_BYTES,
   SLS_FAILURE_RETENTION_MAX_TOTAL_BYTES,
   extractDate,
 } from '../../../src/core/log-retention-service.js';
@@ -26,6 +28,8 @@ function makeConfig(overrides: Partial<LogRetentionConfig> = {}): LogRetentionCo
     hookDebugDays: 7,
     outputDays: 7,
     slsFailedDays: 7,
+    otlpFailedDays: 7,
+    metricAlarmDays: 7,
     ...overrides,
   };
 }
@@ -33,11 +37,19 @@ function makeConfig(overrides: Partial<LogRetentionConfig> = {}): LogRetentionCo
 function daysAgo(n: number): string {
   const d = new Date();
   d.setDate(d.getDate() - n);
-  return d.toISOString().slice(0, 10);
+  return localDate(d);
 }
 
 function today(): string {
-  return new Date().toISOString().slice(0, 10);
+  return localDate(new Date());
+}
+
+function localDate(date: Date): string {
+  return [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, '0'),
+    String(date.getDate()).padStart(2, '0'),
+  ].join('-');
 }
 
 async function writeSizedFile(filePath: string, size: number): Promise<void> {
@@ -220,6 +232,140 @@ describe('LogRetentionService', () => {
       expect(await fs.access(sealed0).then(() => true, () => false)).toBe(false);
       expect(await fs.access(sealed1).then(() => true, () => false)).toBe(true);
       expect(await fs.access(active).then(() => true, () => false)).toBe(true);
+    });
+
+    it('cleans expired OTLP daily files and leaves recent legacy files protected', async () => {
+      const otlpDir = path.join(tmpDir, 'logs', 'otlp-failed');
+      await fs.mkdir(otlpDir, { recursive: true });
+      const expired = path.join(otlpDir, `service-primary-${daysAgo(10)}.jsonl`);
+      const recent = path.join(otlpDir, `service-primary-${today()}.jsonl`);
+      const legacy = path.join(otlpDir, 'service.jsonl');
+      await fs.writeFile(expired, 'old\n');
+      await fs.writeFile(recent, 'recent\n');
+      await fs.writeFile(legacy, 'legacy\n');
+
+      const service = new LogRetentionService(tmpDir, makeConfig({ otlpFailedDays: 7 }));
+      const result = await service.runCleanup();
+
+      expect(result).toEqual({ deleted: 1, errors: 0 });
+      await expect(fs.access(expired)).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(fs.readFile(recent, 'utf8')).resolves.toBe('recent\n');
+      await expect(fs.readFile(legacy, 'utf8')).resolves.toBe('legacy\n');
+    });
+
+    it('cleans expired metric daily and legacy files without touching unknown or state files', async () => {
+      const metricDir = path.join(tmpDir, 'logs', 'metric_alarm');
+      await fs.mkdir(metricDir, { recursive: true });
+      const expired = path.join(metricDir, `pilot-metrics-${daysAgo(10)}.jsonl`);
+      const legacy = path.join(metricDir, 'pilot-input-metrics.jsonl');
+      const tokenState = path.join(metricDir, 'token-usage-state.json');
+      const unknown = path.join(metricDir, 'user-data.jsonl');
+      const unknownDated = path.join(metricDir, `user-data-${daysAgo(10)}.jsonl`);
+      await fs.writeFile(expired, 'old\n');
+      await fs.writeFile(legacy, 'legacy\n');
+      await fs.writeFile(tokenState, '{"state":true}');
+      await fs.writeFile(unknown, 'unknown\n');
+      await fs.writeFile(unknownDated, 'unknown dated\n');
+      const old = new Date();
+      old.setDate(old.getDate() - 10);
+      await fs.utimes(legacy, old, old);
+      await fs.utimes(tokenState, old, old);
+      await fs.utimes(unknown, old, old);
+
+      const service = new LogRetentionService(tmpDir, makeConfig({ metricAlarmDays: 7 }));
+      const result = await service.runCleanup();
+
+      expect(result).toEqual({ deleted: 2, errors: 0 });
+      await expect(fs.access(expired)).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(fs.access(legacy)).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(fs.readFile(tokenState, 'utf8')).resolves.toContain('state');
+      await expect(fs.readFile(unknown, 'utf8')).resolves.toBe('unknown\n');
+      await expect(fs.readFile(unknownDated, 'utf8')).resolves.toBe('unknown dated\n');
+    });
+
+    it('reduces metric_alarm pressure while preserving both today and yesterday', async () => {
+      const metricDir = path.join(tmpDir, 'logs', 'metric_alarm');
+      await fs.mkdir(metricDir, { recursive: true });
+      const fileSize = Math.floor(METRIC_ALARM_RETENTION_MAX_TOTAL_BYTES / 3) + 1;
+      const old = path.join(metricDir, `pilot-metrics-${daysAgo(2)}.jsonl`);
+      const yesterday = path.join(metricDir, `pilot-metrics-${daysAgo(1)}.jsonl`);
+      const current = path.join(metricDir, `pilot-metrics-${today()}.jsonl`);
+      await writeSizedFile(old, fileSize);
+      await writeSizedFile(yesterday, fileSize);
+      await writeSizedFile(current, fileSize);
+
+      const service = new LogRetentionService(tmpDir, makeConfig());
+      const result = await service.runCleanup();
+
+      expect(result).toEqual({ deleted: 1, errors: 0 });
+      await expect(fs.access(old)).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(fs.access(yesterday)).resolves.toBeUndefined();
+      await expect(fs.access(current)).resolves.toBeUndefined();
+    });
+
+    it('keeps OTLP today and yesterday even when they alone exceed the soft limit', async () => {
+      const otlpDir = path.join(tmpDir, 'logs', 'otlp-failed');
+      await fs.mkdir(otlpDir, { recursive: true });
+      const fileSize = Math.floor(OTLP_FAILED_RETENTION_MAX_TOTAL_BYTES / 2) + 1;
+      const yesterday = path.join(otlpDir, `service-${daysAgo(1)}.jsonl`);
+      const current = path.join(otlpDir, `service-${today()}.jsonl`);
+      await writeSizedFile(yesterday, fileSize);
+      await writeSizedFile(current, fileSize);
+
+      const service = new LogRetentionService(tmpDir, makeConfig());
+      const result = await service.runCleanup();
+
+      expect(result).toEqual({ deleted: 0, errors: 0 });
+      await expect(fs.access(yesterday)).resolves.toBeUndefined();
+      await expect(fs.access(current)).resolves.toBeUndefined();
+    });
+
+    it('protects today and yesterday from age cleanup even with a shorter retention value', async () => {
+      const metricDir = path.join(tmpDir, 'logs', 'metric_alarm');
+      await fs.mkdir(metricDir, { recursive: true });
+      const old = path.join(metricDir, `pilot-alarms-${daysAgo(2)}.jsonl`);
+      const yesterday = path.join(metricDir, `pilot-alarms-${daysAgo(1)}.jsonl`);
+      const current = path.join(metricDir, `pilot-alarms-${today()}.jsonl`);
+      await fs.writeFile(old, 'old\n');
+      await fs.writeFile(yesterday, 'yesterday\n');
+      await fs.writeFile(current, 'today\n');
+
+      const service = new LogRetentionService(tmpDir, makeConfig({ metricAlarmDays: 0 }));
+      const result = await service.runCleanup();
+
+      expect(result).toEqual({ deleted: 1, errors: 0 });
+      await expect(fs.access(old)).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(fs.access(yesterday)).resolves.toBeUndefined();
+      await expect(fs.access(current)).resolves.toBeUndefined();
+    });
+
+    it('skips metric state, unknown, hidden, symlink, and directory entries', async () => {
+      const metricDir = path.join(tmpDir, 'logs', 'metric_alarm');
+      await fs.mkdir(metricDir, { recursive: true });
+      const oldDate = daysAgo(10);
+      const state = path.join(metricDir, 'token-usage-state.json');
+      const unknown = path.join(metricDir, `user-data-${oldDate}.jsonl`);
+      const hidden = path.join(metricDir, `.pilot-metrics-${oldDate}.jsonl`);
+      const external = path.join(tmpDir, 'external.jsonl');
+      const symlink = path.join(metricDir, `pilot-metrics-${oldDate}.jsonl`);
+      const directory = path.join(metricDir, `pilot-alarms-${oldDate}.jsonl`);
+      await fs.writeFile(state, '{}');
+      await fs.writeFile(unknown, 'unknown\n');
+      await fs.writeFile(hidden, 'hidden\n');
+      await fs.writeFile(external, 'external\n');
+      await fs.symlink(external, symlink);
+      await fs.mkdir(directory);
+
+      const service = new LogRetentionService(tmpDir, makeConfig());
+      const result = await service.runCleanup();
+
+      expect(result).toEqual({ deleted: 0, errors: 0 });
+      await expect(fs.access(state)).resolves.toBeUndefined();
+      await expect(fs.access(unknown)).resolves.toBeUndefined();
+      await expect(fs.access(hidden)).resolves.toBeUndefined();
+      await expect(fs.lstat(symlink)).resolves.toMatchObject({});
+      await expect(fs.stat(directory)).resolves.toMatchObject({});
+      await expect(fs.readFile(external, 'utf8')).resolves.toBe('external\n');
     });
 
     it('skips unrecognized subdirectories', async () => {

--- a/tests/unit/core/orchestrator.test.ts
+++ b/tests/unit/core/orchestrator.test.ts
@@ -259,6 +259,8 @@ function makeConfig(overrides: Partial<AnalyticsConfig> = {}): AnalyticsConfig {
       hookDebugDays: 7,
       outputDays: 7,
       slsFailedDays: 7,
+      otlpFailedDays: 7,
+      metricAlarmDays: 7,
     },
     hookWatchdog: {
       enabled: false, // disabled by default in tests to avoid spawning child processes

--- a/tests/unit/flushers/otlp-trace-flusher/export.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/export.test.ts
@@ -106,9 +106,10 @@ describe('OtlpTraceFlusher - export', () => {
     await flusher.shutdown();
 
     const failedCalls = vi.mocked(fsUtils.appendLine).mock.calls.filter(
-      (c) => (c[0] as string).includes('otlp-failed'),
+      (call) => (call[0] as string).includes('otlp-failed'),
     );
-    expect(failedCalls.length).toBeGreaterThan(0);
+    expect(failedCalls).toHaveLength(1);
+    expect(failedCalls[0][0]).toMatch(/test-pilot-claude-code__primary-\d{4}-\d{2}-\d{2}\.jsonl$/);
     const written = JSON.parse(failedCalls[0][1] as string);
     expect(written._error).toBeDefined();
     expect(written._error.message).toContain('401');
@@ -185,8 +186,12 @@ describe('OtlpTraceFlusher - export', () => {
     await flusher.shutdown();
 
     const allCalls = vi.mocked(fsUtils.appendLine).mock.calls;
-    const debugCalls = allCalls.filter((c) => (c[0] as string).includes('otlp-debug'));
-    const failedCalls = allCalls.filter((c) => (c[0] as string).includes('otlp-failed'));
+    const debugCalls = allCalls.filter(
+      (c) => (c[0] as string).includes('otlp-debug'),
+    );
+    const failedCalls = allCalls.filter(
+      (c) => (c[0] as string).includes('otlp-failed'),
+    );
     expect(debugCalls.length).toBeGreaterThan(0);
     expect(failedCalls.length).toBeGreaterThan(0);
   });
@@ -300,13 +305,13 @@ describe('OtlpTraceFlusher - multi-backend fan-out', () => {
     await flusher.exportSpansForAgent('claude-code', [makeMockSpan()] as any);
     await flusher.shutdown();
 
-    const failedCalls = vi.mocked(fsUtils.appendLine).mock.calls.filter(
-      (c) => (c[0] as string).includes('otlp-failed'),
-    );
     // only backend-b failed → exactly its endpoint-tagged file is written
-    expect(failedCalls.length).toBeGreaterThan(0);
-    expect(failedCalls.every((c) => (c[0] as string).includes('__backend-b'))).toBe(true);
-    expect(failedCalls.some((c) => (c[0] as string).includes('__backend-a'))).toBe(false);
+    const failedCalls = vi.mocked(fsUtils.appendLine).mock.calls.filter(
+      (call) => (call[0] as string).includes('otlp-failed'),
+    );
+    expect(failedCalls).toHaveLength(1);
+    expect(failedCalls[0][0]).toMatch(/__backend-b-\d{4}-\d{2}-\d{2}\.jsonl$/);
+    expect(failedCalls[0][0]).not.toContain('__backend-a-');
   });
 
   it('sanitizes a malicious endpoint name in the failed-log path', async () => {
@@ -327,16 +332,12 @@ describe('OtlpTraceFlusher - multi-backend fan-out', () => {
     await flusher.shutdown();
 
     const failedCalls = vi.mocked(fsUtils.appendLine).mock.calls.filter(
-      (c) => (c[0] as string).includes('otlp-failed'),
+      (call) => (call[0] as string).includes('otlp-failed'),
     );
-    expect(failedCalls.length).toBeGreaterThan(0);
-    // separators are replaced so the name stays a single file inside otlp-failed
-    // (embedded dots are harmless without separators — no directory traversal)
-    for (const c of failedCalls) {
-      const p = c[0] as string;
-      expect(p).toContain('otlp-failed');
-      expect(p).not.toContain('/tmp/pwn');
-      expect(p).toContain('.._.._.._.._tmp_pwn'); // slashes → '_', dots kept
-    }
+    expect(failedCalls).toHaveLength(1);
+    const failedPath = failedCalls[0][0] as string;
+    expect(failedPath).not.toContain('/tmp/pwn');
+    expect(failedPath).toContain('.._.._.._.._tmp_pwn');
+    expect(failedPath).toMatch(/-\d{4}-\d{2}-\d{2}\.jsonl$/);
   });
 });

--- a/tests/unit/flushers/otlp-trace-flusher/failed-log.test.ts
+++ b/tests/unit/flushers/otlp-trace-flusher/failed-log.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { cleanupTempDir, createTempDir } from '../../../helpers/fixture-builder.js';
+import { OtlpTraceFlusher } from '../../../../src/flushers/otlp-trace-flusher.js';
+
+function mockSpan() {
+  return {
+    spanContext: () => ({ traceId: 'a'.repeat(32), spanId: 'b'.repeat(16) }),
+    parentSpanId: undefined,
+    name: 'failed-span',
+    kind: 0,
+    startTime: [1000, 0] as [number, number],
+    endTime: [1001, 0] as [number, number],
+    attributes: {
+      'gen_ai.agent.type': 'claude-code',
+      'gen_ai.input.messages': 'diagnostic payload',
+    },
+    status: { code: 2, message: 'failed' },
+    resource: { attributes: { 'service.name': 'test-pilot-claude-code' } },
+    events: [],
+    links: [],
+    duration: [1, 0] as [number, number],
+    ended: true,
+    instrumentationLibrary: { name: 'test', version: '1.0.0' },
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+  };
+}
+
+describe('OtlpTraceFlusher failed-log lifecycle', () => {
+  let dataDir: string;
+
+  beforeEach(async () => {
+    dataDir = await createTempDir('otlp-failed-log-');
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await cleanupTempDir(dataDir);
+  });
+
+  it('writes the existing full span and _error to a safe daily file', async () => {
+    const flusher = new OtlpTraceFlusher({
+      enabled: true,
+      endpoints: [{ name: '../../../../tmp/pwn', endpoint: 'http://localhost:4318' }],
+      protocol: 'http/protobuf',
+      serviceName: 'test-pilot',
+      dataDir,
+    });
+
+    await (flusher as any).writeFailedLog(
+      'claude-code',
+      '../../../../tmp/pwn',
+      [mockSpan()],
+      { code: 2, message: 'connection refused' },
+    );
+
+    const failedDir = path.join(dataDir, 'logs', 'otlp-failed');
+    const files = (await fs.readdir(failedDir)).filter(file => file.endsWith('.jsonl'));
+    expect(files).toHaveLength(1);
+    expect(files[0]).toContain('__.._.._.._.._tmp_pwn-');
+    expect(files[0]).toMatch(/-\d{4}-\d{2}-\d{2}\.jsonl$/);
+    expect(files[0]).not.toContain('/');
+
+    const record = JSON.parse(await fs.readFile(path.join(failedDir, files[0]), 'utf8'));
+    expect(record._error).toEqual({ code: 2, message: 'connection refused' });
+    expect(JSON.stringify(record)).toContain('diagnostic payload');
+  });
+
+  it('does not append a recent legacy fixed file', async () => {
+    const failedDir = path.join(dataDir, 'logs', 'otlp-failed');
+    await fs.mkdir(failedDir, { recursive: true });
+    const legacy = path.join(failedDir, 'test-pilot-claude-code__primary.jsonl');
+    await fs.writeFile(legacy, 'legacy\n');
+    const flusher = new OtlpTraceFlusher({
+      enabled: true,
+      endpoints: [{ name: 'primary', endpoint: 'http://localhost:4318' }],
+      protocol: 'http/protobuf',
+      serviceName: 'test-pilot',
+      dataDir,
+    });
+
+    await (flusher as any).writeFailedLog(
+      'claude-code',
+      'primary',
+      [mockSpan()],
+      { code: 2, message: 'failed' },
+    );
+
+    expect(await fs.readFile(legacy, 'utf8')).toBe('legacy\n');
+    const files = (await fs.readdir(failedDir)).filter(file => file.endsWith('.jsonl'));
+    expect(files).toHaveLength(2);
+    expect(files.some(file => /-\d{4}-\d{2}-\d{2}\.jsonl$/.test(file))).toBe(true);
+  });
+
+  it('switches to a new file after the local calendar date changes', async () => {
+    vi.useFakeTimers();
+    const flusher = new OtlpTraceFlusher({
+      enabled: true,
+      endpoints: [{ name: 'primary', endpoint: 'http://localhost:4318' }],
+      protocol: 'http/protobuf',
+      serviceName: 'test-pilot',
+      dataDir,
+    });
+
+    vi.setSystemTime(new Date(2026, 7, 20, 23, 59, 0));
+    await (flusher as any).writeFailedLog(
+      'claude-code',
+      'primary',
+      [mockSpan()],
+      { code: 2, message: 'first day' },
+    );
+    vi.setSystemTime(new Date(2026, 7, 21, 0, 1, 0));
+    await (flusher as any).writeFailedLog(
+      'claude-code',
+      'primary',
+      [mockSpan()],
+      { code: 2, message: 'second day' },
+    );
+
+    const files = await fs.readdir(path.join(dataDir, 'logs', 'otlp-failed'));
+    expect(files).toEqual(expect.arrayContaining([
+      expect.stringMatching(/-2026-08-20\.jsonl$/),
+      expect.stringMatching(/-2026-08-21\.jsonl$/),
+    ]));
+  });
+});

--- a/tests/unit/metrics/metrics-writer.test.ts
+++ b/tests/unit/metrics/metrics-writer.test.ts
@@ -82,6 +82,20 @@ function cpuAboveProcessThreshold(): string {
   return '81';
 }
 
+function managedLogFile(metricDir: string, prefix: string): string {
+  const file = fs.readdirSync(metricDir).find(name => (
+    name.startsWith(`${prefix}-`) && /-\d{4}-\d{2}-\d{2}\.jsonl$/.test(name)
+  ));
+  if (!file) throw new Error(`managed log file not found for ${prefix}`);
+  return path.join(metricDir, file);
+}
+
+function hasManagedLogFile(metricDir: string, prefix: string): boolean {
+  return fs.existsSync(metricDir) && fs.readdirSync(metricDir).some(name => (
+    name.startsWith(`${prefix}-`) && name.endsWith('.jsonl')
+  ));
+}
+
 describe('MetricsWriter', () => {
   let tmpDir: string;
   let writer: MetricsWriter;
@@ -112,7 +126,7 @@ describe('MetricsWriter', () => {
     vi.useRealTimers();
     await writer.start();
 
-    const filePath = path.join(tmpDir, 'logs', 'metric_alarm', 'pilot-metrics.jsonl');
+    const filePath = managedLogFile(path.join(tmpDir, 'logs', 'metric_alarm'), 'pilot-metrics');
     expect(fs.existsSync(filePath)).toBe(true);
 
     const lines = fs.readFileSync(filePath, 'utf-8').trim().split('\n');
@@ -235,22 +249,22 @@ describe('MetricsWriter', () => {
     await writer.stop();
 
     const metricDir = path.join(tmpDir, 'logs', 'metric_alarm');
-    const firstLine = (name: string): any => JSON.parse(
-      fs.readFileSync(path.join(metricDir, name), 'utf-8').trim().split('\n')[0],
+    const firstLine = (prefix: string): any => JSON.parse(
+      fs.readFileSync(managedLogFile(metricDir, prefix), 'utf-8').trim().split('\n')[0],
     );
 
-    const agent = firstLine('pilot-agent-metrics.jsonl');
+    const agent = firstLine('pilot-agent-metrics');
     expect(agent.type).toBe('agent');
     expect(agent.user_id).toBe('u1');
     expect(agent.agent).toBe('test-agent');
     expect(agent.in_events).toBe('5');
 
-    const input = firstLine('pilot-input-metrics.jsonl');
+    const input = firstLine('pilot-input-metrics');
     expect(input.type).toBe('input');
     expect(input.input_name).toBe('test-input');
     expect(input.raw_read_calls).toBe('2');
 
-    const flusher = firstLine('pilot-flusher-metrics.jsonl');
+    const flusher = firstLine('pilot-flusher-metrics');
     expect(flusher.type).toBe('flusher');
     expect(flusher.flusher).toBe('sls');
     expect(flusher.logstore).toBe('store-a');
@@ -331,9 +345,9 @@ describe('MetricsWriter', () => {
     await writer.stop();
 
     const metricDir = path.join(tmpDir, 'logs', 'metric_alarm');
-    expect(fs.existsSync(path.join(metricDir, 'pilot-agent-metrics.jsonl'))).toBe(false);
-    expect(fs.existsSync(path.join(metricDir, 'pilot-input-metrics.jsonl'))).toBe(false);
-    expect(fs.existsSync(path.join(metricDir, 'pilot-flusher-metrics.jsonl'))).toBe(false);
+    expect(hasManagedLogFile(metricDir, 'pilot-agent-metrics')).toBe(false);
+    expect(hasManagedLogFile(metricDir, 'pilot-input-metrics')).toBe(false);
+    expect(hasManagedLogFile(metricDir, 'pilot-flusher-metrics')).toBe(false);
   });
 
   it('includes capture_message_disabled_agents in L1 metrics', async () => {
@@ -351,7 +365,7 @@ describe('MetricsWriter', () => {
     vi.useRealTimers();
     await writer.start();
 
-    const filePath = path.join(tmpDir, 'logs', 'metric_alarm', 'pilot-metrics.jsonl');
+    const filePath = managedLogFile(path.join(tmpDir, 'logs', 'metric_alarm'), 'pilot-metrics');
     const lines = fs.readFileSync(filePath, 'utf-8').trim().split('\n');
     const entry = JSON.parse(lines[0]);
 

--- a/tests/unit/updater/updater-metrics.test.ts
+++ b/tests/unit/updater/updater-metrics.test.ts
@@ -12,6 +12,7 @@ vi.mock('../../../src/utils/fs-utils.js', () => ({
     appendedLines.push({ path, line });
   }),
   ensureDir: vi.fn(),
+  getTodayDateString: () => '2026-09-02',
 }));
 
 const mockSendAlarm = vi.fn();
@@ -30,6 +31,10 @@ vi.mock('node:fs', () => ({
 
 import { UpdaterMetrics } from '../../../src/updater/updater-metrics.js';
 import type { ProcessLiveness } from '../../../src/utils/pid-utils.js';
+
+function isDailyLog(filePath: string, prefix: string): boolean {
+  return filePath.includes(`${prefix}-`) && /-\d{4}-\d{2}-\d{2}\.jsonl$/.test(filePath);
+}
 
 describe('UpdaterMetrics', () => {
   let killSpy: ReturnType<typeof vi.spyOn> | null = null;
@@ -65,13 +70,13 @@ describe('UpdaterMetrics', () => {
   }
 
   describe('writeEvent', () => {
-    it('writes updater event to pilot-updater-events.jsonl after flush', async () => {
+    it('writes updater event to a daily pilot-updater-events file after flush', async () => {
       const m = createMetrics();
       await m.start();
       m.writeEvent('updater_started');
       await m.stop();
 
-      const eventLines = appendedLines.filter(l => l.path.includes('pilot-updater-events.jsonl'));
+      const eventLines = appendedLines.filter(l => isDailyLog(l.path, 'pilot-updater-events'));
       expect(eventLines).toHaveLength(1);
 
       const parsed = JSON.parse(eventLines[0].line);
@@ -90,7 +95,7 @@ describe('UpdaterMetrics', () => {
       });
       await m.stop();
 
-      const eventLines = appendedLines.filter(l => l.path.includes('pilot-updater-events.jsonl'));
+      const eventLines = appendedLines.filter(l => isDailyLog(l.path, 'pilot-updater-events'));
       const parsed = JSON.parse(eventLines[0].line);
       expect(parsed.current_version).toBe('1.0.0');
       expect(parsed.latest_version).toBe('1.0.1');
@@ -102,7 +107,7 @@ describe('UpdaterMetrics', () => {
       m.writeEvent('updater_started');
       await m.stop();
 
-      const eventLines = appendedLines.filter(l => l.path.includes('pilot-updater-events.jsonl'));
+      const eventLines = appendedLines.filter(l => isDailyLog(l.path, 'pilot-updater-events'));
       const parsed = JSON.parse(eventLines[0].line);
       expect(parsed.user_id).toBe('user-123');
     });
@@ -116,7 +121,7 @@ describe('UpdaterMetrics', () => {
       });
       await m.stop();
 
-      const eventLines = appendedLines.filter(l => l.path.includes('pilot-updater-events.jsonl'));
+      const eventLines = appendedLines.filter(l => isDailyLog(l.path, 'pilot-updater-events'));
       const parsed = JSON.parse(eventLines[0].line);
       expect(parsed.error).toBe('download timeout');
       expect(parsed.consecutive_failures).toBe(3);
@@ -124,13 +129,13 @@ describe('UpdaterMetrics', () => {
   });
 
   describe('writeAlarm', () => {
-    it('writes alarm entry to pilot-alarms.jsonl after flush', async () => {
+    it('writes alarm entry to a daily pilot-alarms file after flush', async () => {
       const m = createMetrics();
       await m.start();
       m.writeAlarm('UPDATER_FAILURE_ALARM', '2', 'update failed');
       await m.stop();
 
-      const alarmLines = appendedLines.filter(l => l.path.includes('pilot-alarms.jsonl'));
+      const alarmLines = appendedLines.filter(l => isDailyLog(l.path, 'pilot-alarms'));
       expect(alarmLines).toHaveLength(1);
 
       const parsed = JSON.parse(alarmLines[0].line);
@@ -149,7 +154,7 @@ describe('UpdaterMetrics', () => {
       await m.start();
       await m.stop();
 
-      const alarmLines = appendedLines.filter(l => l.path.includes('pilot-alarms.jsonl'));
+      const alarmLines = appendedLines.filter(l => isDailyLog(l.path, 'pilot-alarms'));
       const formatAlarm = alarmLines
         .map(l => JSON.parse(l.line))
         .find((a: { alarm_type: string }) => a.alarm_type === 'USER_ID_FORMAT_ALARM');
@@ -163,7 +168,7 @@ describe('UpdaterMetrics', () => {
       await m.start();
       await m.stop();
 
-      const alarmLines = appendedLines.filter(l => l.path.includes('pilot-alarms.jsonl'));
+      const alarmLines = appendedLines.filter(l => isDailyLog(l.path, 'pilot-alarms'));
       const formatAlarm = alarmLines
         .map(l => JSON.parse(l.line))
         .find((a: { alarm_type: string }) => a.alarm_type === 'USER_ID_FORMAT_ALARM');
@@ -181,7 +186,7 @@ describe('UpdaterMetrics', () => {
 
       await m.stop();
 
-      const alarmLines = appendedLines.filter(l => l.path.includes('pilot-alarms.jsonl'));
+      const alarmLines = appendedLines.filter(l => isDailyLog(l.path, 'pilot-alarms'));
       const formatAlarms = alarmLines
         .map(l => JSON.parse(l.line))
         .filter((a: { alarm_type: string }) => a.alarm_type === 'USER_ID_FORMAT_ALARM');
@@ -195,12 +200,12 @@ describe('UpdaterMetrics', () => {
       await m.start();
       m.writeEvent('updater_started');
 
-      expect(appendedLines.filter(l => l.path.includes('pilot-updater-events.jsonl'))).toHaveLength(0);
+      expect(appendedLines.filter(l => isDailyLog(l.path, 'pilot-updater-events'))).toHaveLength(0);
 
       await vi.advanceTimersByTimeAsync(30_000);
       await vi.advanceTimersByTimeAsync(0);
 
-      const eventLines = appendedLines.filter(l => l.path.includes('pilot-updater-events.jsonl'));
+      const eventLines = appendedLines.filter(l => isDailyLog(l.path, 'pilot-updater-events'));
       expect(eventLines).toHaveLength(1);
 
       await m.stop();
@@ -214,8 +219,8 @@ describe('UpdaterMetrics', () => {
       m.writeAlarm('UPDATER_FAILURE_ALARM', '2', 'err');
       await m.stop();
 
-      expect(appendedLines.filter(l => l.path.includes('pilot-updater-events.jsonl'))).toHaveLength(2);
-      expect(appendedLines.filter(l => l.path.includes('pilot-alarms.jsonl'))).toHaveLength(1);
+      expect(appendedLines.filter(l => isDailyLog(l.path, 'pilot-updater-events'))).toHaveLength(2);
+      expect(appendedLines.filter(l => isDailyLog(l.path, 'pilot-alarms'))).toHaveLength(1);
     });
   });
 
@@ -227,7 +232,7 @@ describe('UpdaterMetrics', () => {
       await m.stop();
 
       // Events are persisted to the local JSONL only; no pilot_updater_event topic.
-      expect(appendedLines.filter(l => l.path.includes('pilot-updater-events.jsonl'))).toHaveLength(1);
+      expect(appendedLines.filter(l => isDailyLog(l.path, 'pilot-updater-events'))).toHaveLength(1);
       const statusCall = mockSendStatus.mock.calls.find(
         (c: unknown[]) => c[0] === 'pilot_updater_event',
       );
@@ -255,7 +260,7 @@ describe('UpdaterMetrics', () => {
       await m.start();
       await m.stop();
 
-      const alarmLines = appendedLines.filter(l => l.path.includes('pilot-alarms.jsonl'));
+      const alarmLines = appendedLines.filter(l => isDailyLog(l.path, 'pilot-alarms'));
       expect(alarmLines).toHaveLength(0);
     });
 
@@ -266,7 +271,7 @@ describe('UpdaterMetrics', () => {
       await vi.advanceTimersByTimeAsync(3 * 60_000 + 60_000);
       await vi.advanceTimersByTimeAsync(60_000);
 
-      const alarmLines = appendedLines.filter(l => l.path.includes('pilot-alarms.jsonl'));
+      const alarmLines = appendedLines.filter(l => isDailyLog(l.path, 'pilot-alarms'));
       expect(alarmLines).toHaveLength(1);
       const parsed = JSON.parse(alarmLines[0].line);
       expect(parsed.alarm_type).toBe('SERVICE_NOT_RUNNING_ALARM');
@@ -291,7 +296,7 @@ describe('UpdaterMetrics', () => {
       await vi.advanceTimersByTimeAsync(3 * 60_000 + 60_000);
       await vi.advanceTimersByTimeAsync(60_000);
 
-      const alarmLines = appendedLines.filter(l => l.path.includes('pilot-alarms.jsonl'));
+      const alarmLines = appendedLines.filter(l => isDailyLog(l.path, 'pilot-alarms'));
       expect(alarmLines).toHaveLength(1);
       const parsed = JSON.parse(alarmLines[0].line);
       expect(parsed.alarm_type).toBe('SERVICE_NOT_RUNNING_ALARM');
@@ -315,7 +320,7 @@ describe('UpdaterMetrics', () => {
       await vi.advanceTimersByTimeAsync(60_000);
       await m.stop();
 
-      const alarmLines = appendedLines.filter(l => l.path.includes('pilot-alarms.jsonl'));
+      const alarmLines = appendedLines.filter(l => isDailyLog(l.path, 'pilot-alarms'));
       expect(alarmLines).toHaveLength(0);
     });
 
@@ -332,7 +337,7 @@ describe('UpdaterMetrics', () => {
       await vi.advanceTimersByTimeAsync(3 * 60_000 + 60_000);
       await m.stop();
 
-      const alarmLines = appendedLines.filter(l => l.path.includes('pilot-alarms.jsonl'));
+      const alarmLines = appendedLines.filter(l => isDailyLog(l.path, 'pilot-alarms'));
       expect(alarmLines).toHaveLength(0);
     });
 
@@ -344,7 +349,7 @@ describe('UpdaterMetrics', () => {
       await vi.advanceTimersByTimeAsync(60_000);
       await vi.advanceTimersByTimeAsync(60_000);
 
-      const alarmLines = appendedLines.filter(l => l.path.includes('pilot-alarms.jsonl'));
+      const alarmLines = appendedLines.filter(l => isDailyLog(l.path, 'pilot-alarms'));
       expect(alarmLines).toHaveLength(1);
       await m.stop();
     });
@@ -359,4 +364,3 @@ function down(reason: string): ProcessLiveness {
     pidFileState: 'missing',
   };
 }
-


### PR DESCRIPTION
## Summary

- write OTLP failure logs, metrics, alarms, updater events, and input runtime metrics to local-date JSONL files
- clean managed files after 7 days by default and apply 512 MiB / 256 MiB soft directory targets while always protecting today and yesterday
- migrate legacy fixed files through mtime-based cleanup without changing JSON payloads or remote send ordering
- exclude token state, unknown metric files, hidden entries, symlinks, and subdirectories from managed cleanup

## Validation

- `npm run typecheck`
- `npm run build`
- focused Vitest: 10 files, 306 tests passed
- regression Vitest excluding the two locally known Hermes/Python SIGKILL files: 304 files passed, 3991 tests passed, 56 skipped
- `git diff --check`
- local OpenSpec proposal passed strict validation; the repository ignores `/openspec`, so the proposal artifact is not part of this PR