### PR TITLE
fix(service): report restart-collector/restart-updater failures instead of failing silently

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,8 +118,52 @@ AgentDiscoveryService ──发现──→ InputManager ──注册──→ I
 | `~/.loongsuite-pilot/logs/snapshot-store.json` | 快照去重状态 |
 | `~/.loongsuite-pilot/logs/otlp-debug/` | OTLP trace debug 落盘 |
 | `~/.loongsuite-pilot/logs/otlp-failed/` | OTLP trace 失败持久化 |
+| `~/.loongsuite-pilot/logs/last-restart-failure-{collector,updater}.json` | 服务管理脚本留下的重启失败面包屑，node 侧读来富化告警（文件还在 = 上次失败） |
 | `~/.loongsuite-pilot/versions/` | 多版本安装目录 |
 | `~/.loongsuite-pilot/current` | 当前版本指针 |
+
+## `restart-collector` / `restart-updater` 不许无声失败
+
+线上唯一能看到的东西曾经是这一行，没有任何原因：
+
+```
+Cmd-RestartUpdater : Service manager failed to restart updater (init_type=taskscheduler)
+```
+
+三条独立的原因把信息全吃掉了：① 原因都在 `Write-Host`，而调用方用 `execFile`，`err.message` **只带
+stderr**，stdout 整个被丢掉；② 脚本头部 `$ErrorActionPreference = "Stop"` 让 `Write-Error` 变成**终止
+错误**，写在它之后的诊断（包括当年那句 `return`）是死代码；③ 有些分支一个字都不打印（`Get-TaskExists`
+把"任务不存在"和"`Get-ScheduledTask` 自己报错"折叠成同一个 `$false`，见 `windows-scheduledtasks-autoload-gap`）。
+外加一个行为缺陷：自愈分支被 `init_type` 门禁挡在 `background|unknown|""` 之外，`taskscheduler` 装机上
+任务一坏就**永远**只能走到那句 `Write-Error`，每个周期重演一次。
+
+现在的契约，`.ps1` 与 `.sh` 对称：
+
+- 每个非成功出口先 `Write-RestartFailure` / `write_restart_failure` 命名一个 **stage**，再退出；
+  **顺序是承重的**（EAP=Stop 下 `Write-Error` 之后的代码不可达）。
+- stage 标签是 `src/utils/restart-breadcrumb.ts` 的 `RESTART_STAGES`，两侧逐字相同、永不本地化 ——
+  它们是告警流里的聚合键，只有一侧认识的标签等于告警查不出来。
+- 面包屑落在 `logs/last-restart-failure-<target>.json`（`schema: 1`，扁平 `diag`），语义同
+  `crash-breadcrumb`：**文件还在就代表上一次失败**，所以两个命令入口都先清掉它。诊断走文件而不是流，
+  因为流不可靠（`$OutputEncoding` 是 ASCII、EAP=Stop 会改写流、安装器里的 `Restart-StaleCollector`
+  还会 `2>&1` 合流）。
+- node 侧读的时候**校验新鲜度**（`ts >= attemptStart - 5s`）：脚本压根没跑起来（`powershell.exe` 不在、
+  子进程被 kill）时，不能拿上一次留下的文件冒充这次的原因。超时被 kill 单独记成 `stage=timeout`。
+- 告警**复用现有类型**（`UPDATER_FAILURE_ALARM` / `SERVICE_NOT_RUNNING_ALARM`），只富化
+  `alarm_message`：`... | stage=<s> reason="<detail>" init_type=<t> task_state=<s> ...`。event schema
+  和下游 SLS 配置不动。
+- 启动确认是**有界轮询**（`Wait-ForUpdaterAlive` / `wait_for_updater_process`），不是 `Start-Sleep 1`
+  加一次探测 —— 一秒不够 `wscript.exe` → node 落 pid 文件，而这个误判在 `init_type=taskscheduler` 上是
+  终局判决。node 侧的命令超时因此提到 90s：30s 会在脚本诊断到一半时把它杀掉，亲手毁掉证据。
+- 自愈不再看 `init_type`；但 background/nohup 兜底**仍然**只对 `background|unknown|""` 开放（托管装机上
+  它不是修复，是一个游离于服务管理器之外、会在下次注销时死掉的第二个 daemon），跳过时要上报，不许静默。
+
+| 测试 | 约束 |
+|------|------|
+| `tests/unit/scripts/ps1-restart-diagnostics.test.mjs` | `.ps1`：每个 `Write-Error` 之前都有 `Write-RestartFailure`；两个入口都先 `Clear-RestartFailure`；每个 `Start-ScheduledTask` 后面跟着等待；自愈块不提 `$initType` 而兜底仍然门禁；写文件带 `-Encoding UTF8` + `Move-Item`；诊断只读（不碰会删 pid 文件的 `Test-PidRunning`）；`schtasks` 交叉校验保持 prevEAP/`2>&1`/`$LASTEXITCODE` 那套写法 |
+| `tests/unit/scripts/sh-restart-diagnostics.test.mjs` | `.sh` 对称版，外加 `set -euo pipefail` 的两个坑（可能空手而归的探针必须自己 `\|\| true`）、手写 JSON 的每个插值都过 `json_escape`、面包屑路径与 node 侧 `restartFailurePath()` 对齐 |
+| `tests/unit/scripts/ps1-restart-best-effort.test.mjs` | 被拒的重新注册不许跳过 `Start-ScheduledTask`（两个独立 try） |
+| `tests/unit/utils/restart-breadcrumb.test.ts` | 带 BOM 能读、未知 schema/截断文件返回 null、新鲜度窗口、摘要长度预算与引号换行清洗 |
 
 ## 快速入口
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,8 @@ stderr**，stdout 整个被丢掉；② 脚本头部 `$ErrorActionPreference = "
   Stop 之后先等到 State 离开 Running 再 Start。Unix collector wait 只做 `kill -0` /
   `process_matches_installed_entry`，禁止经 `is_running` 删 pid。Unix updater wait 必须是新 pid
   （记录 stop 前 pid）。node 侧的命令超时因此提到 90s：30s 会在脚本诊断到一半时把它杀掉，亲手毁掉证据。
-  超时由 node 自己写 `stage=timeout` 面包屑；`UpdaterWatchdog.stop()` 必须 abort 进行中的 child。
+  超时由 node 自己写 `stage=timeout` 面包屑；`UpdaterWatchdog.stop()` 必须 abort 进行中的 child，
+  并且 `restart()` 在 spawn 之前就要看 `stopping`（health I/O 窗口里 stop 不得再拉起 90s 命令）。
 - 自愈不再看 `init_type`；注册一旦成功就把内存中的类型标成托管并跳过 background/nohup，wait 失败走
   `selfheal-not-running`。background/nohup 兜底**仍然**只对 `background|unknown|""` 开放（托管装机上
   它不是修复，是一个游离于服务管理器之外、会在下次注销时死掉的第二个 daemon），跳过时要上报，不许静默。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,16 +154,23 @@ stderr**，stdout 整个被丢掉；② 脚本头部 `$ErrorActionPreference = "
   和下游 SLS 配置不动。
 - 启动确认是**有界轮询**（`Wait-ForUpdaterAlive` / `wait_for_updater_process`），不是 `Start-Sleep 1`
   加一次探测 —— 一秒不够 `wscript.exe` → node 落 pid 文件，而这个误判在 `init_type=taskscheduler` 上是
-  终局判决。node 侧的命令超时因此提到 90s：30s 会在脚本诊断到一半时把它杀掉，亲手毁掉证据。
-- 自愈不再看 `init_type`；但 background/nohup 兜底**仍然**只对 `background|unknown|""` 开放（托管装机上
+  终局判决。updater 的 wait **只认本 install 的 pid 存活**，不许把 task `State=Running` 当进程已起来；
+  Stop 之后先等到 State 离开 Running 再 Start。Unix collector wait 只做 `kill -0` /
+  `process_matches_installed_entry`，禁止经 `is_running` 删 pid。Unix updater wait 必须是新 pid
+  （记录 stop 前 pid）。node 侧的命令超时因此提到 90s：30s 会在脚本诊断到一半时把它杀掉，亲手毁掉证据。
+  超时由 node 自己写 `stage=timeout` 面包屑；`UpdaterWatchdog.stop()` 必须 abort 进行中的 child。
+- 自愈不再看 `init_type`；注册一旦成功就把内存中的类型标成托管并跳过 background/nohup，wait 失败走
+  `selfheal-not-running`。background/nohup 兜底**仍然**只对 `background|unknown|""` 开放（托管装机上
   它不是修复，是一个游离于服务管理器之外、会在下次注销时死掉的第二个 daemon），跳过时要上报，不许静默。
+- Windows 5.1 的 `ConvertTo-Json` 把嵌套 hashtable 编成 `{Key,Value}[]`。writer 手写 `diag` JSON object
+  （CLM 继续用 hashtable，禁止 `[pscustomobject]`）；reader 把那种数组收成 `Record<string,string>`。
 
 | 测试 | 约束 |
 |------|------|
-| `tests/unit/scripts/ps1-restart-diagnostics.test.mjs` | `.ps1`：每个 `Write-Error` 之前都有 `Write-RestartFailure`；两个入口都先 `Clear-RestartFailure`；每个 `Start-ScheduledTask` 后面跟着等待；自愈块不提 `$initType` 而兜底仍然门禁；写文件带 `-Encoding UTF8` + `Move-Item`；诊断只读（不碰会删 pid 文件的 `Test-PidRunning`）；`schtasks` 交叉校验保持 prevEAP/`2>&1`/`$LASTEXITCODE` 那套写法 |
-| `tests/unit/scripts/sh-restart-diagnostics.test.mjs` | `.sh` 对称版，外加 `set -euo pipefail` 的两个坑（可能空手而归的探针必须自己 `\|\| true`）、手写 JSON 的每个插值都过 `json_escape`、面包屑路径与 node 侧 `restartFailurePath()` 对齐 |
+| `tests/unit/scripts/ps1-restart-diagnostics.test.mjs` | `.ps1`：每个 `Write-Error` 之前都有 `Write-RestartFailure`；两个入口都先 `Clear-RestartFailure`；每个 `Start-ScheduledTask` 后面跟着等待；自愈块不门禁 `$initType` 但注册成功会标成 `taskscheduler`；兜底仍然门禁；写文件带 `-Encoding UTF8` + `Move-Item`，diag 手写 JSON object 而不是嵌套 `ConvertTo-Json`；`Wait-ForUpdaterAlive` 只认 pid；诊断只读（不碰会删 pid 文件的 `Test-PidRunning`）；`schtasks` 交叉校验保持 prevEAP/`2>&1`/`$LASTEXITCODE` 那套写法 |
+| `tests/unit/scripts/sh-restart-diagnostics.test.mjs` | `.sh` 对称版，外加 `set -euo pipefail` 的两个坑（可能空手而归的探针必须自己 `\|\| true`）、手写 JSON 的每个插值都过 `json_escape`、面包屑路径与 node 侧 `restartFailurePath()` 对齐；`wait_for_collector_process` 不得调用 `is_running`/`rm`；updater wait 排除 stop 前 pid |
 | `tests/unit/scripts/ps1-restart-best-effort.test.mjs` | 被拒的重新注册不许跳过 `Start-ScheduledTask`（两个独立 try） |
-| `tests/unit/utils/restart-breadcrumb.test.ts` | 带 BOM 能读、未知 schema/截断文件返回 null、新鲜度窗口、摘要长度预算与引号换行清洗 |
+| `tests/unit/utils/restart-breadcrumb.test.ts` | 带 BOM 能读、未知 schema/截断文件返回 null、新鲜度窗口、摘要长度预算与引号换行清洗；5.1 `{Key,Value}[]` 能被收成 `definition_owner`；timeout writer 落盘 |
 
 ## 快速入口
 

--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -319,6 +319,24 @@ function Test-PidRunning {
     return $false
 }
 
+# Read-only cousin of Test-PidRunning. Wait loops must not delete the pid file: a
+# successor can write a new pid between the probe and the Remove-Item, and Unix
+# wait_for_* is already read-only (kill -0). Stale-pid cleanup stays in Stop-PidFile.
+function Test-PidAlive {
+    param([string]$pidFile)
+    if (-not (Test-Path $pidFile)) { return $false }
+    try {
+        $raw = Get-Content $pidFile -ErrorAction SilentlyContinue
+        if (-not $raw) { return $false }
+        $pidVal = ([string]$raw).Trim()
+        if (-not $pidVal) { return $false }
+        $proc = Get-Process -Id $pidVal -ErrorAction SilentlyContinue
+        return $null -ne $proc
+    } catch {
+        return $false
+    }
+}
+
 function Get-CollectorRuntime {
     # Use [datetime] (a Constrained-Language core type) instead of [datetimeoffset],
     # which is not a core type and throws under CLM (WDAC). Comparisons stay correct
@@ -440,6 +458,140 @@ function Get-TaskRunning {
     return $task.State -eq "Running"
 }
 
+function Get-TaskQuery {
+    param([string]$taskName)
+    $result = @{ task = $null; exists = $false; error = "" }
+    try {
+        $result.task = Get-ScheduledTask -TaskName $taskName -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
+        $result.exists = $null -ne $result.task
+    } catch {
+        $message = [string]$_.Exception.Message
+        $category = ""
+        if ($_.CategoryInfo) { $category = [string]$_.CategoryInfo.Category }
+        # "No MSFT_ScheduledTask objects found ..." is the ordinary not-registered
+        # answer from the CIM-backed cmdlet; only anything else is an unknown.
+        if ($category -eq "ObjectNotFound" -or $message -match "No MSFT_ScheduledTask objects found") {
+            $result.error = ""
+        } else {
+            $result.error = $message
+        }
+    }
+    return $result
+}
+
+# Second opinion on whether the task exists, from a completely different code path
+# (schtasks.exe instead of the ScheduledTasks CIM module). Returns "yes", "no" or
+# "unknown: <reason>". A "no" from Get-TaskQuery next to a "yes" here is the signature
+# of a broken query rather than a missing task.
+#
+# The EAP dance is mandatory, not defensive: under $ErrorActionPreference = "Stop" a
+# native command writing one line to stderr while a 2>&1 redirect is in effect raises a
+# NativeCommandError whose message is that raw line, so every branch below would be
+# skipped and the caller would see the bare schtasks text instead of a diagnosis.
+# Restore in finally -- an exception thrown out of the try would otherwise leave the
+# whole script running under "Continue", silently disabling every later fail-fast check.
+function Test-TaskExistsViaSchtasks {
+    param([string]$taskName)
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    # Preset to a non-zero value: if schtasks.exe never launches at all, $LASTEXITCODE
+    # still holds whatever the previous command left there (possibly 0 = success).
+    $code = 9009
+    try {
+        $out = & schtasks.exe /Query /TN "$TASK_FOLDER\$taskName" 2>&1
+        $code = $LASTEXITCODE
+        if ($code -eq 0) { return "yes" }
+        # Every stderr line arrives as an ErrorRecord, and an empty one stringifies to its
+        # exception type name -- measured on 5.1, the raw join reported
+        # "ERROR: The system cannot find the file specified. System.Management.Automation.RemoteException".
+        # No type literal here (Constrained Language Mode): read .Exception.Message if present.
+        $parts = @()
+        foreach ($item in $out) {
+            $line = [string]$item
+            if ($item.Exception -and $item.Exception.Message) { $line = [string]$item.Exception.Message }
+            $line = $line.Trim()
+            if (-not $line) { continue }
+            if ($line -eq "System.Management.Automation.RemoteException") { continue }
+            $parts += $line
+        }
+        $text = ($parts -join " ").Trim()
+        if ($text.Length -gt 200) { $text = $text.Substring(0, 200) }
+        # The message is localized on non-English Windows, so no attempt is made to
+        # classify it as "no": the exit code plus the raw text is what a human needs.
+        return "unknown: exit=$code $text"
+    } catch {
+        return "unknown: $($_.Exception.Message)"
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+}
+
+# Start a task that Get-ScheduledTask could not see (CIM query failed, or schtasks
+# said yes while CIM said no). Same EAP / 2>&1 / $LASTEXITCODE / finally shape as
+# Test-TaskExistsViaSchtasks: under EAP=Stop a native stderr line would skip every
+# branch below and surface as a bare schtasks message.
+function Invoke-SchtasksRun {
+    param([string]$taskName)
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    $code = 9009
+    $result = @{ ok = $false; error = "" }
+    try {
+        $out = & schtasks.exe /Run /TN "$TASK_FOLDER\$taskName" 2>&1
+        $code = $LASTEXITCODE
+        if ($code -eq 0) {
+            $result.ok = $true
+            return $result
+        }
+        $parts = @()
+        foreach ($item in $out) {
+            $line = [string]$item
+            if ($item.Exception -and $item.Exception.Message) { $line = [string]$item.Exception.Message }
+            $line = $line.Trim()
+            if (-not $line) { continue }
+            if ($line -eq "System.Management.Automation.RemoteException") { continue }
+            $parts += $line
+        }
+        $text = ($parts -join " ").Trim()
+        if ($text.Length -gt 200) { $text = $text.Substring(0, 200) }
+        $result.error = "exit=$code $text"
+        return $result
+    } catch {
+        $result.error = [string]$_.Exception.Message
+        return $result
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+}
+
+# CIM found the task, the query itself broke, or schtasks says yes: Start may still
+# work, so do not skip it. Confirmed missing (CIM not-found AND schtasks did not say
+# yes) is the only case that should re-register.
+function Get-TaskStartIntent {
+    param($Query, [string]$TaskName)
+    $existsSchtasks = Test-TaskExistsViaSchtasks $TaskName
+    $shouldStart = $false
+    if ($Query.exists) { $shouldStart = $true }
+    if ($Query.error) { $shouldStart = $true }
+    if ($existsSchtasks -eq "yes") { $shouldStart = $true }
+    $confirmedMissing = $true
+    if ($Query.exists) { $confirmedMissing = $false }
+    if ($Query.error) { $confirmedMissing = $false }
+    if ($existsSchtasks -eq "yes") { $confirmedMissing = $false }
+    return @{
+        should_start = $shouldStart
+        confirmed_missing = $confirmedMissing
+        exists_schtasks = $existsSchtasks
+    }
+}
+
+function Get-InitType {
+    if (-not (Test-Path $INIT_TYPE_FILE)) { return "" }
+    $value = (Get-Content $INIT_TYPE_FILE -ErrorAction SilentlyContinue)
+    if (-not $value) { return "" }
+    return ([string]$value).Trim()
+}
+
 function Wait-ForCollectorHeartbeat {
     param([int]$TimeoutSeconds = 15)
     $notBefore = (Get-Date).AddSeconds(-2)
@@ -447,13 +599,255 @@ function Wait-ForCollectorHeartbeat {
     do {
         if (
             (Get-CollectorRuntime -NotBefore $notBefore) -or
-            (Test-PidRunning $PID_FILE)
+            (Test-PidAlive $PID_FILE)
         ) {
             return $true
         }
         Start-Sleep -Seconds 1
     } while ((Get-Date) -lt $deadline)
     return $false
+}
+
+function Wait-ForUpdaterAlive {
+    param([int]$TimeoutSeconds = 15)
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        if ((Get-TaskRunning $TASK_NAME_UPDATER) -or (Test-PidAlive $UPDATER_PID_FILE)) {
+            return $true
+        }
+        Start-Sleep -Seconds 1
+    } while ((Get-Date) -lt $deadline)
+    return $false
+}
+
+# ============================================================
+# Restart failure diagnostics
+#
+# Every non-success exit of Cmd-RestartCollector / Cmd-RestartUpdater goes through
+# Write-RestartFailure, which prints the reason and drops a breadcrumb file that the
+# calling collector/updater reads (src/utils/restart-breadcrumb.ts) to enrich its alarm.
+# The file channel exists because the streams are not trustworthy here: the caller uses
+# execFile and only surfaces stderr in err.message, $OutputEncoding is ASCII on 5.1, and
+# the installer's Restart-StaleCollector merges both streams with 2>&1.
+# ============================================================
+function Get-RestartFailureFile {
+    param([string]$Target)
+    return (Join-Path $LOG_DIR "last-restart-failure-$Target.json")
+}
+
+# Cleared at the start of every restart attempt, so a file that is present always
+# describes the most recent attempt (same invariant as the startup-crash breadcrumb).
+function Clear-RestartFailure {
+    param([string]$Target)
+    try {
+        $file = Get-RestartFailureFile $Target
+        if (Test-Path -LiteralPath $file) {
+            Remove-Item -LiteralPath $file -Force -ErrorAction SilentlyContinue
+        }
+    } catch {}
+}
+
+# Whether a failure is a permission denial, which decides between the "register-denied"
+# stage (someone installed while elevated, so the task is owned by BUILTIN\Administrators
+# and this unelevated session can start it but never rewrite it) and a generic
+# registration failure. The HRESULT is checked first because the message is localized on
+# non-English Windows -- on a Chinese box the English phrase never appears, so matching
+# text alone would misfile the single most common real cause.
+function Test-AccessDeniedError {
+    param($ErrorRecord)
+    try {
+        if ($ErrorRecord.Exception -and $null -ne $ErrorRecord.Exception.HResult) {
+            # 0x80070005 E_ACCESSDENIED, as an int32.
+            if ([int]$ErrorRecord.Exception.HResult -eq -2147024891) { return $true }
+        }
+        $message = [string]$ErrorRecord.Exception.Message
+        return ($message -match "(?i)access is denied|0x80070005")
+    } catch {
+        return $false
+    }
+}
+
+# Get-Date -UFormat %s is unusable on 5.1: it formats local time as if it were UTC, so
+# the value is off by the timezone offset (8h here) and the reader's freshness check
+# would either reject this breadcrumb or accept a stale one.
+function Get-EpochSeconds {
+    return [int](((Get-Date).ToUniversalTime() - (Get-Date -Date "1970-01-01 00:00:00")).TotalSeconds)
+}
+
+# Everything worth knowing about why a restart did not take, as a flat string map
+# (flat because the reader renders it into a single-line alarm message, and because a
+# nested [pscustomobject] cannot be built under Constrained Language Mode).
+# Read-only by contract: no Test-PidRunning here, which deletes the pid file it finds
+# stale -- diagnostics must not change the state they are describing.
+function Get-RestartDiagnostics {
+    param(
+        [string]$TaskName,
+        [string]$PidFile,
+        [string]$LogFile,
+        [hashtable]$Extra = $null
+    )
+    $diag = @{}
+
+    $query = Get-TaskQuery $TaskName
+    $diag["exists_ps"] = if ($query.exists) { "yes" } else { "no" }
+    if ($query.error) { $diag["query_error"] = $query.error }
+    # Second opinion from schtasks.exe. "no" from the CIM cmdlet next to "yes" here is
+    # the signature of a broken query rather than a task that is really gone.
+    $diag["exists_schtasks"] = Test-TaskExistsViaSchtasks $TaskName
+
+    $task = $query.task
+    if ($task) {
+        try {
+            $diag["task_state"] = [string]$task.State
+            $principal = $task.Principal
+            if ($principal) {
+                $diag["principal_user"] = [string]$principal.UserId
+                $diag["logon_type"] = [string]$principal.LogonType
+                $diag["run_level"] = [string]$principal.RunLevel
+            }
+            $action = $task.Actions | Select-Object -First 1
+            if ($action) {
+                $diag["action_exe"] = [string]$action.Execute
+                $diag["action_args"] = [string]$action.Arguments
+            }
+        } catch {
+            $diag["task_read_error"] = [string]$_.Exception.Message
+        }
+    }
+
+    try {
+        $info = Get-ScheduledTaskInfo -TaskName $TaskName -TaskPath "$TASK_FOLDER\" -ErrorAction SilentlyContinue
+        if ($info) {
+            $diag["last_run_time"] = [string]$info.LastRunTime
+            $diag["last_task_result"] = ("0x{0:X8}" -f [int]$info.LastTaskResult)
+            $diag["missed_runs"] = [string]$info.NumberOfMissedRuns
+        }
+    } catch {}
+
+    # Owner of the on-disk task definition. An elevated install re-owns it to
+    # BUILTIN\Administrators; UAC filters that group out of an unelevated token, so this
+    # session can start the task but can never delete or re-register it (measured: the
+    # task's own principal keeps only Read, Synchronize). That single field distinguishes
+    # "denied because someone installed as admin" from every other denial.
+    try {
+        $taskFolderLeaf = ([string]$TASK_FOLDER).TrimStart("\")
+        $definition = Join-Path (Join-Path $env:SystemRoot "System32\Tasks") (Join-Path $taskFolderLeaf $TaskName)
+        # No Test-Path short-circuit: on 5.1 Test-Path returns $false for both a missing
+        # file and ERROR_ACCESS_DENIED on System32\Tasks, so an admin-owned definition
+        # was reported as "no definition file". Get-Acl and let catch name the reason.
+        $diag["definition_owner"] = [string](Get-Acl -LiteralPath $definition).Owner
+    } catch {
+        $diag["definition_owner"] = "unreadable: $($_.Exception.Message)"
+    }
+
+    $pidState = "no pid file"
+    try {
+        if ($PidFile -and (Test-Path -LiteralPath $PidFile)) {
+            $pidValue = ([string](Get-Content -LiteralPath $PidFile -ErrorAction SilentlyContinue)).Trim()
+            $proc = $null
+            if ($pidValue) { $proc = Get-Process -Id $pidValue -ErrorAction SilentlyContinue }
+            $pidState = if ($proc) { "pid=$pidValue running" } else { "pid=$pidValue not running" }
+        }
+    } catch {
+        $pidState = "unreadable: $($_.Exception.Message)"
+    }
+    $diag["pid_state"] = $pidState
+
+    try {
+        $node = Resolve-Node
+        $diag["node_bin"] = if ($node) { $node } else { "not found" }
+    } catch {
+        $diag["node_bin"] = "resolve failed: $($_.Exception.Message)"
+    }
+
+    try {
+        if ($LogFile -and (Test-Path -LiteralPath $LogFile)) {
+            $tail = Get-Content -LiteralPath $LogFile -Tail 3 -ErrorAction SilentlyContinue
+            $joined = ([string]($tail -join " / ")).Trim()
+            if ($joined.Length -gt 300) { $joined = $joined.Substring(0, 300) }
+            if ($joined) { $diag["log_tail"] = $joined }
+        }
+    } catch {}
+
+    if ($Extra) {
+        foreach ($key in $Extra.Keys) {
+            $value = [string]$Extra[$key]
+            if ($value) { $diag[$key] = $value }
+        }
+    }
+
+    return $diag
+}
+
+# Prints the failure and persists it. MUST be called before Write-Error / exit: under
+# $ErrorActionPreference = "Stop" (top of this file) Write-Error is a terminating error,
+# so anything after it is unreachable -- that is exactly how the old code path ended up
+# reporting "Service manager failed to restart updater" with no reason attached.
+# Wrapped in try/catch throughout: diagnostics must never become a new failure source.
+function Write-RestartFailure {
+    param(
+        [string]$Target,
+        [string]$Stage,
+        [string]$Detail = "",
+        [hashtable]$Extra = $null
+    )
+    $initType = ""
+    try { $initType = Get-InitType } catch {}
+
+    $diag = @{}
+    try {
+        if ($Target -eq "updater") {
+            $diag = Get-RestartDiagnostics `
+                -TaskName $TASK_NAME_UPDATER `
+                -PidFile $UPDATER_PID_FILE `
+                -LogFile $UPDATER_LOG_FILE `
+                -Extra $Extra
+        } else {
+            $diag = Get-RestartDiagnostics `
+                -TaskName $TASK_NAME_COLLECTOR `
+                -PidFile $PID_FILE `
+                -LogFile $LOG_FILE `
+                -Extra $Extra
+        }
+    } catch {
+        $diag = @{ diag_error = [string]$_.Exception.Message }
+        if ($Extra) {
+            foreach ($key in $Extra.Keys) { $diag[$key] = [string]$Extra[$key] }
+        }
+    }
+
+    # Console copy first: it is the only one a human running the command by hand sees,
+    # and it must survive a failure of the file write below.
+    Write-Host "[restart-failure] target=$Target stage=$Stage init_type=$initType"
+    if ($Detail) { Write-Host "[restart-failure] reason=$Detail" }
+    try {
+        foreach ($key in ($diag.Keys | Sort-Object)) {
+            Write-Host "[restart-failure] ${key}=$($diag[$key])"
+        }
+    } catch {}
+
+    try {
+        Ensure-Dirs
+        $payload = @{
+            schema = 1
+            ts = (Get-EpochSeconds)
+            target = $Target
+            stage = $Stage
+            init_type = $initType
+            detail = $Detail
+            diag = $diag
+        }
+        $file = Get-RestartFailureFile $Target
+        $tmp = "$file.tmp"
+        # -Encoding UTF8 is mandatory: Set-Content defaults to the ANSI codepage while
+        # node reads this as UTF-8, and a non-ASCII account name or localized Windows
+        # message in any field would come back mojibake. 5.1 always adds a BOM; the
+        # reader goes through readJsonFile, which strips it.
+        ($payload | ConvertTo-Json -Depth 5) | Set-Content -LiteralPath $tmp -Encoding UTF8
+        Move-Item -LiteralPath $tmp -Destination $file -Force
+    } catch {
+        Write-Host "[restart-failure] breadcrumb write failed: $($_.Exception.Message)"
+    }
 }
 
 function Start-CompatibleExistingCollectorTask {
@@ -936,28 +1330,42 @@ function Cmd-StartCollector {
         exit 1
     }
 
-    if (Get-TaskExists $TASK_NAME_COLLECTOR) {
+    $query = Get-TaskQuery $TASK_NAME_COLLECTOR
+    $intent = Get-TaskStartIntent $query $TASK_NAME_COLLECTOR
+    $shouldStart = [bool]$intent.should_start
+    $confirmedMissing = [bool]$intent.confirmed_missing
+
+    if ($shouldStart) {
         try {
             Start-ScheduledTask -TaskName $TASK_NAME_COLLECTOR -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
             Write-Host "collector start requested (Task Scheduler)"
             return
         } catch {
+            $run = Invoke-SchtasksRun $TASK_NAME_COLLECTOR
+            if ($run.ok) {
+                Write-Host "collector start requested (schtasks /Run)"
+                return
+            }
             Write-Host "Task Scheduler start failed: $($_.Exception.Message)" -ForegroundColor Yellow
-            Write-Error "Service manager failed to start collector"
-            exit 1
+            if ($query.exists) {
+                Write-Error "Service manager failed to start collector"
+                exit 1
+            }
         }
     }
 
-    try {
-        $ok = Install-CollectorTask $nodeBin -SkipCleanup
-        if ($ok) {
-            Start-ScheduledTask -TaskName $TASK_NAME_COLLECTOR -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
-            Set-Content -Path $INIT_TYPE_FILE -Value "taskscheduler"
-            Write-Host "collector task restored and start requested (Task Scheduler)"
-            return
+    if ($confirmedMissing) {
+        try {
+            $ok = Install-CollectorTask $nodeBin -SkipCleanup
+            if ($ok) {
+                Start-ScheduledTask -TaskName $TASK_NAME_COLLECTOR -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
+                Set-Content -Path $INIT_TYPE_FILE -Value "taskscheduler"
+                Write-Host "collector task restored and start requested (Task Scheduler)"
+                return
+            }
+        } catch {
+            Write-Host "Collector task recovery failed: $($_.Exception.Message)" -ForegroundColor Yellow
         }
-    } catch {
-        Write-Host "Collector task recovery failed: $($_.Exception.Message)" -ForegroundColor Yellow
     }
 
     # A missing task can be the result of an interrupted activation. Keep collection
@@ -999,11 +1407,15 @@ function Schedule-UpdaterRestart {
 # ============================================================
 function Cmd-RestartCollector {
     param([string[]]$Options = @())
+    Clear-RestartFailure "collector"
+
     $deferUpdaterRestart = $false
     foreach ($option in $Options) {
         if ($option -eq "--defer-updater-restart") {
             $deferUpdaterRestart = $true
         } else {
+            Write-RestartFailure -Target "collector" -Stage "service-manager-refused" `
+                -Detail "Unknown restart-collector option: $option"
             Write-Error "Unknown restart-collector option: $option"
             exit 1
         }
@@ -1028,15 +1440,39 @@ function Cmd-RestartCollector {
 
     $nodeBin = Resolve-Node
     if (-not $nodeBin) {
+        Write-RestartFailure -Target "collector" -Stage "node-missing" `
+            -Detail "Resolve-Node found no usable node runtime (needs v18+; checked the pin file, nvm, PATH and the managed runtime)"
         Write-Error "node runtime not found"
         exit 1
     }
 
+    $initType = Get-InitType
+    # See Cmd-RestartUpdater: narrowed as the ladder proceeds so the exit can name a cause.
+    $stage = "service-manager-refused"
+    $detail = "no restart path succeeded"
+    $extra = @{}
+
     # Restart via Task Scheduler if registered
     $restarted = $false
-    if (Get-TaskExists $TASK_NAME_COLLECTOR) {
-        # Re-register with potentially updated paths -- best-effort, and deliberately
-        # in its OWN try so a failure here can no longer skip the start below.
+    $query = Get-TaskQuery $TASK_NAME_COLLECTOR
+    $intent = Get-TaskStartIntent $query $TASK_NAME_COLLECTOR
+    $shouldStart = [bool]$intent.should_start
+    $confirmedMissing = [bool]$intent.confirmed_missing
+    $extra["exists_schtasks"] = [string]$intent.exists_schtasks
+    if ($query.error) {
+        $stage = "task-query-failed"
+        $detail = "Get-ScheduledTask failed: $($query.error)"
+        Write-Host "Task query failed for $TASK_FOLDER\$TASK_NAME_COLLECTOR : $($query.error)" -ForegroundColor Yellow
+    } elseif (-not $query.exists) {
+        $stage = "task-missing"
+        $detail = "scheduled task $TASK_FOLDER\$TASK_NAME_COLLECTOR is not registered"
+        Write-Host "Scheduled task not registered: $TASK_FOLDER\$TASK_NAME_COLLECTOR" -ForegroundColor Yellow
+    }
+
+    if ($shouldStart) {
+        # Re-register with potentially updated paths -- best-effort, and only when CIM
+        # actually found the task. A query-fail or schtasks-yes must not delete+recreate.
+        # The Install call is in its OWN try so a failure here can no longer skip start.
         #
         # A scheduled task grants its own principal only Read: every write ACE sits on
         # BUILTIN\Administrators, and UAC filters that group out of the token of a
@@ -1056,45 +1492,91 @@ function Cmd-RestartCollector {
         # the self-heal branch below is skipped, so the update ended in "Service manager
         # failed to restart collector" + exit 1 while the collector stayed down until the
         # task's own 5-minute watchdog trigger happened to relaunch it.
-        try {
-            Install-CollectorTask $nodeBin | Out-Null
-        } catch {
-            Write-Host "Task re-registration skipped (start still attempted): $($_.Exception.Message)" -ForegroundColor Yellow
+        if ($query.exists) {
+            try {
+                Install-CollectorTask $nodeBin | Out-Null
+            } catch {
+                $extra["register_error"] = [string]$_.Exception.Message
+                Write-Host "Task re-registration skipped (start still attempted): $($_.Exception.Message)" -ForegroundColor Yellow
+            }
         }
         try {
             Start-ScheduledTask -TaskName $TASK_NAME_COLLECTOR -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
-            Write-Host "collector restarted (Task Scheduler)"
-            $restarted = $true
+            # Start-ScheduledTask only means Task Scheduler accepted the request. Waiting
+            # for the heartbeat (the same criterion Cmd-Start uses) is what keeps a new
+            # version that crashes on startup from being reported as a successful restart.
+            if (Wait-ForCollectorHeartbeat 20) {
+                Write-Host "collector restarted (Task Scheduler)"
+                $restarted = $true
+            } else {
+                $stage = "not-running-after-start"
+                $detail = "Start-ScheduledTask returned success but no collector heartbeat or pid appeared within 20s"
+                Write-Host "Task started but no collector heartbeat: $TASK_NAME_COLLECTOR" -ForegroundColor Yellow
+            }
         } catch {
-            Write-Host "Task Scheduler restart failed: $($_.Exception.Message)" -ForegroundColor Yellow
+            $message = [string]$_.Exception.Message
+            $run = Invoke-SchtasksRun $TASK_NAME_COLLECTOR
+            if ($run.ok) {
+                if (Wait-ForCollectorHeartbeat 20) {
+                    Write-Host "collector restarted (schtasks /Run)"
+                    $restarted = $true
+                } else {
+                    $stage = "not-running-after-start"
+                    $detail = "schtasks /Run returned success but no collector heartbeat or pid appeared within 20s"
+                    Write-Host "Task started via schtasks /Run but no collector heartbeat: $TASK_NAME_COLLECTOR" -ForegroundColor Yellow
+                }
+            } else {
+                $extra["start_error"] = $message
+                $extra["schtasks_run_error"] = [string]$run.error
+                $stage = if (Test-AccessDeniedError $_) { "register-denied" } else { "start-failed" }
+                $detail = "Start-ScheduledTask failed: $message"
+                Write-Host "Task Scheduler restart failed: $message" -ForegroundColor Yellow
+            }
         }
     }
 
     if (-not $restarted) {
-        # Self-healing: try to register Task Scheduler for degraded (background/unknown) installs
-        $initType = ""
-        if (Test-Path $INIT_TYPE_FILE) { $initType = (Get-Content $INIT_TYPE_FILE -ErrorAction SilentlyContinue).Trim() }
-        # "background" is a legacy init-type value from pre-Task-Scheduler installs (aligned with Linux nohup/unknown)
-        if ($initType -in @("background", "unknown", "")) {
+        # Self-heal, no longer gated on init_type -- see the equivalent comment in
+        # Cmd-RestartUpdater: the gate left a taskscheduler install with a broken task no
+        # way to repair itself. Only when the task is confirmed missing: a query-fail or
+        # schtasks-yes means Start may still work, and delete+recreate would be denied.
+        if ($confirmedMissing) {
             try {
                 $ok = Install-CollectorTask $nodeBin
-                if ($ok) {
+                if (-not $ok) {
+                    $stage = "bootstrap-missing"
+                    $detail = "Install-CollectorTask declined: collector-daemon.js missing under $BOOTSTRAP_DIR"
+                    Write-Host "Self-heal skipped: $detail" -ForegroundColor Yellow
+                } else {
                     Start-ScheduledTask -TaskName $TASK_NAME_COLLECTOR -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
-                    Start-Sleep -Seconds 1
-                    if (Get-TaskRunning $TASK_NAME_COLLECTOR) {
+                    if (Wait-ForCollectorHeartbeat 20) {
                         Set-Content -Path $INIT_TYPE_FILE -Value "taskscheduler"
                         Write-Host "collector self-healed: registered with Task Scheduler"
                         $restarted = $true
+                    } else {
+                        $stage = "selfheal-not-running"
+                        $detail = "task re-registered but no collector heartbeat within 20s"
+                        Write-Host "Self-heal registered the task but nothing came up" -ForegroundColor Yellow
                     }
                 }
             } catch {
-                Write-Host "Self-heal failed: $($_.Exception.Message)" -ForegroundColor Yellow
+                $message = [string]$_.Exception.Message
+                $extra["selfheal_error"] = $message
+                $stage = if (Test-AccessDeniedError $_) { "register-denied" } else { "selfheal-register-failed" }
+                $detail = "self-heal failed: $message"
+                Write-Host "Self-heal failed: $message" -ForegroundColor Yellow
             }
+        } else {
+            Write-Host "Self-heal skipped: task not confirmed missing (exists_schtasks=$($intent.exists_schtasks))" -ForegroundColor Yellow
         }
         if (-not $restarted) {
+            # Restricted to installs that never had a task, and reported when skipped --
+            # see Cmd-RestartUpdater.
             if ($initType -in @("background", "unknown", "")) {
                 $entry = Join-Path $BOOTSTRAP_DIR "collector-daemon.js"
                 if (-not (Test-Path $entry)) {
+                    Write-RestartFailure -Target "collector" -Stage "bootstrap-missing" `
+                        -Detail "collector-daemon.js not found at $entry" -Extra $extra
                     Write-Error "Bootstrap script missing"
                     exit 1
                 }
@@ -1103,9 +1585,20 @@ function Cmd-RestartCollector {
                 # data dir so it lands at $DATA_DIR\loongsuite-pilot.pid. No Set-Content here --
                 # $proc.Id would be the wrapper pid, not node's.
                 Start-BackgroundDaemon "collector" $nodeBin $entry $LOG_FILE $errLog
-                Write-Host "collector restarted (background fallback, self-heal failed)" -ForegroundColor Yellow
+                if (Wait-ForCollectorHeartbeat 10) {
+                    Write-Host "collector restarted (background fallback after stage=$stage : $detail)" -ForegroundColor Yellow
+                } else {
+                    Write-RestartFailure -Target "collector" -Stage "not-running-after-start" `
+                        -Detail "background fallback started but no collector heartbeat or pid appeared within 10s" `
+                        -Extra $extra
+                    Write-Error "Service manager failed to restart collector (init_type=$initType stage=not-running-after-start): background fallback did not come up"
+                    exit 1
+                }
             } else {
-                Write-Error "Service manager failed to restart collector (init_type=$initType)"
+                # Diagnostics before Write-Error: EAP=Stop makes it terminating, so nothing
+                # after it runs (the old `exit 1` never executed either).
+                Write-RestartFailure -Target "collector" -Stage $stage -Detail $detail -Extra $extra
+                Write-Error "Service manager failed to restart collector (init_type=$initType stage=$stage): $detail"
                 exit 1
             }
         }
@@ -1120,6 +1613,10 @@ function Cmd-RestartCollector {
 # CMD: restart-updater
 # ============================================================
 function Cmd-RestartUpdater {
+    # Any breadcrumb still on disk describes an older attempt. Clearing it here is what
+    # lets the caller treat "file present and fresh" as "this attempt failed, here is why".
+    Clear-RestartFailure "updater"
+
     # Stop updater
     $task = Get-ScheduledTask -TaskName $TASK_NAME_UPDATER -TaskPath "$TASK_FOLDER\" -ErrorAction SilentlyContinue
     if ($task -and $task.State -eq "Running") {
@@ -1137,59 +1634,133 @@ function Cmd-RestartUpdater {
 
     $nodeBin = Resolve-Node
     if (-not $nodeBin) {
+        Write-RestartFailure -Target "updater" -Stage "node-missing" `
+            -Detail "Resolve-Node found no usable node runtime (needs v18+; checked the pin file, nvm, PATH and the managed runtime)"
         Write-Error "node runtime not found"
         return
     }
 
+    $initType = Get-InitType
+    # Stage/detail carry the most specific thing learned so far, so the exit at the
+    # bottom can name a cause instead of just "the service manager refused". They start
+    # at the generic label and are narrowed as the ladder proceeds.
+    $stage = "service-manager-refused"
+    $detail = "no restart path succeeded"
+    $extra = @{}
+
     # Restart via Task Scheduler
     $restarted = $false
-    if (Get-TaskExists $TASK_NAME_UPDATER) {
+    $query = Get-TaskQuery $TASK_NAME_UPDATER
+    $intent = Get-TaskStartIntent $query $TASK_NAME_UPDATER
+    $shouldStart = [bool]$intent.should_start
+    $confirmedMissing = [bool]$intent.confirmed_missing
+    $extra["exists_schtasks"] = [string]$intent.exists_schtasks
+    if ($query.error) {
+        # Not the same thing as "not registered": the query itself broke, so re-registering
+        # is the wrong reflex and the reason must be reported verbatim.
+        $stage = "task-query-failed"
+        $detail = "Get-ScheduledTask failed: $($query.error)"
+        Write-Host "Task query failed for $TASK_FOLDER\$TASK_NAME_UPDATER : $($query.error)" -ForegroundColor Yellow
+    } elseif (-not $query.exists) {
+        $stage = "task-missing"
+        $detail = "scheduled task $TASK_FOLDER\$TASK_NAME_UPDATER is not registered"
+        Write-Host "Scheduled task not registered: $TASK_FOLDER\$TASK_NAME_UPDATER" -ForegroundColor Yellow
+    }
+
+    if ($shouldStart) {
         # Best-effort re-registration in its own try, for the same reason as in
         # Cmd-RestartCollector above (a -RunLevel Limited task cannot rewrite its own
-        # definition; only starting it works). See the comment there.
-        try {
-            Install-UpdaterTask $nodeBin | Out-Null
-        } catch {
-            Write-Host "Task re-registration skipped (start still attempted): $($_.Exception.Message)" -ForegroundColor Yellow
+        # definition; only starting it works). Skip Install when CIM did not actually
+        # find the task: query-fail / schtasks-yes must not delete+recreate.
+        if ($query.exists) {
+            try {
+                Install-UpdaterTask $nodeBin | Out-Null
+            } catch {
+                $extra["register_error"] = [string]$_.Exception.Message
+                Write-Host "Task re-registration skipped (start still attempted): $($_.Exception.Message)" -ForegroundColor Yellow
+            }
         }
         try {
             Start-ScheduledTask -TaskName $TASK_NAME_UPDATER -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
-            Start-Sleep -Seconds 1
-            if (Get-TaskRunning $TASK_NAME_UPDATER) {
+            if (Wait-ForUpdaterAlive) {
                 Write-Host "updater restarted (Task Scheduler)"
                 $restarted = $true
+            } else {
+                $stage = "not-running-after-start"
+                $detail = "Start-ScheduledTask returned success but neither the task reached Running nor an updater pid appeared within 15s"
+                Write-Host "Task started but no updater came up: $TASK_NAME_UPDATER" -ForegroundColor Yellow
             }
         } catch {
-            Write-Host "Task Scheduler restart failed: $($_.Exception.Message)" -ForegroundColor Yellow
+            $message = [string]$_.Exception.Message
+            $run = Invoke-SchtasksRun $TASK_NAME_UPDATER
+            if ($run.ok) {
+                if (Wait-ForUpdaterAlive) {
+                    Write-Host "updater restarted (schtasks /Run)"
+                    $restarted = $true
+                } else {
+                    $stage = "not-running-after-start"
+                    $detail = "schtasks /Run returned success but neither the task reached Running nor an updater pid appeared within 15s"
+                    Write-Host "Task started via schtasks /Run but no updater came up: $TASK_NAME_UPDATER" -ForegroundColor Yellow
+                }
+            } else {
+                $extra["start_error"] = $message
+                $extra["schtasks_run_error"] = [string]$run.error
+                $stage = if (Test-AccessDeniedError $_) { "register-denied" } else { "start-failed" }
+                $detail = "Start-ScheduledTask failed: $message"
+                Write-Host "Task Scheduler restart failed: $message" -ForegroundColor Yellow
+            }
         }
     }
 
     if (-not $restarted) {
-        # Self-healing: try to register Task Scheduler for degraded (background/unknown) installs
-        $initType = ""
-        if (Test-Path $INIT_TYPE_FILE) { $initType = (Get-Content $INIT_TYPE_FILE -ErrorAction SilentlyContinue).Trim() }
-        # "background" is a legacy init-type value from pre-Task-Scheduler installs (aligned with Linux nohup/unknown)
-        if ($initType -in @("background", "unknown", "")) {
+        # Self-heal: re-register from scratch. No longer gated on init_type. The gate used
+        # to read @("background","unknown","") -- so a taskscheduler install whose task was
+        # missing or unusable was not allowed to repair itself and could only fall through
+        # to a reasonless Write-Error, once per updater cycle, forever.
+        # Only when confirmed missing: a query-fail or schtasks-yes is not a missing task.
+        if ($confirmedMissing) {
             try {
                 $ok = Install-UpdaterTask $nodeBin
-                if ($ok) {
+                if (-not $ok) {
+                    $stage = "bootstrap-missing"
+                    $detail = "Install-UpdaterTask declined: updater-daemon.js missing under $BOOTSTRAP_DIR"
+                    Write-Host "Self-heal skipped: $detail" -ForegroundColor Yellow
+                } else {
                     Start-ScheduledTask -TaskName $TASK_NAME_UPDATER -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
-                    Start-Sleep -Seconds 1
-                    if (Get-TaskRunning $TASK_NAME_UPDATER) {
+                    if (Wait-ForUpdaterAlive) {
                         Set-Content -Path $INIT_TYPE_FILE -Value "taskscheduler"
                         Write-Host "updater self-healed: registered with Task Scheduler"
                         $restarted = $true
+                    } else {
+                        $stage = "selfheal-not-running"
+                        $detail = "task re-registered but no updater came up within 15s"
+                        Write-Host "Self-heal registered the task but nothing came up" -ForegroundColor Yellow
                     }
                 }
             } catch {
-                Write-Host "Self-heal failed: $($_.Exception.Message)" -ForegroundColor Yellow
+                $message = [string]$_.Exception.Message
+                $extra["selfheal_error"] = $message
+                $stage = if (Test-AccessDeniedError $_) { "register-denied" } else { "selfheal-register-failed" }
+                $detail = "self-heal failed: $message"
+                Write-Host "Self-heal failed: $message" -ForegroundColor Yellow
             }
+        } else {
+            Write-Host "Self-heal skipped: task not confirmed missing (exists_schtasks=$($intent.exists_schtasks))" -ForegroundColor Yellow
         }
         if (-not $restarted) {
+            # The detached-powershell fallback stays restricted to installs that never had
+            # a task: on a taskscheduler install it is not a repair but a second unmanaged
+            # daemon that dies at the next logoff while hiding the real breakage. What
+            # changed is that skipping it is now reported instead of falling through to a
+            # Write-Error carrying nothing but init_type.
             if ($initType -in @("background", "unknown", "")) {
                 $entry = Join-Path $BOOTSTRAP_DIR "updater-daemon.js"
                 if (-not (Test-Path $entry)) {
-                    Write-Host "Updater bootstrap script missing"
+                    # Used to be Write-Host + return, i.e. exit 0: the caller recorded a
+                    # successful restart of an updater that was never started.
+                    Write-RestartFailure -Target "updater" -Stage "bootstrap-missing" `
+                        -Detail "updater-daemon.js not found at $entry" -Extra $extra
+                    Write-Error "Updater bootstrap script missing"
                     return
                 }
                 $updaterErrLog = Join-Path $LOG_DIR "loongsuite-pilot-updater-err.log"
@@ -1197,9 +1768,21 @@ function Cmd-RestartUpdater {
                 # the data dir so it lands at $DATA_DIR\loongsuite-pilot-updater.pid. No
                 # Set-Content -- $proc.Id would be the wrapper pid, not node's.
                 Start-BackgroundDaemon "updater" $nodeBin $entry $UPDATER_LOG_FILE $updaterErrLog
-                Write-Host "updater restarted (background fallback, self-heal failed)" -ForegroundColor Yellow
+                if (Wait-ForUpdaterAlive 10) {
+                    Write-Host "updater restarted (background fallback after stage=$stage : $detail)" -ForegroundColor Yellow
+                } else {
+                    Write-RestartFailure -Target "updater" -Stage "not-running-after-start" `
+                        -Detail "background fallback started but neither the task reached Running nor an updater pid appeared within 10s" `
+                        -Extra $extra
+                    Write-Error "Service manager failed to restart updater (init_type=$initType stage=not-running-after-start): background fallback did not come up"
+                    return
+                }
             } else {
-                Write-Error "Service manager failed to restart updater (init_type=$initType)"
+                # Order matters: under EAP=Stop (top of this file) Write-Error is a
+                # terminating error, so the diagnostics have to be written BEFORE it. The
+                # `return` that used to sit after it was dead code.
+                Write-RestartFailure -Target "updater" -Stage $stage -Detail $detail -Extra $extra
+                Write-Error "Service manager failed to restart updater (init_type=$initType stage=$stage): $detail"
                 return
             }
         }
@@ -1776,6 +2359,40 @@ if (op === "set") {
     if ($sub -ne "" -and $sub.ToLower() -notin @("help", "-h", "--help")) { exit 1 }
 }
 
+# ============================================================
+# CMD: diagnose-service
+# ============================================================
+# Same collection Write-RestartFailure persists, on demand and without touching
+# anything: the fastest way to answer "why can this box not restart its daemons"
+# without waiting for the next failed cycle.
+function Cmd-DiagnoseService {
+    Write-Host "init_type: $(Get-InitType)"
+    Write-Host "task folder: $TASK_FOLDER"
+    Write-Host ""
+    foreach ($target in @("collector", "updater")) {
+        if ($target -eq "updater") {
+            $diag = Get-RestartDiagnostics -TaskName $TASK_NAME_UPDATER -PidFile $UPDATER_PID_FILE -LogFile $UPDATER_LOG_FILE
+            Write-Host "[updater] task: $TASK_NAME_UPDATER"
+        } else {
+            $diag = Get-RestartDiagnostics -TaskName $TASK_NAME_COLLECTOR -PidFile $PID_FILE -LogFile $LOG_FILE
+            Write-Host "[collector] task: $TASK_NAME_COLLECTOR"
+        }
+        foreach ($key in ($diag.Keys | Sort-Object)) {
+            Write-Host "[$target] ${key}=$($diag[$key])"
+        }
+        $file = Get-RestartFailureFile $target
+        if (Test-Path -LiteralPath $file) {
+            Write-Host "[$target] last restart failure ($file):"
+            Get-Content -LiteralPath $file -Encoding UTF8 -ErrorAction SilentlyContinue | ForEach-Object {
+                Write-Host "[$target]   $_"
+            }
+        } else {
+            Write-Host "[$target] no restart failure recorded"
+        }
+        Write-Host ""
+    }
+}
+
 function Cmd-Help {
     Write-Host "Usage: loongsuite-pilot <command>"
     Write-Host ""
@@ -1797,6 +2414,7 @@ function Cmd-Help {
         Write-Host "  upgrade [opts]  Upgrade to latest or --version <version> (open-source only)"
     }
     Write-Host "  rollback        Roll back to the previous version"
+    Write-Host "  diagnose-service  Dump why the service tasks cannot start/restart"
     Write-Host "  worker          Manage local Workers:"
     Write-Host "                    worker connect/list/status/disconnect/delete"
     Write-Host "  help            Show this help message"
@@ -1831,6 +2449,7 @@ switch ($Command.ToLower()) {
     "restart-collector"  { Cmd-RestartCollector -Options $SubArgs }
     "schedule-updater-restart" { Schedule-UpdaterRestart }
     "restart-updater"    { Cmd-RestartUpdater }
+    "diagnose-service"   { Cmd-DiagnoseService }
     "run"                { Cmd-Run }
     "run-updater"        { Cmd-RunUpdater }
     "span-attr"          { Cmd-SpanAttr }

--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -1623,11 +1623,14 @@ function Cmd-RestartCollector {
                     $detail = "Install-CollectorTask declined: collector-daemon.js missing under $BOOTSTRAP_DIR"
                     Write-Host "Self-heal skipped: $detail" -ForegroundColor Yellow
                 } else {
-                    # Registration succeeded: this install is now managed. Skip the
-                    # background fallback even if wait fails -- otherwise empty/unknown
-                    # init_type would start a second unmanaged daemon next to the task.
-                    Set-Content -Path $INIT_TYPE_FILE -Value "taskscheduler"
+                    # Registration succeeded: this install is now managed. Flip in-memory
+                    # type first so a Set-Content failure cannot fall through to background.
                     $initType = "taskscheduler"
+                    try {
+                        Set-Content -Path $INIT_TYPE_FILE -Value "taskscheduler"
+                    } catch {
+                        # Disk write failed; in-memory type already skips Start-BackgroundDaemon.
+                    }
                     Start-ScheduledTask -TaskName $TASK_NAME_COLLECTOR -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
                     if (Wait-ForCollectorHeartbeat 20) {
                         Write-Host "collector self-healed: registered with Task Scheduler"
@@ -1806,8 +1809,12 @@ function Cmd-RestartUpdater {
                     $detail = "Install-UpdaterTask declined: updater-daemon.js missing under $BOOTSTRAP_DIR"
                     Write-Host "Self-heal skipped: $detail" -ForegroundColor Yellow
                 } else {
-                    Set-Content -Path $INIT_TYPE_FILE -Value "taskscheduler"
                     $initType = "taskscheduler"
+                    try {
+                        Set-Content -Path $INIT_TYPE_FILE -Value "taskscheduler"
+                    } catch {
+                        # Disk write failed; in-memory type already skips Start-BackgroundDaemon.
+                    }
                     Start-ScheduledTask -TaskName $TASK_NAME_UPDATER -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
                     if (Wait-ForUpdaterAlive) {
                         Write-Host "updater self-healed: registered with Task Scheduler"

--- a/scripts/loongsuite-pilot.ps1
+++ b/scripts/loongsuite-pilot.ps1
@@ -321,7 +321,8 @@ function Test-PidRunning {
 
 # Read-only cousin of Test-PidRunning. Wait loops must not delete the pid file: a
 # successor can write a new pid between the probe and the Remove-Item, and Unix
-# wait_for_* is already read-only (kill -0). Stale-pid cleanup stays in Stop-PidFile.
+# wait_for_* is read-only (kill -0 / process_matches_installed_entry). Stale-pid
+# cleanup stays in Stop-PidFile.
 function Test-PidAlive {
     param([string]$pidFile)
     if (-not (Test-Path $pidFile)) { return $false }
@@ -608,13 +609,30 @@ function Wait-ForCollectorHeartbeat {
     return $false
 }
 
+# Task State=Running is not liveness. Start-ScheduledTask makes the task Running as
+# soon as wscript is up, before node has written a pid; Stop-ScheduledTask also leaves
+# State=Running until the old instance actually exits. Collector wait uses a pid check
+# (Get-CollectorRuntime / Test-PidAlive); updater must do the same.
 function Wait-ForUpdaterAlive {
     param([int]$TimeoutSeconds = 15)
     $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
     do {
-        if ((Get-TaskRunning $TASK_NAME_UPDATER) -or (Test-PidAlive $UPDATER_PID_FILE)) {
-            return $true
-        }
+        if (Test-PidAlive $UPDATER_PID_FILE) { return $true }
+        Start-Sleep -Seconds 1
+    } while ((Get-Date) -lt $deadline)
+    return $false
+}
+
+# Best-effort: Start-ScheduledTask on a task that is still Running is often a no-op, so
+# restart would "succeed" against the outgoing instance. Mirror the 10s wait in
+# Start-CompatibleExistingCollectorTask. Failure to leave Running is not fatal; the
+# caller still Stop-PidFile / Start.
+function Wait-ForTaskNotRunning {
+    param([string]$TaskName, [int]$TimeoutSeconds = 10)
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        $task = Get-ScheduledTask -TaskName $TaskName -TaskPath "$TASK_FOLDER\" -ErrorAction SilentlyContinue
+        if (-not $task -or $task.State -ne "Running") { return $true }
         Start-Sleep -Seconds 1
     } while ((Get-Date) -lt $deadline)
     return $false
@@ -672,6 +690,53 @@ function Test-AccessDeniedError {
 # would either reject this breadcrumb or accept a stale one.
 function Get-EpochSeconds {
     return [int](((Get-Date).ToUniversalTime() - (Get-Date -Date "1970-01-01 00:00:00")).TotalSeconds)
+}
+
+# 5.1 ConvertTo-Json serializes a nested hashtable as [{Key, Value}, ...], not a JSON
+# object. The reader then Object.keys the array and loses definition_owner / task_state.
+# Hand-write the diag object the way loongsuite-pilot.sh does. Hashtable-only: CLM.
+function Escape-RestartJsonString {
+    param([string]$Value)
+    $s = [string]$Value
+    if (-not $s) { return "" }
+    $s = $s.Replace("`r", " ").Replace("`n", " ").Replace("`t", " ")
+    $s = $s -replace '[\u0000-\u001F]', ''
+    return $s.Replace('\', '\\').Replace('"', '\"')
+}
+
+function ConvertTo-RestartFailureJson {
+    param(
+        [int]$Ts,
+        [string]$Target,
+        [string]$Stage,
+        [string]$InitType,
+        [string]$Detail,
+        [hashtable]$Diag
+    )
+    $diagLines = @()
+    if ($Diag) {
+        foreach ($key in ($Diag.Keys | Sort-Object)) {
+            $k = Escape-RestartJsonString ([string]$key)
+            if (-not $k) { continue }
+            $v = Escape-RestartJsonString ([string]$Diag[$key])
+            $diagLines += '    "' + $k + '": "' + $v + '"'
+        }
+    }
+    $diagBody = $diagLines -join ",`n"
+    $lines = @(
+        '{'
+        '  "schema": 1,'
+        ('  "ts": ' + $Ts + ',')
+        ('  "target": "' + (Escape-RestartJsonString $Target) + '",')
+        ('  "stage": "' + (Escape-RestartJsonString $Stage) + '",')
+        ('  "init_type": "' + (Escape-RestartJsonString $InitType) + '",')
+        ('  "detail": "' + (Escape-RestartJsonString $Detail) + '",')
+        '  "diag": {'
+        $diagBody
+        '  }'
+        '}'
+    )
+    return ($lines -join "`n")
 }
 
 # Everything worth knowing about why a restart did not take, as a flat string map
@@ -839,11 +904,20 @@ function Write-RestartFailure {
         }
         $file = Get-RestartFailureFile $Target
         $tmp = "$file.tmp"
+        # Hand-written JSON: 5.1 ConvertTo-Json turns a nested hashtable into
+        # [{Key,Value},...], which summarizeRestartFailure cannot read as diag fields.
         # -Encoding UTF8 is mandatory: Set-Content defaults to the ANSI codepage while
         # node reads this as UTF-8, and a non-ASCII account name or localized Windows
         # message in any field would come back mojibake. 5.1 always adds a BOM; the
         # reader goes through readJsonFile, which strips it.
-        ($payload | ConvertTo-Json -Depth 5) | Set-Content -LiteralPath $tmp -Encoding UTF8
+        $json = ConvertTo-RestartFailureJson `
+            -Ts ([int]$payload.ts) `
+            -Target ([string]$payload.target) `
+            -Stage ([string]$payload.stage) `
+            -InitType ([string]$payload.init_type) `
+            -Detail ([string]$payload.detail) `
+            -Diag $payload.diag
+        Set-Content -LiteralPath $tmp -Value $json -Encoding UTF8
         Move-Item -LiteralPath $tmp -Destination $file -Force
     } catch {
         Write-Host "[restart-failure] breadcrumb write failed: $($_.Exception.Message)"
@@ -1425,6 +1499,7 @@ function Cmd-RestartCollector {
     $task = Get-ScheduledTask -TaskName $TASK_NAME_COLLECTOR -TaskPath "$TASK_FOLDER\" -ErrorAction SilentlyContinue
     if ($task -and $task.State -eq "Running") {
         Stop-ScheduledTask -TaskName $TASK_NAME_COLLECTOR -TaskPath "$TASK_FOLDER\" -ErrorAction SilentlyContinue
+        Wait-ForTaskNotRunning $TASK_NAME_COLLECTOR | Out-Null
     }
     Stop-PidFile $PID_FILE
 
@@ -1548,9 +1623,13 @@ function Cmd-RestartCollector {
                     $detail = "Install-CollectorTask declined: collector-daemon.js missing under $BOOTSTRAP_DIR"
                     Write-Host "Self-heal skipped: $detail" -ForegroundColor Yellow
                 } else {
+                    # Registration succeeded: this install is now managed. Skip the
+                    # background fallback even if wait fails -- otherwise empty/unknown
+                    # init_type would start a second unmanaged daemon next to the task.
+                    Set-Content -Path $INIT_TYPE_FILE -Value "taskscheduler"
+                    $initType = "taskscheduler"
                     Start-ScheduledTask -TaskName $TASK_NAME_COLLECTOR -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
                     if (Wait-ForCollectorHeartbeat 20) {
-                        Set-Content -Path $INIT_TYPE_FILE -Value "taskscheduler"
                         Write-Host "collector self-healed: registered with Task Scheduler"
                         $restarted = $true
                     } else {
@@ -1621,6 +1700,7 @@ function Cmd-RestartUpdater {
     $task = Get-ScheduledTask -TaskName $TASK_NAME_UPDATER -TaskPath "$TASK_FOLDER\" -ErrorAction SilentlyContinue
     if ($task -and $task.State -eq "Running") {
         Stop-ScheduledTask -TaskName $TASK_NAME_UPDATER -TaskPath "$TASK_FOLDER\" -ErrorAction SilentlyContinue
+        Wait-ForTaskNotRunning $TASK_NAME_UPDATER | Out-Null
     }
     Stop-PidFile $UPDATER_PID_FILE
 
@@ -1687,7 +1767,7 @@ function Cmd-RestartUpdater {
                 $restarted = $true
             } else {
                 $stage = "not-running-after-start"
-                $detail = "Start-ScheduledTask returned success but neither the task reached Running nor an updater pid appeared within 15s"
+                $detail = "Start-ScheduledTask returned success but no updater pid appeared within 15s"
                 Write-Host "Task started but no updater came up: $TASK_NAME_UPDATER" -ForegroundColor Yellow
             }
         } catch {
@@ -1699,7 +1779,7 @@ function Cmd-RestartUpdater {
                     $restarted = $true
                 } else {
                     $stage = "not-running-after-start"
-                    $detail = "schtasks /Run returned success but neither the task reached Running nor an updater pid appeared within 15s"
+                    $detail = "schtasks /Run returned success but no updater pid appeared within 15s"
                     Write-Host "Task started via schtasks /Run but no updater came up: $TASK_NAME_UPDATER" -ForegroundColor Yellow
                 }
             } else {
@@ -1726,14 +1806,15 @@ function Cmd-RestartUpdater {
                     $detail = "Install-UpdaterTask declined: updater-daemon.js missing under $BOOTSTRAP_DIR"
                     Write-Host "Self-heal skipped: $detail" -ForegroundColor Yellow
                 } else {
+                    Set-Content -Path $INIT_TYPE_FILE -Value "taskscheduler"
+                    $initType = "taskscheduler"
                     Start-ScheduledTask -TaskName $TASK_NAME_UPDATER -TaskPath "$TASK_FOLDER\" -ErrorAction Stop
                     if (Wait-ForUpdaterAlive) {
-                        Set-Content -Path $INIT_TYPE_FILE -Value "taskscheduler"
                         Write-Host "updater self-healed: registered with Task Scheduler"
                         $restarted = $true
                     } else {
                         $stage = "selfheal-not-running"
-                        $detail = "task re-registered but no updater came up within 15s"
+                        $detail = "task re-registered but no updater pid appeared within 15s"
                         Write-Host "Self-heal registered the task but nothing came up" -ForegroundColor Yellow
                     }
                 }
@@ -1772,7 +1853,7 @@ function Cmd-RestartUpdater {
                     Write-Host "updater restarted (background fallback after stage=$stage : $detail)" -ForegroundColor Yellow
                 } else {
                     Write-RestartFailure -Target "updater" -Stage "not-running-after-start" `
-                        -Detail "background fallback started but neither the task reached Running nor an updater pid appeared within 10s" `
+                        -Detail "background fallback started but no updater pid appeared within 10s" `
                         -Extra $extra
                     Write-Error "Service manager failed to restart updater (init_type=$initType stage=not-running-after-start): background fallback did not come up"
                     return

--- a/scripts/loongsuite-pilot.sh
+++ b/scripts/loongsuite-pilot.sh
@@ -83,6 +83,213 @@ ensure_dirs() {
     mkdir -p "$BOOTSTRAP_DIR"
 }
 
+read_init_type() {
+    if [ -f "$INIT_TYPE_FILE" ]; then
+        cat "$INIT_TYPE_FILE" 2>/dev/null | tr -d '[:space:]'
+    fi
+}
+
+# ============================================================
+# Restart failure diagnostics
+#
+# Mirror of the Windows implementation in scripts/loongsuite-pilot.ps1: every
+# non-success exit of cmd_restart_collector / cmd_restart_updater names a stage, prints
+# the reason, and leaves a breadcrumb that the calling collector/updater reads
+# (src/utils/restart-breadcrumb.ts) to enrich its alarm message. Stage labels are shared
+# with the .ps1 verbatim -- they are aggregation keys in the alarm stream.
+# ============================================================
+restart_failure_file() {
+    echo "$LOG_DIR/last-restart-failure-$1.json"
+}
+
+# Cleared at the start of every attempt, so a file that is present always describes the
+# most recent one.
+clear_restart_failure() {
+    rm -f "$(restart_failure_file "$1")" 2>/dev/null || true
+}
+
+# Minimal JSON string escaping. Newlines and tabs become spaces first: the breadcrumb is
+# hand-written (no jq dependency on a customer box), and a raw newline inside a JSON
+# string is a parse error, which the reader would silently degrade to "no diagnostics".
+# Remaining C0 controls (notably ESC from colorized log tails) are stripped: they are
+# not valid in JSON strings unless written as \u00XX, and a raw 0x1B makes JSON.parse fail.
+json_escape() {
+    printf '%s' "$1" | tr '\n\r\t' '   ' | tr -d '\000-\010\013\014\016-\037' | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+# Prints one `key=value` line per fact. Read-only: diagnostics must not change the state
+# they describe.
+collect_restart_diag() {
+    local target="$1"
+    local pid_file log_file unit sys_unit label
+    local target_user init_type
+    target_user=$(whoami)
+    init_type=$(read_init_type)
+    if [ "$target" = "updater" ]; then
+        pid_file="$UPDATER_PID_FILE"
+        log_file="$UPDATER_LOG_FILE"
+        unit="loongsuite-pilot-updater.service"
+        sys_unit="loongsuite-pilot-updater-${target_user}.service"
+        label="$UPDATER_LABEL"
+    else
+        pid_file="$PID_FILE"
+        log_file="$LOG_FILE"
+        unit="loongsuite-pilot.service"
+        sys_unit="loongsuite-pilot-${target_user}.service"
+        label="$SERVICE_LABEL"
+    fi
+
+    echo "os=$(uname -s)"
+    echo "user=$target_user"
+
+    local pid
+    if [ -f "$pid_file" ]; then
+        pid=$(cat "$pid_file" 2>/dev/null | tr -d '[:space:]')
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            echo "pid_state=pid=$pid running"
+        else
+            echo "pid_state=pid=$pid not running"
+        fi
+    else
+        echo "pid_state=no pid file"
+    fi
+
+    case "$(uname -s)" in
+        Darwin)
+            if launchctl list "$label" >/dev/null 2>&1; then
+                echo "service_state=$label loaded"
+            else
+                echo "service_state=$label not loaded"
+            fi
+            # `|| true` on every probe: this file runs under `set -euo pipefail`, and a
+            # grep that finds nothing would otherwise abort the collection halfway and
+            # throw away the facts that come after it.
+            local last_exit
+            last_exit=$(launchctl list "$label" 2>/dev/null | grep LastExitStatus | tr -dc '0-9-') || true
+            [ -n "$last_exit" ] && echo "last_exit_status=$last_exit" || true
+            ;;
+        Linux)
+            if command -v systemctl >/dev/null 2>&1; then
+                echo "unit_state=user active=$(systemctl --user is-active "$unit" 2>&1 | head -1) enabled=$(systemctl --user is-enabled "$unit" 2>&1 | head -1)"
+                echo "system_unit_state=active=$(maybe_sudo_n systemctl is-active "$sys_unit" 2>&1 | head -1) enabled=$(maybe_sudo_n systemctl is-enabled "$sys_unit" 2>&1 | head -1)"
+                echo "unit_result=$(systemctl --user show -p Result -p ExecMainStatus "$unit" 2>/dev/null | tr '\n' ' ')"
+            else
+                echo "unit_state=systemctl not available"
+            fi
+            if [ -f "$HOME/.config/systemd/user/$unit" ]; then
+                echo "unit_file=$HOME/.config/systemd/user/$unit"
+            elif [ -f "$SYSTEMD_SYSTEM_UNIT_DIR/$sys_unit" ]; then
+                echo "unit_file=$SYSTEMD_SYSTEM_UNIT_DIR/$sys_unit"
+            else
+                echo "unit_file=none found"
+            fi
+            ;;
+    esac
+
+    local node_bin
+    node_bin=$(resolve_node 2>/dev/null) || node_bin=""
+    if [ -n "$node_bin" ]; then
+        echo "node_bin=$node_bin"
+    else
+        echo "node_bin=not found"
+    fi
+
+    if [ -f "$log_file" ]; then
+        echo "log_tail=$(tail -n 3 "$log_file" 2>/dev/null | tr '\n\r\t' '   ' | cut -c1-300)"
+    fi
+}
+
+# write_restart_failure <target> <stage> <detail> [extra key=value ...]
+#
+# Prints everything to stderr first (the caller surfaces stderr in its error message)
+# and only then writes the file, so a write failure cannot cost us the diagnosis. The
+# whole body is best-effort: diagnostics must never become a new failure source.
+write_restart_failure() {
+    local target="$1"
+    local stage="$2"
+    local detail="$3"
+    shift 3
+
+    local init_type
+    init_type=$(read_init_type)
+
+    local diag_lines extra
+    diag_lines=$(collect_restart_diag "$target" 2>/dev/null || true)
+    for extra in "$@"; do
+        [ -n "$extra" ] && diag_lines="$diag_lines
+$extra" || true
+    done
+
+    echo "[restart-failure] target=$target stage=$stage init_type=$init_type" >&2
+    [ -n "$detail" ] && echo "[restart-failure] reason=$detail" >&2 || true
+    printf '%s\n' "$diag_lines" | while IFS= read -r line; do
+        [ -n "$line" ] && echo "[restart-failure] $line" >&2 || true
+    done
+
+    ensure_dirs 2>/dev/null || true
+    local file tmp key value first
+    file=$(restart_failure_file "$target")
+    tmp="$file.tmp"
+    first=1
+    {
+        printf '{\n'
+        printf '  "schema": 1,\n'
+        printf '  "ts": %s,\n' "$(date -u +%s)"
+        printf '  "target": "%s",\n' "$(json_escape "$target")"
+        printf '  "stage": "%s",\n' "$(json_escape "$stage")"
+        printf '  "init_type": "%s",\n' "$(json_escape "$init_type")"
+        printf '  "detail": "%s",\n' "$(json_escape "$detail")"
+        printf '  "diag": {\n'
+        while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            key="${line%%=*}"
+            value="${line#*=}"
+            [ -z "$key" ] && continue
+            if [ "$first" -eq 1 ]; then first=0; else printf ',\n'; fi
+            printf '    "%s": "%s"' "$(json_escape "$key")" "$(json_escape "$value")"
+        done <<EOF
+$diag_lines
+EOF
+        printf '\n  }\n}\n'
+    } > "$tmp" 2>/dev/null && mv -f "$tmp" "$file" 2>/dev/null || true
+}
+
+# Bounded waits, replacing a single check one second after asking the service manager to
+# start: one second is not always enough for node to publish its pid file, and a false
+# "not running" verdict used to end in an unexplained restart failure.
+wait_for_collector_process() {
+    local timeout="${1:-15}"
+    local i=0
+    while [ "$i" -lt "$timeout" ]; do
+        if is_running >/dev/null 2>&1; then return 0; fi
+        sleep 1
+        i=$((i + 1))
+    done
+    return 1
+}
+
+wait_for_updater_process() {
+    local timeout="${1:-15}"
+    local i=0
+    local pid=""
+    while [ "$i" -lt "$timeout" ]; do
+        # Scoped to this install, unlike the shared liveness probe below, which ends in a
+        # machine-wide `pgrep -f loongsuite-pilot/bin/updater-daemon`: another data dir's
+        # daemon would confirm a restart that never happened. Measured -- a scratch-HOME run
+        # whose registration silently did nothing still reported "self-healed", because the
+        # real updater of this account was running. find_current_user_processes matches this
+        # install's exact bootstrap path, so it cannot be fooled that way.
+        pid=$(find_current_user_processes updater | head -n 1 || true)
+        if [ -z "$pid" ]; then
+            pid=$(find_current_user_processes updater-wrapper | head -n 1 || true)
+        fi
+        if [ -n "$pid" ]; then return 0; fi
+        sleep 1
+        i=$((i + 1))
+    done
+    return 1
+}
+
 sync_bootstrap_scripts() {
     local version_dir
     version_dir=$(resolve_current_version 2>/dev/null) || true
@@ -789,106 +996,150 @@ cmd_stop() {
     echo "✅ loongsuite-pilot stopped"
 }
 
-# Start the collector without stopping or scanning for existing processes. This
-# is intentionally separate from restart-collector so the updater can recover
-# after a timed-out restart that already stopped the managed service.
 start_collector_after_stop() {
     local target_user
     target_user=$(whoami)
     local sys_unit="loongsuite-pilot-${target_user}.service"
     local initd_script="/etc/init.d/loongsuite-pilot-${target_user}"
-    local init_type=""
-    if [ -f "$INIT_TYPE_FILE" ]; then
-        init_type=$(cat "$INIT_TYPE_FILE" 2>/dev/null | tr -d '[:space:]')
-    fi
+    local init_type
+    init_type=$(read_init_type)
+    # Narrowed as the ladder proceeds so the exit names a cause.
+    local _stage="service-manager-refused"
+    local _detail="no restart path succeeded"
+    local _err=""
 
     ensure_dirs
     sync_bootstrap_scripts
 
-    local _started=false
+    local _restarted=false
     case "$(uname -s)" in
         Darwin)
             if launchctl list "$SERVICE_LABEL" &>/dev/null; then
                 launchctl start "$SERVICE_LABEL" 2>/dev/null || true
                 echo "✅ collector started (launchd)"
-                _started=true
+                _restarted=true
+            else
+                _stage="task-missing"
+                _detail="launchd job $SERVICE_LABEL is not loaded"
+                echo "⚠️  launchd job not loaded: $SERVICE_LABEL" >&2
             fi
             ;;
         Linux)
             case "$init_type" in
                 systemd-user)
                     if systemctl --user is-enabled loongsuite-pilot.service &>/dev/null; then
-                        systemctl --user start loongsuite-pilot.service &>/dev/null
-                        echo "✅ collector started (systemd user-level)"
-                        _started=true
+                        if _err=$(systemctl --user start loongsuite-pilot.service 2>&1); then
+                            echo "✅ collector started (systemd user-level)"
+                            _restarted=true
+                        else
+                            _stage="start-failed"
+                            _detail="systemctl --user start failed: $_err"
+                            echo "❌ systemctl --user start failed: $_err" >&2
+                        fi
+                    else
+                        _stage="task-missing"
+                        _detail="systemd user unit loongsuite-pilot.service is not enabled"
+                        echo "⚠️  systemd user unit not enabled: loongsuite-pilot.service" >&2
                     fi
                     ;;
                 systemd-system|systemd)
                     if [ -f "$SYSTEMD_SYSTEM_UNIT_DIR/$sys_unit" ] && maybe_sudo_n systemctl is-enabled "$sys_unit" &>/dev/null; then
-                        maybe_sudo systemctl start "$sys_unit" &>/dev/null
-                        echo "✅ collector started (systemd system-level)"
-                        _started=true
+                        if _err=$(maybe_sudo systemctl start "$sys_unit" 2>&1); then
+                            echo "✅ collector started (systemd system-level)"
+                            _restarted=true
+                        else
+                            _stage="start-failed"
+                            _detail="systemctl start $sys_unit failed: $_err"
+                            echo "❌ systemctl start $sys_unit failed: $_err" >&2
+                        fi
+                    else
+                        _stage="task-missing"
+                        _detail="system unit $sys_unit is missing or not enabled"
+                        echo "⚠️  system unit missing or not enabled: $sys_unit" >&2
                     fi
                     ;;
                 initd)
                     if [ -f "$initd_script" ]; then
                         maybe_sudo "$initd_script" start &>/dev/null
                         echo "✅ collector started (init.d)"
-                        _started=true
+                        _restarted=true
+                    else
+                        _stage="task-missing"
+                        _detail="init.d script $initd_script does not exist"
+                        echo "⚠️  init.d script missing: $initd_script" >&2
                     fi
+                    ;;
+                *)
+                    _stage="task-missing"
+                    _detail="no service manager registration for init_type=$init_type"
                     ;;
             esac
             ;;
     esac
-    if [ "$_started" = true ]; then
-        sleep 1
-        if ! is_running; then
-            echo "⚠️  service manager reported success but collector process not found"
-            _started=false
+    if [ "$_restarted" = true ]; then
+        if ! wait_for_collector_process 20; then
+            _stage="not-running-after-start"
+            _detail="service manager reported success but no collector process appeared within 20s"
+            echo "⚠️  service manager reported success but collector process not found" >&2
+            _restarted=false
         fi
     fi
-    if [ "$_started" = false ]; then
-        # Self-healing: try to register a proper service for degraded (nohup/unknown) installs
+    if [ "$_restarted" = false ]; then
+        # Self-heal, no longer gated on init_type -- see cmd_restart_updater.
+        local _new_init
+        _new_init=$(detect_init_system "false")
+        if [ "$_new_init" = "none" ]; then
+            _stage="selfheal-register-failed"
+            _detail="no usable init system detected for self-heal"
+            echo "⚠️  self-heal skipped: no usable init system detected" >&2
+        elif autostart_install_collector_only "false" 2>>"$LOG_FILE"; then
+            if wait_for_collector_process 20; then
+                echo "✅ collector self-healed: registered as $_new_init"
+                _restarted=true
+            else
+                _stage="selfheal-not-running"
+                _detail="self-heal registered ($_new_init) but no collector process appeared within 20s"
+                echo "⚠️  collector self-heal registered ($_new_init) but process not found" >&2
+            fi
+        else
+            _stage="selfheal-register-failed"
+            _detail="autostart_install_collector_only failed for $_new_init (details in $LOG_FILE)"
+            echo "❌ collector self-heal registration failed ($_new_init)" >&2
+        fi
+    fi
+    if [ "$_restarted" = false ]; then
         case "$init_type" in
             nohup|unknown|"")
-                local _new_init
-                _new_init=$(detect_init_system "false")
-                if [ "$_new_init" != "none" ]; then
-                    if autostart_install_collector_only "false" 2>>"$LOG_FILE"; then
-                        sleep 1
-                        if is_running; then
-                            echo "✅ collector self-healed: registered as $_new_init"
-                            _started=true
-                        else
-                            echo "⚠️  collector self-heal registered ($_new_init) but process not found" >&2
-                        fi
-                    fi
+                local entry="$BOOTSTRAP_DIR/collector-daemon.js"
+                if [ ! -f "$entry" ]; then
+                    write_restart_failure collector "bootstrap-missing" \
+                        "collector-daemon.js not found at $entry"
+                    echo "❌ Bootstrap script missing" >&2
+                    return 1
                 fi
-                if [ "$_started" = false ]; then
-                    local entry="$BOOTSTRAP_DIR/collector-daemon.js"
-                    if [ ! -f "$entry" ]; then
-                        echo "❌ Bootstrap script missing"
-                        return 1
-                    fi
-                    local node_bin
-                    node_bin=$(resolve_node) || {
-                        echo "❌ node runtime not found" >&2
-                        return 1
-                    }
-                    export AGENT_DATA_COLLECTION_CONFIG="$CONFIG_FILE"
-                    nohup "$node_bin" "$entry" >> "$LOG_FILE" 2>&1 &
-                    echo "$!" > "$PID_FILE"
-                    echo "⚠️  collector started (nohup fallback, self-heal failed)"
-                fi
+                local node_bin
+                node_bin=$(resolve_node) || {
+                    write_restart_failure collector "node-missing" \
+                        "resolve_node found no usable node runtime (needs v18+)"
+                    echo "❌ node runtime not found" >&2
+                    return 1
+                }
+                export AGENT_DATA_COLLECTION_CONFIG="$CONFIG_FILE"
+                nohup "$node_bin" "$entry" >> "$LOG_FILE" 2>&1 &
+                echo "$!" > "$PID_FILE"
+                echo "⚠️  collector started (nohup fallback after stage=$_stage: $_detail)" >&2
                 ;;
             *)
-                echo "❌ Service manager failed to start collector (init_type=$init_type)" >&2
+                write_restart_failure collector "$_stage" "$_detail"
+                echo "❌ Service manager failed to start collector (init_type=$init_type stage=$_stage): $_detail" >&2
                 return 1
                 ;;
         esac
     fi
 
-    if ! is_running; then
+    if ! wait_for_collector_process 10; then
+        write_restart_failure collector "not-running-after-start" \
+            "no collector process found after the start sequence completed (stage reached: $_stage)"
         echo "❌ collector process not found after start" >&2
         return 1
     fi
@@ -916,11 +1167,13 @@ schedule_updater_restart() {
 
 # Restart only the collector (used by updater after deploying a new version)
 cmd_restart_collector() {
+    clear_restart_failure collector
     cleanup_legacy_monitor_processes
     local defer_updater_restart=false
     if [ "${1:-}" = "--defer-updater-restart" ]; then
         defer_updater_restart=true
     elif [ -n "${1:-}" ]; then
+        write_restart_failure collector "service-manager-refused"             "Unknown restart-collector option: $1"
         echo "Unknown restart-collector option: $1" >&2
         return 1
     fi
@@ -965,6 +1218,9 @@ cmd_restart_collector() {
 }
 
 cmd_restart_updater() {
+    # Any breadcrumb still on disk describes an older attempt.
+    clear_restart_failure updater
+
     local target_user
     target_user=$(whoami)
     local sys_unit="loongsuite-pilot-updater-${target_user}.service"
@@ -973,6 +1229,11 @@ cmd_restart_updater() {
     if [ -f "$INIT_TYPE_FILE" ]; then
         init_type=$(cat "$INIT_TYPE_FILE" 2>/dev/null | tr -d '[:space:]')
     fi
+    # Most specific thing learned so far, so the exit at the bottom can name a cause
+    # instead of only echoing init_type. Narrowed as the ladder proceeds.
+    local _stage="service-manager-refused"
+    local _detail="no restart path succeeded"
+    local _err=""
 
     # Stop updater via service manager
     case "$(uname -s)" in
@@ -1008,22 +1269,46 @@ cmd_restart_updater() {
             if launchctl list "$UPDATER_LABEL" &>/dev/null; then
                 launchctl start "$UPDATER_LABEL" 2>/dev/null || true
                 _restarted=true
+            else
+                # Used to fall through in silence, leaving the caller with nothing but the
+                # generic "service manager failed" line.
+                _stage="task-missing"
+                _detail="launchd job $UPDATER_LABEL is not loaded"
+                echo "⚠️  launchd job not loaded: $UPDATER_LABEL" >&2
             fi
             ;;
         Linux)
             case "$init_type" in
                 systemd-user)
                     if systemctl --user is-enabled loongsuite-pilot-updater.service &>/dev/null; then
-                        systemctl --user start loongsuite-pilot-updater.service &>/dev/null
-                        echo "✅ updater restarted (systemd user-level)"
-                        _restarted=true
+                        if _err=$(systemctl --user start loongsuite-pilot-updater.service 2>&1); then
+                            echo "✅ updater restarted (systemd user-level)"
+                            _restarted=true
+                        else
+                            _stage="start-failed"
+                            _detail="systemctl --user start failed: $_err"
+                            echo "❌ systemctl --user start failed: $_err" >&2
+                        fi
+                    else
+                        _stage="task-missing"
+                        _detail="systemd user unit loongsuite-pilot-updater.service is not enabled"
+                        echo "⚠️  systemd user unit not enabled: loongsuite-pilot-updater.service" >&2
                     fi
                     ;;
                 systemd-system|systemd)
                     if [ -f "$SYSTEMD_SYSTEM_UNIT_DIR/$sys_unit" ] && maybe_sudo_n systemctl is-enabled "$sys_unit" &>/dev/null; then
-                        maybe_sudo systemctl start "$sys_unit" &>/dev/null
-                        echo "✅ updater restarted (systemd system-level)"
-                        _restarted=true
+                        if _err=$(maybe_sudo systemctl start "$sys_unit" 2>&1); then
+                            echo "✅ updater restarted (systemd system-level)"
+                            _restarted=true
+                        else
+                            _stage="start-failed"
+                            _detail="systemctl start $sys_unit failed: $_err"
+                            echo "❌ systemctl start $sys_unit failed: $_err" >&2
+                        fi
+                    else
+                        _stage="task-missing"
+                        _detail="system unit $sys_unit is missing or not enabled"
+                        echo "⚠️  system unit missing or not enabled: $sys_unit" >&2
                     fi
                     ;;
                 initd)
@@ -1031,61 +1316,90 @@ cmd_restart_updater() {
                         maybe_sudo "$initd_script" start &>/dev/null
                         echo "✅ updater restarted (init.d)"
                         _restarted=true
+                    else
+                        _stage="task-missing"
+                        _detail="init.d script $initd_script does not exist"
+                        echo "⚠️  init.d script missing: $initd_script" >&2
                     fi
+                    ;;
+                *)
+                    _stage="task-missing"
+                    _detail="no service manager registration for init_type=$init_type"
                     ;;
             esac
             ;;
     esac
-    # Verify the service manager actually started the updater process
+    # Verify the service manager actually started the updater process. Bounded poll
+    # instead of a single check after one second.
     if [ "$_restarted" = true ]; then
-        sleep 1
-        if ! updater_process_exists; then
-            echo "⚠️  service manager reported success but updater process not found"
+        if ! wait_for_updater_process 15; then
+            _stage="not-running-after-start"
+            _detail="service manager reported success but no updater process appeared within 15s"
+            echo "⚠️  service manager reported success but updater process not found" >&2
             _restarted=false
         fi
     fi
     if [ "$_restarted" = false ]; then
-        # Self-healing: try to register a proper service for degraded installs
+        # Self-heal, no longer gated on init_type (same change as in loongsuite-pilot.ps1):
+        # a systemd install whose unit had gone missing was not allowed to re-register
+        # itself and could only reach the failure exit below, every cycle, forever.
+        local _new_init
+        _new_init=$(detect_init_system "false")
+        if [ "$_new_init" = "none" ]; then
+            _stage="selfheal-register-failed"
+            _detail="no usable init system detected for self-heal"
+            echo "⚠️  self-heal skipped: no usable init system detected" >&2
+        elif autostart_install_updater_only "false" 2>>"$UPDATER_LOG_FILE"; then
+            if wait_for_updater_process 15; then
+                echo "✅ updater self-healed: registered as $_new_init"
+                _restarted=true
+            else
+                _stage="selfheal-not-running"
+                _detail="self-heal registered ($_new_init) but no updater process appeared within 15s"
+                echo "⚠️  updater self-heal registered ($_new_init) but process not found" >&2
+            fi
+        else
+            _stage="selfheal-register-failed"
+            _detail="autostart_install_updater_only failed for $_new_init (details in $UPDATER_LOG_FILE)"
+            echo "❌ updater self-heal registration failed ($_new_init)" >&2
+        fi
+    fi
+    if [ "$_restarted" = false ]; then
         case "$init_type" in
             nohup|unknown|"")
-                local _new_init
-                _new_init=$(detect_init_system "false")
-                if [ "$_new_init" != "none" ]; then
-                    if autostart_install_updater_only "false" 2>>"$UPDATER_LOG_FILE"; then
-                        sleep 1
-                        if updater_process_exists; then
-                            echo "✅ updater self-healed: registered as $_new_init"
-                            _restarted=true
-                        else
-                            echo "⚠️  updater self-heal registered ($_new_init) but process not found" >&2
-                        fi
-                    fi
+                local entry="$BOOTSTRAP_DIR/updater-daemon.js"
+                if [ ! -f "$entry" ]; then
+                    write_restart_failure updater "bootstrap-missing" \
+                        "updater-daemon.js not found at $entry"
+                    echo "❌ Updater bootstrap script missing" >&2
+                    return 1
                 fi
-                if [ "$_restarted" = false ]; then
-                    local entry="$BOOTSTRAP_DIR/updater-daemon.js"
-                    if [ ! -f "$entry" ]; then
-                        echo "❌ Updater bootstrap script missing"
-                        return 1
-                    fi
-                    local node_bin
-                    node_bin=$(resolve_node) || {
-                        echo "❌ node runtime not found" >&2
-                        return 1
-                    }
-                    export AGENT_DATA_COLLECTION_CONFIG="$CONFIG_FILE"
-                    nohup "$node_bin" "$entry" >> "$UPDATER_LOG_FILE" 2>&1 &
-                    echo "$!" > "$UPDATER_PID_FILE"
-                    echo "⚠️  updater restarted (nohup fallback, self-heal failed)"
-                fi
+                local node_bin
+                node_bin=$(resolve_node) || {
+                    write_restart_failure updater "node-missing" \
+                        "resolve_node found no usable node runtime (needs v18+)"
+                    echo "❌ node runtime not found" >&2
+                    return 1
+                }
+                export AGENT_DATA_COLLECTION_CONFIG="$CONFIG_FILE"
+                nohup "$node_bin" "$entry" >> "$UPDATER_LOG_FILE" 2>&1 &
+                echo "$!" > "$UPDATER_PID_FILE"
+                echo "⚠️  updater restarted (nohup fallback after stage=$_stage: $_detail)" >&2
                 ;;
             *)
-                echo "❌ Service manager failed to restart updater (init_type=$init_type)" >&2
+                # The nohup fallback stays restricted to installs that never had a service
+                # registration -- on a managed install it is a second unmanaged daemon that
+                # hides the real breakage rather than a repair. Skipping it is now reported.
+                write_restart_failure updater "$_stage" "$_detail"
+                echo "❌ Service manager failed to restart updater (init_type=$init_type stage=$_stage): $_detail" >&2
                 return 1
                 ;;
         esac
     fi
 
-    if ! updater_process_exists; then
+    if ! wait_for_updater_process 10; then
+        write_restart_failure updater "not-running-after-start" \
+            "no updater process found after the restart sequence completed (stage reached: $_stage)"
         echo "❌ updater process not found after restart" >&2
         return 1
     fi

--- a/scripts/loongsuite-pilot.sh
+++ b/scripts/loongsuite-pilot.sh
@@ -257,11 +257,25 @@ EOF
 # Bounded waits, replacing a single check one second after asking the service manager to
 # start: one second is not always enough for node to publish its pid file, and a false
 # "not running" verdict used to end in an unexplained restart failure.
+#
+# Read-only: is_running deletes a pid file whose cmdline has not yet become
+# collector-daemon.js, and wait would then fire that up to timeout times. Probe with
+# kill -0 / process_matches_installed_entry; stale-pid cleanup stays in stop/status.
 wait_for_collector_process() {
     local timeout="${1:-15}"
     local i=0
+    local pid=""
     while [ "$i" -lt "$timeout" ]; do
-        if is_running >/dev/null 2>&1; then return 0; fi
+        if [ -f "$PID_FILE" ]; then
+            pid=$(cat "$PID_FILE" 2>/dev/null || true)
+            if process_matches_installed_entry "$pid" collector; then
+                return 0
+            fi
+        fi
+        pid=$(find_installed_collector_pid)
+        if process_matches_installed_entry "$pid" collector; then
+            return 0
+        fi
         sleep 1
         i=$((i + 1))
     done
@@ -270,6 +284,7 @@ wait_for_collector_process() {
 
 wait_for_updater_process() {
     local timeout="${1:-15}"
+    local exclude_pid="${2:-}"
     local i=0
     local pid=""
     while [ "$i" -lt "$timeout" ]; do
@@ -279,11 +294,13 @@ wait_for_updater_process() {
         # whose registration silently did nothing still reported "self-healed", because the
         # real updater of this account was running. find_current_user_processes matches this
         # install's exact bootstrap path, so it cannot be fooled that way.
+        # exclude_pid is the process that was alive before stop: SIGTERM may not have
+        # finished, and accepting that pid would report a successful restart of the old one.
         pid=$(find_current_user_processes updater | head -n 1 || true)
         if [ -z "$pid" ]; then
             pid=$(find_current_user_processes updater-wrapper | head -n 1 || true)
         fi
-        if [ -n "$pid" ]; then return 0; fi
+        if [ -n "$pid" ] && [ "$pid" != "$exclude_pid" ]; then return 0; fi
         sleep 1
         i=$((i + 1))
     done
@@ -507,13 +524,37 @@ stop_installed_collector_processes() {
 stop_installed_updater_processes() {
     local pid
     local kind
+    local pids=""
     while read -r pid kind; do
         [ -n "$pid" ] || continue
-        process_matches_installed_entry "$pid" "$kind" && kill "$pid" 2>/dev/null || true
+        if process_matches_installed_entry "$pid" "$kind"; then
+            kill "$pid" 2>/dev/null || true
+            pids="$pids $pid"
+        fi
     done < <({
         find_current_user_processes updater-wrapper | while read -r pid; do echo "$pid updater-wrapper"; done
         find_current_user_processes updater | while read -r pid; do echo "$pid updater"; done
     } | sort -u)
+
+    [ -n "$pids" ] || return 0
+
+    local count=0
+    local still
+    local p
+    while [ "$count" -lt 10 ]; do
+        still=false
+        for p in $pids; do
+            if kill -0 "$p" 2>/dev/null; then
+                still=true
+            fi
+        done
+        [ "$still" = true ] || return 0
+        sleep 1
+        count=$((count + 1))
+    done
+    for p in $pids; do
+        kill -9 "$p" 2>/dev/null || true
+    done
 }
 
 is_pid_file_running() {
@@ -1093,6 +1134,9 @@ start_collector_after_stop() {
             _detail="no usable init system detected for self-heal"
             echo "⚠️  self-heal skipped: no usable init system detected" >&2
         elif autostart_install_collector_only "false" 2>>"$LOG_FILE"; then
+            # Registration succeeded: remember the managed type in-memory so a wait
+            # failure cannot fall through to nohup and start a second unmanaged daemon.
+            init_type="$_new_init"
             if wait_for_collector_process 20; then
                 echo "✅ collector self-healed: registered as $_new_init"
                 _restarted=true
@@ -1235,6 +1279,12 @@ cmd_restart_updater() {
     local _detail="no restart path succeeded"
     local _err=""
 
+    local _old_pid=""
+    _old_pid=$(find_current_user_processes updater | head -n 1 || true)
+    if [ -z "$_old_pid" ]; then
+        _old_pid=$(find_current_user_processes updater-wrapper | head -n 1 || true)
+    fi
+
     # Stop updater via service manager
     case "$(uname -s)" in
         Darwin)
@@ -1332,7 +1382,7 @@ cmd_restart_updater() {
     # Verify the service manager actually started the updater process. Bounded poll
     # instead of a single check after one second.
     if [ "$_restarted" = true ]; then
-        if ! wait_for_updater_process 15; then
+        if ! wait_for_updater_process 15 "$_old_pid"; then
             _stage="not-running-after-start"
             _detail="service manager reported success but no updater process appeared within 15s"
             echo "⚠️  service manager reported success but updater process not found" >&2
@@ -1350,7 +1400,8 @@ cmd_restart_updater() {
             _detail="no usable init system detected for self-heal"
             echo "⚠️  self-heal skipped: no usable init system detected" >&2
         elif autostart_install_updater_only "false" 2>>"$UPDATER_LOG_FILE"; then
-            if wait_for_updater_process 15; then
+            init_type="$_new_init"
+            if wait_for_updater_process 15 "$_old_pid"; then
                 echo "✅ updater self-healed: registered as $_new_init"
                 _restarted=true
             else
@@ -1397,7 +1448,7 @@ cmd_restart_updater() {
         esac
     fi
 
-    if ! wait_for_updater_process 10; then
+    if ! wait_for_updater_process 10 "$_old_pid"; then
         write_restart_failure updater "not-running-after-start" \
             "no updater process found after the restart sequence completed (stage reached: $_stage)"
         echo "❌ updater process not found after restart" >&2

--- a/src/core/updater-watchdog.ts
+++ b/src/core/updater-watchdog.ts
@@ -8,6 +8,14 @@ import { readJsonFile } from '../utils/fs-utils.js';
 import { createLogger } from '../utils/logger.js';
 import { checkProcessLiveness, UPDATER_PROCESS_PATTERNS } from '../utils/pid-utils.js';
 import type { ProcessLiveness } from '../utils/pid-utils.js';
+import {
+  describeRestartCommandError,
+  isRestartCommandTimeout,
+  isRestartFailureFresh,
+  readRestartFailure,
+  sanitizeAlarmText,
+  summarizeRestartFailure,
+} from '../utils/restart-breadcrumb.js';
 import { updaterRuntimePath, type UpdaterRuntimeState } from '../updater/runtime-state.js';
 
 const execFileAsync = promisify(execFile);
@@ -18,7 +26,19 @@ const DEFAULT_STALE_HEARTBEAT_MS = 3 * 60_000;
 const DEFAULT_STARTUP_GRACE_MS = 3 * 60_000;
 const DEFAULT_SLEEP_WAKE_GRACE_MS = 3 * 60_000;
 const DEFAULT_RESTART_COOLDOWN_MS = 10 * 60_000;
-const COMMAND_TIMEOUT_MS = 30_000;
+
+// The service script now waits for the restarted process to actually come up (bounded
+// polls of up to ~20s per path, and it may try several paths in a row) instead of
+// sleeping one second and guessing. A 30s cap would kill it mid-diagnosis and destroy
+// the very evidence this watchdog reports, so the cap sits well above the script's own
+// worst case and exists only to stop a wedged child from pinning the timer forever.
+const COMMAND_TIMEOUT_MS = 90_000;
+
+// How far back a breadcrumb still explains "the updater is not running now". Bounded so
+// a months-old failure never gets attached to today's alarm; generous enough to cover
+// the restart cooldown, during which no new attempt is made and the previous failure is
+// still the live explanation.
+const RECENT_RESTART_FAILURE_MS = 30 * 60_000;
 
 function homeDir(): string {
   return process.env.HOME ?? process.env.USERPROFILE ?? os.homedir();
@@ -99,6 +119,7 @@ export class UpdaterWatchdog {
   private lastTickAt = 0;
   private sleepWakeGraceUntil = 0;
   private lastRestartAt = 0;
+  private checking = false;
 
   constructor(opts: UpdaterWatchdogOptions) {
     this.enabled = opts.enabled;
@@ -144,7 +165,20 @@ export class UpdaterWatchdog {
   async runCheck(): Promise<UpdaterWatchdogResult> {
     if (!this.enabled) return { status: 'disabled' };
     if (isAgentShellCurrentVersion(this.dataDir)) return { status: 'disabled' };
+    // 90s command timeout vs 60s tick: without this, an overlapping runCheck records
+    // SERVICE_NOT_RUNNING_ALARM (no breadcrumb yet) then hits cooldown.
+    if (this.checking) {
+      return { status: 'restart-rate-limited', reason: 'check already in flight', restarted: false };
+    }
+    this.checking = true;
+    try {
+      return await this.runCheckLocked();
+    } finally {
+      this.checking = false;
+    }
+  }
 
+  private async runCheckLocked(): Promise<UpdaterWatchdogResult> {
     const now = Date.now();
     if (this.lastTickAt > 0 && now - this.lastTickAt > this.intervalMs + this.sleepWakeGraceMs) {
       this.sleepWakeGraceUntil = now + this.sleepWakeGraceMs;
@@ -167,7 +201,7 @@ export class UpdaterWatchdog {
       // survive the suspend, and Task Scheduler's own repeating trigger will bring the
       // updater back within the window without help.
       if (this.inGraceWindow(now)) return { status: 'grace', reason: processState.reason };
-      this.recordServiceAlarm(processState.reason);
+      this.recordServiceAlarm(await this.withLastRestartFailure(processState.reason));
       return this.restart('missing-process', processState.reason);
     }
 
@@ -178,7 +212,7 @@ export class UpdaterWatchdog {
       // snapshot of a handover, not a broken updater. The alarm has to stay behind the
       // check too -- an alarm raised on every install is noise that hides the real ones.
       if (this.inGraceWindow(now)) return { status: 'grace', reason };
-      this.recordFailureAlarm(reason);
+      this.recordFailureAlarm(await this.withLastRestartFailure(reason));
       return this.restart('command-mismatch', reason);
     }
 
@@ -186,14 +220,14 @@ export class UpdaterWatchdog {
     if (!heartbeat) {
       const reason = 'updater heartbeat is missing';
       if (this.inGraceWindow(now)) return { status: 'grace', reason };
-      this.recordFailureAlarm(reason);
+      this.recordFailureAlarm(await this.withLastRestartFailure(reason));
       return this.restart('missing-heartbeat', reason);
     }
 
     if (processState.pid !== undefined && heartbeat.pid !== processState.pid && process.platform !== 'win32') {
       const reason = `updater heartbeat pid ${heartbeat.pid} does not match running pid ${processState.pid}`;
       if (this.inGraceWindow(now)) return { status: 'grace', reason };
-      this.recordFailureAlarm(reason);
+      this.recordFailureAlarm(await this.withLastRestartFailure(reason));
       return this.restart('pid-mismatch', reason);
     }
 
@@ -201,7 +235,7 @@ export class UpdaterWatchdog {
     if (!Number.isFinite(heartbeatAt) || now - heartbeatAt > this.staleHeartbeatMs) {
       const reason = 'updater heartbeat is stale';
       if (this.inGraceWindow(now)) return { status: 'grace', reason };
-      this.recordFailureAlarm(reason);
+      this.recordFailureAlarm(await this.withLastRestartFailure(reason));
       return this.restart('stale-heartbeat', reason);
     }
 
@@ -251,9 +285,10 @@ export class UpdaterWatchdog {
     }
 
     this.lastRestartAt = now;
+    const attemptStartedAt = now;
     try {
-      if (process.platform === 'win32') {
-        await execFileAsync('powershell.exe', [
+      const result = process.platform === 'win32'
+        ? await execFileAsync('powershell.exe', [
           '-NoProfile',
           '-ExecutionPolicy',
           'Bypass',
@@ -263,20 +298,70 @@ export class UpdaterWatchdog {
         ], {
           timeout: COMMAND_TIMEOUT_MS,
           windowsHide: true,
-        });
-      } else {
-        await execFileAsync(this.loongsuitePilotBin, ['restart-updater'], {
+        })
+        : await execFileAsync(this.loongsuitePilotBin, ['restart-updater'], {
           timeout: COMMAND_TIMEOUT_MS,
         });
-      }
-      logger.warn('updater-watchdog requested updater restart', { status, reason });
+      // Even a successful restart is worth its transcript: the script reports which
+      // recovery path it had to take (plain start, re-register, self-heal), and a
+      // non-empty stderr on a zero exit means a non-terminating error was written.
+      logger.warn('updater-watchdog requested updater restart', {
+        status,
+        reason,
+        stdout: sanitizeAlarmText(result.stdout ?? '', 1_000),
+        stderr: sanitizeAlarmText(result.stderr ?? '', 1_000),
+      });
       return { status: 'restart-attempted', reason, restarted: true };
     } catch (err) {
-      const message = `updater restart command failed: ${String(err)}`;
+      const detail = describeRestartCommandError(err);
+      // Freshness matters more than presence: a script that never ran (powershell.exe
+      // missing, child killed before its first statement) would otherwise be "explained"
+      // by whatever the previous attempt left on disk.
+      const breadcrumb = await this.readRestartFailure(attemptStartedAt);
+      const diagnosis = breadcrumb
+        ? summarizeRestartFailure(breadcrumb)
+        : isRestartCommandTimeout(err)
+          ? 'stage=timeout reason="restart command killed by timeout before it reported a stage"'
+          : 'stage=unknown reason="restart command left no diagnostics"';
+      const message = `updater restart command failed: ${detail} | ${diagnosis}`;
       this.recordFailureAlarm(message);
-      logger.error('updater-watchdog restart failed', { reason, error: String(err) });
+      logger.error('updater-watchdog restart failed', {
+        reason,
+        error: detail,
+        stage: breadcrumb?.stage ?? (isRestartCommandTimeout(err) ? 'timeout' : 'unknown'),
+        initType: breadcrumb?.init_type,
+        diag: breadcrumb?.diag,
+      });
       return { status: 'restart-failed', reason: message, restarted: false };
     }
+  }
+
+  /**
+   * The breadcrumb left by the service script, when it belongs to an attempt no older
+   * than `notBeforeMs`. Never throws: diagnostics must not be able to break recovery.
+   */
+  private async readRestartFailure(notBeforeMs: number) {
+    try {
+      const breadcrumb = await readRestartFailure(this.dataDir, 'updater');
+      if (!breadcrumb || !isRestartFailureFresh(breadcrumb, notBeforeMs)) return null;
+      return breadcrumb;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Appends why the last restart attempt failed, if one did recently.
+   *
+   * These alarms fire *before* this tick's restart, so the newest evidence available is
+   * the previous attempt's breadcrumb — and when the cooldown is suppressing retries,
+   * that breadcrumb is the live explanation for the updater still being down.
+   */
+  private async withLastRestartFailure(message: string): Promise<string> {
+    const breadcrumb = await this.readRestartFailure(Date.now() - RECENT_RESTART_FAILURE_MS);
+    return breadcrumb
+      ? `${message} | last_restart_failure: ${summarizeRestartFailure(breadcrumb)}`
+      : message;
   }
 
   private recordServiceAlarm(message: string): void {

--- a/src/core/updater-watchdog.ts
+++ b/src/core/updater-watchdog.ts
@@ -15,6 +15,7 @@ import {
   readRestartFailure,
   sanitizeAlarmText,
   summarizeRestartFailure,
+  writeRestartFailure,
 } from '../utils/restart-breadcrumb.js';
 import { updaterRuntimePath, type UpdaterRuntimeState } from '../updater/runtime-state.js';
 
@@ -120,6 +121,8 @@ export class UpdaterWatchdog {
   private sleepWakeGraceUntil = 0;
   private lastRestartAt = 0;
   private checking = false;
+  private stopping = false;
+  private restartAbort: AbortController | null = null;
 
   constructor(opts: UpdaterWatchdogOptions) {
     this.enabled = opts.enabled;
@@ -146,6 +149,7 @@ export class UpdaterWatchdog {
     }
     this.startedAt = Date.now();
     this.lastTickAt = 0;
+    this.stopping = false;
     logger.info('updater-watchdog started', {
       intervalMs: this.intervalMs,
       staleHeartbeatMs: this.staleHeartbeatMs,
@@ -157,9 +161,13 @@ export class UpdaterWatchdog {
   }
 
   stop(): void {
-    if (!this.timer) return;
-    clearInterval(this.timer);
-    this.timer = null;
+    this.stopping = true;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    this.restartAbort?.abort();
+    this.restartAbort = null;
   }
 
   async runCheck(): Promise<UpdaterWatchdogResult> {
@@ -286,6 +294,8 @@ export class UpdaterWatchdog {
 
     this.lastRestartAt = now;
     const attemptStartedAt = now;
+    const abort = new AbortController();
+    this.restartAbort = abort;
     try {
       const result = process.platform === 'win32'
         ? await execFileAsync('powershell.exe', [
@@ -298,9 +308,11 @@ export class UpdaterWatchdog {
         ], {
           timeout: COMMAND_TIMEOUT_MS,
           windowsHide: true,
+          signal: abort.signal,
         })
         : await execFileAsync(this.loongsuitePilotBin, ['restart-updater'], {
           timeout: COMMAND_TIMEOUT_MS,
+          signal: abort.signal,
         });
       // Even a successful restart is worth its transcript: the script reports which
       // recovery path it had to take (plain start, re-register, self-heal), and a
@@ -313,10 +325,22 @@ export class UpdaterWatchdog {
       });
       return { status: 'restart-attempted', reason, restarted: true };
     } catch (err) {
+      if (this.stopping) {
+        logger.info('updater-watchdog restart aborted by stop');
+        return { status: 'restart-failed', reason: 'aborted by stop', restarted: false };
+      }
       const detail = describeRestartCommandError(err);
       // Freshness matters more than presence: a script that never ran (powershell.exe
       // missing, child killed before its first statement) would otherwise be "explained"
       // by whatever the previous attempt left on disk.
+      if (isRestartCommandTimeout(err)) {
+        // The script entry cleared the file; a killed wait never writes one. Persist
+        // stage=timeout so cooldown SERVICE_NOT_RUNNING_ALARM still has a live explanation.
+        writeRestartFailure(this.dataDir, 'updater', {
+          stage: 'timeout',
+          detail: 'restart command killed by timeout before it reported a stage',
+        });
+      }
       const breadcrumb = await this.readRestartFailure(attemptStartedAt);
       const diagnosis = breadcrumb
         ? summarizeRestartFailure(breadcrumb)
@@ -333,6 +357,8 @@ export class UpdaterWatchdog {
         diag: breadcrumb?.diag,
       });
       return { status: 'restart-failed', reason: message, restarted: false };
+    } finally {
+      if (this.restartAbort === abort) this.restartAbort = null;
     }
   }
 

--- a/src/core/updater-watchdog.ts
+++ b/src/core/updater-watchdog.ts
@@ -94,7 +94,7 @@ export interface UpdaterWatchdogOptions {
   sleepWakeGraceMs?: number;
   restartCooldownMs?: number;
   alarmManager?: AlarmManager;
-  updaterLiveness?: (pidFile: string) => ProcessLiveness;
+  updaterLiveness?: (pidFile: string) => ProcessLiveness | Promise<ProcessLiveness>;
 }
 
 /**
@@ -114,7 +114,7 @@ export class UpdaterWatchdog {
   private readonly sleepWakeGraceMs: number;
   private readonly restartCooldownMs: number;
   private readonly alarmManager: AlarmManager | null;
-  private readonly updaterLiveness: (pidFile: string) => ProcessLiveness;
+  private readonly updaterLiveness: (pidFile: string) => ProcessLiveness | Promise<ProcessLiveness>;
   private timer: ReturnType<typeof setInterval> | null = null;
   private startedAt = Date.now();
   private lastTickAt = 0;
@@ -172,6 +172,7 @@ export class UpdaterWatchdog {
 
   async runCheck(): Promise<UpdaterWatchdogResult> {
     if (!this.enabled) return { status: 'disabled' };
+    if (this.stopping) return { status: 'disabled', reason: 'stopped' };
     if (isAgentShellCurrentVersion(this.dataDir)) return { status: 'disabled' };
     // 90s command timeout vs 60s tick: without this, an overlapping runCheck records
     // SERVICE_NOT_RUNNING_ALARM (no breadcrumb yet) then hits cooldown.
@@ -197,6 +198,8 @@ export class UpdaterWatchdog {
     this.lastTickAt = now;
 
     const processState = await this.readUpdaterProcess();
+    const stopped = this.stoppedResult();
+    if (stopped) return stopped;
     if (!processState.running) {
       // Grace-checked like every branch below, and for the same reason. start() runs the
       // first check immediately, and on a fresh install the collector is running before
@@ -225,6 +228,8 @@ export class UpdaterWatchdog {
     }
 
     const heartbeat = await readJsonFile<UpdaterRuntimeState>(updaterRuntimePath(this.dataDir));
+    const stoppedAfterHeartbeat = this.stoppedResult();
+    if (stoppedAfterHeartbeat) return stoppedAfterHeartbeat;
     if (!heartbeat) {
       const reason = 'updater heartbeat is missing';
       if (this.inGraceWindow(now)) return { status: 'grace', reason };
@@ -257,7 +262,7 @@ export class UpdaterWatchdog {
     reason: string;
   }> {
     const pidFile = path.join(this.dataDir, 'loongsuite-pilot-updater.pid');
-    const liveness = this.updaterLiveness(pidFile);
+    const liveness = await this.updaterLiveness(pidFile);
     if (!liveness.running) {
       if (liveness.pid !== undefined && liveness.pidFileProcessAlive && liveness.pidFileCommandMatched === false) {
         return {
@@ -282,20 +287,35 @@ export class UpdaterWatchdog {
     return now - this.startedAt < this.startupGraceMs || now < this.sleepWakeGraceUntil;
   }
 
+  private stoppedResult(): UpdaterWatchdogResult | null {
+    if (!this.stopping) return null;
+    return { status: 'restart-failed', reason: 'aborted by stop', restarted: false };
+  }
+
   private async restart(
     status: Exclude<UpdaterWatchdogStatus, 'disabled' | 'healthy' | 'grace' | 'restart-rate-limited' | 'restart-attempted' | 'restart-failed'>,
     reason: string,
   ): Promise<UpdaterWatchdogResult> {
+    const stoppedBefore = this.stoppedResult();
+    if (stoppedBefore) return stoppedBefore;
+
     const now = Date.now();
     if (this.lastRestartAt > 0 && now - this.lastRestartAt < this.restartCooldownMs) {
       logger.warn('updater-watchdog restart skipped by cooldown', { reason });
       return { status: 'restart-rate-limited', reason, restarted: false };
     }
 
-    this.lastRestartAt = now;
-    const attemptStartedAt = now;
+    // Arm abort before spawn so a stop() that lands in this window still cancels.
     const abort = new AbortController();
     this.restartAbort = abort;
+    const stoppedAfterArm = this.stoppedResult();
+    if (stoppedAfterArm) {
+      this.restartAbort = null;
+      return stoppedAfterArm;
+    }
+
+    this.lastRestartAt = now;
+    const attemptStartedAt = now;
     try {
       const result = process.platform === 'win32'
         ? await execFileAsync('powershell.exe', [

--- a/src/updater/updater.ts
+++ b/src/updater/updater.ts
@@ -15,6 +15,14 @@ import {
   makeTarStagingDir,
   replaceDirWith,
 } from '../utils/win-archive.js';
+import {
+  describeRestartCommandError,
+  isRestartCommandTimeout,
+  isRestartFailureFresh,
+  readRestartFailure,
+  summarizeRestartFailure,
+  type RestartFailureBreadcrumb,
+} from '../utils/restart-breadcrumb.js';
 import { compareVersions, computeSha256, deterministicBucket } from './version-utils.js';
 import type { UpdaterMetrics } from './updater-metrics.js';
 import { updaterRuntimePath, type UpdaterRuntimeState } from './runtime-state.js';
@@ -28,7 +36,10 @@ const NPM_INSTALL_TIMEOUT_MS = 2 * 60_000;
 const MAX_BACKOFF_MS = 6 * 60 * 60_000; // 6 hours
 const MAX_CONSECUTIVE_FAILURES = 10;
 const MAX_VERSION_GC_REMOVALS_PER_CHECK = 1;
-const COLLECTOR_COMMAND_TIMEOUT_MS = 30_000;
+// Matches UpdaterWatchdog's cap: restart-collector polls for the collector's heartbeat
+// instead of sleeping a second and guessing, and killing it early would throw away both
+// the restart and the diagnostics it was about to write.
+const COLLECTOR_COMMAND_TIMEOUT_MS = 90_000;
 const COLLECTOR_HEALTH_TIMEOUT_MS = 30_000;
 const COLLECTOR_HEALTH_POLL_MS = 500;
 
@@ -1107,17 +1118,35 @@ export class Updater {
     const previousPid = typeof previousRuntime?.pid === 'number' ? previousRuntime.pid : null;
     const restartStartedAt = Date.now();
     let recoveryAttempted = false;
+    let diagnosed: {
+      detail: string;
+      diagnosis: string;
+      stage: string;
+      breadcrumb: RestartFailureBreadcrumb | null;
+    } | null = null;
 
     try {
       await this.runCollectorCommand('restart-collector');
-    } catch (err: any) {
+    } catch (err: unknown) {
+      diagnosed = await this.diagnoseCollectorRestartFailure(restartStartedAt, err);
       logger.warn('collector restart failed', {
-        error: String(err?.message || err),
-        stdout: err?.stdout?.trim?.() || undefined,
-        stderr: err?.stderr?.trim?.() || undefined,
+        error: diagnosed.detail,
+        stage: diagnosed.stage,
+        initType: diagnosed.breadcrumb?.init_type,
+        diag: diagnosed.breadcrumb?.diag,
       });
-      await this.startCollectorForRecovery(err);
-      recoveryAttempted = true;
+      try {
+        await this.startCollectorForRecovery(err);
+        recoveryAttempted = true;
+      } catch (recoveryErr) {
+        // Alarm only when recovery also failed: a start-collector rescue after a
+        // timed-out restart is the #328 path working, not a stuck collector.
+        void this.metrics?.writeAlarm(
+          'UPDATER_FAILURE_ALARM', '2',
+          `collector restart command failed: ${diagnosed.detail} | ${diagnosed.diagnosis}`,
+        );
+        throw recoveryErr;
+      }
     }
 
     try {
@@ -1128,7 +1157,17 @@ export class Updater {
         targetGitCommit,
       );
     } catch (healthErr) {
-      if (recoveryAttempted) throw healthErr;
+      if (recoveryAttempted) {
+        const first = diagnosed
+          ? `${diagnosed.detail} | ${diagnosed.diagnosis}`
+          : 'restart-collector failed';
+        const healthReason = healthErr instanceof Error ? healthErr.message : String(healthErr);
+        void this.metrics?.writeAlarm(
+          'UPDATER_FAILURE_ALARM', '2',
+          `collector restart command failed: ${first}; health check failed after start-collector recovery: ${healthReason}`,
+        );
+        throw healthErr;
+      }
       logger.warn('collector failed post-restart health check; attempting start-only recovery', {
         error: String(healthErr),
       });
@@ -1172,6 +1211,36 @@ export class Updater {
           + `start-only recovery also failed (${this.formatCommandFailure(recoveryErr)})`,
       );
     }
+  }
+
+  private async diagnoseCollectorRestartFailure(
+    attemptStartedAt: number,
+    err: unknown,
+  ): Promise<{
+    detail: string;
+    diagnosis: string;
+    stage: string;
+    breadcrumb: RestartFailureBreadcrumb | null;
+  }> {
+    const detail = describeRestartCommandError(err);
+    let breadcrumb: RestartFailureBreadcrumb | null = null;
+    try {
+      breadcrumb = await readRestartFailure(this.paths.dataDir, 'collector');
+      if (breadcrumb && !isRestartFailureFresh(breadcrumb, attemptStartedAt)) breadcrumb = null;
+    } catch {
+      breadcrumb = null;
+    }
+    const diagnosis = breadcrumb
+      ? summarizeRestartFailure(breadcrumb)
+      : isRestartCommandTimeout(err)
+        ? 'stage=timeout reason="restart command killed by timeout before it reported a stage"'
+        : 'stage=unknown reason="restart command left no diagnostics"';
+    return {
+      detail,
+      diagnosis,
+      stage: breadcrumb?.stage ?? (isRestartCommandTimeout(err) ? 'timeout' : 'unknown'),
+      breadcrumb,
+    };
   }
 
   private formatCommandFailure(error: unknown): string {

--- a/src/updater/updater.ts
+++ b/src/updater/updater.ts
@@ -21,6 +21,7 @@ import {
   isRestartFailureFresh,
   readRestartFailure,
   summarizeRestartFailure,
+  writeRestartFailure,
   type RestartFailureBreadcrumb,
 } from '../utils/restart-breadcrumb.js';
 import { compareVersions, computeSha256, deterministicBucket } from './version-utils.js';
@@ -1223,6 +1224,12 @@ export class Updater {
     breadcrumb: RestartFailureBreadcrumb | null;
   }> {
     const detail = describeRestartCommandError(err);
+    if (isRestartCommandTimeout(err)) {
+      writeRestartFailure(this.paths.dataDir, 'collector', {
+        stage: 'timeout',
+        detail: 'restart command killed by timeout before it reported a stage',
+      });
+    }
     let breadcrumb: RestartFailureBreadcrumb | null = null;
     try {
       breadcrumb = await readRestartFailure(this.paths.dataDir, 'collector');

--- a/src/utils/restart-breadcrumb.ts
+++ b/src/utils/restart-breadcrumb.ts
@@ -1,0 +1,212 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { readJsonFile } from './fs-utils.js';
+
+export type RestartTarget = 'collector' | 'updater';
+
+/**
+ * Stage labels the service scripts write. Stable, ASCII, never localized: they are
+ * aggregation keys in the alarm stream, so renaming one breaks every saved query.
+ *
+ * `timeout` is the one label node produces itself — the script was killed before it
+ * could write anything, so nobody else can report it.
+ */
+export const RESTART_STAGES = [
+  'node-missing',
+  'bootstrap-missing',
+  'task-missing',
+  'task-query-failed',
+  'register-denied',
+  'start-failed',
+  'not-running-after-start',
+  'selfheal-register-failed',
+  'selfheal-not-running',
+  'service-manager-refused',
+  'timeout',
+] as const;
+
+export interface RestartFailureBreadcrumb {
+  schema: 1;
+  /** Epoch seconds, matching writeStartupCrash. */
+  ts: number;
+  target: RestartTarget;
+  stage: string;
+  init_type?: string;
+  detail?: string;
+  /** Flat string map — the scripts cannot emit nested JSON safely under CLM. */
+  diag?: Record<string, string>;
+}
+
+const DETAIL_MAX_CHARS = 300;
+const VALUE_MAX_CHARS = 200;
+const SUMMARY_MAX_CHARS = 900;
+
+/**
+ * Diag keys worth carrying into the alarm message, most diagnostic first. Anything
+ * else the script recorded still reaches the log (the full breadcrumb is logged); the
+ * order here only decides what survives the SUMMARY_MAX_CHARS budget.
+ */
+const DIAG_KEY_ORDER = [
+  'task_state',
+  'exists_ps',
+  'exists_schtasks',
+  'query_error',
+  'last_task_result',
+  'last_run_time',
+  'missed_runs',
+  'register_error',
+  'start_error',
+  'selfheal_error',
+  'principal_user',
+  'logon_type',
+  'run_level',
+  'definition_owner',
+  'action_exe',
+  'node_bin',
+  'pid_state',
+  'service_state',
+  'unit_state',
+  'log_tail',
+];
+
+export function restartFailurePath(dataDir: string, target: RestartTarget): string {
+  return path.join(dataDir, 'logs', `last-restart-failure-${target}.json`);
+}
+
+/**
+ * Reads the breadcrumb the service script left behind, or null when absent,
+ * unreadable, or written by an unknown schema.
+ *
+ * Goes through readJsonFile because the writer is PowerShell 5.1, whose
+ * `Set-Content -Encoding UTF8` always emits a BOM — JSON.parse rejects it.
+ */
+export async function readRestartFailure(
+  dataDir: string,
+  target: RestartTarget,
+): Promise<RestartFailureBreadcrumb | null> {
+  const parsed = await readJsonFile<RestartFailureBreadcrumb>(restartFailurePath(dataDir, target));
+  if (!parsed || parsed.schema !== 1 || !parsed.stage) return null;
+  return parsed;
+}
+
+/**
+ * Removes the breadcrumb, so a file that is present always describes the most recent
+ * restart attempt rather than some earlier one (same invariant as clearStartupCrash).
+ * The scripts clear it on entry; this exists for callers that recover by other means.
+ */
+export function clearRestartFailure(dataDir: string, target: RestartTarget): void {
+  try {
+    fs.rmSync(restartFailurePath(dataDir, target), { force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Whether the breadcrumb belongs to the attempt that started at `attemptStartMs`.
+ *
+ * Without this check a script that never ran at all (powershell.exe missing, the
+ * process killed before its first statement) would be explained by whatever the
+ * previous failure left on disk — the most misleading possible outcome for an alarm.
+ * `skewMs` absorbs the one-second resolution of the epoch-seconds timestamp plus any
+ * clock jitter between the two processes.
+ */
+export function isRestartFailureFresh(
+  breadcrumb: RestartFailureBreadcrumb,
+  attemptStartMs: number,
+  skewMs = 5_000,
+): boolean {
+  const ts = Number(breadcrumb.ts);
+  if (!Number.isFinite(ts) || ts <= 0) return false;
+  return ts * 1000 >= attemptStartMs - skewMs;
+}
+
+/**
+ * Renders the breadcrumb as an alarm-message suffix — message only, no schema change,
+ * same approach as UpdaterMetrics.buildNotRunningMessage.
+ */
+export function summarizeRestartFailure(breadcrumb: RestartFailureBreadcrumb): string {
+  const parts = [`stage=${sanitizeAlarmText(breadcrumb.stage, 60)}`];
+  if (breadcrumb.detail) {
+    parts.push(`reason="${sanitizeAlarmText(breadcrumb.detail, DETAIL_MAX_CHARS)}"`);
+  }
+  if (breadcrumb.init_type) parts.push(`init_type=${sanitizeAlarmText(breadcrumb.init_type, 40)}`);
+
+  const diag = breadcrumb.diag ?? {};
+  const keys = Object.keys(diag);
+  const ordered = [
+    ...DIAG_KEY_ORDER.filter(k => keys.includes(k)),
+    ...keys.filter(k => !DIAG_KEY_ORDER.includes(k)).sort(),
+  ];
+  let rendered = parts.join(' ');
+  for (const key of ordered) {
+    const value = sanitizeAlarmText(String(diag[key] ?? ''), VALUE_MAX_CHARS);
+    if (!value) continue;
+    const next = `${rendered} ${sanitizeAlarmText(key, 40)}="${value}"`;
+    if (next.length > SUMMARY_MAX_CHARS) break;
+    rendered = next;
+  }
+  return rendered;
+}
+
+/**
+ * Keeps a value safe to embed in `key="..."`: no quotes or control characters that
+ * would break downstream parsing, and bounded so one huge log tail cannot push the
+ * stage out of a truncated alarm message.
+ *
+ * Exported because the restart callers embed their own fields (exec error text,
+ * captured stdout) into the same message and must bound them the same way.
+ */
+export function sanitizeAlarmText(text: string, maxChars: number): string {
+  return text.replace(/["\r\n\t]+/g, ' ').replace(/\s+/g, ' ').trim().slice(0, maxChars);
+}
+
+/** The parts of a child_process error the restart callers report on. */
+export interface RestartCommandError {
+  message?: string;
+  killed?: boolean;
+  signal?: string | null;
+  code?: number | string | null;
+  stdout?: string;
+  stderr?: string;
+}
+
+/**
+ * Whether the command was killed by its own timeout rather than exiting on its own.
+ * A killed script cannot have written a breadcrumb, so this is the only stage node
+ * has to infer by itself.
+ */
+export function isRestartCommandTimeout(err: unknown): boolean {
+  const e = (err ?? {}) as RestartCommandError;
+  return e.killed === true || e.signal === 'SIGTERM' || e.code === 'ETIMEDOUT';
+}
+
+/**
+ * Renders a failed restart command as bounded `key="value"` fields.
+ *
+ * Both stream tails are included on purpose: the service scripts print their
+ * diagnostics with Write-Host / echo, and node's own `err.message` carries stderr
+ * only — which is exactly how the original production report ended up as a single
+ * unexplained "Command failed" line. Tails rather than heads, because the useful
+ * part of a restart transcript is always at the end.
+ */
+export function describeRestartCommandError(err: unknown): string {
+  const e = (err ?? {}) as RestartCommandError;
+  const parts: string[] = [];
+  if (e.killed === true || e.signal) parts.push(`killed=${e.killed === true} signal=${e.signal ?? 'none'}`);
+  if (e.code !== undefined && e.code !== null) parts.push(`exit=${e.code}`);
+  const stderr = tailText(e.stderr, DETAIL_MAX_CHARS);
+  const stdout = tailText(e.stdout, DETAIL_MAX_CHARS);
+  if (stderr) parts.push(`stderr="${stderr}"`);
+  if (stdout) parts.push(`stdout="${stdout}"`);
+  if (parts.length === 0) {
+    const message = sanitizeAlarmText(String(e.message ?? err ?? ''), DETAIL_MAX_CHARS);
+    if (message) parts.push(`err="${message}"`);
+  }
+  return parts.join(' ') || 'no error detail';
+}
+
+function tailText(text: string | undefined, maxChars: number): string {
+  const clean = sanitizeAlarmText(String(text ?? ''), Number.MAX_SAFE_INTEGER);
+  return clean.length > maxChars ? clean.slice(clean.length - maxChars) : clean;
+}

--- a/src/utils/restart-breadcrumb.ts
+++ b/src/utils/restart-breadcrumb.ts
@@ -86,7 +86,7 @@ export async function readRestartFailure(
 ): Promise<RestartFailureBreadcrumb | null> {
   const parsed = await readJsonFile<RestartFailureBreadcrumb>(restartFailurePath(dataDir, target));
   if (!parsed || parsed.schema !== 1 || !parsed.stage) return null;
-  return parsed;
+  return { ...parsed, diag: coerceRestartDiag(parsed.diag) };
 }
 
 /**
@@ -100,6 +100,71 @@ export function clearRestartFailure(dataDir: string, target: RestartTarget): voi
   } catch {
     // best-effort
   }
+}
+
+/**
+ * Persists a breadcrumb from the node caller. Used when the service script was
+ * killed before it could write one (timeout) so cooldown alarms still have a stage.
+ * Best-effort: diagnostics must never throw into recovery.
+ */
+export function writeRestartFailure(
+  dataDir: string,
+  target: RestartTarget,
+  fields: {
+    stage: string;
+    init_type?: string;
+    detail?: string;
+    diag?: Record<string, string>;
+  },
+): void {
+  try {
+    const breadcrumb: RestartFailureBreadcrumb = {
+      schema: 1,
+      ts: Math.floor(Date.now() / 1000),
+      target,
+      stage: fields.stage,
+      init_type: fields.init_type,
+      detail: fields.detail,
+      diag: fields.diag,
+    };
+    const file = restartFailurePath(dataDir, target);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(tmp, `${JSON.stringify(breadcrumb, null, 2)}\n`, 'utf8');
+    fs.renameSync(tmp, file);
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * PowerShell 5.1 ConvertTo-Json emits a nested hashtable as [{Key, Value}, ...].
+ * Accept that shape (and a normal object) so definition_owner still reaches the alarm.
+ */
+export function coerceRestartDiag(raw: unknown): Record<string, string> | undefined {
+  if (raw == null) return undefined;
+  if (Array.isArray(raw)) {
+    const out: Record<string, string> = {};
+    for (const item of raw) {
+      if (!item || typeof item !== 'object') continue;
+      const rec = item as Record<string, unknown>;
+      const key = rec.Key ?? rec.key;
+      const value = rec.Value ?? rec.value;
+      if (typeof key === 'string' && key.length > 0) {
+        out[key] = value == null ? '' : String(value);
+      }
+    }
+    return out;
+  }
+  if (typeof raw === 'object') {
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+      if (value == null || typeof value === 'object') continue;
+      out[key] = String(value);
+    }
+    return out;
+  }
+  return undefined;
 }
 
 /**

--- a/tests/unit/core/updater-watchdog.test.ts
+++ b/tests/unit/core/updater-watchdog.test.ts
@@ -60,6 +60,19 @@ async function writeHeartbeat(
   );
 }
 
+/**
+ * Writes the restart-failure breadcrumb the way loongsuite-pilot.ps1 does, BOM included:
+ * PowerShell 5.1 has no utf8NoBOM, so `Set-Content -Encoding UTF8` always emits one.
+ */
+async function writeBreadcrumb(dataDir: string, payload: unknown): Promise<void> {
+  await fs.mkdir(path.join(dataDir, 'logs'), { recursive: true });
+  await fs.writeFile(
+    path.join(dataDir, 'logs', 'last-restart-failure-updater.json'),
+    `\uFEFF${JSON.stringify(payload, null, 2)}\n`,
+    'utf-8',
+  );
+}
+
 function makeAlarmManager(): AlarmManager {
   return new AlarmManager({ ip: '127.0.0.1', version: 'test', userId: 'test-user' });
 }
@@ -147,6 +160,47 @@ describe('UpdaterWatchdog', () => {
       alarm_type: 'SERVICE_NOT_RUNNING_ALARM',
       input_name: 'updater',
     });
+  });
+
+  it('does not alarm from an overlapping tick while restart-updater is still running', async () => {
+    let release: ((value: { stdout: string; stderr: string }) => void) | undefined;
+    mockExecFileAsync.mockImplementation((cmd: string, _args?: unknown, opts?: { timeout?: number }) => {
+      if (cmd === '/bin/loongsuite-pilot') {
+        expect(opts?.timeout).toBe(90_000);
+        return new Promise((resolve) => {
+          release = resolve;
+        });
+      }
+      return Promise.resolve({ stdout: '', stderr: '' });
+    });
+    const alarms = makeAlarmManager();
+    const wd = new UpdaterWatchdog({
+      enabled: true,
+      dataDir: tmpDir,
+      loongsuitePilotBin: '/bin/loongsuite-pilot',
+      startupGraceMs: 0,
+      alarmManager: alarms,
+    });
+
+    const first = wd.runCheck();
+    await vi.waitFor(() => {
+      expect(mockExecFileAsync.mock.calls.some(([cmd]) => cmd === '/bin/loongsuite-pilot')).toBe(true);
+    });
+    // serialize() drains the map; snapshot once so the overlapping tick can be shown
+    // to have added nothing.
+    expect(alarms.serialize().filter((a) => a.alarm_type === 'SERVICE_NOT_RUNNING_ALARM')).toHaveLength(1);
+
+    const second = await wd.runCheck();
+    expect(second).toEqual({
+      status: 'restart-rate-limited',
+      reason: 'check already in flight',
+      restarted: false,
+    });
+    expect(alarms.serialize()).toEqual([]);
+    expect(mockExecFileAsync.mock.calls.filter(([cmd]) => cmd === '/bin/loongsuite-pilot')).toHaveLength(1);
+
+    release?.({ stdout: '', stderr: '' });
+    await expect(first).resolves.toMatchObject({ status: 'restart-attempted' });
   });
 
   it('uses startup grace before restarting for a missing updater process', async () => {
@@ -398,6 +452,135 @@ describe('UpdaterWatchdog', () => {
     expect(alarms.serialize()).toEqual(expect.arrayContaining([
       expect.objectContaining({ alarm_type: 'UPDATER_FAILURE_ALARM', input_name: 'updater' }),
     ]));
+  });
+
+  it('enriches the failure alarm with the breadcrumb the script left behind', async () => {
+    // The production symptom this fixes: the alarm said only "Command failed:
+    // powershell.exe ... restart-updater". execFile puts the child's stderr in
+    // err.message and nothing else, so the reasons the script printed on stdout never
+    // reached the alarm -- and under $ErrorActionPreference = "Stop" the script's own
+    // Write-Error is terminating, so it could not print them afterwards either.
+    await writeBreadcrumb(tmpDir, {
+      schema: 1,
+      ts: Math.floor(Date.now() / 1000),
+      target: 'updater',
+      stage: 'register-denied',
+      init_type: 'taskscheduler',
+      detail: 'self-heal failed: Access is denied.',
+      diag: { task_state: 'Ready', definition_owner: 'BUILTIN\\Administrators' },
+    });
+    mockExecFileAsync.mockImplementation((cmd: string) => {
+      if (cmd === '/bin/loongsuite-pilot') {
+        return Promise.reject(Object.assign(new Error('Command failed: loongsuite-pilot restart-updater'), {
+          code: 1,
+          stdout: '[restart-failure] target=updater stage=register-denied\n',
+          stderr: 'Service manager failed to restart updater\n',
+        }));
+      }
+      return Promise.resolve({ stdout: '', stderr: '' });
+    });
+    const alarms = makeAlarmManager();
+    const wd = new UpdaterWatchdog({
+      enabled: true,
+      dataDir: tmpDir,
+      loongsuitePilotBin: '/bin/loongsuite-pilot',
+      startupGraceMs: 0,
+      alarmManager: alarms,
+    });
+
+    const result = await wd.runCheck();
+
+    expect(result.status).toBe('restart-failed');
+    const message = alarms.serialize()
+      .find((a) => a.alarm_type === 'UPDATER_FAILURE_ALARM' && a.alarm_message.includes('restart command failed'))
+      ?.alarm_message ?? '';
+    expect(message).toContain('stage=register-denied');
+    expect(message).toContain('reason="self-heal failed: Access is denied."');
+    expect(message).toContain('init_type=taskscheduler');
+    expect(message).toContain('definition_owner="BUILTIN\\Administrators"');
+    expect(message).toContain('exit=1');
+    expect(message).toContain('stdout="[restart-failure] target=updater stage=register-denied"');
+    expect(message).toContain('stderr="Service manager failed to restart updater"');
+  });
+
+  it('ignores a breadcrumb left by an earlier attempt', async () => {
+    await writeBreadcrumb(tmpDir, {
+      schema: 1,
+      ts: Math.floor(Date.now() / 1000) - 600,
+      target: 'updater',
+      stage: 'register-denied',
+      detail: 'stale evidence from ten minutes ago',
+    });
+    mockExecFileAsync.mockImplementation((cmd: string) => {
+      if (cmd === '/bin/loongsuite-pilot') return Promise.reject(new Error('spawn ENOENT'));
+      return Promise.resolve({ stdout: '', stderr: '' });
+    });
+    const alarms = makeAlarmManager();
+    const wd = new UpdaterWatchdog({
+      enabled: true,
+      dataDir: tmpDir,
+      loongsuitePilotBin: '/bin/loongsuite-pilot',
+      startupGraceMs: 0,
+      alarmManager: alarms,
+    });
+
+    await wd.runCheck();
+
+    const message = alarms.serialize()
+      .find((a) => a.alarm_message.includes('restart command failed'))?.alarm_message ?? '';
+    expect(message).toContain('stage=unknown');
+    expect(message).not.toContain('register-denied');
+    expect(message).not.toContain('stale evidence');
+  });
+
+  it('reports a timeout kill as its own stage', async () => {
+    mockExecFileAsync.mockImplementation((cmd: string) => {
+      if (cmd === '/bin/loongsuite-pilot') {
+        return Promise.reject(Object.assign(new Error('Command failed'), { killed: true, signal: 'SIGTERM' }));
+      }
+      return Promise.resolve({ stdout: '', stderr: '' });
+    });
+    const alarms = makeAlarmManager();
+    const wd = new UpdaterWatchdog({
+      enabled: true,
+      dataDir: tmpDir,
+      loongsuitePilotBin: '/bin/loongsuite-pilot',
+      startupGraceMs: 0,
+      alarmManager: alarms,
+    });
+
+    await wd.runCheck();
+
+    const message = alarms.serialize()
+      .find((a) => a.alarm_message.includes('restart command failed'))?.alarm_message ?? '';
+    expect(message).toContain('stage=timeout');
+    expect(message).toContain('killed=true signal=SIGTERM');
+  });
+
+  it('attaches the previous restart failure to the alarm raised before this restart', async () => {
+    await writeBreadcrumb(tmpDir, {
+      schema: 1,
+      ts: Math.floor(Date.now() / 1000) - 300,
+      target: 'updater',
+      stage: 'task-missing',
+      init_type: 'taskscheduler',
+      detail: 'scheduled task LoongsuitePilotUpdater does not exist',
+    });
+    const alarms = makeAlarmManager();
+    const wd = new UpdaterWatchdog({
+      enabled: true,
+      dataDir: tmpDir,
+      loongsuitePilotBin: '/bin/loongsuite-pilot',
+      startupGraceMs: 0,
+      alarmManager: alarms,
+    });
+
+    await wd.runCheck();
+
+    const message = alarms.serialize()
+      .find((a) => a.alarm_type === 'SERVICE_NOT_RUNNING_ALARM')?.alarm_message ?? '';
+    expect(message).toContain('last_restart_failure: stage=task-missing');
+    expect(message).toContain('reason="scheduled task LoongsuitePilotUpdater does not exist"');
   });
 
   it('defaults Windows pilot bin to loongsuite-pilot-service.ps1', async () => {

--- a/tests/unit/core/updater-watchdog.test.ts
+++ b/tests/unit/core/updater-watchdog.test.ts
@@ -624,6 +624,53 @@ describe('UpdaterWatchdog', () => {
     expect(alarms.serialize().filter((a) => a.alarm_type === 'UPDATER_FAILURE_ALARM')).toEqual([]);
   });
 
+  it('does not launch restart-updater after stop()', async () => {
+    const wd = new UpdaterWatchdog({
+      enabled: true,
+      dataDir: tmpDir,
+      loongsuitePilotBin: '/bin/loongsuite-pilot',
+      startupGraceMs: 0,
+    });
+    wd.stop();
+    const result = await wd.runCheck();
+    expect(result.status).toBe('disabled');
+    expect(result.reason).toBe('stopped');
+    expect(mockExecFileAsync.mock.calls.filter(([cmd]) => cmd === '/bin/loongsuite-pilot')).toHaveLength(0);
+  });
+
+  it('does not launch restart-updater if stop() raced during the health probe', async () => {
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let probeStarted!: () => void;
+    const probeStartedP = new Promise<void>((resolve) => {
+      probeStarted = resolve;
+    });
+    const wd = new UpdaterWatchdog({
+      enabled: true,
+      dataDir: tmpDir,
+      loongsuitePilotBin: '/bin/loongsuite-pilot',
+      startupGraceMs: 0,
+      updaterLiveness: async () => {
+        probeStarted();
+        await held;
+        return { running: false, source: 'none', reason: 'missing pid file' };
+      },
+    });
+
+    const pending = wd.runCheck();
+    await probeStartedP;
+    wd.stop();
+    release();
+    const result = await pending;
+
+    expect(result.status).toBe('restart-failed');
+    expect(result.reason).toBe('aborted by stop');
+    expect(result.restarted).toBe(false);
+    expect(mockExecFileAsync.mock.calls.filter(([cmd]) => cmd === '/bin/loongsuite-pilot')).toHaveLength(0);
+  });
+
   it('attaches the previous restart failure to the alarm raised before this restart', async () => {
     await writeBreadcrumb(tmpDir, {
       schema: 1,

--- a/tests/unit/core/updater-watchdog.test.ts
+++ b/tests/unit/core/updater-watchdog.test.ts
@@ -555,6 +555,73 @@ describe('UpdaterWatchdog', () => {
       .find((a) => a.alarm_message.includes('restart command failed'))?.alarm_message ?? '';
     expect(message).toContain('stage=timeout');
     expect(message).toContain('killed=true signal=SIGTERM');
+
+    const breadcrumbFile = path.join(tmpDir, 'logs', 'last-restart-failure-updater.json');
+    const written = JSON.parse(await fs.readFile(breadcrumbFile, 'utf-8'));
+    expect(written.stage).toBe('timeout');
+  });
+
+  it('attaches the timeout breadcrumb to cooldown SERVICE_NOT_RUNNING_ALARM', async () => {
+    mockExecFileAsync.mockImplementation((cmd: string) => {
+      if (cmd === '/bin/loongsuite-pilot') {
+        return Promise.reject(Object.assign(new Error('Command failed'), { killed: true, signal: 'SIGTERM' }));
+      }
+      return Promise.resolve({ stdout: '', stderr: '' });
+    });
+    const alarms = makeAlarmManager();
+    const wd = new UpdaterWatchdog({
+      enabled: true,
+      dataDir: tmpDir,
+      loongsuitePilotBin: '/bin/loongsuite-pilot',
+      startupGraceMs: 0,
+      restartCooldownMs: 60_000,
+      alarmManager: alarms,
+    });
+
+    expect((await wd.runCheck()).status).toBe('restart-failed');
+    expect((await wd.runCheck()).status).toBe('restart-rate-limited');
+    const service = alarms.serialize()
+      .filter((a) => a.alarm_type === 'SERVICE_NOT_RUNNING_ALARM')
+      .pop()?.alarm_message ?? '';
+    expect(service).toContain('last_restart_failure: stage=timeout');
+  });
+
+  it('aborts an in-flight restart on stop without recording a failure alarm', async () => {
+    let seenSignal: AbortSignal | undefined;
+    let commandStarted!: () => void;
+    const commandStartedP = new Promise<void>((resolve) => {
+      commandStarted = resolve;
+    });
+    mockExecFileAsync.mockImplementation((cmd: string, _args?: unknown, opts?: { signal?: AbortSignal }) => {
+      if (cmd === '/bin/loongsuite-pilot') {
+        seenSignal = opts?.signal;
+        commandStarted();
+        return new Promise((_resolve, reject) => {
+          opts?.signal?.addEventListener('abort', () => {
+            reject(Object.assign(new Error('The operation was aborted'), { code: 'ABORT_ERR' }));
+          });
+        });
+      }
+      return Promise.resolve({ stdout: '', stderr: '' });
+    });
+    const alarms = makeAlarmManager();
+    const wd = new UpdaterWatchdog({
+      enabled: true,
+      dataDir: tmpDir,
+      loongsuitePilotBin: '/bin/loongsuite-pilot',
+      startupGraceMs: 0,
+      alarmManager: alarms,
+    });
+
+    const pending = wd.runCheck();
+    await commandStartedP;
+    wd.stop();
+    const result = await pending;
+
+    expect(seenSignal?.aborted).toBe(true);
+    expect(result.status).toBe('restart-failed');
+    expect(result.reason).toBe('aborted by stop');
+    expect(alarms.serialize().filter((a) => a.alarm_type === 'UPDATER_FAILURE_ALARM')).toEqual([]);
   });
 
   it('attaches the previous restart failure to the alarm raised before this restart', async () => {

--- a/tests/unit/scripts/ps1-restart-best-effort.test.mjs
+++ b/tests/unit/scripts/ps1-restart-best-effort.test.mjs
@@ -40,9 +40,12 @@ const bodyOf = (name) => {
 };
 
 // The "task already registered" branch, up to the `if (-not $restarted)` fallback.
+// Three spellings of the condition are accepted: the original `Get-TaskExists`, the
+// `$query.exists` form the diagnostics work introduced, and `$shouldStart` which also
+// covers CIM query-fail / schtasks-yes so those paths still Start instead of re-register.
 const existingTaskBranch = (body) => {
-  const start = body.search(/if \(Get-TaskExists /);
-  expect(start, 'no Get-TaskExists branch').toBeGreaterThan(-1);
+  const start = body.search(/if \((?:Get-TaskExists |\$query\.exists|\$shouldStart)/);
+  expect(start, 'no existing-task branch').toBeGreaterThan(-1);
   const rest = body.slice(start);
   const end = rest.search(/if \(-not \$restarted\)/);
   return end === -1 ? rest : rest.slice(0, end);

--- a/tests/unit/scripts/ps1-restart-diagnostics.test.mjs
+++ b/tests/unit/scripts/ps1-restart-diagnostics.test.mjs
@@ -1,0 +1,295 @@
+// restart-collector / restart-updater must never fail without saying why.
+//
+// The production report this pins was one line with no cause in it:
+//   Cmd-RestartUpdater : Service manager failed to restart updater (init_type=taskscheduler)
+// Everything that would have explained it was unreachable or unreadable:
+//   * the reasons were printed with Write-Host, and the caller uses execFile, whose
+//     err.message carries stderr only -- stdout was dropped on the floor;
+//   * $ErrorActionPreference = "Stop" (top of the script) makes Write-Error a
+//     *terminating* error, so any diagnostics written after it -- including the old
+//     `return` / `exit 1` -- were dead code;
+//   * several branches printed nothing at all.
+//
+// So every non-success exit now goes through Write-RestartFailure, which prints the
+// reason and drops a breadcrumb file that the caller reads (src/utils/restart-breadcrumb.ts)
+// to enrich its alarm. These checks pin the shape of that contract, not any wording.
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const SERVICE_PS1 = 'scripts/loongsuite-pilot.ps1';
+const BREADCRUMB_TS = 'src/utils/restart-breadcrumb.ts';
+const text = readFileSync(SERVICE_PS1, 'utf-8');
+
+// Drop comment lines so prose about Write-RestartFailure cannot satisfy a structural check.
+const codeOf = (s) => s.split('\n').filter((line) => !/^\s*#/.test(line)).join('\n');
+
+// Body = from the function header to the next top-level `function` declaration. Brace
+// counting would trip over the format strings and script blocks in this file.
+const bodyOf = (name) => {
+  const start = text.indexOf(`function ${name} {`);
+  expect(start, `${name} not found in ${SERVICE_PS1}`).toBeGreaterThan(-1);
+  const rest = text.slice(start + `function ${name} {`.length);
+  const end = rest.search(/\nfunction \S+ \{/);
+  return codeOf(end === -1 ? rest : rest.slice(0, end));
+};
+
+const RESTART_CMDS = [
+  { fn: 'Cmd-RestartCollector', target: 'collector', wait: 'Wait-ForCollectorHeartbeat' },
+  { fn: 'Cmd-RestartUpdater', target: 'updater', wait: 'Wait-ForUpdaterAlive' },
+];
+
+describe('restart commands report every failure path', () => {
+  for (const { fn, target } of RESTART_CMDS) {
+    it(`${fn}: every Write-Error is preceded by Write-RestartFailure`, () => {
+      const body = bodyOf(fn);
+      const segments = body.split('Write-Error');
+      // Trailing segment is the code after the last Write-Error, not an exit.
+      const beforeExits = segments.slice(0, -1);
+      expect(beforeExits.length, `${fn} has no Write-Error exits to check`).toBeGreaterThan(1);
+      beforeExits.forEach((segment, i) => {
+        expect(
+          segment.includes('Write-RestartFailure'),
+          `${fn}: the Write-Error at exit #${i + 1} has no Write-RestartFailure before it. `
+            + 'Under $ErrorActionPreference = "Stop" Write-Error terminates the script, so '
+            + 'diagnostics placed after it never run.',
+        ).toBe(true);
+      });
+    });
+
+    it(`${fn}: clears the previous breadcrumb before doing anything`, () => {
+      // "A breadcrumb exists" must mean "the most recent attempt failed". Without this the
+      // reader would explain a script that never even started with an older failure.
+      const body = bodyOf(fn);
+      const clearAt = body.indexOf(`Clear-RestartFailure "${target}"`);
+      expect(clearAt, `${fn} does not clear the ${target} breadcrumb`).toBeGreaterThan(-1);
+      const firstWrite = body.indexOf('Write-RestartFailure');
+      expect(firstWrite).toBeGreaterThan(clearAt);
+    });
+  }
+
+  it('the fallback exit reports the stage it reached, not just init_type', () => {
+    // The whole point of tracking $stage forward through the ladder: the final exit used
+    // to carry init_type and nothing else.
+    for (const { fn } of RESTART_CMDS) {
+      const body = bodyOf(fn);
+      expect(body).toContain('-Stage $stage -Detail $detail -Extra $extra');
+      expect(body).toMatch(/Write-Error "Service manager failed to restart \w+ \(init_type=\$initType stage=\$stage\): \$detail"/);
+    }
+  });
+});
+
+describe('restart commands verify the service actually came up', () => {
+  for (const { fn, wait } of RESTART_CMDS) {
+    it(`${fn}: every Start-ScheduledTask is followed by ${wait}`, () => {
+      // Start-ScheduledTask only means Task Scheduler accepted the request. The old code
+      // slept one second and probed once, which is not enough for wscript.exe -> node to
+      // reach Running -- good restarts were reported as failures, and with
+      // init_type=taskscheduler that verdict was terminal.
+      const body = bodyOf(fn);
+      // Statement starts only: the name also appears inside the $detail strings.
+      const starts = [...body.matchAll(/^[ \t]*Start-ScheduledTask\b/gm)];
+      expect(starts.length, `${fn} does not start the task on both paths`).toBeGreaterThan(1);
+      starts.forEach((match, i) => {
+        const window = body.slice(match.index, match.index + 400);
+        expect(
+          window.includes(wait),
+          `${fn}: Start-ScheduledTask #${i + 1} is not followed by ${wait}, so a task that `
+            + 'never comes up would be reported as a successful restart',
+        ).toBe(true);
+      });
+    });
+  }
+
+  for (const wait of ['Wait-ForCollectorHeartbeat', 'Wait-ForUpdaterAlive']) {
+    it(`${wait} polls to a deadline instead of sleeping once`, () => {
+      const body = bodyOf(wait);
+      expect(body).toContain('$deadline');
+      expect(body).toMatch(/while \(\(Get-Date\) -lt \$deadline\)/);
+    });
+  }
+});
+
+describe('self-heal is reachable on a taskscheduler install', () => {
+  for (const { fn } of RESTART_CMDS) {
+    it(`${fn}: the self-heal branch is not gated on init_type`, () => {
+      // The original defect behind the production report: with init_type=taskscheduler a
+      // task that was missing or unusable was not allowed to be re-registered, so the run
+      // could only fall through to the reasonless Write-Error -- forever, once per cycle.
+      const body = bodyOf(fn);
+      const selfHealAt = body.indexOf('if (-not $restarted)');
+      const fallbackAt = body.indexOf('if ($initType -in @(');
+      expect(selfHealAt, `${fn} has no self-heal branch`).toBeGreaterThan(-1);
+      expect(fallbackAt, `${fn} has no init_type-gated fallback`).toBeGreaterThan(selfHealAt);
+      expect(
+        body.slice(selfHealAt, fallbackAt).includes('$initType'),
+        `${fn}: the self-heal branch still consults $initType`,
+      ).toBe(false);
+    });
+
+    it(`${fn}: the unmanaged background fallback stays gated`, () => {
+      // Self-heal opening up does not open this up: on a taskscheduler install a detached
+      // powershell is not a repair, it is a second daemon that dies at the next logoff
+      // while hiding the real breakage. Skipping it must be reported, not silent.
+      const body = bodyOf(fn);
+      expect(body).toContain('if ($initType -in @("background", "unknown", ""))');
+      const fallbackAt = body.indexOf('if ($initType -in @(');
+      expect(body.slice(fallbackAt)).toContain('Write-RestartFailure');
+    });
+  }
+});
+
+describe('the breadcrumb writer is safe for the reader', () => {
+  const writer = bodyOf('Write-RestartFailure');
+
+  it('writes UTF-8 and renames into place', () => {
+    // Set-Content defaults to the ANSI codepage while node reads UTF-8: a localized
+    // Windows message or a non-ASCII account name would arrive as mojibake.
+    expect(writer).toContain('-Encoding UTF8');
+    expect(writer).toContain('ConvertTo-Json');
+    expect(writer).toMatch(/Move-Item -LiteralPath \$tmp -Destination \$file -Force/);
+  });
+
+  it('prints to the console before touching the file', () => {
+    // The console copy is the only one a human running the command by hand sees, and it
+    // must survive a failure of the file write.
+    expect(writer.indexOf('Write-Host "[restart-failure]')).toBeGreaterThan(-1);
+    expect(writer.indexOf('Write-Host "[restart-failure]')).toBeLessThan(writer.indexOf('Set-Content'));
+  });
+
+  it('builds the payload with hashtables only', () => {
+    // Constrained Language Mode: [pscustomobject]@{} throws on 5.1 CLM (measured), so the
+    // payload and the diag map have to be plain hashtables.
+    expect(writer).not.toContain('pscustomobject');
+    expect(writer).not.toContain('New-Object');
+    expect(bodyOf('Get-RestartDiagnostics')).not.toContain('pscustomobject');
+  });
+
+  it('collects diagnostics read-only', () => {
+    // Test-PidRunning deletes a pid file whose process is gone. A diagnostic must not
+    // change the state it is describing -- least of all the state the next probe reads.
+    expect(bodyOf('Get-RestartDiagnostics')).not.toContain('Test-PidRunning');
+  });
+
+  it('timestamps in real UTC epoch seconds', () => {
+    // Get-Date -UFormat %s on 5.1 formats local time as if it were UTC, so the value is
+    // off by the timezone offset and the reader's freshness check would misjudge it.
+    const epoch = bodyOf('Get-EpochSeconds');
+    expect(epoch).toContain('ToUniversalTime()');
+    expect(epoch).not.toContain('UFormat');
+  });
+});
+
+describe('the schtasks cross-check survives EAP=Stop', () => {
+  for (const fn of ['Test-TaskExistsViaSchtasks', 'Invoke-SchtasksRun']) {
+  it(`${fn} uses the prevEAP / 2>&1 / $LASTEXITCODE shape`, () => {
+    // Under $ErrorActionPreference = "Stop", a native command writing a single line to
+    // stderr with a 2>&1 redirect in effect raises a terminating NativeCommandError whose
+    // message is that raw line: every branch below would be skipped and the caller would
+    // see raw schtasks text instead of a diagnosis. See AGENTS.md rule 2.
+    const body = bodyOf(fn);
+    expect(body).toContain('$prevEAP = $ErrorActionPreference');
+    expect(body).toContain('$ErrorActionPreference = "Continue"');
+    expect(body).toMatch(/finally \{\s*\$ErrorActionPreference = \$prevEAP/);
+
+    // $LASTEXITCODE must be read on the very next line -- any command in between
+    // overwrites it -- and be preset non-zero in case schtasks.exe never launches.
+    // The captured stderr is a report field, so it must not carry the capture's own
+    // artifacts: an empty stderr line arrives as an ErrorRecord that stringifies to its
+    // exception type name (measured on 5.1).
+    expect(body).toContain('System.Management.Automation.RemoteException');
+    expect(body).not.toMatch(/\[System\.Management\.Automation\.ErrorRecord\]/);
+
+    const lines = body.split('\n').map((l) => l.trim()).filter(Boolean);
+    const nativeAt = lines.findIndex((l) => l.includes('& schtasks.exe') && l.includes('2>&1'));
+    expect(nativeAt, 'no schtasks.exe call with 2>&1').toBeGreaterThan(-1);
+    expect(lines[nativeAt + 1]).toBe('$code = $LASTEXITCODE');
+    expect(lines.slice(0, nativeAt).some((l) => /^\$code = [1-9]/.test(l))).toBe(true);
+  });
+  }
+});
+
+describe('stage labels agree with the reader', () => {
+  it('every stage the script writes is known to restart-breadcrumb.ts', () => {
+    // The stages are aggregation keys in the alarm stream. A label only one side knows
+    // makes the alarm unqueryable, which is a silent failure of its own.
+    const tsText = readFileSync(BREADCRUMB_TS, 'utf-8');
+    const listed = tsText.slice(
+      tsText.indexOf('RESTART_STAGES = ['),
+      tsText.indexOf('] as const'),
+    );
+    const known = new Set([...listed.matchAll(/'([a-z-]+)'/g)].map((m) => m[1]));
+    expect(known.size).toBeGreaterThan(5);
+
+    const code = codeOf(text);
+    const used = new Set([
+      ...[...code.matchAll(/-Stage "([^"$]+)"/g)].map((m) => m[1]),
+      ...[...code.matchAll(/\$stage = "([^"$]+)"/g)].map((m) => m[1]),
+    ]);
+    expect(used.size).toBeGreaterThan(5);
+    expect([...used].filter((stage) => !known.has(stage))).toEqual([]);
+  });
+});
+
+describe('query-fail still starts the task', () => {
+  it('Get-TaskStartIntent starts on query error or schtasks yes, and only confirms missing otherwise', () => {
+    const body = bodyOf('Get-TaskStartIntent');
+    expect(body).toContain('Test-TaskExistsViaSchtasks');
+    expect(body).toContain('$Query.error');
+    expect(body).toContain('$existsSchtasks -eq "yes"');
+    expect(body).toContain('should_start');
+    expect(body).toContain('confirmed_missing');
+  });
+
+  for (const { fn } of RESTART_CMDS) {
+    it(`${fn}: Start-ScheduledTask is gated on $shouldStart, self-heal on $confirmedMissing`, () => {
+      const body = bodyOf(fn);
+      expect(body).toContain('Get-TaskStartIntent');
+      expect(body).toContain('if ($shouldStart)');
+      expect(body).toContain('Invoke-SchtasksRun');
+      const selfHealAt = body.indexOf('if (-not $restarted)');
+      expect(selfHealAt).toBeGreaterThan(-1);
+      expect(body.indexOf('if ($confirmedMissing)', selfHealAt)).toBeGreaterThan(selfHealAt);
+    });
+  }
+});
+
+describe('wait loops do not delete pid files', () => {
+  it('Test-PidAlive is read-only', () => {
+    const body = bodyOf('Test-PidAlive');
+    expect(body).toContain('Get-Process -Id');
+    expect(body).not.toContain('Remove-Item');
+    expect(body).not.toContain('Stop-Process');
+  });
+
+  for (const wait of ['Wait-ForCollectorHeartbeat', 'Wait-ForUpdaterAlive']) {
+    it(`${wait} uses Test-PidAlive, not Test-PidRunning`, () => {
+      const body = bodyOf(wait);
+      expect(body).toContain('Test-PidAlive');
+      expect(body).not.toContain('Test-PidRunning');
+      expect(body).not.toContain('Remove-Item');
+    });
+  }
+});
+
+describe('Windows background fallback waits instead of faking success', () => {
+  for (const { fn, wait } of RESTART_CMDS) {
+    it(`${fn}: Start-BackgroundDaemon is followed by ${wait} and fails closed`, () => {
+      const body = bodyOf(fn);
+      const fallbackAt = body.indexOf('Start-BackgroundDaemon');
+      expect(fallbackAt, `${fn} has no Start-BackgroundDaemon`).toBeGreaterThan(-1);
+      const window = body.slice(fallbackAt, fallbackAt + 1200);
+      expect(window).toContain(wait);
+      expect(window).toContain('Write-RestartFailure');
+      expect(window).toContain('not-running-after-start');
+    });
+  }
+});
+
+describe('definition_owner does not treat Access Denied as missing', () => {
+  it('Get-RestartDiagnostics calls Get-Acl without a Test-Path short-circuit', () => {
+    const body = bodyOf('Get-RestartDiagnostics');
+    expect(body).toContain('Get-Acl');
+    expect(body).toContain('unreadable:');
+    expect(body).not.toContain('no definition file');
+  });
+});

--- a/tests/unit/scripts/ps1-restart-diagnostics.test.mjs
+++ b/tests/unit/scripts/ps1-restart-diagnostics.test.mjs
@@ -120,10 +120,15 @@ describe('self-heal is reachable on a taskscheduler install', () => {
       const fallbackAt = body.indexOf('if ($initType -in @(');
       expect(selfHealAt, `${fn} has no self-heal branch`).toBeGreaterThan(-1);
       expect(fallbackAt, `${fn} has no init_type-gated fallback`).toBeGreaterThan(selfHealAt);
+      const selfHeal = body.slice(selfHealAt, fallbackAt);
       expect(
-        body.slice(selfHealAt, fallbackAt).includes('$initType'),
-        `${fn}: the self-heal branch still consults $initType`,
+        /if \(\$initType/.test(selfHeal),
+        `${fn}: the self-heal branch still gates on $initType`,
       ).toBe(false);
+      expect(
+        selfHeal.includes('$initType = "taskscheduler"'),
+        `${fn}: self-heal must mark $initType managed so wait failure cannot nohup/background`,
+      ).toBe(true);
     });
 
     it(`${fn}: the unmanaged background fallback stays gated`, () => {
@@ -145,7 +150,8 @@ describe('the breadcrumb writer is safe for the reader', () => {
     // Set-Content defaults to the ANSI codepage while node reads UTF-8: a localized
     // Windows message or a non-ASCII account name would arrive as mojibake.
     expect(writer).toContain('-Encoding UTF8');
-    expect(writer).toContain('ConvertTo-Json');
+    expect(writer).toContain('ConvertTo-RestartFailureJson');
+    expect(writer).not.toContain('ConvertTo-Json');
     expect(writer).toMatch(/Move-Item -LiteralPath \$tmp -Destination \$file -Force/);
   });
 
@@ -162,6 +168,18 @@ describe('the breadcrumb writer is safe for the reader', () => {
     expect(writer).not.toContain('pscustomobject');
     expect(writer).not.toContain('New-Object');
     expect(bodyOf('Get-RestartDiagnostics')).not.toContain('pscustomobject');
+    expect(bodyOf('ConvertTo-RestartFailureJson')).not.toContain('pscustomobject');
+  });
+
+  it('hand-writes diag as a JSON object, not nested ConvertTo-Json', () => {
+    // 5.1 ConvertTo-Json emits a nested hashtable as [{Key, Value}, ...]. The alarm
+    // renderer would then lose definition_owner / task_state. Writer must emit
+    // `"key": "value"` pairs the same way the .sh json_escape path does.
+    const json = bodyOf('ConvertTo-RestartFailureJson');
+    expect(json).not.toContain('ConvertTo-Json');
+    expect(json).toContain('Escape-RestartJsonString');
+    expect(json).toContain('"diag": {');
+    expect(json).toContain('": "');
   });
 
   it('collects diagnostics read-only', () => {
@@ -267,6 +285,25 @@ describe('wait loops do not delete pid files', () => {
       expect(body).toContain('Test-PidAlive');
       expect(body).not.toContain('Test-PidRunning');
       expect(body).not.toContain('Remove-Item');
+    });
+  }
+
+  it('Wait-ForUpdaterAlive does not treat task Running as the process being up', () => {
+    const body = bodyOf('Wait-ForUpdaterAlive');
+    expect(body).not.toContain('Get-TaskRunning');
+    expect(body).toContain('Test-PidAlive $UPDATER_PID_FILE');
+  });
+
+  for (const { fn, task } of [
+    { fn: 'Cmd-RestartCollector', task: 'TASK_NAME_COLLECTOR' },
+    { fn: 'Cmd-RestartUpdater', task: 'TASK_NAME_UPDATER' },
+  ]) {
+    it(`${fn}: Stop-ScheduledTask waits for State to leave Running before Start`, () => {
+      const body = bodyOf(fn);
+      const stopAt = body.indexOf('Stop-ScheduledTask');
+      expect(stopAt, `${fn} does not stop the task`).toBeGreaterThan(-1);
+      const window = body.slice(stopAt, stopAt + 400);
+      expect(window).toContain(`Wait-ForTaskNotRunning $${task}`);
     });
   }
 });

--- a/tests/unit/scripts/ps1-restart-diagnostics.test.mjs
+++ b/tests/unit/scripts/ps1-restart-diagnostics.test.mjs
@@ -129,6 +129,10 @@ describe('self-heal is reachable on a taskscheduler install', () => {
         selfHeal.includes('$initType = "taskscheduler"'),
         `${fn}: self-heal must mark $initType managed so wait failure cannot nohup/background`,
       ).toBe(true);
+      expect(
+        selfHeal.indexOf('$initType = "taskscheduler"'),
+        `${fn}: $initType must flip before wait, so a failed Set-Content cannot background`,
+      ).toBeLessThan(selfHeal.search(/Wait-For(?:CollectorHeartbeat|UpdaterAlive)/));
     });
 
     it(`${fn}: the unmanaged background fallback stays gated`, () => {

--- a/tests/unit/scripts/sh-restart-diagnostics.test.mjs
+++ b/tests/unit/scripts/sh-restart-diagnostics.test.mjs
@@ -1,0 +1,260 @@
+// The POSIX half of the restart diagnostics contract, kept symmetric with
+// tests/unit/scripts/ps1-restart-diagnostics.test.mjs.
+//
+// Same defect, same fix: restart-collector / restart-updater used to end in
+// "Service manager failed to restart <x> (init_type=...)" with the actual cause either
+// unprinted or lost, and several branches (`systemctl --user is-enabled` missing a unit,
+// a launchd job that is not loaded) said nothing at all. Every non-success exit now names
+// a stage and leaves the same breadcrumb file the .ps1 writes, which the calling
+// collector/updater reads via src/utils/restart-breadcrumb.ts.
+//
+// This file also pins the two `set -euo pipefail` hazards that would silently gut the
+// diagnostics on the platforms this script actually runs on.
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const SERVICE_SH = 'scripts/loongsuite-pilot.sh';
+const BREADCRUMB_TS = 'src/utils/restart-breadcrumb.ts';
+const text = readFileSync(SERVICE_SH, 'utf-8');
+
+// Drop comment lines so prose about write_restart_failure cannot satisfy a structural check.
+const codeOf = (s) => s.split('\n').filter((line) => !/^\s*#/.test(line)).join('\n');
+
+// Body = from the function header to the next top-level `name() {` declaration.
+const bodyOf = (name) => {
+  const start = text.indexOf(`\n${name}() {`);
+  expect(start, `${name} not found in ${SERVICE_SH}`).toBeGreaterThan(-1);
+  const rest = text.slice(start + `\n${name}() {`.length);
+  const end = rest.search(/\n[a-z_][a-z0-9_]*\(\) \{/);
+  return codeOf(end === -1 ? rest : rest.slice(0, end));
+};
+
+const RESTART_CMDS = [
+  // Collector start/self-heal lives in start_collector_after_stop so restart-collector
+  // and the #328 start-collector recovery path share one ladder. The updater command
+  // stays self-contained because there is no equivalent start-updater recovery.
+  { fn: 'start_collector_after_stop', target: 'collector', wait: 'wait_for_collector_process', exit: 'return 1', verb: 'start' },
+  { fn: 'cmd_restart_updater', target: 'updater', wait: 'wait_for_updater_process', exit: 'return 1', verb: 'restart' },
+];
+
+describe('restart commands report every failure path', () => {
+  for (const { fn, target, exit, verb } of RESTART_CMDS) {
+    it(`${fn}: every \`${exit}\` is preceded by write_restart_failure`, () => {
+      const body = bodyOf(fn);
+      const exits = [...body.matchAll(new RegExp(`^[ \\t]*${exit}\\b`, 'gm'))];
+      expect(exits.length, `${fn} has no ${exit} to check`).toBeGreaterThan(1);
+      let from = 0;
+      exits.forEach((match, i) => {
+        const segment = body.slice(from, match.index);
+        expect(
+          segment.includes('write_restart_failure'),
+          `${fn}: the \`${exit}\` at exit #${i + 1} has no write_restart_failure before it, so `
+            + 'the caller gets an exit code with no cause attached',
+        ).toBe(true);
+        from = match.index;
+      });
+    });
+
+    it(`${fn}: the final exit reports the stage it reached, not just init_type`, () => {
+      const body = bodyOf(fn);
+      expect(body).toContain(`write_restart_failure ${target} "$_stage" "$_detail"`);
+      expect(body).toContain(
+        `Service manager failed to ${verb} ${target} (init_type=$init_type stage=$_stage): $_detail`,
+      );
+    });
+  }
+
+  it('cmd_restart_collector clears the previous breadcrumb before start_collector_after_stop', () => {
+    // start_collector_after_stop is also the #328 recovery path; clearing inside it
+    // would wipe the restart-collector breadcrumb the updater just failed on.
+    const body = bodyOf('cmd_restart_collector');
+    const clearAt = body.indexOf('clear_restart_failure collector');
+    expect(clearAt, 'cmd_restart_collector does not clear the collector breadcrumb').toBeGreaterThan(-1);
+    expect(body.indexOf('start_collector_after_stop')).toBeGreaterThan(clearAt);
+  });
+
+  it('cmd_restart_updater clears the previous breadcrumb before doing anything', () => {
+    const body = bodyOf('cmd_restart_updater');
+    const clearAt = body.indexOf('clear_restart_failure updater');
+    expect(clearAt, 'cmd_restart_updater does not clear the updater breadcrumb').toBeGreaterThan(-1);
+    expect(body.indexOf('write_restart_failure')).toBeGreaterThan(clearAt);
+  });
+});
+
+describe('restart commands verify the process actually came up', () => {
+  for (const { fn, wait } of RESTART_CMDS) {
+    it(`${fn}: confirms liveness after the service manager reports success`, () => {
+      // The service manager accepting a start request is not the same as the process
+      // existing. The old single check one second later produced false "not running"
+      // verdicts, which then surfaced as an unexplained restart failure.
+      const body = bodyOf(fn);
+      const waits = [...body.matchAll(new RegExp(`${wait} \\d+`, 'g'))];
+      expect(waits.length, `${fn} does not wait for the process`).toBeGreaterThan(2);
+      const successAt = body.indexOf('if [ "$_restarted" = true ]; then');
+      expect(successAt, `${fn} does not re-check a reported-successful start`).toBeGreaterThan(-1);
+      expect(body.slice(successAt, successAt + 300)).toContain(wait);
+    });
+  }
+
+  for (const wait of ['wait_for_collector_process', 'wait_for_updater_process']) {
+    it(`${wait} polls up to a bounded timeout`, () => {
+      const body = bodyOf(wait);
+      expect(body).toMatch(/local timeout="\$\{1:-\d+\}"/);
+      expect(body).toContain('while [ "$i" -lt "$timeout" ]');
+      expect(body).toContain('return 1');
+    });
+  }
+
+  it('wait_for_updater_process only accepts this install\'s own updater', () => {
+    // updater_process_exists() ends in a machine-wide `pgrep -f
+    // loongsuite-pilot/bin/updater-daemon`. Measured: a run whose registration silently did
+    // nothing still reported "self-healed", because another data dir's updater was alive.
+    // find_current_user_processes matches this install's exact bootstrap path.
+    const body = bodyOf('wait_for_updater_process');
+    expect(body).toContain('find_current_user_processes updater');
+    expect(body).not.toContain('updater_process_exists');
+  });
+});
+
+describe('self-heal is reachable on a managed install', () => {
+  // The stop section at the top of each command also switches on init_type, so the
+  // fallback gate has to be located relative to the self-heal branch.
+  const branches = (fn) => {
+    const body = bodyOf(fn);
+    const selfHealAt = body.indexOf('if [ "$_restarted" = false ]; then');
+    expect(selfHealAt, `${fn} has no self-heal branch`).toBeGreaterThan(-1);
+    const fallbackAt = body.indexOf('case "$init_type" in', selfHealAt);
+    expect(fallbackAt, `${fn} has no init_type-gated fallback`).toBeGreaterThan(selfHealAt);
+    return { body, selfHealAt, fallbackAt };
+  };
+
+  for (const { fn } of RESTART_CMDS) {
+    it(`${fn}: the self-heal branch is not gated on init_type`, () => {
+      // The original defect: an install whose unit had gone missing was not allowed to
+      // re-register itself, so it could only reach the failure exit -- every cycle, forever.
+      const { body, selfHealAt, fallbackAt } = branches(fn);
+      expect(
+        body.slice(selfHealAt, fallbackAt).includes('$init_type'),
+        `${fn}: the self-heal branch still consults $init_type`,
+      ).toBe(false);
+    });
+
+    it(`${fn}: the unmanaged nohup fallback stays gated`, () => {
+      // On a managed install a bare nohup daemon is not a repair: it is a second process
+      // outside the service manager, hiding the real breakage. Skipping it is reported.
+      const { body, fallbackAt } = branches(fn);
+      expect(body.slice(fallbackAt)).toContain('nohup|unknown|"")');
+      expect(body.slice(fallbackAt)).toContain('write_restart_failure');
+    });
+  }
+});
+
+describe('the breadcrumb writer is safe for the reader', () => {
+  const writer = bodyOf('write_restart_failure');
+
+  it('writes to a temp file and renames into place', () => {
+    // The reader may look at any moment; a half-written JSON file would parse as nothing.
+    expect(writer).toContain('tmp="$file.tmp"');
+    expect(writer).toMatch(/> "\$tmp" 2>\/dev\/null && mv -f "\$tmp" "\$file"/);
+  });
+
+  it('prints to stderr before touching the file', () => {
+    // stderr is what the caller's error message carries, and it must survive a failed
+    // write. The console copy is also the only one a human running the command by hand sees.
+    const printAt = writer.indexOf('echo "[restart-failure] target=');
+    expect(printAt).toBeGreaterThan(-1);
+    expect(printAt).toBeLessThan(writer.indexOf('tmp="$file.tmp"'));
+  });
+
+  it('escapes every string it interpolates into the JSON', () => {
+    // No jq on a customer box, so the JSON is hand-written: an unescaped quote from a
+    // systemctl message would make the file unparseable, which readJsonFile degrades to
+    // "no diagnostics" without a word.
+    const printfLines = writer.split('\n').filter((l) => /printf '  "/.test(l) || /printf '    "/.test(l));
+    expect(printfLines.length).toBeGreaterThan(4);
+    for (const line of printfLines) {
+      if (!line.includes('%s')) continue;
+      if (/"ts": %s/.test(line)) continue; // a number, from date -u +%s
+      expect(line, `unescaped interpolation: ${line.trim()}`).toContain('json_escape');
+    }
+    const escape = bodyOf('json_escape');
+    expect(escape).toContain("tr '\\n\\r\\t'");
+    expect(escape).toContain("tr -d '\\000-\\010\\013\\014\\016-\\037'");
+    expect(escape).toContain('s/\\\\/\\\\\\\\/g');
+    expect(escape).toContain('s/"/\\\\"/g');
+  });
+
+  it('json_escape strips ESC so handwritten JSON stays parseable', () => {
+    const start = text.indexOf('\njson_escape() {');
+    expect(start).toBeGreaterThan(-1);
+    const rest = text.slice(start + 1);
+    const end = rest.search(/\n[a-z_][a-z0-9_]*\(\) \{/);
+    const fn = rest.slice(0, end === -1 ? undefined : end);
+    const result = execFileSync(
+      'bash',
+      ['-c', `${fn}\nprintf '{"x":"%s"}\\n' "$(json_escape $'a\\x1bb')"`],
+      { encoding: 'utf8' },
+    );
+    const parsed = JSON.parse(result);
+    expect(parsed.x).toBe('ab');
+    expect(parsed.x).not.toContain('\x1b');
+  });
+
+  it('survives set -euo pipefail while collecting facts', () => {
+    // pipefail makes a no-match grep inside $(...) fail the assignment, and with -e that
+    // aborts the whole collection, throwing away every fact after it. Each probe that can
+    // legitimately find nothing has to absorb its own failure.
+    const collect = bodyOf('collect_restart_diag');
+    const risky = collect.split('\n').filter((l) => /\$\(.*\|.*grep/.test(l) || /^\s*\[ -n .* \] && echo/.test(l));
+    expect(risky.length).toBeGreaterThan(0);
+    for (const line of risky) {
+      expect(line.trimEnd(), `must not abort the collection: ${line.trim()}`).toMatch(/\|\| true$/);
+    }
+    // The collection itself is best-effort for the same reason.
+    expect(writer).toContain('collect_restart_diag "$target" 2>/dev/null || true');
+  });
+
+  it('collects read-only', () => {
+    // A diagnostic must not change the state it describes. `kill -0` probes, it does not
+    // signal; nothing here removes a stale pid file the next probe would want to see.
+    const collect = bodyOf('collect_restart_diag');
+    expect(collect).toContain('kill -0 "$pid"');
+    expect(collect).not.toMatch(/\brm\b/);
+    expect(collect).not.toMatch(/\bkill -(9|TERM|15)\b/);
+  });
+
+  it('timestamps in UTC epoch seconds', () => {
+    expect(writer).toContain('date -u +%s');
+  });
+});
+
+describe('the two sides agree on the contract', () => {
+  it('puts the breadcrumb where the node reader looks for it', () => {
+    // restartFailurePath() builds <dataDir>/logs/last-restart-failure-<target>.json.
+    expect(text).toContain('LOG_DIR="$DATA_DIR/logs"');
+    expect(bodyOf('restart_failure_file')).toContain('echo "$LOG_DIR/last-restart-failure-$1.json"');
+    expect(readFileSync(BREADCRUMB_TS, 'utf-8')).toContain("'logs', `last-restart-failure-${target}.json`");
+  });
+
+  it('every stage the script writes is known to restart-breadcrumb.ts', () => {
+    // The stages are aggregation keys in the alarm stream. A label only one side knows
+    // makes the alarm unqueryable, which is a silent failure of its own.
+    const tsText = readFileSync(BREADCRUMB_TS, 'utf-8');
+    const listed = tsText.slice(tsText.indexOf('RESTART_STAGES = ['), tsText.indexOf('] as const'));
+    const known = new Set([...listed.matchAll(/'([a-z-]+)'/g)].map((m) => m[1]));
+    expect(known.size).toBeGreaterThan(5);
+
+    const code = codeOf(text);
+    const used = new Set([
+      ...[...code.matchAll(/write_restart_failure \w+ "([a-z-]+)"/g)].map((m) => m[1]),
+      ...[...code.matchAll(/_stage="([a-z-]+)"/g)].map((m) => m[1]),
+    ]);
+    expect(used.size).toBeGreaterThan(5);
+    expect([...used].filter((stage) => !known.has(stage))).toEqual([]);
+  });
+
+  it('uses the same schema version the reader accepts', () => {
+    expect(bodyOf('write_restart_failure')).toContain('"schema": 1');
+  });
+});

--- a/tests/unit/scripts/sh-restart-diagnostics.test.mjs
+++ b/tests/unit/scripts/sh-restart-diagnostics.test.mjs
@@ -80,6 +80,13 @@ describe('restart commands report every failure path', () => {
     expect(clearAt, 'cmd_restart_updater does not clear the updater breadcrumb').toBeGreaterThan(-1);
     expect(body.indexOf('write_restart_failure')).toBeGreaterThan(clearAt);
   });
+
+  it('cmd_restart_updater waits for a new pid, not the process it just signalled', () => {
+    const body = bodyOf('cmd_restart_updater');
+    expect(body).toContain('_old_pid=$(find_current_user_processes updater');
+    const waits = [...body.matchAll(/wait_for_updater_process \d+ "\$_old_pid"/g)];
+    expect(waits.length, 'every updater wait must exclude the pre-stop pid').toBeGreaterThan(2);
+  });
 });
 
 describe('restart commands verify the process actually came up', () => {
@@ -114,6 +121,27 @@ describe('restart commands verify the process actually came up', () => {
     const body = bodyOf('wait_for_updater_process');
     expect(body).toContain('find_current_user_processes updater');
     expect(body).not.toContain('updater_process_exists');
+    expect(body).toContain('exclude_pid');
+    expect(body).toContain('"$pid" != "$exclude_pid"');
+  });
+
+  it('wait_for_collector_process is read-only and does not call is_running', () => {
+    // is_running rm's a pid file whose cmdline has not yet become collector-daemon.js.
+    // A wait loop would do that up to timeout times. Probe with kill -0 /
+    // process_matches_installed_entry; stale cleanup stays in stop/status.
+    const body = bodyOf('wait_for_collector_process');
+    expect(body).not.toContain('is_running');
+    expect(body).not.toMatch(/\brm\b/);
+    expect(body).not.toMatch(/\bmv\b/);
+    expect(body).toContain('process_matches_installed_entry');
+    expect(body).toContain('find_installed_collector_pid');
+  });
+
+  it('stop_installed_updater_processes waits and SIGKILLs, matching stop_pid_file', () => {
+    const body = bodyOf('stop_installed_updater_processes');
+    expect(body).toContain('kill -0');
+    expect(body).toContain('kill -9');
+    expect(body).toMatch(/count.*-lt 10/);
   });
 });
 
@@ -138,6 +166,10 @@ describe('self-heal is reachable on a managed install', () => {
         body.slice(selfHealAt, fallbackAt).includes('$init_type'),
         `${fn}: the self-heal branch still consults $init_type`,
       ).toBe(false);
+      expect(
+        body.slice(selfHealAt, fallbackAt).includes('init_type="$_new_init"'),
+        `${fn}: self-heal must mark init_type managed so wait failure cannot nohup`,
+      ).toBe(true);
     });
 
     it(`${fn}: the unmanaged nohup fallback stays gated`, () => {

--- a/tests/unit/scripts/sh-restart-diagnostics.test.mjs
+++ b/tests/unit/scripts/sh-restart-diagnostics.test.mjs
@@ -170,6 +170,11 @@ describe('self-heal is reachable on a managed install', () => {
         body.slice(selfHealAt, fallbackAt).includes('init_type="$_new_init"'),
         `${fn}: self-heal must mark init_type managed so wait failure cannot nohup`,
       ).toBe(true);
+      const selfHeal = body.slice(selfHealAt, fallbackAt);
+      expect(
+        selfHeal.indexOf('init_type="$_new_init"'),
+        `${fn}: init_type must flip before wait`,
+      ).toBeLessThan(selfHeal.search(/wait_for_(?:collector|updater)_process/));
     });
 
     it(`${fn}: the unmanaged nohup fallback stays gated`, () => {

--- a/tests/unit/updater/updater.test.ts
+++ b/tests/unit/updater/updater.test.ts
@@ -1193,6 +1193,144 @@ describe('Updater', () => {
     });
   });
 
+  describe('restartCollector failure reporting', () => {
+    function attachMetrics(updater: Updater): unknown[][] {
+      const calls: unknown[][] = [];
+      updater.setMetrics({
+        writeAlarm: (...args: unknown[]) => { calls.push(args); return Promise.resolve(); },
+        writeEvent: () => Promise.resolve(),
+      } as never);
+      return calls;
+    }
+
+    function failRestartWith(err: unknown): void {
+      mockExecFile.mockImplementation((cmd: string, args: string[]) => {
+        if (String(cmd).includes('loongsuite-pilot') || (args ?? []).includes('restart-collector') || (args ?? []).includes('start-collector')) {
+          return Promise.reject(err);
+        }
+        return Promise.resolve({ stdout: '', stderr: '' });
+      });
+    }
+
+    it('alarms with the stage the service script recorded when recovery also fails', async () => {
+      mockReadJsonFile.mockImplementation((file: string) => {
+        if (String(file).includes('last-restart-failure-collector.json')) {
+          return Promise.resolve({
+            schema: 1,
+            ts: Math.floor(Date.now() / 1000),
+            target: 'collector',
+            stage: 'register-denied',
+            init_type: 'taskscheduler',
+            detail: 'self-heal failed: Access is denied.',
+            diag: { definition_owner: 'BUILTIN\\Administrators' },
+          });
+        }
+        if (String(file).endsWith('/logs/runtime.json')) {
+          return Promise.resolve({
+            status: 'active',
+            packageVersion: '1.0.2',
+            pid: process.pid,
+            updatedAt: new Date().toISOString(),
+          });
+        }
+        return Promise.resolve({});
+      });
+      failRestartWith(Object.assign(new Error('Command failed'), {
+        code: 1,
+        stdout: '[restart-failure] target=collector stage=register-denied\n',
+        stderr: 'Service manager failed to restart collector\n',
+      }));
+
+      const updater = new Updater(makeConfig(), tmpDir);
+      const alarms = attachMetrics(updater);
+      await expect((updater as any).restartCollector('1.0.2', false)).rejects.toThrow();
+
+      expect(alarms).toHaveLength(1);
+      const [type, level, message] = alarms[0] as [string, string, string];
+      expect(type).toBe('UPDATER_FAILURE_ALARM');
+      expect(level).toBe('2');
+      expect(message).toContain('stage=register-denied');
+      expect(message).toContain('reason="self-heal failed: Access is denied."');
+      expect(message).toContain('definition_owner="BUILTIN\\Administrators"');
+      expect(message).toContain('stdout="[restart-failure] target=collector stage=register-denied"');
+    });
+
+    it('does not attribute an older breadcrumb to this attempt', async () => {
+      mockReadJsonFile.mockImplementation((file: string) => {
+        if (String(file).includes('last-restart-failure-collector.json')) {
+          return Promise.resolve({
+            schema: 1,
+            ts: Math.floor(Date.now() / 1000) - 900,
+            target: 'collector',
+            stage: 'register-denied',
+            detail: 'stale evidence from fifteen minutes ago',
+          });
+        }
+        return Promise.resolve({});
+      });
+      failRestartWith(new Error('spawn ENOENT'));
+
+      const updater = new Updater(makeConfig(), tmpDir);
+      const alarms = attachMetrics(updater);
+      await expect((updater as any).restartCollector('1.0.2', false)).rejects.toThrow();
+
+      const message = (alarms[0] as [string, string, string])[2];
+      expect(message).toContain('stage=unknown');
+      expect(message).not.toContain('register-denied');
+      expect(message).not.toContain('stale evidence');
+    });
+
+    it('stays silent when the restart succeeds', async () => {
+      const updater = new Updater(makeConfig(), tmpDir);
+      const alarms = attachMetrics(updater);
+      await (updater as any).restartCollector('1.0.2', false);
+      expect(alarms).toEqual([]);
+    });
+
+    it('alarms with the first restart stage when start-collector succeeds but health never appears', async () => {
+      mockExecFile.mockImplementation((_cmd: string, args: string[]) => {
+        if ((args ?? []).includes('restart-collector')) {
+          return Promise.reject(Object.assign(new Error('Command failed'), {
+            code: 1,
+            stdout: '[restart-failure] target=collector stage=task-missing\n',
+            stderr: 'Service manager failed to restart collector\n',
+          }));
+        }
+        return Promise.resolve({ stdout: '', stderr: '' });
+      });
+      mockReadJsonFile.mockImplementation((file: string) => {
+        if (String(file).includes('last-restart-failure-collector.json')) {
+          return Promise.resolve({
+            schema: 1,
+            ts: Math.floor(Date.now() / 1000),
+            target: 'collector',
+            stage: 'task-missing',
+            init_type: 'taskscheduler',
+            detail: 'scheduled task is not registered',
+            diag: {},
+          });
+        }
+        if (String(file).endsWith('/logs/runtime.json')) return Promise.resolve(null);
+        return Promise.resolve({});
+      });
+
+      const updater = new Updater(makeConfig(), tmpDir);
+      const alarms = attachMetrics(updater);
+      const pending = (updater as any).restartCollector('1.0.2', false);
+      const assertion = expect(pending).rejects.toThrow(/did not become healthy/);
+      await vi.runAllTimersAsync();
+      await assertion;
+
+      expect(alarms).toHaveLength(1);
+      const [type, level, message] = alarms[0] as [string, string, string];
+      expect(type).toBe('UPDATER_FAILURE_ALARM');
+      expect(level).toBe('2');
+      expect(message).toContain('stage=task-missing');
+      expect(message).toContain('health check failed after start-collector recovery');
+      expect(message).toContain('runtime record not found');
+    });
+  });
+
   // ─── check(): reentry protection ─────────────────────
 
   describe('check - reentry protection', () => {

--- a/tests/unit/updater/updater.test.ts
+++ b/tests/unit/updater/updater.test.ts
@@ -47,11 +47,18 @@ vi.mock('node:fs/promises', () => ({
   mkdtemp: (...args: [string]) => mockFsMkdtemp(...args),
 }));
 
+const mockWriteFileSync = vi.fn();
+const mockRenameSync = vi.fn();
+
 // --- Mock node:fs (createWriteStream) ---
 vi.mock('node:fs', () => ({
   createWriteStream: vi.fn(() => ({ fake: true })),
   createReadStream: vi.fn(),
   readdirSync: vi.fn(() => []),
+  mkdirSync: vi.fn(),
+  writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
+  renameSync: (...args: unknown[]) => mockRenameSync(...args),
+  rmSync: vi.fn(),
 }));
 
 // --- Mock stream pipeline ---
@@ -1278,6 +1285,23 @@ describe('Updater', () => {
       expect(message).toContain('stage=unknown');
       expect(message).not.toContain('register-denied');
       expect(message).not.toContain('stale evidence');
+    });
+
+    it('writes a timeout breadcrumb when restart-collector is killed', async () => {
+      failRestartWith(Object.assign(new Error('Command failed'), { killed: true, signal: 'SIGTERM' }));
+
+      const updater = new Updater(makeConfig(), tmpDir);
+      const alarms = attachMetrics(updater);
+      await expect((updater as any).restartCollector('1.0.2', false)).rejects.toThrow();
+
+      const payload = mockWriteFileSync.mock.calls
+        .map((call) => String(call[1] ?? ''))
+        .find((text) => text.includes('"stage"'));
+      expect(payload).toBeTruthy();
+      expect(JSON.parse(payload as string).stage).toBe('timeout');
+      expect(JSON.parse(payload as string).target).toBe('collector');
+      const message = (alarms[0] as [string, string, string])[2];
+      expect(message).toContain('stage=timeout');
     });
 
     it('stays silent when the restart succeeds', async () => {

--- a/tests/unit/utils/restart-breadcrumb.test.ts
+++ b/tests/unit/utils/restart-breadcrumb.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  clearRestartFailure,
+  describeRestartCommandError,
+  isRestartCommandTimeout,
+  isRestartFailureFresh,
+  readRestartFailure,
+  restartFailurePath,
+  sanitizeAlarmText,
+  summarizeRestartFailure,
+  type RestartFailureBreadcrumb,
+} from '../../../src/utils/restart-breadcrumb.js';
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lsp-restart-'));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+/** Writes the file the way a service script does, optionally with a UTF-8 BOM. */
+function writeBreadcrumb(
+  target: 'collector' | 'updater',
+  payload: unknown,
+  { bom = false }: { bom?: boolean } = {},
+): void {
+  const file = restartFailurePath(dataDir, target);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${bom ? '﻿' : ''}${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+describe('restart-breadcrumb reader', () => {
+  it('reads a breadcrumb written with a BOM', async () => {
+    // PowerShell 5.1 has no utf8NoBOM: `Set-Content -Encoding UTF8` always writes one,
+    // and JSON.parse rejects it. Because readJsonFile swallows parse errors, a BOM would
+    // degrade to "no diagnostics" -- silently, which is the whole thing being fixed here.
+    writeBreadcrumb('updater', {
+      schema: 1,
+      ts: 1_700_000_000,
+      target: 'updater',
+      stage: 'register-denied',
+      init_type: 'taskscheduler',
+      detail: 'Access is denied.',
+      diag: { definition_owner: 'BUILTIN\\Administrators' },
+    }, { bom: true });
+
+    const bc = await readRestartFailure(dataDir, 'updater');
+    expect(bc).not.toBeNull();
+    expect(bc!.stage).toBe('register-denied');
+    expect(bc!.diag?.definition_owner).toBe('BUILTIN\\Administrators');
+  });
+
+  it('returns null for a missing file, an unknown schema, and a stage-less payload', async () => {
+    expect(await readRestartFailure(dataDir, 'collector')).toBeNull();
+
+    writeBreadcrumb('collector', { schema: 2, ts: 1, target: 'collector', stage: 'task-missing' });
+    expect(await readRestartFailure(dataDir, 'collector')).toBeNull();
+
+    writeBreadcrumb('collector', { schema: 1, ts: 1, target: 'collector' });
+    expect(await readRestartFailure(dataDir, 'collector')).toBeNull();
+  });
+
+  it('returns null for a truncated file instead of throwing', async () => {
+    const file = restartFailurePath(dataDir, 'updater');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, '{"schema": 1, "stage": "task-mis');
+    expect(await readRestartFailure(dataDir, 'updater')).toBeNull();
+  });
+
+  it('clears the file and tolerates a second clear', async () => {
+    writeBreadcrumb('updater', { schema: 1, ts: 1, target: 'updater', stage: 'timeout' });
+    clearRestartFailure(dataDir, 'updater');
+    expect(await readRestartFailure(dataDir, 'updater')).toBeNull();
+    expect(() => clearRestartFailure(dataDir, 'updater')).not.toThrow();
+  });
+
+  it('places the file under logs/ per target', () => {
+    expect(restartFailurePath('/d', 'updater')).toBe(path.join('/d', 'logs', 'last-restart-failure-updater.json'));
+    expect(restartFailurePath('/d', 'collector')).toBe(path.join('/d', 'logs', 'last-restart-failure-collector.json'));
+  });
+});
+
+describe('isRestartFailureFresh', () => {
+  const at = (ts: number): RestartFailureBreadcrumb =>
+    ({ schema: 1, ts, target: 'updater', stage: 'start-failed' });
+
+  it('accepts a breadcrumb written during the attempt', () => {
+    const start = 1_700_000_000_000;
+    expect(isRestartFailureFresh(at(start / 1000 + 3), start)).toBe(true);
+  });
+
+  it('accepts one written just before the attempt started, within the skew', () => {
+    // The script's epoch-seconds resolution alone can place its own write up to a second
+    // before the millisecond timestamp node took when it spawned the command.
+    const start = 1_700_000_000_000;
+    expect(isRestartFailureFresh(at(start / 1000 - 2), start)).toBe(true);
+    expect(isRestartFailureFresh(at(start / 1000 - 60), start)).toBe(false);
+  });
+
+  it('rejects a missing or nonsensical timestamp', () => {
+    const start = 1_700_000_000_000;
+    expect(isRestartFailureFresh(at(0), start)).toBe(false);
+    expect(isRestartFailureFresh(at(Number.NaN), start)).toBe(false);
+    expect(isRestartFailureFresh({ schema: 1, target: 'updater', stage: 'x' } as RestartFailureBreadcrumb, start)).toBe(false);
+  });
+});
+
+describe('summarizeRestartFailure', () => {
+  it('leads with the stage and quotes the reason', () => {
+    const summary = summarizeRestartFailure({
+      schema: 1,
+      ts: 1,
+      target: 'updater',
+      stage: 'register-denied',
+      init_type: 'taskscheduler',
+      detail: 'Register-ScheduledTask failed',
+      diag: { task_state: 'Ready', definition_owner: 'BUILTIN\\Administrators' },
+    });
+    expect(summary.startsWith('stage=register-denied')).toBe(true);
+    expect(summary).toContain('reason="Register-ScheduledTask failed"');
+    expect(summary).toContain('init_type=taskscheduler');
+    expect(summary).toContain('task_state="Ready"');
+    expect(summary).toContain('definition_owner="BUILTIN\\Administrators"');
+  });
+
+  it('drops empty diag values so the script can emit placeholder keys', () => {
+    const summary = summarizeRestartFailure({
+      schema: 1, ts: 1, target: 'updater', stage: 'task-missing',
+      diag: { start_error: '', selfheal_error: '   ', task_state: 'Ready' },
+    });
+    expect(summary).not.toContain('start_error');
+    expect(summary).not.toContain('selfheal_error');
+    expect(summary).toContain('task_state="Ready"');
+  });
+
+  it('keeps the stage readable no matter how large the diagnostics are', () => {
+    const summary = summarizeRestartFailure({
+      schema: 1, ts: 1, target: 'updater', stage: 'not-running-after-start',
+      detail: 'x'.repeat(5_000),
+      diag: {
+        log_tail: 'y'.repeat(5_000),
+        task_state: 'Ready',
+        extra_one: 'z'.repeat(5_000),
+        extra_two: 'w'.repeat(5_000),
+      },
+    });
+    expect(summary.startsWith('stage=not-running-after-start')).toBe(true);
+    expect(summary.length).toBeLessThanOrEqual(1_000);
+    // The ordered keys win the budget over the alphabetical extras.
+    expect(summary).toContain('task_state="Ready"');
+  });
+
+  it('strips quotes, newlines and tabs that would break key="value" parsing', () => {
+    const summary = summarizeRestartFailure({
+      schema: 1, ts: 1, target: 'collector', stage: 'start-failed',
+      detail: 'boom "quoted"\nsecond line\tafter tab',
+    });
+    expect(summary).toBe('stage=start-failed reason="boom quoted second line after tab"');
+  });
+});
+
+describe('describeRestartCommandError', () => {
+  it('reports both stream tails, because the scripts print diagnostics on stdout', () => {
+    const detail = describeRestartCommandError({
+      message: 'Command failed: powershell.exe ...',
+      code: 1,
+      stdout: '[restart-failure] target=updater stage=register-denied',
+      stderr: 'Cmd-RestartUpdater : Service manager failed to restart updater',
+    });
+    expect(detail).toContain('exit=1');
+    expect(detail).toContain('stdout="[restart-failure] target=updater stage=register-denied"');
+    expect(detail).toContain('stderr="Cmd-RestartUpdater : Service manager failed to restart updater"');
+  });
+
+  it('keeps the end of a long stream, where the failure actually is', () => {
+    const detail = describeRestartCommandError({ code: 1, stdout: `${'a'.repeat(5_000)}THE-REAL-REASON` });
+    expect(detail).toContain('THE-REAL-REASON');
+    expect(detail.length).toBeLessThan(1_000);
+  });
+
+  it('falls back to the error message when there is no output at all', () => {
+    const detail = describeRestartCommandError(new Error('spawn powershell.exe ENOENT'));
+    expect(detail).toContain('spawn powershell.exe ENOENT');
+    expect(describeRestartCommandError(undefined)).toBe('no error detail');
+  });
+
+  it('recognises a timeout kill', () => {
+    expect(isRestartCommandTimeout({ killed: true, signal: 'SIGTERM' })).toBe(true);
+    expect(isRestartCommandTimeout({ code: 'ETIMEDOUT' })).toBe(true);
+    expect(isRestartCommandTimeout({ code: 1 })).toBe(false);
+    expect(isRestartCommandTimeout(new Error('nope'))).toBe(false);
+  });
+});
+
+describe('sanitizeAlarmText', () => {
+  it('collapses whitespace and truncates', () => {
+    expect(sanitizeAlarmText('  a\t b \n c  ', 100)).toBe('a b c');
+    expect(sanitizeAlarmText('abcdef', 3)).toBe('abc');
+  });
+});

--- a/tests/unit/utils/restart-breadcrumb.test.ts
+++ b/tests/unit/utils/restart-breadcrumb.test.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import {
   clearRestartFailure,
+  coerceRestartDiag,
   describeRestartCommandError,
   isRestartCommandTimeout,
   isRestartFailureFresh,
@@ -11,6 +12,7 @@ import {
   restartFailurePath,
   sanitizeAlarmText,
   summarizeRestartFailure,
+  writeRestartFailure,
   type RestartFailureBreadcrumb,
 } from '../../../src/utils/restart-breadcrumb.js';
 
@@ -83,6 +85,55 @@ describe('restart-breadcrumb reader', () => {
   it('places the file under logs/ per target', () => {
     expect(restartFailurePath('/d', 'updater')).toBe(path.join('/d', 'logs', 'last-restart-failure-updater.json'));
     expect(restartFailurePath('/d', 'collector')).toBe(path.join('/d', 'logs', 'last-restart-failure-collector.json'));
+  });
+
+  it('maps 5.1 Key/Value arrays and ignores nested objects', () => {
+    expect(coerceRestartDiag([
+      { Key: 'definition_owner', Value: 'BUILTIN\\Administrators' },
+      { key: 'task_state', value: 'Ready' },
+    ])).toEqual({
+      definition_owner: 'BUILTIN\\Administrators',
+      task_state: 'Ready',
+    });
+    expect(coerceRestartDiag({ task_state: 'Ready' })).toEqual({ task_state: 'Ready' });
+    expect(coerceRestartDiag(null)).toBeUndefined();
+  });
+
+  it('coerces the 5.1 ConvertTo-Json nested-hashtable shape into a string map', async () => {
+    // Windows PowerShell 5.1 serializes `@{ diag = @{ definition_owner = "..." } }` as
+    // `"diag": [{ "Key": "...", "Value": "..." }, ...]`. CI writes JSON.stringify objects,
+    // so this fixture is the only thing that pins the real on-box shape.
+    writeBreadcrumb('updater', {
+      schema: 1,
+      ts: 1_700_000_000,
+      target: 'updater',
+      stage: 'register-denied',
+      init_type: 'taskscheduler',
+      detail: 'Access is denied.',
+      diag: [
+        { Key: 'definition_owner', Value: 'BUILTIN\\Administrators' },
+        { Key: 'task_state', Value: 'Ready' },
+        { Key: 'exists_schtasks', Value: 'yes' },
+      ],
+    });
+
+    const bc = await readRestartFailure(dataDir, 'updater');
+    expect(bc?.diag?.definition_owner).toBe('BUILTIN\\Administrators');
+    expect(bc?.diag?.task_state).toBe('Ready');
+    const summary = summarizeRestartFailure(bc!);
+    expect(summary).toContain('definition_owner="BUILTIN\\Administrators"');
+    expect(summary).toContain('task_state="Ready"');
+    expect(summary).not.toContain('[object Object]');
+  });
+
+  it('writeRestartFailure persists a timeout breadcrumb the cooldown alarm can read', async () => {
+    writeRestartFailure(dataDir, 'updater', {
+      stage: 'timeout',
+      detail: 'restart command killed by timeout before it reported a stage',
+    });
+    const bc = await readRestartFailure(dataDir, 'updater');
+    expect(bc?.stage).toBe('timeout');
+    expect(summarizeRestartFailure(bc!)).toContain('stage=timeout');
   });
 });
 


### PR DESCRIPTION
## Summary
- Windows `restart-updater` used to fail with only `init_type=taskscheduler`: diagnostics were on stdout (`execFile` keeps stderr), `Write-Error` under `$ErrorActionPreference=Stop` was terminating, and `Get-TaskQuery` still skipped `Start-ScheduledTask` on CIM query failure.
- Service scripts now write `logs/last-restart-failure-{collector,updater}.json` before exiting; watchdog/updater reuse existing alarms and attach `stage` / `reason`. Bounded waits replace a one-second probe; background fallback waits too.
- Query-fail / `schtasks=yes` still tries `Start-ScheduledTask` then `schtasks /Run`; self-heal re-register only after the task is confirmed missing. Wait loops no longer delete pid files.

## Test plan
- [x] `vitest run` on `ps1-restart-diagnostics`, `sh-restart-diagnostics`, `ps1-restart-best-effort`, `restart-breadcrumb`, `updater-watchdog`, `updater.test.ts`
- [ ] Confirm a `taskscheduler` install still starts the existing task when re-registration is Access Denied
- [ ] Confirm CIM query failure does not delete/recreate the task


Made with [Cursor](https://cursor.com)