### PR TITLE
fix(codex): support single-quoted TOML section keys in trust writer (…

### DIFF
--- a/src/deployment/codex-trust-writer.ts
+++ b/src/deployment/codex-trust-writer.ts
@@ -177,6 +177,9 @@ function decodeTomlBasicString(value: string): string | null {
 }
 
 function tomlKeyCandidates(value: string): string[] {
+  if (value.startsWith("'") && value.endsWith("'")) {
+    return [value.slice(1, -1)];
+  }
   const decoded = decodeTomlBasicString(value);
   const raw = value.startsWith('"') && value.endsWith('"') ? value.slice(1, -1) : null;
   return [...new Set([decoded, raw].filter((candidate): candidate is string => candidate !== null))];
@@ -188,18 +191,20 @@ interface ParsedTrustSection {
   enabledLine?: string;
 }
 
+const TOML_HOOK_STATE_CAPTURE = /^\s*\[hooks\.state\.(("(?:\\.|[^"\\])*")|('[^']*'))\]\s*$/;
+
 function parseTrustSections(content: string): ParsedTrustSection[] {
   const lines = content.split('\n');
   const sections: ParsedTrustSection[] = [];
-  const header = /^\s*\[hooks\.state\.("(?:\\.|[^"\\])*")\]\s*$/;
   for (let i = 0; i < lines.length; i++) {
-    const match = lines[i]!.match(header);
+    const match = lines[i]!.match(TOML_HOOK_STATE_CAPTURE);
     if (!match) continue;
-    const key = tomlKeyCandidates(match[1]!)[0];
+    const rawKeyToken = match[1]!;
+    const key = tomlKeyCandidates(rawKeyToken)[0];
     if (key === undefined) continue;
     const section: ParsedTrustSection = { key };
     for (let j = i + 1; j < lines.length && !/^\s*\[/.test(lines[j]!); j++) {
-      const hash = lines[j]!.match(/^\s*trusted_hash\s*=\s*"([^"]+)"/);
+      const hash = lines[j]!.match(/^\s*trusted_hash\s*=\s*["']([^"']+)["']/);
       if (hash) section.hash = hash[1];
       if (/^\s*enabled\s*=/.test(lines[j]!)) section.enabledLine = lines[j]!.trim();
     }
@@ -212,10 +217,9 @@ function removeExactTrustSections(content: string, keys: ReadonlySet<string>): s
   if (keys.size === 0) return content;
   const lines = content.split('\n');
   const out: string[] = [];
-  const header = /^\s*\[hooks\.state\.("(?:\\.|[^"\\])*")\]\s*$/;
   let skipping = false;
   for (const line of lines) {
-    const match = line.match(header);
+    const match = line.match(TOML_HOOK_STATE_CAPTURE);
     if (match) {
       skipping = tomlKeyCandidates(match[1]!).some(key => keys.has(key));
       if (!skipping) out.push(line);

--- a/tests/unit/deployment/codex-trust-writer.test.ts
+++ b/tests/unit/deployment/codex-trust-writer.test.ts
@@ -478,4 +478,66 @@ describe('writeTrustedHashes / verifyTrustHashes 闭环', () => {
     expect(repaired).toContain('enabled = false');
     expect(repaired).toContain(`trusted_hash = "${hash}"`);
   });
+
+  test('recognizes single-quoted TOML keys and trusted_hash without false missing-key repair', () => {
+    const windowsHooksPath = String.raw`C:\Users\navy\.codex\hooks.json`;
+    const location: InstalledCodexHookLocation = {
+      eventName: 'SessionStart',
+      eventKey: 'session_start',
+      groupIndex: 0,
+      handlerIndex: 0,
+      matcher: '*',
+      handler: { type: 'command', command: 'powershell.exe -File hook.ps1 session-start' },
+    };
+    const key = installedHookStateKey(windowsHooksPath, location);
+    const hash = computeInstalledHookTrustHash(location);
+
+    // Codex native rust toml serializer writes literal strings with single quotes on Windows
+    fs.writeFileSync(configPath, [
+      `[hooks.state.'${key}']`,
+      `trusted_hash = '${hash}'`,
+      '',
+    ].join('\n'));
+
+    const opts = {
+      configPath,
+      hooksJsonAbsPath: windowsHooksPath,
+      locations: { SessionStart: location },
+      marker: 'otel-codex-hook',
+    };
+
+    const verify = verifyTrustHashes(opts);
+    expect(verify.valid).toBe(true);
+    expect(verify.mismatches).toEqual([]);
+    expect(writeTrustedHashes(opts)).toBe(false);
+  });
+
+  test('removeTrustBlock removes single-quoted trust sections cleanly', () => {
+    const windowsHooksPath = String.raw`C:\Users\navy\.codex\hooks.json`;
+    const location: InstalledCodexHookLocation = {
+      eventName: 'SessionStart',
+      eventKey: 'session_start',
+      groupIndex: 0,
+      handlerIndex: 0,
+      matcher: '*',
+      handler: { type: 'command', command: 'powershell.exe -File hook.ps1 session-start' },
+    };
+    const key = installedHookStateKey(windowsHooksPath, location);
+    const hash = computeInstalledHookTrustHash(location);
+
+    fs.writeFileSync(configPath, [
+      `[hooks.state.'${key}']`,
+      `trusted_hash = "${hash}"`,
+      '',
+      '[hooks.state."third-party@plugin:stop:0:0"]',
+      'trusted_hash = "sha256:KEEP"',
+      '',
+    ].join('\n'));
+
+    const removed = removeTrustBlock(configPath, 'otel-codex-hook', [key]);
+    expect(removed).toBe(true);
+    const content = fs.readFileSync(configPath, 'utf8');
+    expect(content).not.toContain(key);
+    expect(content).toContain('sha256:KEEP');
+  });
 });


### PR DESCRIPTION
…#380)
### Summary

Fixes #380.

In Windows environments, Codex (backed by Rust's `toml` serializer) persists path-based table keys as TOML literal strings using single quotes (e.g. `[hooks.state.'C:\Users\...:session_start:0:0']`) to avoid backslash escaping issues.

Previously, `codex-trust-writer.ts` only matched double-quoted keys (`[hooks.state."..."]`). As a result:
1. `parseTrustSections` failed to match any existing entries, leading `verifyTrustHashes` to falsely consider keys missing (`False Missing`).
2. The periodic `HookWatchdog` repeatedly appended duplicate double-quoted trust sections to `~/.codex/config.toml`.
3. Conflicting and corrupted configurations prevented Codex from launching properly, and manually deleting entries caused an endless loop of re-injection.

### Changes

- **`src/deployment/codex-trust-writer.ts`**:
  - Updated table header regex to capture both single-quoted (`'...'`) and double-quoted (`"..."`) keys.
  - Enhanced `tomlKeyCandidates` to unwrap single-quoted literal keys directly without JSON-string decoding.
  - Updated `trusted_hash` regex to accept both single and double quotes.
  - Updated `removeExactTrustSections` to cleanly identify and purge single-quoted keys upon undeploy/cleanup.
- **`tests/unit/deployment/codex-trust-writer.test.ts`**:
  - Added unit test verifying that single-quoted keys in `config.toml` pass hash verification without false missing-key repair.
  - Added unit test verifying that `removeTrustBlock` properly removes single-quoted trust blocks while preserving third-party sections.

### Verification

- Ran `vitest run tests/unit/deployment/codex-trust-writer.test.ts` (24/24 passed).
- Built project via `npm run build` (successful).
- Verified manually against local Windows `~/.codex/config.toml` files.
