### PR TITLE
fix(qoder-cn): collect qoderclicn LLM duration and token usage

### DIFF
--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -546,17 +546,16 @@ async function processTranscript(agentId, logPrefix, transcriptPath, sessionId, 
     // session_meta, other types: ignored
   }
 
-  // --- Phase 2.5 (qoder-cn only): Skip processing if transcript hasn't reached Stop ---
-  // For qoder-cn, only process the transcript when the Stop progress event has been
-  // written. A PostToolUse retry (which runs before Stop is written) would see an
-  // incomplete ReAct chain and produce partial events. The Stop retry (fired after
-  // the final assistant text is written) sees the complete chain and can correctly
-  // generate all llm.request events with proper input.messages_delta (including
-  // tool_result as input delta for step 2).
+  // --- Phase 2.5 (qoder-cn only): Skip processing until the transcript is terminal ---
+  // QoderCN does not guarantee that its progress Stop row is visible when the Stop
+  // hook process runs. In SDK --print mode the terminal assistant row and
+  // last-prompt marker can already be durable while progress Stop is appended only
+  // after the hook returns. Accept all terminal forms understood by the retry path;
+  // otherwise a complete managed-runtime turn is silently dropped forever.
   if (agentId === 'qoder-cn') {
-    const hasStop = progressEvents.some(pe => pe.hookEvent === 'Stop');
-    if (!hasStop) {
-      logDebug(agentId, `Transcript not yet complete (no Stop event in progress). Skipping processing.`);
+    const hasTerminalMarker = hasQoderCnTerminalMarker(progressEvents, parsed);
+    if (!hasTerminalMarker) {
+      logDebug(agentId, `Transcript not yet complete (no terminal marker). Skipping processing.`);
       return;
     }
     // A precise retry snapshot already contains the complete target Turn. Only
@@ -753,6 +752,15 @@ const TERMINAL_STOP_REASONS = new Set([
 
 function isTerminalStopReason(reason) {
   return typeof reason === 'string' && TERMINAL_STOP_REASONS.has(reason);
+}
+
+export function hasQoderCnTerminalMarker(progressEvents, rows) {
+  return progressEvents.some(event => event?.hookEvent === 'Stop')
+    || rows.some(row => row?.type === 'last-prompt')
+    || rows.some(row => (
+      row?.type === 'assistant'
+      && isTerminalStopReason(row?.message?.stop_reason)
+    ));
 }
 
 export function findTriggeredTurnWindow(snapshot, triggerEndLine) {

--- a/assets/hooks/qodercli-runtime-wrapper.sh
+++ b/assets/hooks/qodercli-runtime-wrapper.sh
@@ -2,10 +2,10 @@
 #
 # Launch qodercli with the token intercept scoped to this process only.
 #
-# npm qodercli distributions are Node.js entrypoints and require NODE_OPTIONS
-# --import. Native qodercli distributions are Bun executables and require
-# BUN_OPTIONS --preload. Set LOONGSUITE_QODERCLI_RUNTIME=node|bun to override
-# auto-detection, or LOONGSUITE_QODERCLI_BIN to provide the real executable.
+# npm and bundled SDK qodercli distributions are Node.js entrypoints and require
+# NODE_OPTIONS --import. Native qodercli distributions are Bun executables and
+# require BUN_OPTIONS --preload. Set LOONGSUITE_QODERCLI_RUNTIME=node|bun to
+# override auto-detection, or LOONGSUITE_QODERCLI_BIN to provide the real entry.
 
 SCRIPT_DIR=$(CDPATH= cd "$(dirname "$0")" 2>/dev/null && pwd)
 INTERCEPT_SCRIPT="$SCRIPT_DIR/qodercli-token-intercept.mjs"
@@ -20,18 +20,38 @@ if [ -z "$QODERCLI_BIN" ]; then
   exit 127
 fi
 
-# Missing hook assets must never prevent qodercli from starting.
-if [ ! -f "$INTERCEPT_SCRIPT" ]; then
-  exec "$QODERCLI_BIN" "$@"
-fi
-
 QODERCLI_RUNTIME="${LOONGSUITE_QODERCLI_RUNTIME:-}"
 if [ -z "$QODERCLI_RUNTIME" ]; then
-  if LC_ALL=C head -c 128 "$QODERCLI_BIN" 2>/dev/null | grep -aq '^#!.*node'; then
-    QODERCLI_RUNTIME=node
-  else
-    QODERCLI_RUNTIME=bun
+  case "$QODERCLI_BIN" in
+    *.js|*.cjs|*.mjs) QODERCLI_RUNTIME=node ;;
+    *)
+      if LC_ALL=C head -c 128 "$QODERCLI_BIN" 2>/dev/null | grep -aq '^#!.*node'; then
+        QODERCLI_RUNTIME=node
+      else
+        QODERCLI_RUNTIME=bun
+      fi
+      ;;
+  esac
+fi
+
+launch_qodercli() {
+  if [ "$QODERCLI_RUNTIME" = "node" ]; then
+    QODERCLI_NODE_BIN="${LOONGSUITE_QODERCLI_NODE_BIN:-}"
+    if [ -z "$QODERCLI_NODE_BIN" ]; then
+      QODERCLI_NODE_BIN=$(command -v node 2>/dev/null || true)
+    fi
+    if [ -z "$QODERCLI_NODE_BIN" ]; then
+      echo "loongsuite-pilot: node executable not found for qodercli entry" >&2
+      exit 127
+    fi
+    exec "$QODERCLI_NODE_BIN" "$QODERCLI_BIN" "$@"
   fi
+  exec "$QODERCLI_BIN" "$@"
+}
+
+# Missing hook assets must never prevent qodercli from starting.
+if [ ! -f "$INTERCEPT_SCRIPT" ]; then
+  launch_qodercli "$@"
 fi
 
 if [ "$QODERCLI_RUNTIME" = "node" ]; then
@@ -50,4 +70,4 @@ else
   export BUN_OPTIONS
 fi
 
-exec "$QODERCLI_BIN" "$@"
+launch_qodercli "$@"

--- a/assets/hooks/qodercli-runtime-wrapper.sh
+++ b/assets/hooks/qodercli-runtime-wrapper.sh
@@ -1,26 +1,36 @@
 #!/bin/sh
 #
-# Launch qodercli with the token intercept scoped to this process only.
+# Launch a Qoder CLI with the token intercept scoped to this process only.
 #
-# npm and bundled SDK qodercli distributions are Node.js entrypoints and require
-# NODE_OPTIONS --import. Native qodercli distributions are Bun executables and
-# require BUN_OPTIONS --preload. Set LOONGSUITE_QODERCLI_RUNTIME=node|bun to
-# override auto-detection, or LOONGSUITE_QODERCLI_BIN to provide the real entry.
+# Serves both product lines: LOONGSUITE_QODERCLI_FLAVOR selects which one, and
+# defaults to qodercli so an rc block written by an older install keeps working.
+# The rc block installed for the CN build sets it to qoderclicn.
+#
+# npm and bundled SDK distributions are Node.js entrypoints and require
+# NODE_OPTIONS --import. Native distributions are Bun executables and require
+# BUN_OPTIONS --preload. Set <FLAVOR>_RUNTIME=node|bun to override
+# auto-detection, or <FLAVOR>_BIN to provide the real entry, where <FLAVOR> is
+# LOONGSUITE_QODERCLI or LOONGSUITE_QODERCLICN. The names are per flavor on
+# purpose: a value exported for one product line must not redirect the other.
 
 SCRIPT_DIR=$(CDPATH= cd "$(dirname "$0")" 2>/dev/null && pwd)
 INTERCEPT_SCRIPT="$SCRIPT_DIR/qodercli-token-intercept.mjs"
-QODERCLI_BIN="${LOONGSUITE_QODERCLI_BIN:-}"
+QODERCLI_FLAVOR="${LOONGSUITE_QODERCLI_FLAVOR:-qodercli}"
+FLAVOR_VAR=$(printf '%s' "$QODERCLI_FLAVOR" | tr 'a-z-' 'A-Z_')
+INTERCEPT_FILE_NAME="${LOONGSUITE_INTERCEPT_FILE:-${QODERCLI_FLAVOR}-intercept.jsonl}"
+
+eval "QODERCLI_BIN=\${LOONGSUITE_${FLAVOR_VAR}_BIN:-}"
 
 if [ -z "$QODERCLI_BIN" ]; then
-  QODERCLI_BIN=$(command -v qodercli 2>/dev/null || true)
+  QODERCLI_BIN=$(command -v "$QODERCLI_FLAVOR" 2>/dev/null || true)
 fi
 
 if [ -z "$QODERCLI_BIN" ]; then
-  echo "loongsuite-pilot: qodercli executable not found" >&2
+  echo "loongsuite-pilot: $QODERCLI_FLAVOR executable not found" >&2
   exit 127
 fi
 
-QODERCLI_RUNTIME="${LOONGSUITE_QODERCLI_RUNTIME:-}"
+eval "QODERCLI_RUNTIME=\${LOONGSUITE_${FLAVOR_VAR}_RUNTIME:-}"
 if [ -z "$QODERCLI_RUNTIME" ]; then
   case "$QODERCLI_BIN" in
     *.js|*.cjs|*.mjs) QODERCLI_RUNTIME=node ;;
@@ -36,12 +46,12 @@ fi
 
 launch_qodercli() {
   if [ "$QODERCLI_RUNTIME" = "node" ]; then
-    QODERCLI_NODE_BIN="${LOONGSUITE_QODERCLI_NODE_BIN:-}"
+    eval "QODERCLI_NODE_BIN=\${LOONGSUITE_${FLAVOR_VAR}_NODE_BIN:-}"
     if [ -z "$QODERCLI_NODE_BIN" ]; then
       QODERCLI_NODE_BIN=$(command -v node 2>/dev/null || true)
     fi
     if [ -z "$QODERCLI_NODE_BIN" ]; then
-      echo "loongsuite-pilot: node executable not found for qodercli entry" >&2
+      echo "loongsuite-pilot: node executable not found for $QODERCLI_FLAVOR entry" >&2
       exit 127
     fi
     exec "$QODERCLI_NODE_BIN" "$QODERCLI_BIN" "$@"
@@ -49,10 +59,13 @@ launch_qodercli() {
   exec "$QODERCLI_BIN" "$@"
 }
 
-# Missing hook assets must never prevent qodercli from starting.
+# Missing hook assets must never prevent the CLI from starting.
 if [ ! -f "$INTERCEPT_SCRIPT" ]; then
   launch_qodercli "$@"
 fi
+
+# Read by the preload script to pick its output file.
+export LOONGSUITE_INTERCEPT_FILE="$INTERCEPT_FILE_NAME"
 
 if [ "$QODERCLI_RUNTIME" = "node" ]; then
   PILOT_PRELOAD_OPTION="--import=$INTERCEPT_SCRIPT"

--- a/assets/hooks/qodercli-runtime-wrapper.sh
+++ b/assets/hooks/qodercli-runtime-wrapper.sh
@@ -30,12 +30,31 @@ if [ -z "$QODERCLI_BIN" ]; then
   exit 127
 fi
 
+# True for a readable file that opens with no shebang and holds no NUL byte.
+# Such a file is a Node entrypoint: a Bun executable is compiled and carries NUL
+# bytes in its header, and anything the kernel can launch on its own names an
+# interpreter on the first line. Reading the file also follows the symlink a PATH
+# entry usually is, so no path resolution is needed to reach the real bytes.
+# A file we cannot read yields no evidence and is left to the caller's fallback.
+is_shebangless_text() {
+  LC_ALL=C head -c 2 "$1" 2>/dev/null | grep -aq '^#!' && return 1
+  _read=$(LC_ALL=C head -c 128 "$1" 2>/dev/null | wc -c | tr -d ' ')
+  [ "$_read" -gt 0 ] || return 1
+  _text=$(LC_ALL=C head -c 128 "$1" 2>/dev/null | LC_ALL=C tr -d '\000' | wc -c | tr -d ' ')
+  [ "$_read" = "$_text" ]
+}
+
 eval "QODERCLI_RUNTIME=\${LOONGSUITE_${FLAVOR_VAR}_RUNTIME:-}"
 if [ -z "$QODERCLI_RUNTIME" ]; then
   case "$QODERCLI_BIN" in
     *.js|*.cjs|*.mjs) QODERCLI_RUNTIME=node ;;
     *)
       if LC_ALL=C head -c 128 "$QODERCLI_BIN" 2>/dev/null | grep -aq '^#!.*node'; then
+        QODERCLI_RUNTIME=node
+      elif is_shebangless_text "$QODERCLI_BIN"; then
+        # A PATH entry's name carries no extension, so the arm above is all that
+        # stood between a bundled entry and the Bun branch, which exec's the file
+        # directly: the kernel refuses JS text and the CLI never starts.
         QODERCLI_RUNTIME=node
       else
         QODERCLI_RUNTIME=bun

--- a/assets/hooks/qodercli-token-intercept.mjs
+++ b/assets/hooks/qodercli-token-intercept.mjs
@@ -1,8 +1,11 @@
-// Cross-runtime preload script for qodercli token & system prompt capture.
+// Cross-runtime preload script for token & system prompt capture, shared by the
+// qodercli (international) and qoderclicn (CN) product lines.
 // Injected via:
-//   Bun:  BUN_OPTIONS="--preload=<this-file>" qodercli ...
-//   Node: NODE_OPTIONS="--import=<this-file>" qodercli ...
-// Writes to: ~/.loongsuite-pilot/logs/qodercli-intercept.jsonl
+//   Bun:  BUN_OPTIONS="--preload=<this-file>" <cli> ...
+//   Node: NODE_OPTIONS="--import=<this-file>" <cli> ...
+// Writes to: ~/.loongsuite-pilot/logs/<LOONGSUITE_INTERCEPT_FILE>, defaulting to
+// qodercli-intercept.jsonl. The runtime wrapper sets the variable per product
+// line so two installs on one machine do not interleave into one stream.
 //
 // Two hooks:
 //   JSON.parse  → captures token usage from SSE response (last event with .usage + .choices)
@@ -14,7 +17,11 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 const INTERCEPT_DIR = path.join(process.env.HOME || "/tmp", ".loongsuite-pilot", "logs");
-const INTERCEPT_FILE = path.join(INTERCEPT_DIR, "qodercli-intercept.jsonl");
+// basename() keeps the value inside the log dir no matter what it holds.
+const INTERCEPT_FILE = path.join(
+  INTERCEPT_DIR,
+  path.basename(process.env.LOONGSUITE_INTERCEPT_FILE || "qodercli-intercept.jsonl"),
+);
 const MIN_SYSTEM_PROMPT_LENGTH = 100;
 
 try { fs.mkdirSync(INTERCEPT_DIR, { recursive: true }); } catch {}

--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -1203,6 +1203,16 @@ _sed_inplace() {
     fi
 }
 
+# Is `needle` present INSIDE the begin/end marker region of `file`?
+# Signature checks must be scoped this way rather than grepping the whole rc
+# file: the qodercli and qoderclicn blocks both name the same wrapper script, so
+# a file-wide match lets one block vouch for the other and a stale block never
+# gets migrated. Mirrors extractMarkerBlock() in src/core/hook-watchdog.ts.
+_rc_block_contains() {
+    local file="$1" begin="$2" end="$3" needle="$4"
+    sed -n "/$begin/,/$end/p" "$file" 2>/dev/null | grep -qF "$needle"
+}
+
 inject_qodercli_token_intercept() {
     # Not selected: clean up any stale block from a prior install, then bail.
     if ! echo "$SELECTED_AGENTS" | grep -q 'qoder'; then remove_qodercli_token_intercept; return 0; fi
@@ -1227,7 +1237,10 @@ inject_qodercli_token_intercept() {
         # so the new guarded block below replaces it (the old bare block
         # parse-errors under a user alias, which is exactly what we're fixing).
         if grep -q 'loongsuite-pilot BEGIN qodercli-intercept' "$file" 2>/dev/null; then
-            if grep -qF 'qodercli-runtime-wrapper.sh' "$file"; then return 0; fi
+            if _rc_block_contains "$file" \
+                'loongsuite-pilot BEGIN qodercli-intercept' \
+                'loongsuite-pilot END qodercli-intercept' \
+                'qodercli-runtime-wrapper.sh'; then return 0; fi
             _sed_inplace '/# loongsuite-pilot BEGIN qodercli-intercept/,/# loongsuite-pilot END qodercli-intercept/d' "$file"
         fi
         [ -s "$file" ] && [ "$(tail -c1 "$file" | wc -l)" -eq 0 ] && echo "" >> "$file"
@@ -1280,6 +1293,81 @@ remove_qodercli_token_intercept() {
         fi
     done
 }
+
+# The CN line gets its own function rather than sharing the one above: that
+# block's exact bytes are part of a released idempotency contract (the watchdog
+# greps for them), so it is left untouched. Only the marker and the flavor
+# variable differ here — the wrapper and preload script are the same assets.
+inject_qoderclicn_token_intercept() {
+    # Not selected: clean up any stale block from a prior install, then bail.
+    if ! echo "$SELECTED_AGENTS" | grep -q 'qoder-cn'; then remove_qoderclicn_token_intercept; return 0; fi
+    if ! command -v qoderclicn >/dev/null 2>&1; then return 0; fi
+
+    local intercept_script="$DATA_DIR/hooks/qodercli-token-intercept.mjs"
+    local runtime_wrapper="$DATA_DIR/hooks/qodercli-runtime-wrapper.sh"
+    if [ ! -f "$intercept_script" ] || [ ! -f "$runtime_wrapper" ]; then return 0; fi
+
+    msg "==> 配置 qoderclicn token 采集..." "==> Configuring qoderclicn token intercept..."
+
+    _inject_cn_to_rc() {
+        local file="$1"
+        if [ ! -f "$file" ]; then return 0; fi
+        if [ ! -w "$file" ]; then
+            msg "    ⚠️  $file 不可写，跳过" "    ⚠️  $file is not writable, skipping"
+            return 0
+        fi
+        # Migrate-or-skip, same shape as the qodercli block: the signature is the
+        # flavor assignment, since the wrapper name cannot tell the two apart.
+        if grep -q 'loongsuite-pilot BEGIN qoderclicn-intercept' "$file" 2>/dev/null; then
+            if _rc_block_contains "$file" \
+                'loongsuite-pilot BEGIN qoderclicn-intercept' \
+                'loongsuite-pilot END qoderclicn-intercept' \
+                'LOONGSUITE_QODERCLI_FLAVOR=qoderclicn'; then return 0; fi
+            _sed_inplace '/# loongsuite-pilot BEGIN qoderclicn-intercept/,/# loongsuite-pilot END qoderclicn-intercept/d' "$file"
+        fi
+        [ -s "$file" ] && [ "$(tail -c1 "$file" | wc -l)" -eq 0 ] && echo "" >> "$file"
+        # Double-quoted heredoc so $DATA_DIR expands at install time. $@ is
+        # escaped to defer expansion to runtime. Keep byte-identical to the
+        # watchdog's blockFn (src/core/hook-watchdog.ts, id qoderclicn-rc).
+        cat >> "$file" << INTERCEPTBLOCK
+
+# loongsuite-pilot BEGIN qoderclicn-intercept
+if ! alias qoderclicn >/dev/null 2>&1 && ! typeset -f qoderclicn >/dev/null 2>&1; then
+  eval 'qoderclicn() { LOONGSUITE_QODERCLI_FLAVOR=qoderclicn "$DATA_DIR/hooks/qodercli-runtime-wrapper.sh" "\$@"; }'
+fi
+# loongsuite-pilot END qoderclicn-intercept
+INTERCEPTBLOCK
+        msg "    ✅ 已写入 $file (请执行 source $file 或打开新终端)" \
+            "    ✅ Written to $file (run: source $file or open a new terminal)"
+    }
+
+    case "${SHELL:-/bin/bash}" in
+        */zsh)  _inject_cn_to_rc "$HOME/.zshrc" ;;
+        */bash) _inject_cn_to_rc "$HOME/.bashrc" ;;
+        *)      _inject_cn_to_rc "$HOME/.bashrc" ;;
+    esac
+
+    if _rc_user_override_present qoderclicn \
+        'loongsuite-pilot BEGIN qoderclicn-intercept' \
+        'loongsuite-pilot END qoderclicn-intercept'; then
+        msg "    ⚠️  检测到你已自定义 qoderclicn(alias/function)，为避免覆盖，采集未启用。" \
+            "    ⚠️  Detected your own 'qoderclicn' (alias/function); collection is disabled to avoid clobbering it."
+        msg "        如需启用采集，请让你的定义调用： LOONGSUITE_QODERCLI_FLAVOR=qoderclicn $runtime_wrapper" \
+            "        To enable collection, have your definition call: LOONGSUITE_QODERCLI_FLAVOR=qoderclicn $runtime_wrapper"
+    fi
+    echo ""
+}
+
+remove_qoderclicn_token_intercept() {
+    for file in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.profile"; do
+        if [ -f "$file" ] && grep -q 'loongsuite-pilot BEGIN qoderclicn-intercept' "$file" 2>/dev/null; then
+            _sed_inplace '/# loongsuite-pilot BEGIN qoderclicn-intercept/,/# loongsuite-pilot END qoderclicn-intercept/d' "$file"
+            msg "    已清理 qoderclicn token intercept ($file)" \
+                "    Cleaned up qoderclicn token intercept ($file)"
+        fi
+    done
+}
+
 
 # ============================================================
 # QoderWork-family runtime wrapper: intercept token usage via the SDK-wide
@@ -1977,6 +2065,7 @@ cmd_install() {
     write_config
     install_loongsuite_pilot_command
     inject_qodercli_token_intercept
+    inject_qoderclicn_token_intercept
     inject_qoderwork_runtime_wrapper
     inject_claude_code_fetch_intercept
 
@@ -2879,6 +2968,7 @@ cmd_uninstall() {
     remove_hook_configs
     remove_grok_build_hook_config
     remove_qodercli_token_intercept
+    remove_qoderclicn_token_intercept
     remove_qoderwork_runtime_wrapper
     remove_claude_code_fetch_intercept
     echo ""

--- a/src/core/hook-watchdog.ts
+++ b/src/core/hook-watchdog.ts
@@ -79,40 +79,75 @@ export interface WinRuntimeInterceptDefinition {
 }
 
 /**
+ * Prefix shared by every block this file writes into an rc file. It marks where
+ * a block whose END marker went missing has to stop: at the next block's BEGIN.
+ */
+const MARKER_BEGIN_PREFIX = 'loongsuite-pilot BEGIN ';
+
+/** True when `line` opens some block other than the one `begin` delimits. */
+function startsAnotherBlock(line: string, begin: string): boolean {
+  return line.includes(MARKER_BEGIN_PREFIX) && !line.includes(begin);
+}
+
+/**
  * Remove a marker-delimited block (inclusive of the BEGIN/END marker lines)
  * from rc-file content. Any line containing `begin` starts the cut and any
  * line containing `end` ends it; non-block lines are preserved verbatim.
+ *
+ * A block whose END marker is missing stops at the next block's BEGIN line
+ * instead of running to EOF. Running to EOF would drop every block written
+ * after it along with whatever the user keeps below them -- PATH edits, nvm
+ * init, aliases -- because repair() writes the stripped result back over the
+ * file. A repeated BEGIN for this same block keeps the cut open, so a file that
+ * accumulated duplicates collapses to a single removal.
  */
 export function stripMarkerBlock(content: string, begin: string, end: string): string {
   const out: string[] = [];
   let inBlock = false;
   for (const line of content.split('\n')) {
-    if (!inBlock && line.includes(begin)) { inBlock = true; continue; }
-    if (inBlock && line.includes(end)) { inBlock = false; continue; }
-    if (!inBlock) out.push(line);
+    if (!inBlock) {
+      if (line.includes(begin)) inBlock = true;
+      else out.push(line);
+      continue;
+    }
+    if (line.includes(end)) { inBlock = false; continue; }
+    if (startsAnotherBlock(line, begin)) { inBlock = false; out.push(line); continue; }
+    // Still inside the block: dropped.
   }
   return out.join('\n');
 }
 
 /**
- * Return the marker-delimited block (inclusive of the BEGIN/END marker lines),
- * or null when the BEGIN marker is absent. Unterminated blocks yield everything
- * from the BEGIN marker on, so a truncated rc file still reads as one block.
+ * Return the marker-delimited block, or null when the BEGIN marker is absent.
+ * `text` is inclusive of the marker lines and `terminated` reports whether the
+ * END marker was found; an unterminated block stops before the next block's
+ * BEGIN line rather than running to EOF.
  *
  * Callers use this instead of scanning whole-file content when they need to
  * answer a question ABOUT one block: two blocks in the same rc file can share
- * substrings (the qodercli and qoderclicn blocks both name the same wrapper
- * script), and a file-wide `includes` would let one satisfy the other's check.
+ * substrings, and a file-wide `includes` would let one satisfy the other's
+ * check. Bounding an unterminated block at the next BEGIN keeps that scoping
+ * intact even when the END marker was lost, and `terminated` lets callers treat
+ * the damaged block as something to rewrite rather than as already current.
  */
-export function extractMarkerBlock(content: string, begin: string, end: string): string | null {
+export function extractMarkerBlock(
+  content: string,
+  begin: string,
+  end: string,
+): { text: string; terminated: boolean } | null {
   const lines = content.split('\n');
   const start = lines.findIndex(line => line.includes(begin));
   if (start === -1) return null;
-  const rest = lines.slice(start + 1);
-  const relEnd = rest.findIndex(line => line.includes(end));
-  return relEnd === -1
-    ? lines.slice(start).join('\n')
-    : lines.slice(start, start + 1 + relEnd + 1).join('\n');
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (line.includes(end)) {
+      return { text: lines.slice(start, i + 1).join('\n'), terminated: true };
+    }
+    if (startsAnotherBlock(line, begin)) {
+      return { text: lines.slice(start, i).join('\n'), terminated: false };
+    }
+  }
+  return { text: lines.slice(start).join('\n'), terminated: false };
 }
 
 export function parseWindowsUserEnv(output: string, envName: string): string {
@@ -619,11 +654,15 @@ export class HookWatchdog {
   }> {
     return [
       {
+        // `signature` is this block's own function definition, not the wrapper
+        // script name: one wrapper serves both product lines, so the script name
+        // also occurs inside the qoderclicn block and could not tell a stale
+        // block of this shape apart from a current CN one.
         id: 'qodercli-rc',
         agentId: 'qoder',
         marker: 'loongsuite-pilot BEGIN qodercli-intercept',
         endMarker: 'loongsuite-pilot END qodercli-intercept',
-        signature: 'qodercli-runtime-wrapper.sh',
+        signature: "eval 'qodercli() {",
         scriptName: 'qodercli-runtime-wrapper.sh',
         blockFn: (p) => [
           '',
@@ -637,8 +676,8 @@ export class HookWatchdog {
       {
         // Same wrapper script as qodercli, told apart by the flavor variable the
         // block exports. `signature` is that assignment rather than the script
-        // name, because the script name alone cannot distinguish this block from
-        // the qodercli one.
+        // name, for the same reason as above: the shared script name cannot
+        // distinguish this block from the qodercli one.
         id: 'qoderclicn-rc',
         agentId: 'qoder-cn',
         marker: 'loongsuite-pilot BEGIN qoderclicn-intercept',
@@ -858,7 +897,10 @@ export class HookWatchdog {
             const content = await fs.readFile(rcPath, 'utf-8');
             const block = extractMarkerBlock(content, rc.marker, rc.endMarker);
             if (block !== null) {
-              if (block.includes(rc.signature)) anyCurrent = true;
+              // A block that lost its END marker is damaged whatever it holds:
+              // the blocks written after it sit inside its unclosed region.
+              if (!block.terminated) return false;
+              if (block.text.includes(rc.signature)) anyCurrent = true;
               else return false; // marker present but old shape → migrate
             }
           }
@@ -873,7 +915,9 @@ export class HookWatchdog {
             const content = await fs.readFile(rcPath, 'utf-8');
             const block = extractMarkerBlock(content, rc.marker, rc.endMarker);
             if (block !== null) {
-              if (block.includes(rc.signature)) continue; // already current
+              // Unterminated blocks fall through to the rewrite below, which
+              // re-emits both markers.
+              if (block.terminated && block.text.includes(rc.signature)) continue; // already current
               // Stale block: strip the old marker region, then append fresh.
               const stripped = stripMarkerBlock(content, rc.marker, rc.endMarker).replace(/\n+$/, '\n');
               await fs.writeFile(rcPath, stripped + rc.blockFn(scriptPath) + '\n');

--- a/src/core/hook-watchdog.ts
+++ b/src/core/hook-watchdog.ts
@@ -94,6 +94,27 @@ export function stripMarkerBlock(content: string, begin: string, end: string): s
   return out.join('\n');
 }
 
+/**
+ * Return the marker-delimited block (inclusive of the BEGIN/END marker lines),
+ * or null when the BEGIN marker is absent. Unterminated blocks yield everything
+ * from the BEGIN marker on, so a truncated rc file still reads as one block.
+ *
+ * Callers use this instead of scanning whole-file content when they need to
+ * answer a question ABOUT one block: two blocks in the same rc file can share
+ * substrings (the qodercli and qoderclicn blocks both name the same wrapper
+ * script), and a file-wide `includes` would let one satisfy the other's check.
+ */
+export function extractMarkerBlock(content: string, begin: string, end: string): string | null {
+  const lines = content.split('\n');
+  const start = lines.findIndex(line => line.includes(begin));
+  if (start === -1) return null;
+  const rest = lines.slice(start + 1);
+  const relEnd = rest.findIndex(line => line.includes(end));
+  return relEnd === -1
+    ? lines.slice(start).join('\n')
+    : lines.slice(start, start + 1 + relEnd + 1).join('\n');
+}
+
 export function parseWindowsUserEnv(output: string, envName: string): string {
   for (const line of output.split(/\r?\n/)) {
     const match = line.match(/^\s*(\S+)\s+REG_(?:EXPAND_)?SZ\s+(.*)$/);
@@ -566,7 +587,7 @@ export class HookWatchdog {
 
 
   /**
-   * Shell-rc intercept block definitions (qodercli + claude-code).
+   * Shell-rc intercept block definitions (qodercli + qoderclicn + claude-code).
    *
    * blockFn must stay byte-identical to the block written by the installer
    * (deploy/installer-opensource.sh inject_*), so the marker-based idempotency
@@ -582,7 +603,9 @@ export class HookWatchdog {
    * `signature` is a substring unique to the CURRENT block shape. check()/
    * repair() use it — not just `marker` — to detect and migrate
    * an older block that shares the same marker (e.g. the released bare
-   * `<cli>() {...}` form). Keep it byte-identical to the installer's grep.
+   * `<cli>() {...}` form). It is matched WITHIN the block's own marker region,
+   * not across the whole rc file, so a neighbouring block cannot vouch for a
+   * stale one. Keep it byte-identical to the installer's grep.
    * `endMarker` bounds the block for removal/migration.
    */
   static interceptRcBlockDefs(): Array<{
@@ -609,6 +632,26 @@ export class HookWatchdog {
           `  eval 'qodercli() { "${p}" "$@"; }'`,
           'fi',
           '# loongsuite-pilot END qodercli-intercept',
+        ].join('\n'),
+      },
+      {
+        // Same wrapper script as qodercli, told apart by the flavor variable the
+        // block exports. `signature` is that assignment rather than the script
+        // name, because the script name alone cannot distinguish this block from
+        // the qodercli one.
+        id: 'qoderclicn-rc',
+        agentId: 'qoder-cn',
+        marker: 'loongsuite-pilot BEGIN qoderclicn-intercept',
+        endMarker: 'loongsuite-pilot END qoderclicn-intercept',
+        signature: 'LOONGSUITE_QODERCLI_FLAVOR=qoderclicn',
+        scriptName: 'qodercli-runtime-wrapper.sh',
+        blockFn: (p) => [
+          '',
+          '# loongsuite-pilot BEGIN qoderclicn-intercept',
+          'if ! alias qoderclicn >/dev/null 2>&1 && ! typeset -f qoderclicn >/dev/null 2>&1; then',
+          `  eval 'qoderclicn() { LOONGSUITE_QODERCLI_FLAVOR=qoderclicn "${p}" "$@"; }'`,
+          'fi',
+          '# loongsuite-pilot END qoderclicn-intercept',
         ].join('\n'),
       },
       {
@@ -813,8 +856,9 @@ export class HookWatchdog {
             if (!await fileExists(rcPath)) continue;
             anyRcExists = true;
             const content = await fs.readFile(rcPath, 'utf-8');
-            if (content.includes(rc.marker)) {
-              if (content.includes(rc.signature)) anyCurrent = true;
+            const block = extractMarkerBlock(content, rc.marker, rc.endMarker);
+            if (block !== null) {
+              if (block.includes(rc.signature)) anyCurrent = true;
               else return false; // marker present but old shape → migrate
             }
           }
@@ -827,8 +871,9 @@ export class HookWatchdog {
           for (const rcPath of rcPaths) {
             if (!await fileExists(rcPath)) continue; // never create rc files
             const content = await fs.readFile(rcPath, 'utf-8');
-            if (content.includes(rc.marker)) {
-              if (content.includes(rc.signature)) continue; // already current
+            const block = extractMarkerBlock(content, rc.marker, rc.endMarker);
+            if (block !== null) {
+              if (block.includes(rc.signature)) continue; // already current
               // Stale block: strip the old marker region, then append fresh.
               const stripped = stripMarkerBlock(content, rc.marker, rc.endMarker).replace(/\n+$/, '\n');
               await fs.writeFile(rcPath, stripped + rc.blockFn(scriptPath) + '\n');

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -986,6 +986,7 @@ export class Orchestrator extends EventEmitter {
     const qoderCnTraceInput = new QoderCnTraceInput({
       stateStore: this.stateStore,
       logDir: qoderCnLogDir,
+      pollIntervalMs: listenerCfg['qoder-cn-trace']?.pollInterval,
     });
     this.inputManager.registerInput(qoderCnTraceInput);
     entries.push(

--- a/src/inputs/qoder-cn-trace/qoder-cn-trace-input.ts
+++ b/src/inputs/qoder-cn-trace/qoder-cn-trace-input.ts
@@ -176,39 +176,48 @@ export class QoderCnTraceInput extends BaseInput {
 
     // The IDE and qoderclicn share one agentId and therefore one hook history,
     // so the variant has to be recovered here. A CLI session is recognised by
-    // two signals the IDE does not produce: the transcript's usage.request_id
-    // (surfaced by the hook as agent.client_request_id) and a segments directory
-    // of its own. Both are required, so an IDE session stays on the SQLite path
-    // even if a later IDE build starts carrying a request id, and a history
-    // collected before the hook shipped that field degrades to the previous
-    // behaviour instead of losing its tokens.
+    // the transcript's usage.request_id, surfaced by the hook as
+    // agent.client_request_id, which the IDE does not produce. A history
+    // collected before the hook shipped that field carries no request id either,
+    // so it degrades to the SQLite path instead of losing its tokens.
+    //
+    // The presence of segments is deliberately NOT part of this decision.
+    // Segments are written by the CLI itself and can lag behind the hook record,
+    // so gating on them sent a CLI turn whose segments had not landed yet down
+    // the IDE path, where its intercept was never read at all. The Hook offset is
+    // committed before enrichment, so those tokens were lost for good rather than
+    // repaired on a later poll. The cost of dropping segments as a signal is that
+    // an IDE build which one day starts carrying a request id would take the CLI
+    // path; it would find no exact intercept match and end up with no tokens,
+    // which is what gating on segments already produced for real CLI turns.
     let interceptData: InterceptData | null = null;
     for (const [sessionId, sessionEntries] of sessionGroups) {
-      // Here the segment read is itself the second discriminator signal, so it
-      // cannot be deferred behind a missing-data check the way the international
-      // input defers it. Handing the reader this batch's exact request ids keeps
-      // the guarantee that check exists for: the Hook offset is committed before
-      // enrichment, so a record that is not visible yet has to be waited for now
-      // or never. Absent ids cost one short retry; present ids cost nothing.
-      const segments = hasClientRequestId(sessionEntries)
+      const isCliSession = hasClientRequestId(sessionEntries);
+      // Handing the reader this batch's exact request ids buys one bounded retry
+      // for an id missing from the first snapshot, for the same now-or-never
+      // reason: the Hook offset is committed before enrichment.
+      const segments = isCliSession
         ? await this.readCliSegments(sessionId, collectCliExpectedRequestIds(sessionEntries))
         : [];
 
-      if (segments.length > 0) {
+      if (isCliSession) {
         // Tokens come from the runtime intercept rather than from the segments:
         // on this build the segment records and the transcript both report zero
         // token counts and carry only `credits`, same as the international one.
-        // Segments are read for the response timings, which are the only source
-        // of a non-zero LLM duration.
+        // The intercept joins on an exact gen_ai.response.id, so its usefulness
+        // does not depend on whether segments have landed.
         interceptData ??= await readInterceptData(undefined, CN_INTERCEPT_FILE);
         enrichCliPrimary(
           sessionEntries,
           interceptData.systemPrompt?.content,
           interceptData.tokens,
         );
-        // Only fills what Hook plus intercept left missing, so it is safe to run
-        // unconditionally once the segments are in hand.
-        enrichCliFromSegments(sessionEntries, segments);
+        // Segments only supply the response timings, which are the only source of
+        // a non-zero LLM duration. Without them the turn keeps a zero duration,
+        // but its tokens are already in place above.
+        if (segments.length > 0) {
+          enrichCliFromSegments(sessionEntries, segments);
+        }
       } else {
         // Intentionally ignores matchedDbPath: agent.type must never be derived from
         // which candidate DB matched. See resolveQoderCnDbPaths in sqlite-token-reader.

--- a/src/inputs/qoder-cn-trace/qoder-cn-trace-input.ts
+++ b/src/inputs/qoder-cn-trace/qoder-cn-trace-input.ts
@@ -10,16 +10,24 @@ import { filterBootstrapHistoryTurns } from '../base/bootstrap-turn-filter.js';
 import { createHookHistoryStartupCheckpoint } from '../base/hook-history-checkpoint.js';
 import { enrichCanonicalEntryWithGit } from '../../normalization/enrich-git-context.js';
 import { readSqliteTokensForSession } from './sqlite-token-reader.js';
-import { enrichIdeTurn, injectTraceId } from '../qoder-trace/token-enricher.js';
+import { enrichCliTurn, enrichIdeTurn, injectTraceId } from '../qoder-trace/token-enricher.js';
+import { readSegmentTokensForSession, QODER_CN_SEGMENTS_ROOT } from '../qoder-trace/segment-token-reader.js';
+import { readInterceptData, type InterceptData } from '../qoder-trace/intercept-token-reader.js';
+
+// Written by the runtime wrapper that launches qoderclicn. Kept separate from
+// the international build's file so a machine running both keeps the two
+// streams apart.
+const CN_INTERCEPT_FILE = 'qoderclicn-intercept.jsonl';
 
 export interface QoderCnTraceInputOptions extends InputOptions {
   logDir?: string;
 }
 
 /**
- * Multi-source merge input for QoderCN (IDE-only).
- * Reads hook JSONL (content+structure) and SQLite (IDE tokens),
- * merges per session, outputs enriched events for both event logs (SLS)
+ * Multi-source merge input for the QoderCN product line (IDE + qoderclicn).
+ * Reads hook JSONL (content+structure) and, per session, either SQLite (IDE
+ * tokens) or session segments plus the runtime intercept (CLI tokens and
+ * response timings), then outputs enriched events for both event logs (SLS)
  * and trace conversion (ARMS).
  *
  * Pattern mirrors qoder-trace-input.ts: always emit immediately, never buffer.
@@ -135,28 +143,62 @@ export class QoderCnTraceInput extends BaseInput {
       dedupeEventsInTurn(turnEntries);
     }
 
-    // Aggregate all turns in the same session so enrichIdeTurn can use
-    // SQLite request ordering to match tokens correctly across turns.
+    // Aggregate all turns in the same session: enrichIdeTurn needs SQLite
+    // request ordering to match tokens across turns, and the CLI/IDE variant is
+    // decided per session rather than per turn.
     // Mirrors qoder-trace-input.ts ideSessionGroups pattern.
-    const ideSessionGroups = new Map<string, AgentActivityEntry[]>();
+    const sessionGroups = new Map<string, AgentActivityEntry[]>();
     const noSessionEntries: AgentActivityEntry[] = [];
     for (const [, turnEntries] of mergedGroups) {
       const sessionId = this.extractSessionId(turnEntries);
       if (sessionId) {
-        const sessionEntries = ideSessionGroups.get(sessionId) ?? [];
+        const sessionEntries = sessionGroups.get(sessionId) ?? [];
         sessionEntries.push(...turnEntries);
-        ideSessionGroups.set(sessionId, sessionEntries);
+        sessionGroups.set(sessionId, sessionEntries);
       } else {
         noSessionEntries.push(...turnEntries);
       }
     }
 
-    for (const [sessionId, sessionEntries] of ideSessionGroups) {
-      // Intentionally ignores matchedDbPath: agent.type must never be derived from
-      // which candidate DB matched. See resolveQoderCnDbPaths in sqlite-token-reader.
-      const { rows: sqliteRows } = await readSqliteTokensForSession(sessionId);
-      enrichIdeTurn(sessionEntries, sqliteRows);
-      // Post-processing after enrichIdeTurn:
+    // The IDE and qoderclicn share one agentId and therefore one hook history,
+    // so the variant has to be recovered here. A CLI session is recognised by
+    // two signals the IDE does not produce: the transcript's usage.request_id
+    // (surfaced by the hook as agent.client_request_id) and a segments directory
+    // of its own. Both are required, so an IDE session stays on the SQLite path
+    // even if a later IDE build starts carrying a request id, and a history
+    // collected before the hook shipped that field degrades to the previous
+    // behaviour instead of losing its tokens.
+    let interceptData: InterceptData | null = null;
+    for (const [sessionId, sessionEntries] of sessionGroups) {
+      const segments = hasClientRequestId(sessionEntries)
+        ? await readSegmentTokensForSession(sessionId, [], QODER_CN_SEGMENTS_ROOT)
+        : [];
+
+      if (segments.length > 0) {
+        // Tokens come from the runtime intercept rather than from the segments:
+        // on this build the segment records and the transcript both report zero
+        // token counts and carry only `credits`, same as the international one.
+        // Segments are read for the response timings, which are the only source
+        // of a non-zero LLM duration.
+        interceptData ??= await readInterceptData(undefined, CN_INTERCEPT_FILE);
+        enrichCliTurn(
+          sessionEntries,
+          segments,
+          interceptData.systemPrompt?.content,
+          interceptData.tokens,
+        );
+      } else {
+        // Intentionally ignores matchedDbPath: agent.type must never be derived from
+        // which candidate DB matched. See resolveQoderCnDbPaths in sqlite-token-reader.
+        const { rows: sqliteRows } = await readSqliteTokensForSession(sessionId);
+        enrichIdeTurn(sessionEntries, sqliteRows);
+      }
+
+      // Shared by both variants: these repair hook-level artefacts inherited
+      // from the one processor both go through (step-less user boundary,
+      // 'unknown' model on tool events, container spans ending before their
+      // children). They deliberately leave the llm.* / tool.* timestamps the
+      // enrichment above just wrote.
       expandContainerTimes(sessionEntries);
       propagateModelToToolEvents(sessionEntries);
       computeToolCallDurations(sessionEntries);
@@ -165,7 +207,7 @@ export class QoderCnTraceInput extends BaseInput {
 
     // Aggregate all session entries.
     const allSessionEntries: AgentActivityEntry[] = [];
-    for (const sessionEntries of ideSessionGroups.values()) {
+    for (const sessionEntries of sessionGroups.values()) {
       allSessionEntries.push(...sessionEntries);
     }
 
@@ -280,6 +322,16 @@ export class QoderCnTraceInput extends BaseInput {
     }
     return undefined;
   }
+}
+
+// A CLI turn's llm.response carries the transcript's usage.request_id, which
+// the hook writes as agent.client_request_id. The IDE transcript has no such
+// field, so its absence is what keeps IDE sessions on the SQLite path.
+function hasClientRequestId(entries: AgentActivityEntry[]): boolean {
+  return entries.some(e => {
+    const raw = (e as Record<string, unknown>)['agent.client_request_id'];
+    return typeof raw === 'string' && raw !== '';
+  });
 }
 
 // Deduplicate events within a single turn by (step_id, event_name, tool_call_id).

--- a/src/inputs/qoder-cn-trace/qoder-cn-trace-input.ts
+++ b/src/inputs/qoder-cn-trace/qoder-cn-trace-input.ts
@@ -10,7 +10,13 @@ import { filterBootstrapHistoryTurns } from '../base/bootstrap-turn-filter.js';
 import { createHookHistoryStartupCheckpoint } from '../base/hook-history-checkpoint.js';
 import { enrichCanonicalEntryWithGit } from '../../normalization/enrich-git-context.js';
 import { readSqliteTokensForSession } from './sqlite-token-reader.js';
-import { enrichCliTurn, enrichIdeTurn, injectTraceId } from '../qoder-trace/token-enricher.js';
+import {
+  collectCliExpectedRequestIds,
+  enrichCliFromSegments,
+  enrichCliPrimary,
+  enrichIdeTurn,
+  injectTraceId,
+} from '../qoder-trace/token-enricher.js';
 import { readSegmentTokensForSession, QODER_CN_SEGMENTS_ROOT } from '../qoder-trace/segment-token-reader.js';
 import { readInterceptData, type InterceptData } from '../qoder-trace/intercept-token-reader.js';
 
@@ -78,6 +84,14 @@ export class QoderCnTraceInput extends BaseInput {
     } else {
       this.logger.info('history checkpoint initialized before first hook record');
     }
+  }
+
+  /** Seam mirroring the international input so tests can observe the join keys. */
+  protected readCliSegments(
+    sessionId: string,
+    expectedRequestIds: readonly string[],
+  ): ReturnType<typeof readSegmentTokensForSession> {
+    return readSegmentTokensForSession(sessionId, expectedRequestIds, QODER_CN_SEGMENTS_ROOT);
   }
 
   protected async collect(): Promise<AgentActivityEntry[]> {
@@ -170,8 +184,14 @@ export class QoderCnTraceInput extends BaseInput {
     // behaviour instead of losing its tokens.
     let interceptData: InterceptData | null = null;
     for (const [sessionId, sessionEntries] of sessionGroups) {
+      // Here the segment read is itself the second discriminator signal, so it
+      // cannot be deferred behind a missing-data check the way the international
+      // input defers it. Handing the reader this batch's exact request ids keeps
+      // the guarantee that check exists for: the Hook offset is committed before
+      // enrichment, so a record that is not visible yet has to be waited for now
+      // or never. Absent ids cost one short retry; present ids cost nothing.
       const segments = hasClientRequestId(sessionEntries)
-        ? await readSegmentTokensForSession(sessionId, [], QODER_CN_SEGMENTS_ROOT)
+        ? await this.readCliSegments(sessionId, collectCliExpectedRequestIds(sessionEntries))
         : [];
 
       if (segments.length > 0) {
@@ -181,12 +201,14 @@ export class QoderCnTraceInput extends BaseInput {
         // Segments are read for the response timings, which are the only source
         // of a non-zero LLM duration.
         interceptData ??= await readInterceptData(undefined, CN_INTERCEPT_FILE);
-        enrichCliTurn(
+        enrichCliPrimary(
           sessionEntries,
-          segments,
           interceptData.systemPrompt?.content,
           interceptData.tokens,
         );
+        // Only fills what Hook plus intercept left missing, so it is safe to run
+        // unconditionally once the segments are in hand.
+        enrichCliFromSegments(sessionEntries, segments);
       } else {
         // Intentionally ignores matchedDbPath: agent.type must never be derived from
         // which candidate DB matched. See resolveQoderCnDbPaths in sqlite-token-reader.
@@ -240,6 +262,7 @@ export class QoderCnTraceInput extends BaseInput {
   // ─── Hook JSONL reading ─────────────────────────────────────────────────────
 
   private async readHookJsonl(): Promise<AgentActivityEntry[]> {
+    const runtime = this.getInputRuntimeAccumulator();
     const today = getTodayDateString();
     const logFileName = `${this.logPrefix}-${today}.jsonl`;
     const logFile = path.join(this.logDir, logFileName);
@@ -259,26 +282,81 @@ export class QoderCnTraceInput extends BaseInput {
       offset = 0;
     }
     if (stat.size <= offset) return [];
+    runtime?.observeBacklog(stat.size - offset);
 
     const handle = await fs.open(logFile, 'r');
     const entries: AgentActivityEntry[] = [];
     try {
       const buf = Buffer.alloc(stat.size - offset);
-      await handle.read(buf, 0, buf.length, offset);
-      const text = buf.toString('utf-8');
-      this.setState({ lastFile: logFileName, lastOffset: stat.size });
+      const readStartedAt = runtime?.now();
+      const { bytesRead } = await handle.read(buf, 0, buf.length, offset);
+      if (runtime && readStartedAt !== undefined) {
+        runtime.observeRead(bytesRead, buf.length, runtime.now() - readStartedAt);
+      }
+      const snapshot = buf.subarray(0, bytesRead);
 
-      const lines = text.split('\n').filter(l => l.trim().length > 0);
+      // The hook may still be appending its last record when stat() returns.
+      // Parse and commit only bytes that end in a newline: committing stat.size
+      // would move the offset past a half-written line whose JSON.parse just
+      // failed, so that record could never be read again.
+      const lastNewline = snapshot.lastIndexOf(0x0a);
+      if (lastNewline < 0) return [];
+
+      const completeLength = lastNewline + 1;
+      const completeBytes = snapshot.subarray(0, completeLength);
+      this.setState({ lastFile: logFileName, lastOffset: offset + completeLength });
+
+      const completeText = completeBytes.toString('utf-8');
+      // Multi-byte characters break the line.length shortcut for per-record
+      // byte accounting, so those batches walk the buffer newline by newline.
+      const asciiBatch = completeText.length === completeBytes.length;
+      const lines = completeText.split('\n');
+      let records = 0;
+      let parseSuccessRecords = 0;
+      let parseFailedRecords = 0;
+      let maxRecordBytes = 0;
+      let recordStartOffset = 0;
 
       for (const line of lines) {
+        let recordBytes = line.length + 1;
+        if (!asciiBatch) {
+          const newline = completeBytes.indexOf(0x0a, recordStartOffset);
+          if (newline < 0) break;
+          recordBytes = newline - recordStartOffset + 1;
+          recordStartOffset = newline + 1;
+        }
+        if (!line.trim()) continue;
+        records++;
+        maxRecordBytes = Math.max(maxRecordBytes, recordBytes);
+        let record: Record<string, unknown>;
         try {
-          const record = JSON.parse(line) as Record<string, unknown>;
+          const parsed: unknown = JSON.parse(line);
+          if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            parseFailedRecords++;
+            continue;
+          }
+          record = parsed as Record<string, unknown>;
+          parseSuccessRecords++;
+        } catch (err) {
+          parseFailedRecords++;
+          this.logger.warn('invalid JSONL line', { error: String(err) });
+          continue;
+        }
+
+        try {
           const entry = await this.transformRecord(record);
           if (entry) entries.push(entry);
         } catch (err) {
           this.logger.warn('invalid JSONL line', { error: String(err) });
         }
       }
+      runtime?.observeCommittedBatch({
+        records,
+        bytes: completeLength,
+        parseSuccessRecords,
+        parseFailedRecords,
+        maxRecordBytes,
+      });
     } finally {
       await handle.close();
     }

--- a/src/inputs/qoder-trace/segment-token-reader.ts
+++ b/src/inputs/qoder-trace/segment-token-reader.ts
@@ -11,8 +11,23 @@ const EXPECTED_ID_RETRY_DELAY_MS = 25;
 const SESSION_IDLE_MS = 60_000;
 const SESSION_MAX_SIZE = 50;
 
-function getSessionsDir(): string {
-  return resolveHome('~/.qoder/logs/sessions');
+/** Sessions root of the international build. */
+export const QODER_SEGMENTS_ROOT = '~/.qoder/logs/sessions';
+/** Sessions root of the QoderCN build. */
+export const QODER_CN_SEGMENTS_ROOT = '~/.qoder-cn/logs/sessions';
+
+function getSessionsDir(segmentsRoot: string): string {
+  return resolveHome(segmentsRoot);
+}
+
+/**
+ * Key the in-memory index by root as well as session id. The two product lines
+ * mint session ids independently, so one id can exist under both roots; keying
+ * by session id alone would apply one line's per-file offsets to the other
+ * line's files.
+ */
+function segmentStateKey(segmentsRoot: string, sessionId: string): string {
+  return `${segmentsRoot}::${sessionId}`;
 }
 
 interface SegmentEvent {
@@ -82,8 +97,9 @@ export interface SegmentTokenData {
 export async function readSegmentTokensForSession(
   sessionId: string,
   expectedRequestIds: readonly string[] = [],
+  segmentsRoot: string = QODER_SEGMENTS_ROOT,
 ): Promise<SegmentTokenData[]> {
-  const first = await readSegmentTokensOnce(sessionId);
+  const first = await readSegmentTokensOnce(sessionId, segmentsRoot);
   let missing = missingExpectedRequestIds(expectedRequestIds, first.data);
   if (missing.length === 0 || !first.retryable) return first.data;
 
@@ -91,11 +107,12 @@ export async function readSegmentTokensForSession(
   // the last opportunity to attach this segment to its Hook entries. Retry
   // once only when an exact request id proves the first snapshot is incomplete.
   await delay(EXPECTED_ID_RETRY_DELAY_MS);
-  const second = await readSegmentTokensOnce(sessionId);
+  const second = await readSegmentTokensOnce(sessionId, segmentsRoot);
   missing = missingExpectedRequestIds(expectedRequestIds, second.data);
   if (missing.length > 0) {
     logger.warn('expected segment requests remain unavailable after one bounded retry', {
       sessionId,
+      segmentsRoot,
       missingRequestIds: [...new Set(missing)],
       missingCount: missing.length,
     });
@@ -103,12 +120,16 @@ export async function readSegmentTokensForSession(
   return second.data;
 }
 
-async function readSegmentTokensOnce(sessionId: string): Promise<SegmentReadAttempt> {
+async function readSegmentTokensOnce(
+  sessionId: string,
+  segmentsRoot: string,
+): Promise<SegmentReadAttempt> {
   const now = Date.now();
-  evictIdleSessions(sessionId, now);
+  const stateKey = segmentStateKey(segmentsRoot, sessionId);
+  evictIdleSessions(stateKey, now);
 
-  const scan = await findSegmentFilesForSession(sessionId);
-  let state = sessionStates.get(sessionId);
+  const scan = await findSegmentFilesForSession(sessionId, segmentsRoot);
+  let state = sessionStates.get(stateKey);
   if (!state && scan.files.length === 0) {
     return { data: [], retryable: scan.retryable && !scan.stableFailure };
   }
@@ -116,7 +137,7 @@ async function readSegmentTokensOnce(sessionId: string): Promise<SegmentReadAtte
   if (!state) {
     evictOldestSessionIfFull();
     state = { files: new Map(), data: [], lastAccessMs: now };
-    sessionStates.set(sessionId, state);
+    sessionStates.set(stateKey, state);
   }
   state.lastAccessMs = now;
 
@@ -383,14 +404,17 @@ function resolveRequestStart(
   return { ts: 0, anchor: 'none' };
 }
 
-async function findSegmentFilesForSession(sessionId: string): Promise<SegmentFileScan> {
+async function findSegmentFilesForSession(
+  sessionId: string,
+  segmentsRoot: string,
+): Promise<SegmentFileScan> {
   let cwdDirs: Dirent[];
   try {
-    cwdDirs = await fs.readdir(getSessionsDir(), { withFileTypes: true });
+    cwdDirs = await fs.readdir(getSessionsDir(segmentsRoot), { withFileTypes: true });
   } catch (err) {
     if (!isMissingPath(err)) {
       logger.info('qoder sessions root unavailable; keeping any previously parsed segment data', {
-        dir: getSessionsDir(),
+        dir: getSessionsDir(segmentsRoot),
         error: String(err),
       });
     }
@@ -408,7 +432,7 @@ async function findSegmentFilesForSession(sessionId: string): Promise<SegmentFil
   let stableFailure = false;
   for (const cwdDir of cwdDirs) {
     if (!cwdDir.isDirectory()) continue;
-    const segDir = path.join(getSessionsDir(), cwdDir.name, sessionId, 'segments');
+    const segDir = path.join(getSessionsDir(segmentsRoot), cwdDir.name, sessionId, 'segments');
     let entries: Dirent[];
     try {
       entries = await fs.readdir(segDir, { withFileTypes: true });
@@ -479,25 +503,25 @@ function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-function evictIdleSessions(currentSessionId: string, now: number): void {
-  for (const [sessionId, state] of sessionStates) {
-    if (sessionId !== currentSessionId && now - state.lastAccessMs > SESSION_IDLE_MS) {
-      sessionStates.delete(sessionId);
+function evictIdleSessions(currentStateKey: string, now: number): void {
+  for (const [stateKey, state] of sessionStates) {
+    if (stateKey !== currentStateKey && now - state.lastAccessMs > SESSION_IDLE_MS) {
+      sessionStates.delete(stateKey);
     }
   }
 }
 
 function evictOldestSessionIfFull(): void {
   if (sessionStates.size < SESSION_MAX_SIZE) return;
-  let oldestId: string | undefined;
+  let oldestKey: string | undefined;
   let oldestAccess = Infinity;
-  for (const [sessionId, state] of sessionStates) {
+  for (const [stateKey, state] of sessionStates) {
     if (state.lastAccessMs < oldestAccess) {
-      oldestId = sessionId;
+      oldestKey = stateKey;
       oldestAccess = state.lastAccessMs;
     }
   }
-  if (oldestId) sessionStates.delete(oldestId);
+  if (oldestKey) sessionStates.delete(oldestKey);
 }
 
 function isMissingPath(err: unknown): boolean {

--- a/tests/unit/core/hook-watchdog-intercept.test.ts
+++ b/tests/unit/core/hook-watchdog-intercept.test.ts
@@ -533,6 +533,45 @@ describe('intercept rc target check/repair/cleanup against a temp rc (real closu
     expect(await cnTarget.check()).toBe(true);
   });
 
+  it('treats a qodercli block that lost its END marker as unhealthy', async () => {
+    // A partial write or a hand edit can drop the END marker. Extraction used to
+    // run to EOF, so the damaged block absorbed everything below it; its own
+    // current-shape body then satisfied the signature check and check() reported
+    // healthy forever. Worse, had it reported unhealthy, repair()'s strip would
+    // have cut to EOF and taken the CN block and the user's own lines with it.
+    const targets = HookWatchdog.defaultInterceptTargets(tmp, () => true, [zshrc]);
+    const cliTarget = targets.find(t => t.id === 'qodercli-rc')!;
+    const cnTarget = targets.find(t => t.id === 'qoderclicn-rc')!;
+
+    fs.writeFileSync(zshrc, '');
+    await cnTarget.repair();
+    const cnBlock = fs.readFileSync(zshrc, 'utf-8').trim();
+    // Installer order puts qodercli first, so the CN block sits below it.
+    fs.writeFileSync(zshrc, [
+      '# user-top',
+      '# loongsuite-pilot BEGIN qodercli-intercept',
+      `  eval 'qodercli() { "/tmp/pilot/hooks/qodercli-runtime-wrapper.sh" "$@"; }'`,
+      // END marker deliberately absent.
+      cnBlock,
+      'export PATH=/user/bin:$PATH',
+      '',
+    ].join('\n'));
+
+    expect(await cliTarget.check()).toBe(false);
+    expect(await cnTarget.check()).toBe(true); // the CN block reads as current
+
+    await cliTarget.repair();
+    const rc = fs.readFileSync(zshrc, 'utf-8');
+    expect(rc.match(/BEGIN qodercli-intercept/g)!.length).toBe(1); // rewritten once
+    expect(rc.match(/END qodercli-intercept/g)!.length).toBe(1);   // now terminated
+    expect(rc.match(/BEGIN qoderclicn-intercept/g)!.length).toBe(1);
+    expect(rc).toContain('LOONGSUITE_QODERCLI_FLAVOR=qoderclicn'); // CN body intact
+    expect(rc).toContain('# user-top');
+    expect(rc).toContain('export PATH=/user/bin:$PATH');           // user tail intact
+    expect(await cliTarget.check()).toBe(true);
+    expect(await cnTarget.check()).toBe(true);
+  });
+
   it('keeps the two wrapper flavors independent in one rc file', async () => {
     const targets = HookWatchdog.defaultInterceptTargets(tmp, () => true, [zshrc]);
     const cliTarget = targets.find(t => t.id === 'qodercli-rc')!;
@@ -610,6 +649,40 @@ describe('stripMarkerBlock', () => {
     const out = stripMarkerBlock(content, BEGIN, END);
     expect(out.split('\n')).toEqual(['before', 'after']);
   });
+
+  it('an unterminated block does not swallow the next block or user content', () => {
+    // repair() writes this result back over the rc file, so cutting to EOF here
+    // deletes the sibling blocks and whatever the user keeps below them.
+    const content = [
+      'export PATH=/x:$PATH',
+      '# loongsuite-pilot BEGIN claude-code-intercept',
+      'claude() { echo old; }',
+      // END marker deliberately absent.
+      '# loongsuite-pilot BEGIN qodercli-intercept',
+      "  eval 'qodercli() { :; }'",
+      '# loongsuite-pilot END qodercli-intercept',
+      'alias ll=ls',
+    ].join('\n');
+    const out = stripMarkerBlock(content, BEGIN, END);
+    expect(out).not.toContain('claude() { echo old; }');  // damaged block removed
+    expect(out).toContain('BEGIN qodercli-intercept');    // sibling block survives
+    expect(out).toContain("eval 'qodercli() { :; }");
+    expect(out).toContain('export PATH=/x:$PATH');        // user content survives
+    expect(out).toContain('alias ll=ls');
+  });
+
+  it('collapses repeated BEGINs of the same block into one removal', () => {
+    const content = [
+      'before',
+      '# loongsuite-pilot BEGIN claude-code-intercept',
+      'first',
+      '# loongsuite-pilot BEGIN claude-code-intercept',
+      'second',
+      '# loongsuite-pilot END claude-code-intercept',
+      'after',
+    ].join('\n');
+    expect(stripMarkerBlock(content, BEGIN, END).split('\n')).toEqual(['before', 'after']);
+  });
 });
 
 describe('extractMarkerBlock', () => {
@@ -622,12 +695,35 @@ describe('extractMarkerBlock', () => {
 
   it('returns only the block, excluding surrounding content', () => {
     const content = ['before', BEGIN, 'body', END, 'after'].join('\n');
-    expect(extractMarkerBlock(content, BEGIN, END)).toBe([BEGIN, 'body', END].join('\n'));
+    expect(extractMarkerBlock(content, BEGIN, END)).toEqual({
+      text: [BEGIN, 'body', END].join('\n'),
+      terminated: true,
+    });
   });
 
-  it('returns the tail when the END marker is missing', () => {
+  it('reports an unterminated block and returns its tail', () => {
     const content = ['before', BEGIN, 'body'].join('\n');
-    expect(extractMarkerBlock(content, BEGIN, END)).toBe([BEGIN, 'body'].join('\n'));
+    expect(extractMarkerBlock(content, BEGIN, END)).toEqual({
+      text: [BEGIN, 'body'].join('\n'),
+      terminated: false,
+    });
+  });
+
+  it('stops an unterminated block at the next block BEGIN, not at EOF', () => {
+    // Running to EOF pulled the following block into this one's text, which is
+    // how a neighbour could end up satisfying this block's signature check.
+    const content = [
+      'before',
+      BEGIN,
+      'body',
+      '# loongsuite-pilot BEGIN qoderclicn-intercept',
+      'cn body',
+      '# loongsuite-pilot END qoderclicn-intercept',
+    ].join('\n');
+    expect(extractMarkerBlock(content, BEGIN, END)).toEqual({
+      text: [BEGIN, 'body'].join('\n'),
+      terminated: false,
+    });
   });
 });
 
@@ -654,16 +750,26 @@ describe('interceptRcBlockDefs migration metadata', () => {
     }
   });
 
-  it('tells the two wrapper flavors apart by signature, not by script name', () => {
+  it('gives every block a signature no other block can satisfy', () => {
+    // A signature that also occurs in a sibling block would let that sibling
+    // vouch for a stale block of this shape. Per-block scoping is the other half
+    // of the defence; neither half should be load-bearing on its own.
+    const defs = HookWatchdog.interceptRcBlockDefs();
+    for (const a of defs) {
+      for (const b of defs) {
+        if (a.id === b.id) continue;
+        expect(b.blockFn(`/tmp/hooks/${b.scriptName}`)).not.toContain(a.signature);
+      }
+    }
+  });
+
+  it('keeps the shared wrapper script name out of both flavors\' signatures', () => {
     const defs = HookWatchdog.interceptRcBlockDefs();
     const cli = defs.find(d => d.id === 'qodercli-rc')!;
     const cn = defs.find(d => d.id === 'qoderclicn-rc')!;
     expect(cn.scriptName).toBe(cli.scriptName); // one wrapper serves both
-    // qodercli's signature is that shared script name, so it also occurs inside
-    // the CN block. Only per-block scoping keeps a stale qodercli block
-    // detectable next to a current CN one; the reverse never collides.
-    expect(cn.blockFn(`/tmp/hooks/${cn.scriptName}`)).toContain(cli.signature);
-    expect(cli.blockFn(`/tmp/hooks/${cli.scriptName}`)).not.toContain(cn.signature);
+    expect(cli.signature).not.toContain(cli.scriptName);
+    expect(cn.signature).not.toContain(cn.scriptName);
   });
 
   it('exposes cleanup() on every default intercept target', () => {

--- a/tests/unit/core/hook-watchdog-intercept.test.ts
+++ b/tests/unit/core/hook-watchdog-intercept.test.ts
@@ -5,6 +5,7 @@ import {
   HookWatchdog,
   parseWindowsUserEnv,
   stripMarkerBlock,
+  extractMarkerBlock,
   type InterceptCheckTarget,
 } from '../../../src/core/hook-watchdog.js';
 import type { HookWatchdogConfig } from '../../../src/types/index.js';
@@ -411,6 +412,7 @@ describe('intercept rc target check/repair/cleanup against a temp rc (real closu
   const path = require('node:path') as typeof import('node:path');
 
   const SCRIPT = 'claude-code-fetch-intercept.mjs';
+  const WRAPPER = 'qodercli-runtime-wrapper.sh';
   const SIG = 'if ! alias claude >/dev/null 2>&1';
   const OLD_BARE_BLOCK = [
     '# loongsuite-pilot BEGIN claude-code-intercept',
@@ -433,6 +435,7 @@ describe('intercept rc target check/repair/cleanup against a temp rc (real closu
     tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pilot-rc-real-'));
     fs.mkdirSync(path.join(tmp, 'hooks'), { recursive: true });
     fs.writeFileSync(path.join(tmp, 'hooks', SCRIPT), '// stub\n');
+    fs.writeFileSync(path.join(tmp, 'hooks', WRAPPER), '# stub\n');
     zshrc = path.join(tmp, '.zshrc');
     bashrc = path.join(tmp, '.bashrc');
   });
@@ -502,6 +505,61 @@ describe('intercept rc target check/repair/cleanup against a temp rc (real closu
     expect(rc).toContain('# keep');
   });
 
+  it('does not let a current qoderclicn block mask a stale qodercli one', async () => {
+    // Both blocks name the same wrapper script, which is qodercli's signature,
+    // so a file-wide signature scan would read the stale qodercli block as
+    // current and never migrate it.
+    const targets = HookWatchdog.defaultInterceptTargets(tmp, () => true, [zshrc]);
+    const cliTarget = targets.find(t => t.id === 'qodercli-rc')!;
+    const cnTarget = targets.find(t => t.id === 'qoderclicn-rc')!;
+
+    fs.writeFileSync(zshrc, '');
+    await cnTarget.repair();                       // current CN block present
+    expect(await cnTarget.check()).toBe(true);
+    fs.appendFileSync(zshrc, [
+      '# loongsuite-pilot BEGIN qodercli-intercept',
+      'qodercli() { BUN_OPTIONS="--preload=/old ${BUN_OPTIONS}" command qodercli "$@"; }',
+      '# loongsuite-pilot END qodercli-intercept',
+      '',
+    ].join('\n'));
+
+    expect(await cliTarget.check()).toBe(false);   // stale, despite the CN block
+    await cliTarget.repair();
+    const rc = fs.readFileSync(zshrc, 'utf-8');
+    expect(rc).not.toContain('--preload=/old');    // old bare form migrated
+    expect(rc.match(/BEGIN qodercli-intercept/g)!.length).toBe(1);
+    expect(rc.match(/BEGIN qoderclicn-intercept/g)!.length).toBe(1); // CN untouched
+    expect(await cliTarget.check()).toBe(true);
+    expect(await cnTarget.check()).toBe(true);
+  });
+
+  it('keeps the two wrapper flavors independent in one rc file', async () => {
+    const targets = HookWatchdog.defaultInterceptTargets(tmp, () => true, [zshrc]);
+    const cliTarget = targets.find(t => t.id === 'qodercli-rc')!;
+    const cnTarget = targets.find(t => t.id === 'qoderclicn-rc')!;
+
+    fs.writeFileSync(zshrc, '');
+    await cliTarget.repair();
+    // The CN block is absent even though qodercli's marker prefix is similar.
+    expect(await cnTarget.check()).toBe(false);
+    await cnTarget.repair();
+
+    const rc = fs.readFileSync(zshrc, 'utf-8');
+    expect(rc).toContain("eval 'qodercli() { \"");                       // no flavor var
+    expect(rc).toContain('LOONGSUITE_QODERCLI_FLAVOR=qoderclicn');
+    expect(rc.match(/BEGIN qodercli-intercept/g)!.length).toBe(1);
+    expect(rc.match(/BEGIN qoderclicn-intercept/g)!.length).toBe(1);
+
+    // Disabling one flavor must not strip the other's block.
+    const cnDisabled = HookWatchdog
+      .defaultInterceptTargets(tmp, id => id !== 'qoder-cn', [zshrc])
+      .find(t => t.id === 'qoderclicn-rc')!;
+    await cnDisabled.cleanup!();
+    const after = fs.readFileSync(zshrc, 'utf-8');
+    expect(after).not.toContain('qoderclicn-intercept');
+    expect(after).toContain('BEGIN qodercli-intercept');
+  });
+
   it('disabled target: runCheck() runs cleanup() and does not re-inject', async () => {
     fs.writeFileSync(zshrc, '');
     await claudeTarget(true).repair(); // block present
@@ -554,6 +612,25 @@ describe('stripMarkerBlock', () => {
   });
 });
 
+describe('extractMarkerBlock', () => {
+  const BEGIN = 'loongsuite-pilot BEGIN claude-code-intercept';
+  const END = 'loongsuite-pilot END claude-code-intercept';
+
+  it('returns null when the BEGIN marker is absent', () => {
+    expect(extractMarkerBlock('a\nb\n', BEGIN, END)).toBeNull();
+  });
+
+  it('returns only the block, excluding surrounding content', () => {
+    const content = ['before', BEGIN, 'body', END, 'after'].join('\n');
+    expect(extractMarkerBlock(content, BEGIN, END)).toBe([BEGIN, 'body', END].join('\n'));
+  });
+
+  it('returns the tail when the END marker is missing', () => {
+    const content = ['before', BEGIN, 'body'].join('\n');
+    expect(extractMarkerBlock(content, BEGIN, END)).toBe([BEGIN, 'body'].join('\n'));
+  });
+});
+
 describe('interceptRcBlockDefs migration metadata', () => {
   it('exposes signature + endMarker matching the block body', () => {
     for (const def of HookWatchdog.interceptRcBlockDefs()) {
@@ -561,14 +638,32 @@ describe('interceptRcBlockDefs migration metadata', () => {
       expect(block).toContain(def.marker);       // BEGIN marker present
       expect(block).toContain(def.endMarker);    // END marker present
       expect(block).toContain(def.signature);    // current-shape signature present
-      // qodercli uses the runtime wrapper name so the previous Bun-only guarded
-      // block is migrated; other intercepts still key on their guard line.
-      if (def.id === 'qodercli-rc') {
-        expect(def.signature).toBe('qodercli-runtime-wrapper.sh');
-      } else {
-        expect(def.signature).toMatch(/^if ! alias \S+ >\/dev\/null 2>&1$/);
+    }
+  });
+
+  it('keeps markers mutually non-overlapping so per-block scoping is unambiguous', () => {
+    const defs = HookWatchdog.interceptRcBlockDefs();
+    for (const a of defs) {
+      for (const b of defs) {
+        if (a.id === b.id) continue;
+        // extractMarkerBlock matches a marker as a substring of a line, so one
+        // marker containing another would make the two blocks indistinguishable.
+        expect(a.marker.includes(b.marker)).toBe(false);
+        expect(a.endMarker.includes(b.endMarker)).toBe(false);
       }
     }
+  });
+
+  it('tells the two wrapper flavors apart by signature, not by script name', () => {
+    const defs = HookWatchdog.interceptRcBlockDefs();
+    const cli = defs.find(d => d.id === 'qodercli-rc')!;
+    const cn = defs.find(d => d.id === 'qoderclicn-rc')!;
+    expect(cn.scriptName).toBe(cli.scriptName); // one wrapper serves both
+    // qodercli's signature is that shared script name, so it also occurs inside
+    // the CN block. Only per-block scoping keeps a stale qodercli block
+    // detectable next to a current CN one; the reverse never collides.
+    expect(cn.blockFn(`/tmp/hooks/${cn.scriptName}`)).toContain(cli.signature);
+    expect(cli.blockFn(`/tmp/hooks/${cli.scriptName}`)).not.toContain(cn.signature);
   });
 
   it('exposes cleanup() on every default intercept target', () => {

--- a/tests/unit/core/orchestrator.test.ts
+++ b/tests/unit/core/orchestrator.test.ts
@@ -382,6 +382,20 @@ describe('Orchestrator', () => {
       await orch.stop();
     });
 
+    it('passes the configured QoderCN trace poll interval to the input', async () => {
+      const config = makeConfig();
+      config.listeners['qoder-cn-trace'] = { enabled: true, pollInterval: 1000 };
+
+      const orch = new Orchestrator(config);
+      await orch.start();
+
+      const input = (orch as any).inputManager.getInput('qoder-cn-trace');
+      expect(input).toBeDefined();
+      expect(input.pollIntervalMs).toBe(1000);
+
+      await orch.stop();
+    });
+
     it('uses the configured dataDir for all QwenWorkCN Hook and intercept paths', async () => {
       const dataDir = '/tmp/custom-pilot-data';
       const orch = new Orchestrator(makeConfig({ dataDir }));

--- a/tests/unit/hooks/qoder-control-message-turns.test.mjs
+++ b/tests/unit/hooks/qoder-control-message-turns.test.mjs
@@ -247,4 +247,31 @@ describe('qoder slash-command control rows', () => {
     expect(partsOf(records.find(r => r['event.name'] === 'other'))).toEqual(['杭州天气']);
     expect(partsOf(records.find(r => r['event.name'] === 'llm.request'))).toEqual(['杭州天气']);
   });
+
+  it('applies the shared CLI control-row filtering to QoderCN SDK transcripts', () => {
+    const prompt = promptRow('杭州天气');
+    const assistant = assistantRow('杭州今天多云。');
+    const turns = splitContentEventsIntoTurns([
+      caveatRow(), commandRow(), stdoutRow(), prompt, assistant,
+    ]);
+
+    expect(turns).toHaveLength(1);
+    const records = buildEventsFromBoundaries(
+      buildLlmBoundaries(progress, turns[0]),
+      turns[0],
+      turns[0],
+      'turn-qoder-cn-sdk',
+      'session-qoder-cn-sdk',
+      'qoder-cn',
+      {},
+      '/tmp/cwd',
+    );
+
+    expect(records.every(r => r['gen_ai.agent.type'] === 'qoder-cn')).toBe(true);
+    for (const record of records) {
+      for (const part of partsOf(record)) {
+        expect(part).not.toMatch(/command-message|command-name|local-command/u);
+      }
+    }
+  });
 });

--- a/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
+++ b/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
@@ -10,6 +10,7 @@ import {
   buildEventsFromBoundaries,
   findIncrementalTurnEndLine,
   findTriggeredTurnWindow,
+  hasQoderCnTerminalMarker,
   isRetryLockStale,
   readRetryLock,
   releaseRetryLock,
@@ -664,6 +665,26 @@ describe('findTriggeredTurnWindow stop source variants (B3 P0)', () => {
       stopLine: null,
       endLine: null,
     });
+  });
+});
+
+describe('hasQoderCnTerminalMarker', () => {
+  it('accepts the traditional progress Stop marker', () => {
+    expect(hasQoderCnTerminalMarker([{ hookEvent: 'Stop' }], [])).toBe(true);
+  });
+
+  it('accepts SDK print-mode terminal rows before progress Stop is appended', () => {
+    expect(hasQoderCnTerminalMarker([], [
+      { type: 'assistant', message: { stop_reason: 'end_turn' } },
+      { type: 'last-prompt', lastPrompt: 'summarize the file' },
+    ])).toBe(true);
+  });
+
+  it('rejects a mid-tool snapshot', () => {
+    expect(hasQoderCnTerminalMarker([], [
+      { type: 'assistant', message: { stop_reason: 'tool_use' } },
+      { type: 'user', message: { content: [{ type: 'tool_result' }] } },
+    ])).toBe(false);
   });
 });
 

--- a/tests/unit/hooks/qodercli-runtime-wrapper.test.mjs
+++ b/tests/unit/hooks/qodercli-runtime-wrapper.test.mjs
@@ -37,6 +37,25 @@ async function makeFixture(qodercliSource, withIntercept = true, qodercliName = 
   };
 }
 
+/** Add another executable to an existing fixture's bin dir. */
+async function addBin(fixture, name, source) {
+  const p = path.join(fixture.bin, name);
+  await fs.writeFile(p, source, { mode: 0o755 });
+  return p;
+}
+
+/**
+ * A launcher that reports which entry actually ran plus the intercept file the
+ * wrapper picked. `id` is what tells the two product lines' entries apart.
+ */
+const probe = (id) => `#!/bin/sh
+printf '{"id":"${id}","interceptFile":"%s","nodeOptions":"%s","bunOptions":"%s"}\\n' "$LOONGSUITE_INTERCEPT_FILE" "$NODE_OPTIONS" "$BUN_OPTIONS"
+`;
+
+// A PATH with the usual utilities (the wrapper shells out to tr/head/grep) but
+// no CLI of either flavor, so only an explicit override can resolve an entry.
+const BARE_PATH = '/usr/bin:/bin';
+
 describe('qodercli runtime wrapper', () => {
   it('uses NODE_OPTIONS --import for a Node shebang and preserves user options', async () => {
     const fixture = await makeFixture(`#!/usr/bin/env node
@@ -108,6 +127,123 @@ console.log(JSON.stringify({
     expect(output.nodeOptions).toContain('qodercli-token-intercept.mjs');
     expect(output.bunOptions).toBe('');
     expect(output.args).toEqual(['hello']);
+  });
+
+  it('scopes the intercept file to the qoderclicn flavor', async () => {
+    // The CN rc block launches this same wrapper with LOONGSUITE_QODERCLI_FLAVOR
+    // set; the derived intercept file name is the only thing keeping the two
+    // product lines' token output apart. Nothing asserted that name before, so
+    // both lines could have been writing to one file unnoticed.
+    const fixture = await makeFixture(probe('CN'), true, 'qoderclicn');
+    const result = spawnSync('sh', [fixture.wrapper, 'hello'], {
+      env: {
+        ...process.env,
+        LOONGSUITE_QODERCLI_FLAVOR: 'qoderclicn',
+        PATH: `${fixture.bin}:${BARE_PATH}`,
+        NODE_OPTIONS: '',
+        BUN_OPTIONS: '',
+      },
+      encoding: 'utf-8',
+    });
+    expect(result.status, result.stderr).toBe(0);
+    const output = JSON.parse(result.stdout.trim());
+    expect(output.id).toBe('CN'); // resolved `qoderclicn` off PATH, not `qodercli`
+    expect(output.interceptFile).toBe('qoderclicn-intercept.jsonl');
+    expect(output.bunOptions).toContain('qodercli-token-intercept.mjs'); // one shared asset
+  });
+
+  it('keeps the default flavor writing to the qodercli intercept file', async () => {
+    // Counterpart to the CN case: proves the name is derived from the flavor
+    // rather than hard-coded on either side.
+    const fixture = await makeFixture(probe('INTL'));
+    const result = spawnSync('sh', [fixture.wrapper], {
+      env: {
+        ...process.env,
+        PATH: `${fixture.bin}:${BARE_PATH}`,
+        NODE_OPTIONS: '',
+        BUN_OPTIONS: '',
+      },
+      encoding: 'utf-8',
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout.trim()).interceptFile).toBe('qodercli-intercept.jsonl');
+  });
+
+  it('does not let the qodercli entry override redirect the qoderclicn flavor', async () => {
+    // The wrapper's contract: "The names are per flavor on purpose: a value
+    // exported for one product line must not redirect the other." A user with
+    // LOONGSUITE_QODERCLI_BIN exported for the international CLI must still get
+    // the CN entry when running qoderclicn.
+    const fixture = await makeFixture(probe('INTL'), true, 'qodercli');
+    await addBin(fixture, 'qoderclicn', probe('CN'));
+    const result = spawnSync('sh', [fixture.wrapper], {
+      env: {
+        ...process.env,
+        LOONGSUITE_QODERCLI_FLAVOR: 'qoderclicn',
+        LOONGSUITE_QODERCLI_BIN: fixture.qodercli, // the OTHER line's override
+        PATH: `${fixture.bin}:${BARE_PATH}`,
+        NODE_OPTIONS: '',
+        BUN_OPTIONS: '',
+      },
+      encoding: 'utf-8',
+    });
+    expect(result.status, result.stderr).toBe(0);
+    const output = JSON.parse(result.stdout.trim());
+    expect(output.id).toBe('CN'); // international override stayed inert
+    expect(output.interceptFile).toBe('qoderclicn-intercept.jsonl');
+  });
+
+  it('honours the per-flavor LOONGSUITE_QODERCLICN_BIN override', async () => {
+    // The flavor-derived override name has to actually work, or the CN line
+    // would have no way to point at a non-PATH entry.
+    const fixture = await makeFixture(probe('INTL'), true, 'qodercli');
+    const cnBin = await addBin(fixture, 'cn-entry', probe('CN'));
+    const result = spawnSync('sh', [fixture.wrapper], {
+      env: {
+        ...process.env,
+        LOONGSUITE_QODERCLI_FLAVOR: 'qoderclicn',
+        LOONGSUITE_QODERCLICN_BIN: cnBin,
+        PATH: BARE_PATH, // nothing named qoderclicn is reachable
+        NODE_OPTIONS: '',
+        BUN_OPTIONS: '',
+      },
+      encoding: 'utf-8',
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout.trim()).id).toBe('CN');
+  });
+
+  it('lets LOONGSUITE_INTERCEPT_FILE override the derived name', async () => {
+    const fixture = await makeFixture(probe('CN'), true, 'qoderclicn');
+    const result = spawnSync('sh', [fixture.wrapper], {
+      env: {
+        ...process.env,
+        LOONGSUITE_QODERCLI_FLAVOR: 'qoderclicn',
+        LOONGSUITE_INTERCEPT_FILE: 'custom-intercept.jsonl',
+        PATH: `${fixture.bin}:${BARE_PATH}`,
+        NODE_OPTIONS: '',
+        BUN_OPTIONS: '',
+      },
+      encoding: 'utf-8',
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout.trim()).interceptFile).toBe('custom-intercept.jsonl');
+  });
+
+  it('names the missing executable by flavor when nothing resolves', async () => {
+    const fixture = await makeFixture(probe('INTL'), true, 'qodercli');
+    const result = spawnSync('sh', [fixture.wrapper], {
+      env: {
+        ...process.env,
+        LOONGSUITE_QODERCLI_FLAVOR: 'qoderclicn',
+        PATH: BARE_PATH,
+        NODE_OPTIONS: '',
+        BUN_OPTIONS: '',
+      },
+      encoding: 'utf-8',
+    });
+    expect(result.status).toBe(127);
+    expect(result.stderr).toContain('qoderclicn executable not found');
   });
 
   it('fails open when the intercept asset is missing', async () => {

--- a/tests/unit/hooks/qodercli-runtime-wrapper.test.mjs
+++ b/tests/unit/hooks/qodercli-runtime-wrapper.test.mjs
@@ -129,6 +129,96 @@ console.log(JSON.stringify({
     expect(output.args).toEqual(['hello']);
   });
 
+  it('routes a shebang-less entry reached through PATH to Node', async () => {
+    // The real install puts a link on PATH whose name carries no extension
+    // (~/.local/bin/qodercli -> .../qodercli-1.1.42), so the extension arm never
+    // fires and classification falls through to the file header. A bundled entry
+    // has no shebang, and the header check read that absence as "then it is Bun":
+    // the entry got exec'd directly, the kernel refused a JS text file, and the
+    // shell then tried to run JS as a shell script. The CLI did not start at all.
+    // The .mjs test above passes LOONGSUITE_QODERCLI_BIN with the extension still
+    // on it, so it settles on the extension arm and never reaches this one.
+    const fixture = await makeFixture(`
+console.log(JSON.stringify({
+  nodeOptions: process.env.NODE_OPTIONS,
+  bunOptions: process.env.BUN_OPTIONS || '',
+  args: process.argv.slice(2)
+}));
+`, true, 'entry.mjs');
+    // The name command -v resolves carries no extension, unlike its target.
+    await fs.symlink(fixture.qodercli, path.join(fixture.bin, 'qodercli'));
+    const result = spawnSync('sh', [fixture.wrapper, 'hello'], {
+      env: {
+        ...process.env,
+        // No _BIN, so resolution goes through PATH. The full PATH stays on so
+        // the Node the wrapper falls back to is reachable; fixture.bin comes
+        // first, so the entry resolved is this test's.
+        PATH: `${fixture.bin}:${process.env.PATH}`,
+        NODE_OPTIONS: '',
+        BUN_OPTIONS: '',
+      },
+      encoding: 'utf-8',
+    });
+    expect(result.status, result.stderr).toBe(0);
+    const output = JSON.parse(result.stdout.trim());
+    expect(output.nodeOptions).toContain('--import=');
+    expect(output.nodeOptions).toContain('qodercli-token-intercept.mjs');
+    expect(output.bunOptions).toBe('');
+    expect(output.args).toEqual(['hello']);
+  });
+
+  it('does not hand a compiled entry reached through PATH to Node', async () => {
+    // Counterpart to the test above: the Node arm must not widen into compiled
+    // entries, because `exec node <binary>` fails outright and would trade one
+    // startup failure for another. A Mach-O header followed by NUL bytes is
+    // enough to exercise the classification -- the file never has to be
+    // loadable, and copying a real system binary is not portable here anyway.
+    // A stub named `node` on PATH is what would report having been used.
+    const fixture = await makeFixture('unused\n', true, 'placeholder');
+    await fs.writeFile(
+      path.join(fixture.bin, 'qodercli'),
+      Buffer.from([0xcf, 0xfa, 0xed, 0xfe, ...new Array(28).fill(0)]),
+      { mode: 0o755 },
+    );
+    await addBin(fixture, 'node', '#!/bin/sh\necho NODE_TOOK_IT\n');
+    const result = spawnSync('sh', [fixture.wrapper, 'hello'], {
+      env: {
+        ...process.env,
+        PATH: `${fixture.bin}:${BARE_PATH}`,
+        NODE_OPTIONS: '',
+        BUN_OPTIONS: '',
+      },
+      encoding: 'utf-8',
+    });
+    // The entry resolved, so this is really the classification talking and not
+    // an early bail-out with an empty stdout.
+    expect(result.stderr).not.toContain('executable not found');
+    expect(result.stdout).not.toContain('NODE_TOOK_IT');
+  });
+
+  it('leaves an entry whose bytes cannot be read on the previous path', async () => {
+    // "No shebang and no NUL byte" must mean bytes were read and looked like
+    // text, not that reading produced nothing. Reading can come up empty for a
+    // binary too -- a distribution that ships mode 111, for instance -- and
+    // routing that to Node turns a CLI that starts today into one that does not.
+    // An empty file stands in for the whole class here because it needs no
+    // permission trick, which would be a no-op for a root test runner.
+    const fixture = await makeFixture('unused\n', true, 'placeholder');
+    await fs.writeFile(path.join(fixture.bin, 'qodercli'), '', { mode: 0o755 });
+    await addBin(fixture, 'node', '#!/bin/sh\necho NODE_TOOK_IT\n');
+    const result = spawnSync('sh', [fixture.wrapper, 'hello'], {
+      env: {
+        ...process.env,
+        PATH: `${fixture.bin}:${BARE_PATH}`,
+        NODE_OPTIONS: '',
+        BUN_OPTIONS: '',
+      },
+      encoding: 'utf-8',
+    });
+    expect(result.stderr).not.toContain('executable not found');
+    expect(result.stdout).not.toContain('NODE_TOOK_IT');
+  });
+
   it('scopes the intercept file to the qoderclicn flavor', async () => {
     // The CN rc block launches this same wrapper with LOONGSUITE_QODERCLI_FLAVOR
     // set; the derived intercept file name is the only thing keeping the two

--- a/tests/unit/hooks/qodercli-runtime-wrapper.test.mjs
+++ b/tests/unit/hooks/qodercli-runtime-wrapper.test.mjs
@@ -13,7 +13,7 @@ afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
 });
 
-async function makeFixture(qodercliSource, withIntercept = true) {
+async function makeFixture(qodercliSource, withIntercept = true, qodercliName = 'qodercli') {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), 'pilot-qoder-wrapper-'));
   tempDirs.push(root);
   const hooks = path.join(root, 'hooks');
@@ -27,12 +27,13 @@ async function makeFixture(qodercliSource, withIntercept = true) {
   if (withIntercept) {
     await fs.writeFile(path.join(hooks, 'qodercli-token-intercept.mjs'), 'export {};\n');
   }
-  const qodercli = path.join(bin, 'qodercli');
+  const qodercli = path.join(bin, qodercliName);
   await fs.writeFile(qodercli, qodercliSource, { mode: 0o755 });
   return {
     root,
     wrapper: path.join(hooks, 'qodercli-runtime-wrapper.sh'),
     bin,
+    qodercli,
   };
 }
 
@@ -82,6 +83,31 @@ printf '{"nodeOptions":"%s","bunOptions":"%s","arg":"%s"}\\n' "$NODE_OPTIONS" "$
     expect(output.bunOptions).toContain('qodercli-token-intercept.mjs');
     expect(output.bunOptions).toContain('/user/own.mjs');
     expect(output.arg).toBe('hello');
+  });
+
+  it('runs a bundled SDK .mjs entry through Node without requiring a shebang', async () => {
+    const fixture = await makeFixture(`
+console.log(JSON.stringify({
+  nodeOptions: process.env.NODE_OPTIONS,
+  bunOptions: process.env.BUN_OPTIONS || '',
+  args: process.argv.slice(2)
+}));
+`, true, 'qoder-worker-runtime.obf.mjs');
+    const result = spawnSync('sh', [fixture.wrapper, 'hello'], {
+      env: {
+        ...process.env,
+        LOONGSUITE_QODERCLI_BIN: fixture.qodercli,
+        NODE_OPTIONS: '',
+        BUN_OPTIONS: '',
+      },
+      encoding: 'utf-8',
+    });
+    expect(result.status, result.stderr).toBe(0);
+    const output = JSON.parse(result.stdout.trim());
+    expect(output.nodeOptions).toContain('--import=');
+    expect(output.nodeOptions).toContain('qodercli-token-intercept.mjs');
+    expect(output.bunOptions).toBe('');
+    expect(output.args).toEqual(['hello']);
   });
 
   it('fails open when the intercept asset is missing', async () => {

--- a/tests/unit/inputs/qoder-cn-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-cn-trace-input.test.ts
@@ -297,6 +297,8 @@ describe('QoderCnTraceInput.collect (session-level enrich)', () => {
     record['multica.issue.id'] = 'AGE-992';
     record['multica.user.id'] = 'staff-1';
     record['multica.api_token'] = 'blocked';
+    record['agentcore.task_id'] = 'task-managed-runtime';
+    record['agentcore.subtask_id'] = 'subtask-managed-runtime';
     await writeHookJsonl(logDir, [record]);
 
     const entries = await collectOnce();
@@ -304,6 +306,8 @@ describe('QoderCnTraceInput.collect (session-level enrich)', () => {
     expect(entries[0]).toMatchObject({
       'multica.issue.id': 'AGE-992',
       'multica.user.id': 'staff-1',
+      'agentcore.task_id': 'task-managed-runtime',
+      'agentcore.subtask_id': 'subtask-managed-runtime',
     });
     expect(entries[0]).not.toHaveProperty('multica.api_token');
   });

--- a/tests/unit/inputs/qoder-cn-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-cn-trace-input.test.ts
@@ -311,6 +311,195 @@ describe('QoderCnTraceInput.collect (session-level enrich)', () => {
     });
     expect(entries[0]).not.toHaveProperty('multica.api_token');
   });
+
+  it('repairs a qoderclicn turn from the CN segments root and the CN intercept', async () => {
+    // The defect this covers: the CLI hook stamps llm.request and llm.response
+    // from the same progress tick, so the span carries no duration, and the
+    // transcript reports no usage. Duration has to come from the segment pair
+    // and usage from the runtime intercept; neither source alone is enough.
+    const sessionId = 'cli-sess-join';
+    const clientRequestId = 'creq-join-1';
+    const responseId = 'resp-join-1';
+    const now = Date.now();
+
+    const request = buildEntry({
+      event: 'llm.request', turn: 'cli-turn', step: 'cli-turn:s1', session: sessionId, ts: now,
+    });
+    request['agent.client_request_id'] = clientRequestId;
+    const response = buildEntry({
+      event: 'llm.response', turn: 'cli-turn', step: 'cli-turn:s1', session: sessionId, ts: now,
+    });
+    response['agent.client_request_id'] = clientRequestId;
+    response['gen_ai.response.id'] = responseId;
+    await writeHookJsonl(logDir, [request, response]);
+
+    await writeSegments(cnSegmentsRoot(), sessionId, clientRequestId, now - 4000, now - 1000);
+    await writeCnIntercept([{
+      type: 'token',
+      id: responseId,
+      ts: now,
+      prompt_tokens: 1234,
+      completion_tokens: 56,
+      cached_tokens: 1000,
+      total_tokens: 1290,
+    }]);
+
+    const entries = await collectOnce();
+    const outRequest = entries.find(e => e['event.name'] === 'llm.request')!;
+    const outResponse = entries.find(e => e['event.name'] === 'llm.response')!;
+
+    expect(outResponse['gen_ai.usage.input_tokens']).toBe(1234);
+    expect(outResponse['gen_ai.usage.output_tokens']).toBe(56);
+    expect(outResponse['gen_ai.usage.cache_read.input_tokens']).toBe(1000);
+    expect(spanDurationMs(outRequest, outResponse)).toBe(3000);
+    expect(outResponse['gen_ai.response.model']).toBe('qwen3-max');
+  });
+
+  it('never reads the international segments root for a QoderCN session', async () => {
+    // The two product lines mint session ids independently, so one id can exist
+    // under both roots. Reading ~/.qoder here would stamp these entries with
+    // another product's clock instead of leaving them unrepaired.
+    const sessionId = 'cli-sess-wrong-root';
+    const clientRequestId = 'creq-wrong-root';
+    const now = Date.now();
+
+    const request = buildEntry({
+      event: 'llm.request', turn: 'cli-turn-2', step: 'cli-turn-2:s1', session: sessionId, ts: now,
+    });
+    request['agent.client_request_id'] = clientRequestId;
+    const response = buildEntry({
+      event: 'llm.response', turn: 'cli-turn-2', step: 'cli-turn-2:s1', session: sessionId, ts: now,
+    });
+    response['agent.client_request_id'] = clientRequestId;
+    await writeHookJsonl(logDir, [request, response]);
+
+    const internationalRoot = path.join(tmpHome, '.qoder', 'logs', 'sessions');
+    await writeSegments(internationalRoot, sessionId, clientRequestId, now - 4000, now - 1000);
+
+    const entries = await collectOnce();
+    const outRequest = entries.find(e => e['event.name'] === 'llm.request')!;
+    const outResponse = entries.find(e => e['event.name'] === 'llm.response')!;
+
+    expect(spanDurationMs(outRequest, outResponse)).toBe(0);
+    expect(outResponse['gen_ai.response.model']).toBe('auto');
+  });
+
+  it('hands this batch client request ids to the segment reader', async () => {
+    // Without the exact ids the reader cannot tell an empty snapshot apart from
+    // one that is merely late, and the Hook offset is already committed by the
+    // time enrichment runs, so a late record would never be attached at all.
+    const sessionId = 'cli-sess-expected-ids';
+    const now = Date.now();
+    const records: Record<string, unknown>[] = [];
+    for (const [index, requestId] of ['creq-a', 'creq-b'].entries()) {
+      const turn = `cli-turn-ids-${index}`;
+      const request = buildEntry({
+        event: 'llm.request', turn, step: `${turn}:s1`, session: sessionId, ts: now + index,
+      });
+      request['agent.client_request_id'] = requestId;
+      const response = buildEntry({
+        event: 'llm.response', turn, step: `${turn}:s1`, session: sessionId, ts: now + index,
+      });
+      response['agent.client_request_id'] = requestId;
+      response['gen_ai.response.id'] = `resp-${requestId}`;
+      records.push(request, response);
+    }
+    await writeHookJsonl(logDir, records);
+
+    class TestInput extends QoderCnTraceInput {
+      observedRequestIds: string[] = [];
+
+      protected override async readCliSegments(
+        _sessionId: string,
+        expectedRequestIds: readonly string[],
+      ): Promise<[]> {
+        this.observedRequestIds = [...expectedRequestIds];
+        return [];
+      }
+    }
+
+    const input = new TestInput({
+      stateStore: stateStore as any,
+      logDir,
+      pollIntervalMs: 60_000,
+    });
+    await input.start();
+    await input.stop();
+
+    expect(input.observedRequestIds).toEqual(['creq-a', 'creq-b']);
+  });
+
+  it('never commits a half-written record and reads it on the next poll', async () => {
+    // stat() can return while the hook is still appending. Committing stat.size
+    // would step over the tail of a record whose JSON.parse just failed, so that
+    // event would be lost permanently rather than merely delayed.
+    const sessionId = 'sess-partial';
+    const completeRecords = [
+      buildEntry({
+        event: 'llm.request', turn: 'turn-complete', step: 'turn-complete:s1',
+        session: sessionId, ts: 1_780_000_030_000,
+      }),
+      buildEntry({
+        event: 'llm.response', turn: 'turn-complete', step: 'turn-complete:s1',
+        session: sessionId, ts: 1_780_000_031_000,
+      }),
+    ];
+    const lateRecord = buildEntry({
+      event: 'llm.response', turn: 'turn-late', step: 'turn-late:s1',
+      session: sessionId, ts: 1_780_000_032_000,
+    });
+
+    const logFileName = `qoder-cn-${getTodayDateString()}.jsonl`;
+    const logFile = path.join(logDir, logFileName);
+    const completeText = `${completeRecords.map(r => JSON.stringify(r)).join('\n')}\n`;
+    const lateLine = JSON.stringify(lateRecord);
+    const splitAt = Math.floor(lateLine.length / 2);
+    await fs.writeFile(logFile, completeText + lateLine.slice(0, splitAt), 'utf-8');
+
+    const input = new QoderCnTraceInput({
+      stateStore: stateStore as any,
+      logDir,
+      pollIntervalMs: 60_000,
+    });
+
+    const first = await (input as any).collect() as AgentActivityEntry[];
+    expect(first.map(e => e['gen_ai.turn.id'])).toEqual(['turn-complete', 'turn-complete']);
+    // The offset stops at the last newline, not at stat.size.
+    expect(stateStore.get('qoder-cn-trace')).toMatchObject({
+      lastFile: logFileName,
+      lastOffset: Buffer.byteLength(completeText, 'utf-8'),
+    });
+
+    await fs.appendFile(logFile, `${lateLine.slice(splitAt)}\n`, 'utf-8');
+
+    const second = await (input as any).collect() as AgentActivityEntry[];
+    expect(second.map(e => e['gen_ai.turn.id'])).toEqual(['turn-late']);
+  });
+
+  it('holds the offset when the batch contains no complete record at all', async () => {
+    const logFileName = `qoder-cn-${getTodayDateString()}.jsonl`;
+    const logFile = path.join(logDir, logFileName);
+    const record = buildEntry({
+      event: 'llm.response', turn: 'turn-only-partial', step: 'turn-only-partial:s1',
+      session: 'sess-only-partial', ts: 1_780_000_033_000,
+    });
+    const line = JSON.stringify(record);
+    await fs.writeFile(logFile, line.slice(0, 20), 'utf-8');
+
+    const input = new QoderCnTraceInput({
+      stateStore: stateStore as any,
+      logDir,
+      pollIntervalMs: 60_000,
+    });
+
+    expect(await (input as any).collect()).toEqual([]);
+    expect(stateStore.get('qoder-cn-trace')?.lastOffset ?? 0).toBe(0);
+
+    await fs.appendFile(logFile, `${line.slice(20)}\n`, 'utf-8');
+
+    const second = await (input as any).collect() as AgentActivityEntry[];
+    expect(second.map(e => e['gen_ai.turn.id'])).toEqual(['turn-only-partial']);
+  });
 });
 
 // --- Test helpers ---
@@ -416,4 +605,50 @@ function execSql(dbPath: string, sql: string, params: unknown[] = []): Promise<v
       });
     });
   });
+}
+
+function cnSegmentsRoot(): string {
+  return path.join(tmpHome, '.qoder-cn', 'logs', 'sessions');
+}
+
+async function writeSegments(
+  root: string,
+  sessionId: string,
+  requestId: string,
+  startTs: number,
+  endTs: number,
+): Promise<void> {
+  const dir = path.join(root, 'Users-project', sessionId, 'segments');
+  await fs.mkdir(dir, { recursive: true });
+  const lines = [
+    JSON.stringify({
+      type: 'model.request.started',
+      request_id: requestId,
+      loop_id: `loop-${requestId}`,
+      ts: startTs,
+    }),
+    // Zero token counts on purpose: this build reports only `credits` in the
+    // segment, which is why usage must come from the intercept instead.
+    JSON.stringify({
+      type: 'model.response.completed',
+      request_id: requestId,
+      loop_id: `loop-${requestId}`,
+      ts: endTs,
+      data: { input_tokens: 0, output_tokens: 0, model: 'qwen3-max' },
+    }),
+  ];
+  await fs.writeFile(path.join(dir, 'segment-0.jsonl'), `${lines.join('\n')}\n`, 'utf-8');
+}
+
+async function writeCnIntercept(records: Record<string, unknown>[]): Promise<void> {
+  const dir = path.join(tmpHome, '.loongsuite-pilot', 'logs');
+  await fs.mkdir(dir, { recursive: true });
+  const lines = records.map(r => JSON.stringify(r)).join('\n');
+  await fs.writeFile(path.join(dir, 'qoderclicn-intercept.jsonl'), `${lines}\n`, 'utf-8');
+}
+
+function spanDurationMs(request: AgentActivityEntry, response: AgentActivityEntry): number {
+  const requestNs = BigInt(request.time_unix_nano as string);
+  const responseNs = BigInt(response.time_unix_nano as string);
+  return Number((responseNs - requestNs) / 1_000_000n);
 }

--- a/tests/unit/inputs/qoder-cn-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-cn-trace-input.test.ts
@@ -355,6 +355,50 @@ describe('QoderCnTraceInput.collect (session-level enrich)', () => {
     expect(outResponse['gen_ai.response.model']).toBe('qwen3-max');
   });
 
+  it('still applies intercept usage when the segments have not landed yet', async () => {
+    // Segments are written by the CLI and can lag behind the hook record. Routing
+    // such a turn to the IDE path meant its intercept was never read, and because
+    // the Hook offset is committed before enrichment those tokens were gone for
+    // good. Usage joins on an exact gen_ai.response.id, so it does not depend on
+    // the segments at all; only the duration does.
+    const sessionId = 'cli-sess-no-segments';
+    const clientRequestId = 'creq-no-segments';
+    const responseId = 'resp-no-segments';
+    const now = Date.now();
+
+    const request = buildEntry({
+      event: 'llm.request', turn: 'cli-turn', step: 'cli-turn:s1', session: sessionId, ts: now,
+    });
+    request['agent.client_request_id'] = clientRequestId;
+    const response = buildEntry({
+      event: 'llm.response', turn: 'cli-turn', step: 'cli-turn:s1', session: sessionId, ts: now,
+    });
+    response['agent.client_request_id'] = clientRequestId;
+    response['gen_ai.response.id'] = responseId;
+    await writeHookJsonl(logDir, [request, response]);
+
+    // Deliberately no writeSegments call.
+    await writeCnIntercept([{
+      type: 'token',
+      id: responseId,
+      ts: now,
+      prompt_tokens: 700,
+      completion_tokens: 42,
+      cached_tokens: 0,
+      total_tokens: 742,
+    }]);
+
+    const entries = await collectOnce();
+    const outRequest = entries.find(e => e['event.name'] === 'llm.request')!;
+    const outResponse = entries.find(e => e['event.name'] === 'llm.response')!;
+
+    expect(outResponse['gen_ai.usage.input_tokens']).toBe(700);
+    expect(outResponse['gen_ai.usage.output_tokens']).toBe(42);
+    // The duration stays zero: only the segments carry the response timings, and
+    // that is the accepted residual loss rather than an oversight.
+    expect(spanDurationMs(outRequest, outResponse)).toBe(0);
+  });
+
   it('never reads the international segments root for a QoderCN session', async () => {
     // The two product lines mint session ids independently, so one id can exist
     // under both roots. Reading ~/.qoder here would stamp these entries with

--- a/tests/unit/inputs/qoder-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-trace-input.test.ts
@@ -2162,6 +2162,7 @@ describe('QoderTraceInput multimodal', () => {
           'gen_ai.turn.id': 'ide-turn',
           'gen_ai.tool.call.result': `Image file: ${imgPath}`,
           'multica.issue.id': 'IDE-992',
+          'agentcore.task_id': 'task-ide-runtime',
           time_unix_nano: '1780000000000000000',
         };
         const cliTool = {
@@ -2172,6 +2173,7 @@ describe('QoderTraceInput multimodal', () => {
           'gen_ai.turn.id': 'cli-turn',
           'gen_ai.tool.call.result': `Image file: ${imgPath}`,
           'multica.issue.id': 'CLI-992',
+          'agentcore.task_id': 'task-cli-runtime',
           time_unix_nano: '1780000000000000000',
         };
         await fs.writeFile(
@@ -2205,6 +2207,8 @@ describe('QoderTraceInput multimodal', () => {
         expect(Array.isArray(cli['gen_ai.tool.call.result'])).toBe(true);
         expect(ide['multica.issue.id']).toBe('IDE-992');
         expect(cli['multica.issue.id']).toBe('CLI-992');
+        expect(ide['agentcore.task_id']).toBe('task-ide-runtime');
+        expect(cli['agentcore.task_id']).toBe('task-cli-runtime');
       } finally {
         await fs.rm(tmpDir, { recursive: true, force: true });
       }


### PR DESCRIPTION
## Problem

qoderclicn (the QoderCN CLI) produced LLM spans with zero duration and no token usage. Three separate causes:

1. The hook records `llm.request` and `llm.response` in the same tick, so the Hook interval alone yields a zero-width span. The real timings only exist in the session segments.
2. On this build both the segment records and the transcript report zero token counts and carry only `credits`, so usage has to come from the runtime intercept instead.
3. The segment reader was called without the batch's request ids, so it could not distinguish "this request does not exist" from "this request has not been flushed yet".

## Changes

**Runtime and hook** (`17c9e94b`, authored by @流屿) — support a managed QoderCN runtime so `qoderclicn` is wrapped and its intercept file is written.

**CLI collection** (`56cb3d66`) — route qoderclicn sessions to the CLI branch, join intercept usage by `gen_ai.response.id` and segment timings by `agent.client_request_id`, and parameterise the segments root so the CN reader never touches `~/.qoder`.

**Enrichment alignment and hook reader** (`9c8aa0b0`) — two fixes:

- Segment enrichment now mirrors the international input's two-stage model: `enrichCliPrimary` applies hook and intercept data, then `enrichCliFromSegments` fills only what is still missing. The reader receives this batch's exact client request ids via `collectCliExpectedRequestIds`, so an unflushed request gets the bounded retry added in #367. This matters because the hook offset is committed before enrichment: a record missed on the first read can never be repaired on a later poll.

- The hook JSONL reader was losing records. It discarded `bytesRead`, committed the offset at `stat.size`, and never truncated to the last newline, so a record still being appended when `stat()` returned would fail `JSON.parse` while the offset had already moved past its tail. It now follows `BaseHookInput`: read the actual byte count, parse and commit only through the last newline, hold the offset when no complete record is present, and report backlog/read/committed-batch metrics to the runtime accumulator.

## Note on a deliberate divergence from #367

The international input defers the segment read behind `needsCliSegmentFallback` to save I/O. The CN input cannot: QoderCN IDE and qoderclicn share one agent id and one hook history, so the presence of segments is itself the signal that routes a session to the CLI branch. The read therefore happens whenever `agent.client_request_id` is present. `enrichCliFromSegments` is gap-only, so running it unconditionally once segments are in hand is equivalent to running it only on fallback. The `expectedRequestIds` argument is still passed, since that is what the retry actually depends on.

## Testing

`tsc --noEmit` clean. 48 files / 672 tests pass across `tests/unit/inputs/`, `tests/unit/core/orchestrator.test.ts` and `tests/integration/qoder-cli-segment-span-timing.test.ts`.

The CLI branch of the CN input previously had no test coverage at all. Five tests were added:

- repairs a qoderclicn turn from the CN segments root and the CN intercept (end-to-end: real segment and intercept files, asserts usage, span duration and model)
- never reads the international segments root for a QoderCN session
- hands this batch's client request ids to the segment reader
- never commits a half-written record and reads it on the next poll
- holds the offset when the batch contains no complete record at all

Each was verified against a mutated implementation to confirm it fails when the fix is reverted (swapping the segments root constant, committing `stat.size`, and committing on the `lastNewline < 0` path).

## Known gaps, intentionally not in this PR

Both are now tracked separately:

- **#376** — the CN input has no multimodal collection. Only the qoderclicn half is wiring: `qoder-cli-multimodal` derives paths from the entry itself and is root-agnostic. The IDE half is not, because `qoder-ide-multimodal` reads attachments through `readAttachedImagePathsForRequestIds`, which resolves the *international* DB set, and the CN reader has no attachment reader at all.
- **#377** — `resolveQoderCnDbPaths` has no profile-level enumeration, unlike `listHashedProfileDbPaths` on the international side. This affects CN **IDE** token enrichment on remote/multi-profile setups, not qoderclicn. It has not been reproduced on a CN build, so the issue records that limit explicitly.

