### PR TITLE
fix(updater): harden collector recovery edge cases

### DIFF
--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -884,6 +884,39 @@ function Cmd-Restart {
     Cmd-Start
 }
 
+function Start-BackgroundDaemon {
+    param(
+        [string]$DaemonName,
+        [string]$NodeBin,
+        [string]$Entry,
+        [string]$OutputLog,
+        [string]$ErrorLog
+    )
+    $launcherPath = Join-Path $BOOTSTRAP_DIR "$DaemonName-background.ps1"
+    $escapedDataDir = ([string]$DATA_DIR).Replace("'", "''")
+    $escapedCacheDir = ([string]$CACHE_DIR).Replace("'", "''")
+    $escapedConfig = ([string]$CONFIG_FILE).Replace("'", "''")
+    $escapedNode = ([string]$NodeBin).Replace("'", "''")
+    $escapedEntry = ([string]$Entry).Replace("'", "''")
+    $escapedOutput = ([string]$OutputLog).Replace("'", "''")
+    $escapedError = ([string]$ErrorLog).Replace("'", "''")
+    @(
+        "`$env:LOONGSUITE_PILOT_DATA_DIR = '$escapedDataDir'",
+        "`$env:LOONGSUITE_PILOT_CACHE_DIR = '$escapedCacheDir'",
+        "`$env:AGENT_DATA_COLLECTION_CONFIG = '$escapedConfig'",
+        "& '$escapedNode' '$escapedEntry' >> '$escapedOutput' 2>> '$escapedError'"
+    ) | Set-Content -LiteralPath $launcherPath -Encoding Unicode
+
+    # Use -File so paths are parsed only inside the generated script, where every
+    # single quote has been escaped. Directly interpolating them into -Command breaks
+    # profiles and custom data dirs such as C:\Users\O'Brien.
+    $launcherArgs = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$launcherPath`""
+    Start-Process -FilePath "powershell.exe" `
+        -ArgumentList $launcherArgs `
+        -WorkingDirectory $CACHE_DIR `
+        -WindowStyle Hidden
+}
+
 # Start the collector without stopping it or scanning for processes. This command is
 # the updater's recovery path after restart-collector times out: the timed-out command
 # may already have completed the stop half, so running another restart would extend the
@@ -936,10 +969,7 @@ function Cmd-StartCollector {
         exit 1
     }
     $errLog = Join-Path $LOG_DIR "loongsuite-pilot-service-err.log"
-    Start-Process -FilePath "powershell.exe" `
-        -ArgumentList "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:LOONGSUITE_PILOT_DATA_DIR='$DATA_DIR'; `$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$entry' >> '$LOG_FILE' 2>> '$errLog'`"" `
-        -WorkingDirectory $CACHE_DIR `
-        -WindowStyle Hidden
+    Start-BackgroundDaemon "collector" $nodeBin $entry $LOG_FILE $errLog
     Write-Host "collector start requested (background fallback)" -ForegroundColor Yellow
 }
 
@@ -1072,10 +1102,7 @@ function Cmd-RestartCollector {
                 # node publishes its own pid file on Windows (see src/index.ts); export the
                 # data dir so it lands at $DATA_DIR\loongsuite-pilot.pid. No Set-Content here --
                 # $proc.Id would be the wrapper pid, not node's.
-                Start-Process -FilePath "powershell.exe" `
-                    -ArgumentList "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:LOONGSUITE_PILOT_DATA_DIR='$DATA_DIR'; `$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$entry' >> '$LOG_FILE' 2>> '$errLog'`"" `
-                    -WorkingDirectory $CACHE_DIR `
-                    -WindowStyle Hidden
+                Start-BackgroundDaemon "collector" $nodeBin $entry $LOG_FILE $errLog
                 Write-Host "collector restarted (background fallback, self-heal failed)" -ForegroundColor Yellow
             } else {
                 Write-Error "Service manager failed to restart collector (init_type=$initType)"
@@ -1169,10 +1196,7 @@ function Cmd-RestartUpdater {
                 # node publishes its own pid file on Windows (see src/updater/index.ts); export
                 # the data dir so it lands at $DATA_DIR\loongsuite-pilot-updater.pid. No
                 # Set-Content -- $proc.Id would be the wrapper pid, not node's.
-                Start-Process -FilePath "powershell.exe" `
-                    -ArgumentList "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command `"`$env:LOONGSUITE_PILOT_DATA_DIR='$DATA_DIR'; `$env:AGENT_DATA_COLLECTION_CONFIG='$CONFIG_FILE'; & '$nodeBin' '$entry' >> '$UPDATER_LOG_FILE' 2>> '$updaterErrLog'`"" `
-                    -WorkingDirectory $CACHE_DIR `
-                    -WindowStyle Hidden
+                Start-BackgroundDaemon "updater" $nodeBin $entry $UPDATER_LOG_FILE $updaterErrLog
                 Write-Host "updater restarted (background fallback, self-heal failed)" -ForegroundColor Yellow
             } else {
                 Write-Error "Service manager failed to restart updater (init_type=$initType)"

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -378,7 +378,13 @@ export class Orchestrator extends EventEmitter {
     // may be disabled, but Windows Task Scheduler still needs runtime.json to
     // distinguish a healthy collector from a task whose child process died.
     const packageVersion = this.readPackageVersion();
-    this.runtimeWriter = new RuntimeWriter(this.dataDir, this.config.statusBar, packageVersion);
+    const packageGitCommit = this.readPackageGitCommit();
+    this.runtimeWriter = new RuntimeWriter(
+      this.dataDir,
+      this.config.statusBar,
+      packageVersion,
+      packageGitCommit,
+    );
     this.runtimeWriter.start();
 
     // MetricsSummaryWriter is a collector-owned source shared by every local
@@ -1696,6 +1702,21 @@ export class Orchestrator extends EventEmitter {
       // ignore
     }
     return 'unknown';
+  }
+
+  private readPackageGitCommit(): string {
+    try {
+      const pilotDir = this.resolvePilotDir();
+      const versionFile = path.join(pilotDir, 'VERSION');
+      if (fsSync.existsSync(versionFile)) {
+        const content = fsSync.readFileSync(versionFile, 'utf8');
+        const match = content.match(/^git_commit=(.+)$/m);
+        if (match) return match[1].trim();
+      }
+    } catch {
+      // ignore
+    }
+    return '';
   }
 
   private resolvePilotDir(moduleUrl: string = import.meta.url): string {

--- a/src/status-bar/runtime-writer.ts
+++ b/src/status-bar/runtime-writer.ts
@@ -10,6 +10,7 @@ const logger = createLogger('RuntimeWriter');
 export interface RuntimeRecord {
   status: string;
   packageVersion: string;
+  gitCommit?: string;
   pid: number;
   updatedAt: string;
 }
@@ -18,12 +19,14 @@ export class RuntimeWriter {
   private readonly filePath: string;
   private readonly config: StatusBarConfig;
   private readonly packageVersion: string;
+  private readonly gitCommit: string;
   private intervalTimer: ReturnType<typeof setInterval> | null = null;
 
-  constructor(dataDir: string, config: StatusBarConfig, packageVersion: string) {
+  constructor(dataDir: string, config: StatusBarConfig, packageVersion: string, gitCommit = '') {
     this.filePath = path.join(dataDir, 'logs', 'runtime.json');
     this.config = config;
     this.packageVersion = packageVersion;
+    this.gitCommit = gitCommit;
   }
 
   start(): void {
@@ -62,6 +65,7 @@ export class RuntimeWriter {
         pid: process.pid,
         updatedAt: new Date().toISOString(),
       };
+      if (this.gitCommit) record.gitCommit = this.gitCommit;
       await ensureDir(path.dirname(this.filePath));
       await writeJsonFile(this.filePath, record);
     } catch (err) {

--- a/src/updater/updater.ts
+++ b/src/updater/updater.ts
@@ -169,6 +169,7 @@ export interface ResolvedTarget {
 interface CollectorRuntimeRecord {
   status?: unknown;
   packageVersion?: unknown;
+  gitCommit?: unknown;
   pid?: unknown;
   updatedAt?: unknown;
 }
@@ -261,11 +262,14 @@ export class Updater {
           remote: target.version,
           channel,
         });
-        const activeVersion = local?.version || target.version;
+        const activeVersion: LocalVersion = local ?? {
+          version: target.version,
+          gitCommit: target.git_commit,
+        };
         const collectorRecovered = await this.recoverCurrentCollectorIfNeeded(activeVersion);
         if (collectorRecovered) {
           void this.metrics?.writeEvent('collector_restarted', {
-            latest_version: activeVersion,
+            latest_version: activeVersion.version,
           });
         }
         this.consecutiveFailures = 0;
@@ -301,7 +305,11 @@ export class Updater {
         latest_version: target.version,
       });
 
-      await this.restartCollector(target.version, local?.version === target.version);
+      await this.restartCollector(
+        target.version,
+        local?.version === target.version,
+        target.git_commit,
+      );
       void this.metrics?.writeEvent('collector_restarted', {
         latest_version: target.version,
       });
@@ -1089,7 +1097,11 @@ export class Updater {
     }
   }
 
-  private async restartCollector(targetVersion: string, requireNewPid: boolean): Promise<void> {
+  private async restartCollector(
+    targetVersion: string,
+    requireNewPid: boolean,
+    targetGitCommit = '',
+  ): Promise<void> {
     logger.info('restarting collector service');
     const previousRuntime = requireNewPid ? await this.readCollectorRuntime() : null;
     const previousPid = typeof previousRuntime?.pid === 'number' ? previousRuntime.pid : null;
@@ -1109,14 +1121,24 @@ export class Updater {
     }
 
     try {
-      await this.waitForCollectorHealth(targetVersion, restartStartedAt, previousPid);
+      await this.waitForCollectorHealth(
+        targetVersion,
+        restartStartedAt,
+        previousPid,
+        targetGitCommit,
+      );
     } catch (healthErr) {
       if (recoveryAttempted) throw healthErr;
       logger.warn('collector failed post-restart health check; attempting start-only recovery', {
         error: String(healthErr),
       });
       await this.startCollectorForRecovery(healthErr);
-      await this.waitForCollectorHealth(targetVersion, restartStartedAt, previousPid);
+      await this.waitForCollectorHealth(
+        targetVersion,
+        restartStartedAt,
+        previousPid,
+        targetGitCommit,
+      );
     }
 
     logger.info('collector restarted and healthy', { targetVersion });
@@ -1188,33 +1210,75 @@ export class Updater {
     return readJsonFile<CollectorRuntimeRecord>(this.paths.collectorRuntimeFile);
   }
 
-  private async recoverCurrentCollectorIfNeeded(targetVersion: string): Promise<boolean> {
+  private async recoverCurrentCollectorIfNeeded(target: LocalVersion): Promise<boolean> {
     const runtime = await this.readCollectorRuntime();
-    const healthFailure = this.collectorHealthFailure(runtime, targetVersion, 0, null);
+    const healthFailure = this.collectorHealthFailure(
+      runtime,
+      target.version,
+      0,
+      null,
+      target.gitCommit,
+    );
     if (!healthFailure) return false;
 
-    logger.warn('current version is installed but collector is unhealthy; attempting start-only recovery', {
-      targetVersion,
+    const livePid = this.liveCollectorPid(runtime);
+    if (livePid !== null) {
+      logger.warn('current version is installed but a stale collector is still alive; restarting it', {
+        targetVersion: target.version,
+        targetGitCommit: target.gitCommit || undefined,
+        collectorPid: livePid,
+        error: healthFailure,
+      });
+      await this.restartCollector(target.version, true, target.gitCommit);
+      return true;
+    }
+
+    logger.warn('current version is installed but collector is not running; attempting start-only recovery', {
+      targetVersion: target.version,
+      targetGitCommit: target.gitCommit || undefined,
       error: healthFailure,
     });
     const recoveryStartedAt = Date.now();
     await this.startCollectorForRecovery(new Error(healthFailure));
-    await this.waitForCollectorHealth(targetVersion, recoveryStartedAt, null);
-    logger.info('collector recovered and healthy', { targetVersion });
+    await this.waitForCollectorHealth(
+      target.version,
+      recoveryStartedAt,
+      null,
+      target.gitCommit,
+    );
+    logger.info('collector recovered and healthy', { targetVersion: target.version });
     return true;
+  }
+
+  private liveCollectorPid(runtime: CollectorRuntimeRecord | null): number | null {
+    const pid = runtime?.pid;
+    if (!Number.isInteger(pid) || (pid as number) <= 0) return null;
+    try {
+      process.kill(pid as number, 0);
+      return pid as number;
+    } catch {
+      return null;
+    }
   }
 
   private async waitForCollectorHealth(
     targetVersion: string,
     notBeforeMs: number,
     previousPid: number | null,
+    targetGitCommit = '',
   ): Promise<void> {
     const deadline = Date.now() + COLLECTOR_HEALTH_TIMEOUT_MS;
     let lastFailure = 'runtime record not found';
 
     while (true) {
       const runtime = await this.readCollectorRuntime();
-      lastFailure = this.collectorHealthFailure(runtime, targetVersion, notBeforeMs, previousPid);
+      lastFailure = this.collectorHealthFailure(
+        runtime,
+        targetVersion,
+        notBeforeMs,
+        previousPid,
+        targetGitCommit,
+      );
       if (!lastFailure) return;
       if (Date.now() >= deadline) break;
       await new Promise<void>((resolve) => setTimeout(resolve, COLLECTOR_HEALTH_POLL_MS));
@@ -1230,11 +1294,15 @@ export class Updater {
     targetVersion: string,
     notBeforeMs: number,
     previousPid: number | null,
+    targetGitCommit = '',
   ): string {
     if (!runtime) return 'runtime record not found';
     if (runtime.status !== 'active') return `runtime status is ${String(runtime.status)}`;
     if (runtime.packageVersion !== targetVersion) {
       return `runtime version is ${String(runtime.packageVersion)}, expected ${targetVersion}`;
+    }
+    if (targetGitCommit && runtime.gitCommit !== targetGitCommit) {
+      return `runtime git commit is ${String(runtime.gitCommit)}, expected ${targetGitCommit}`;
     }
 
     const updatedAtMs = typeof runtime.updatedAt === 'string' ? Date.parse(runtime.updatedAt) : NaN;
@@ -1245,11 +1313,7 @@ export class Updater {
     const pid = runtime.pid;
     if (!Number.isInteger(pid) || (pid as number) <= 0) return 'runtime PID is invalid';
     if (previousPid !== null && pid === previousPid) return 'collector PID did not change';
-    try {
-      process.kill(pid as number, 0);
-    } catch {
-      return `collector PID ${String(pid)} is not alive`;
-    }
+    if (this.liveCollectorPid(runtime) === null) return `collector PID ${String(pid)} is not alive`;
     return '';
   }
 

--- a/tests/integration/updater-flow.test.ts
+++ b/tests/integration/updater-flow.test.ts
@@ -115,12 +115,13 @@ describe('Updater integration (real filesystem)', () => {
     await fs.writeFile(path.join(testDir, 'current'), dirName + '\n');
   }
 
-  async function writeCollectorRuntime(version: string) {
+  async function writeCollectorRuntime(version: string, gitCommit = '') {
     const logsDir = path.join(testDir, 'logs');
     await fs.mkdir(logsDir, { recursive: true });
     await fs.writeFile(path.join(logsDir, 'runtime.json'), JSON.stringify({
       status: 'active',
       packageVersion: version,
+      ...(gitCommit ? { gitCommit } : {}),
       pid: process.pid,
       updatedAt: new Date().toISOString(),
     }));
@@ -265,7 +266,7 @@ describe('Updater integration (real filesystem)', () => {
   it('does NOT downgrade when remote version is older', async () => {
     const v2Dir = await createFakeVersion('1.0.2', 'bbb');
     await setCurrentPointer(v2Dir);
-    await writeCollectorRuntime('1.0.2');
+    await writeCollectorRuntime('1.0.2', 'bbb');
 
     // Remote says 1.0.1 (older)
     mockFetch.mockResolvedValueOnce({
@@ -295,7 +296,7 @@ describe('Updater integration (real filesystem)', () => {
       }),
     });
     mockExecFile.mockImplementation(async (_cmd: string, args: string[]) => {
-      if (args.includes('start-collector')) await writeCollectorRuntime('1.0.2');
+      if (args.includes('start-collector')) await writeCollectorRuntime('1.0.2', 'bbb');
       return { stdout: '', stderr: '' };
     });
     const updater = new Updater(makeConfig(), testDir);

--- a/tests/unit/scripts/ps1-updater-handoff.test.mjs
+++ b/tests/unit/scripts/ps1-updater-handoff.test.mjs
@@ -34,6 +34,20 @@ describe('Windows updater handoff and collector recovery commands', () => {
     expect(body).toMatch(/if \(-not \$SkipCleanup\) \{[\s\S]*schtasks\.exe \/Delete/);
   });
 
+  it('launches background fallbacks through an escaped script file', () => {
+    const helper = bodyOf('Start-BackgroundDaemon');
+    expect(helper).toContain(".Replace(\"'\", \"''\")");
+    expect(helper).toContain('Set-Content -LiteralPath $launcherPath -Encoding Unicode');
+    expect(helper).toContain('-File `"$launcherPath`"');
+    expect(helper).not.toContain('-Command');
+
+    for (const command of ['Cmd-StartCollector', 'Cmd-RestartCollector', 'Cmd-RestartUpdater']) {
+      const body = bodyOf(command);
+      expect(body).toContain('Start-BackgroundDaemon');
+      expect(body).not.toContain('-Command');
+    }
+  });
+
   it('restart-collector can defer updater restart until health validation completes', () => {
     const body = bodyOf('Cmd-RestartCollector');
     expect(body).toContain('--defer-updater-restart');

--- a/tests/unit/status-bar/runtime-writer.test.ts
+++ b/tests/unit/status-bar/runtime-writer.test.ts
@@ -33,7 +33,7 @@ describe('RuntimeWriter', () => {
   });
 
   it('writes runtime.json on start', async () => {
-    const writer = new RuntimeWriter(tmpDir, makeConfig(), '1.2.3');
+    const writer = new RuntimeWriter(tmpDir, makeConfig(), '1.2.3', 'abc123');
     writer.start();
 
     // Give async write time to complete
@@ -44,6 +44,7 @@ describe('RuntimeWriter', () => {
 
     expect(content.status).toBe('active');
     expect(content.packageVersion).toBe('1.2.3');
+    expect(content.gitCommit).toBe('abc123');
     expect(content.pid).toBe(process.pid);
     expect(content.updatedAt).toBeTruthy();
 

--- a/tests/unit/updater/updater.test.ts
+++ b/tests/unit/updater/updater.test.ts
@@ -181,6 +181,7 @@ describe('Updater', () => {
         return Promise.resolve({
           status: 'active',
           packageVersion: '1.0.2',
+          gitCommit: 'bbb',
           pid: process.pid,
           updatedAt: new Date().toISOString(),
         });
@@ -300,6 +301,17 @@ describe('Updater', () => {
         return Promise.reject(new Error('ENOENT'));
       });
       mockFsAccess.mockResolvedValue(undefined); // versions dir exists
+      mockReadJsonFile.mockImplementation((filePath: string) => (
+        String(filePath).endsWith('/logs/runtime.json')
+          ? Promise.resolve({
+            status: 'active',
+            packageVersion: '1.0.2',
+            gitCommit: 'aaa',
+            pid: process.pid,
+            updatedAt: new Date().toISOString(),
+          })
+          : Promise.resolve({})
+      ));
 
       const updater = new Updater(makeConfig(), tmpDir);
       await updater.check();
@@ -327,6 +339,7 @@ describe('Updater', () => {
         return Promise.resolve(runtimeReads === 1 ? null : {
           status: 'active',
           packageVersion: '1.0.2',
+          gitCommit: 'aaa',
           pid: process.pid,
           updatedAt: new Date().toISOString(),
         });
@@ -375,6 +388,47 @@ describe('Updater', () => {
       expect(pilotCommands()).not.toContain('schedule-updater-restart');
       expect(gc).not.toHaveBeenCalled();
       expect((updater as any).consecutiveFailures).toBe(1);
+    });
+
+    it.each([
+      ['an old version', '1.0.1', 'old'],
+      ['an old build of the same version', '1.0.2', 'old'],
+    ])('restarts a live collector running %s', async (_case, packageVersion, gitCommit) => {
+      mockFetch.mockResolvedValueOnce(makeResponseJson(
+        makeManifest({ version: '1.0.2', git_commit: 'aaa' }),
+      ));
+      mockFsReadFile.mockImplementation((filePath: string) => {
+        if (filePath.endsWith('/current')) return Promise.resolve('1.0.2_aaa\n');
+        if (filePath.endsWith('/VERSION')) {
+          return Promise.resolve('version=1.0.2\ngit_commit=aaa\n');
+        }
+        return Promise.reject(new Error('ENOENT'));
+      });
+      mockFsAccess.mockResolvedValue(undefined);
+      let runtimeReads = 0;
+      mockReadJsonFile.mockImplementation((filePath: string) => {
+        if (!String(filePath).endsWith('/logs/runtime.json')) return Promise.resolve({});
+        runtimeReads++;
+        return Promise.resolve(runtimeReads <= 2 ? {
+          status: 'active',
+          packageVersion,
+          gitCommit,
+          pid: process.pid,
+          updatedAt: new Date().toISOString(),
+        } : {
+          status: 'active',
+          packageVersion: '1.0.2',
+          gitCommit: 'aaa',
+          pid: process.ppid,
+          updatedAt: new Date().toISOString(),
+        });
+      });
+      const updater = new Updater(makeConfig(), tmpDir);
+
+      await updater.check();
+
+      expect(pilotCommands()).toEqual(['restart-collector', 'schedule-updater-restart']);
+      expect((updater as any).consecutiveFailures).toBe(0);
     });
   });
 
@@ -973,6 +1027,7 @@ describe('Updater', () => {
         return Promise.resolve({
           status: 'active',
           packageVersion: '1.0.2',
+          gitCommit: 'bbb',
           pid: process.pid,
           updatedAt: new Date().toISOString(),
         });
@@ -1070,6 +1125,7 @@ describe('Updater', () => {
       const runtime = {
         status: 'active',
         packageVersion: '1.0.2',
+        gitCommit: 'bbb',
         pid: process.pid,
         updatedAt: new Date(now).toISOString(),
       };
@@ -1077,6 +1133,9 @@ describe('Updater', () => {
       expect((updater as any).collectorHealthFailure(
         { ...runtime, packageVersion: '1.0.1' }, '1.0.2', now, null,
       )).toContain('expected 1.0.2');
+      expect((updater as any).collectorHealthFailure(
+        { ...runtime, gitCommit: 'aaa' }, '1.0.2', now, null, 'bbb',
+      )).toContain('expected bbb');
       expect((updater as any).collectorHealthFailure(
         { ...runtime, updatedAt: new Date(now - 1).toISOString() }, '1.0.2', now, null,
       )).toBe('runtime record predates restart');
@@ -1186,6 +1245,17 @@ describe('Updater', () => {
         return Promise.reject(new Error('ENOENT'));
       });
       mockFsAccess.mockResolvedValue(undefined);
+      mockReadJsonFile.mockImplementation((filePath: string) => (
+        String(filePath).endsWith('/logs/runtime.json')
+          ? Promise.resolve({
+            status: 'active',
+            packageVersion: '1.0.2',
+            gitCommit: 'aaa',
+            pid: process.pid,
+            updatedAt: new Date().toISOString(),
+          })
+          : Promise.resolve({})
+      ));
 
       const updater = new Updater(makeConfig(), tmpDir);
 


### PR DESCRIPTION
## Summary

- launch Windows background fallbacks through a generated, escaped PowerShell script instead of interpolating paths into `-Command`
- record the package git commit in collector runtime health data
- restart a live collector whose version or commit does not match the active package, while keeping start-only recovery for a dead collector

This follows up on the two unresolved review comments from #328:

- https://github.com/alibaba/loongsuite-pilot/pull/328#discussion_r3914055622
- https://github.com/alibaba/loongsuite-pilot/pull/328#discussion_r3914091376

## Validation

- `npm run typecheck`
- `npm run build`
- `npm test` — 307 files passed, 4033 tests passed, 57 skipped
- Windows 11 ECD / PowerShell 5.1 acceptance:
  - candidate and generated launcher parse with zero errors
  - apostrophe-containing paths are escaped and launched via `-File`
  - live wrong-version and same-version/wrong-commit collectors route to restart
  - dead collector routes to start-only recovery
