### PR TITLE
fix(installer): keep ASCII 8.3 TEMP when expand yields a CJK path

### DIFF
--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -384,12 +384,21 @@ function Get-PilotAsciiTempRoot {
     if ($env:TEMP) { $root = $env:TEMP }
     elseif ($env:TMP) { $root = $env:TMP }
     elseif ($env:SystemRoot) { $root = (Join-Path $env:SystemRoot "Temp") }
-    if ($root -notmatch '[^\x20-\x7E]') {
-        # 8.3 TEMP (ZHANG~1.WAN) is ASCII, so this branch used to return it as-is
-        # and skip the long-name expand that Remove-Item / Move-Item need.
-        $root = Get-PilotLongPath $root
-        $script:PILOT_ASCII_TEMP_ROOT = $root
-        return $root
+    # 8.3 TEMP (ZHANG~1.WAN) is ASCII, so a charset check on $root used to
+    # return it as-is and skip the long-name expand that Remove-Item /
+    # Move-Item need. Expanding is still required -- but only keep the
+    # expanded form when it is still ASCII. A CJK profile (short base +
+    # over-long extension) hands out an ASCII 8.3 TEMP that Get-PilotLongPath
+    # turns back into the long CJK path; tar.exe then fails with
+    # "Failed to open 'C:\Users\??.HOST\...'". In that case keep $root as
+    # the 8.3 form, try the machine-wide ASCII candidates below, and if
+    # none of those are writable return the 8.3 so tar still has a path
+    # it can open. Remove-Item / Move-Item callers wrap Get-PilotLongPath
+    # themselves.
+    $expanded = Get-PilotLongPath $root
+    if ($expanded -notmatch '[^\x20-\x7E]') {
+        $script:PILOT_ASCII_TEMP_ROOT = $expanded
+        return $expanded
     }
     $candidates = @()
     if ($env:SystemRoot) { $candidates += (Join-Path $env:SystemRoot "Temp") }
@@ -410,11 +419,15 @@ function Get-PilotAsciiTempRoot {
             return $candidate
         } catch {}
     }
-    # Nothing writable: keep the old behaviour rather than failing outright.
-    # Same $root as the ASCII early return, so the same 8.3 expand applies.
-    $root = Get-PilotLongPath $root
-    $script:PILOT_ASCII_TEMP_ROOT = $root
-    return $root
+    # Nothing writable: prefer the original ASCII 8.3 over the expanded CJK
+    # long name. If $root itself is already CJK there is no ASCII option
+    # left; return $expanded (same as $root) rather than failing here.
+    if ($root -notmatch '[^\x20-\x7E]') {
+        $script:PILOT_ASCII_TEMP_ROOT = $root
+        return $root
+    }
+    $script:PILOT_ASCII_TEMP_ROOT = $expanded
+    return $expanded
 }
 
 # Re-inherit the destination's ACL on a tree that was Move-Item'd out of the ASCII root.

--- a/tests/unit/deploy/installer-short-path.test.mjs
+++ b/tests/unit/deploy/installer-short-path.test.mjs
@@ -252,15 +252,23 @@ describe('installers survive an 8.3 short %TEMP%', () => {
       expect(offenders, 'use Remove-PilotPathQuietly').toEqual([]);
     });
 
-    it(`${f} Get-PilotAsciiTempRoot expands an ASCII 8.3 TEMP`, () => {
-      const fn = functionOf(ps1, 'Get-PilotAsciiTempRoot');
-      expect(fn, 'Get-PilotAsciiTempRoot must exist').not.toBe('');
-      // Pure-ASCII 8.3 TEMP used to skip expand because the charset check passed.
-      // Both the early return and the nothing-writable fallback start from that
-      // same $root, so both must expand.
-      const hits = fn.match(/Get-PilotLongPath \$root/g) || [];
-      expect(hits.length).toBeGreaterThanOrEqual(2);
-    });
+    // Public installer is updated on GitHub separately; the CJK re-check
+    // may lag in the internal tree until this PR lands and syncs back. On
+    // the GitHub tree this file is the only variant, so the assertion runs.
+    if (f !== 'installer-opensource.ps1' || !present.includes('installer.ps1')) {
+      it(`${f} Get-PilotAsciiTempRoot expands an ASCII 8.3 TEMP only when the long name stays ASCII`, () => {
+        const fn = functionOf(ps1, 'Get-PilotAsciiTempRoot');
+        expect(fn, 'Get-PilotAsciiTempRoot must exist').not.toBe('');
+        // Expanding ZHANG~1.WAN to zhang.wang is required (Remove-Item), but
+        // expanding a CJK profile's ASCII 8.3 TEMP to the long CJK path is what
+        // made tar.exe fail with "Failed to open 'C:\\Users\\??.HOST\\...'".
+        // Keep the expanded form only when it is still ASCII; otherwise leave
+        // the 8.3 for tar.exe and let Remove-Item / Move-Item wrap Get-PilotLongPath.
+        expect(fn).toMatch(/\$expanded = Get-PilotLongPath \$root/);
+        expect(fn).toMatch(/\$expanded -notmatch '\[\^\\x20-\\x7E\]'/);
+        expect(fn).toMatch(/\$root -notmatch '\[\^\\x20-\\x7E\]'/);
+      });
+    }
 
     if (f !== 'installer-opensource.ps1') {
       it(`${f} 7-Zip fallback cleans the intermediate .tar quietly`, () => {

--- a/tests/unit/scripts/ps1-nonascii-windows-paths.test.mjs
+++ b/tests/unit/scripts/ps1-nonascii-windows-paths.test.mjs
@@ -259,6 +259,7 @@ describe('non-ASCII Windows account names survive every .ps1 boundary', () => {
   it('the ASCII temp root is probed for writability and never used for secrets', () => {
     const variants = ['deploy/installer.ps1', 'deploy/installer-inner.ps1',
                       'deploy/installer-opensource.ps1'].filter(existsSync);
+    const withExpanded = [];
     for (const file of variants) {
       const block = blockOf(read(file), 'pilot-ascii-temp');
       expect(block, file).toBeTruthy();
@@ -271,10 +272,25 @@ describe('non-ASCII Windows account names survive every .ps1 boundary', () => {
       // Config payloads carry the SLS AccessKeySecret and the CMS license key, so they
       // keep going to $DataDir; this root can be C:\Windows\Temp.
       expect(read(file)).not.toMatch(/\$cfgTmp = Join-Path \(Get-PilotAsciiTempRoot\)/);
+      // Expanding an ASCII 8.3 TEMP is required for Remove-Item, but the long
+      // name has to be re-checked: a CJK profile's 8.3 is ASCII and
+      // Get-PilotLongPath turns it back into CJK, which tar.exe cannot open.
+      if (/\$expanded = Get-PilotLongPath \$root/.test(code)) {
+        withExpanded.push(file);
+        expect(code, file).toMatch(/\$expanded -notmatch/);
+      }
     }
-    if (variants.length > 0) {
-      // The block is shared verbatim, same reason as the identity helpers.
-      const blocks = variants.map(f => blockOf(read(f), 'pilot-ascii-temp'));
+    // Internal copies must have the CJK-safe expand. The public installer
+    // may lag until the GitHub PR lands and syncs back; on the GitHub tree
+    // it is the only variant, so it must have it.
+    for (const f of ['deploy/installer.ps1', 'deploy/installer-inner.ps1']) {
+      if (variants.includes(f)) expect(withExpanded, f).toContain(f);
+    }
+    if (!variants.includes('deploy/installer.ps1') && variants.includes('deploy/installer-opensource.ps1')) {
+      expect(withExpanded).toContain('deploy/installer-opensource.ps1');
+    }
+    if (withExpanded.length > 0) {
+      const blocks = withExpanded.map(f => blockOf(read(f), 'pilot-ascii-temp'));
       expect(new Set(blocks).size).toBe(1);
     }
   });


### PR DESCRIPTION
## Summary
- `Get-PilotLongPath` of an ASCII 8.3 `%TEMP%` can produce a CJK long path (short base + over-long extension). `tar.exe` then fails with `Failed to open 'C:\Users\??.HOST\...'`.
- Keep the expanded form only when it stays ASCII (`zhang.wang`). Otherwise try `%SystemRoot%\Temp`, and if that is not writable leave the 8.3 for tar. `Remove-Item` / `Move-Item` still wrap `Get-PilotLongPath`.
- Pin the CJK re-check in `installer-short-path.test.mjs` and `ps1-nonascii-windows-paths.test.mjs`.

Internal `installer.ps1` / `installer-inner.ps1` stay on the GitLab CR: https://code.alibaba-inc.com/sls/loongsuite-pilot/codereview/29726848

## Test plan
- [ ] `npx vitest run tests/unit/deploy/installer-short-path.test.mjs tests/unit/scripts/ps1-nonascii-windows-paths.test.mjs`
- [ ] Confirm this PR does not touch `installer.ps1` / `installer-inner.ps1` (GitHub tree only has the public installer)


Made with [Cursor](https://cursor.com)