### PR TITLE
fix(openclaw): prevent session-only traces

### DIFF
--- a/assets/plugins/openclaw/plugin.mjs
+++ b/assets/plugins/openclaw/plugin.mjs
@@ -17,11 +17,12 @@
  * ground truth — do NOT synthesize payloads.
  *
  * Span mapping (per /event-log-spec):
- *   ENTRY  ← session_start / session_end (sessionId)
- *   AGENT  ← before_agent_run → agent_end (runId)
+ *   ENTRY / AGENT ← before_agent_run → agent_end (runId)
  *   STEP   ← model_call_started / model_call_ended (callId = <runId>:model:<N>)
  *   LLM    ← llm_input / llm_output / model_call_* (callId)
  *   TOOL   ← before_tool_call / after_tool_call / tool_result_persist (toolCallId)
+ *   session_start / session_end stay in the private raw log as lifecycle signals
+ *   and are filtered by OpenClawPluginInput before the canonical event pipeline.
  */
 
 import fs from "node:fs";

--- a/src/inputs/openclaw-plugin/openclaw-plugin-input.ts
+++ b/src/inputs/openclaw-plugin/openclaw-plugin-input.ts
@@ -7,6 +7,7 @@ import { resolveHome, directoryExists } from '../../utils/fs-utils.js';
 import { transformHookRecord } from '../base/hook-record-transform.js';
 
 const DEFAULT_PILOT_DATA_DIR = '~/.loongsuite-pilot';
+const SESSION_LIFECYCLE_HOOKS = new Set(['session_start', 'session_end']);
 
 export type OpenClawPluginInputOptions =
   Omit<Partial<HookInputOptions>, 'stateStore'>
@@ -60,6 +61,25 @@ export class OpenClawPluginInput extends BaseHookInput {
   protected async transformRecord(
     record: Record<string, unknown>,
   ): Promise<AgentActivityEntry | null> {
-    return transformHookRecord(record, ClientType.OpenClaw, 'openclaw');
+    const hook = record['agent.openclaw.hook'];
+
+    // Session lifecycle hooks are collector control-plane signals, not turns.
+    // Forwarding them creates trace groups with only ENTRY and AGENT spans.
+    if (typeof hook === 'string' && SESSION_LIFECYCLE_HOOKS.has(hook)) {
+      return null;
+    }
+
+    let canonicalRecord = record;
+    if (hook === 'before_model_resolve') {
+      // before_agent_run contains the same prompt plus richer turn context and
+      // is the single canonical source for ENTRY/AGENT input messages.
+      canonicalRecord = { ...record };
+      delete canonicalRecord['gen_ai.input.messages'];
+      delete canonicalRecord['gen_ai.input.messages_delta'];
+      delete canonicalRecord['input.messages'];
+      delete canonicalRecord['input.messages_delta'];
+    }
+
+    return transformHookRecord(canonicalRecord, ClientType.OpenClaw, 'openclaw');
   }
 }

--- a/tests/integration/openclaw-plugin-event-log-flow.test.ts
+++ b/tests/integration/openclaw-plugin-event-log-flow.test.ts
@@ -109,6 +109,9 @@ describe('OpenClaw plugin to InputManager trace flow', () => {
     expect(records.every(record => record['user.id'] === 'channel-sender')).toBe(true);
     expect(records.every(record =>
       !('agent.pilot.invocation.user.id' in record))).toBe(true);
+    const agentRun = records.find(record =>
+      record['agent.openclaw.hook'] === 'before_agent_run');
+    expect(agentRun?.['gen_ai.input.messages_delta']).toHaveLength(1);
     const terminal = records.find(record => record['agent.openclaw.hook'] === 'llm_output');
     expect(terminal).toMatchObject({
       'event.name': 'other',
@@ -180,6 +183,9 @@ describe('OpenClaw plugin to InputManager trace flow', () => {
         'gen_ai.usage.output_tokens': 326,
         'gen_ai.usage.total_tokens': 27778,
       });
+      const agentInput = JSON.parse(String(agentSpan?.attributes['gen_ai.input.messages']));
+      expect(agentInput).toHaveLength(1);
+      expect(agentInput[0]).toMatchObject({ role: 'user' });
     } finally {
       if (previousStability === undefined) delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
       else process.env.OTEL_SEMCONV_STABILITY_OPT_IN = previousStability;

--- a/tests/unit/inputs/openclaw-plugin-input.test.ts
+++ b/tests/unit/inputs/openclaw-plugin-input.test.ts
@@ -103,6 +103,92 @@ describe('OpenClawPluginInput', () => {
     });
   });
 
+  it('drops session lifecycle events from the canonical pipeline', async () => {
+    const today = new Date();
+    const date = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+    const records = ['session_start', 'session_end'].map((hook, index) => ({
+      time_unix_nano: String(1784188800000000000n + BigInt(index)),
+      'event.id': `session-event-${index}`,
+      'event.name': 'other',
+      'user.id': 'user-1',
+      'trace_id': 'session-trace',
+      'gen_ai.session.id': 'session-1',
+      'gen_ai.agent.type': 'openclaw',
+      'agent.openclaw.hook': hook,
+    }));
+    await fs.writeFile(
+      path.join(tmpDir, `openclaw-${date}.jsonl`),
+      `${records.map(record => JSON.stringify(record)).join('\n')}\n`,
+    );
+
+    const input = new OpenClawPluginInput({
+      stateStore: stateStore as never,
+      logDir: tmpDir,
+      pollIntervalMs: 60_000,
+    });
+    const entries: AgentActivityEntry[] = [];
+    input.on('entries', batch => entries.push(...batch));
+
+    await input.start();
+    await input.stop();
+
+    expect(entries).toEqual([]);
+  });
+
+  it('uses before_agent_run as the single canonical turn input source', async () => {
+    const today = new Date();
+    const date = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+    const prompt = [{ role: 'user', parts: [{ type: 'text', content: 'hello' }] }];
+    const common = {
+      'event.name': 'other',
+      'user.id': 'user-1',
+      'gen_ai.session.id': 'session-1',
+      'gen_ai.turn.id': 'turn-1',
+      'gen_ai.agent.type': 'openclaw',
+    };
+    const records = [
+      {
+        ...common,
+        time_unix_nano: '1784188800000000000',
+        'event.id': 'model-resolve',
+        'agent.openclaw.hook': 'before_model_resolve',
+        'gen_ai.input.messages_delta': prompt,
+        'input.messages': prompt,
+      },
+      {
+        ...common,
+        time_unix_nano: '1784188800000000001',
+        'event.id': 'agent-run',
+        'agent.openclaw.hook': 'before_agent_run',
+        'gen_ai.input.messages_delta': prompt,
+        'gen_ai.system_instructions': 'system prompt',
+      },
+    ];
+    await fs.writeFile(
+      path.join(tmpDir, `openclaw-${date}.jsonl`),
+      `${records.map(record => JSON.stringify(record)).join('\n')}\n`,
+    );
+
+    const input = new OpenClawPluginInput({
+      stateStore: stateStore as never,
+      logDir: tmpDir,
+      pollIntervalMs: 60_000,
+    });
+    const entries: AgentActivityEntry[] = [];
+    input.on('entries', batch => entries.push(...batch));
+
+    await input.start();
+    await input.stop();
+
+    expect(entries).toHaveLength(2);
+    const modelResolve = entries.find(entry => entry['agent.openclaw.hook'] === 'before_model_resolve');
+    expect(modelResolve?.['gen_ai.input.messages']).toBeUndefined();
+    expect(modelResolve?.['gen_ai.input.messages_delta']).toBeUndefined();
+    const agentRun = entries.find(entry => entry['agent.openclaw.hook'] === 'before_agent_run');
+    expect(agentRun?.['gen_ai.input.messages_delta']).toEqual(prompt);
+    expect(agentRun?.['gen_ai.system_instructions']).toBe('system prompt');
+  });
+
   it('tightens an existing log directory when the input starts', async () => {
     if (process.platform === 'win32') return;
     await fs.chmod(tmpDir, 0o755);


### PR DESCRIPTION
## Summary

- filter OpenClaw `session_start` and `session_end` records at the OpenClaw input boundary so lifecycle-only groups cannot become ENTRY + AGENT traces
- keep `before_model_resolve` metadata while removing its duplicate canonical input payload; `before_agent_run` remains the single ENTRY/AGENT input source
- keep raw OpenClaw plugin JSONL and `llm_output` terminal flushing unchanged
- leave the shared `JsonlFlusher` and generic OTLP converter untouched

## Evidence

For local OpenClaw data from 2026-08-27 through 2026-09-03:

- all 19 exported root-only trace IDs correlated with session lifecycle events
- 27 lifecycle records will be filtered before the canonical pipeline
- input-bearing `other` records drop from 68 to 34, matching the 34 completed turns

## Tests

- `npm test -- --run tests/unit/hooks/openclaw tests/unit/inputs/openclaw-plugin-input.test.ts tests/integration/openclaw-plugin-event-log-flow.test.ts tests/unit/flushers/otlp-trace-flusher` (163 passed)
- `npm run typecheck`
- `npm run build`

Fixes #373