### PR TITLE
fix(multimodal): extract Qoder IDE image-only turns by synthesizing a uri-only request

### DIFF
--- a/src/inputs/qoder-trace/qoder-ide-multimodal.ts
+++ b/src/inputs/qoder-trace/qoder-ide-multimodal.ts
@@ -18,7 +18,10 @@ import {
 } from '../../multimodal/index.js';
 import { LruMap, MULTIMODAL_LRU_LIMIT } from '../../multimodal/uploader/lru-set.js';
 import { createLogger } from '../../utils/logger.js';
-import { readAttachedImagePathsForRequestIds, readChatRecordGmtCreateMs } from './sqlite-token-reader.js';
+import {
+  readAttachedImagePathsForRequestIds,
+  type AttachedImageLookup,
+} from './sqlite-token-reader.js';
 
 const logger = createLogger('QoderIdeMultimodal');
 
@@ -37,14 +40,14 @@ const MARKDOWN_IMAGE_RE = new RegExp(
 );
 
 /**
- * request_id → attached paths. Process-local LRU.
- * Map values may be `[]` (confirmed empty or already attached). Ids absent from a lookup are not cached.
+ * request_id → attached lookup. Process-local LRU.
+ * `paths: []` means confirmed empty or already attached. Ids absent from a lookup are not cached.
  */
-const attachedPathsByRequestId = new LruMap<string[]>(MULTIMODAL_LRU_LIMIT);
+const attachedLookupByRequestId = new LruMap<AttachedImageLookup>(MULTIMODAL_LRU_LIMIT);
 
 /** Clear process-local attachedImagePaths cache. */
 export function clearAttachedImagePathsCache(): void {
-  attachedPathsByRequestId.clear();
+  attachedLookupByRequestId.clear();
 }
 
 interface EnrichStats {
@@ -136,12 +139,12 @@ async function enrichInputAttachedImages(
   const uniqueIds = [...new Set(requestIds)];
   if (uniqueIds.length === 0) return;
 
-  const byRequest = new Map<string, string[]>();
+  const byRequest = new Map<string, AttachedImageLookup>();
   const newIds: string[] = [];
   for (const id of uniqueIds) {
-    const cached = attachedPathsByRequestId.get(id);
+    const cached = attachedLookupByRequestId.get(id);
     if (cached !== undefined) {
-      if (cached.length > 0) byRequest.set(id, cached);
+      if (cached.paths.length > 0) byRequest.set(id, cached);
     } else {
       newIds.push(id);
     }
@@ -151,8 +154,8 @@ async function enrichInputAttachedImages(
     try {
       const fetched = await readAttachedImagePathsWithRetry(newIds);
       for (const [id, found] of fetched) {
-        attachedPathsByRequestId.set(id, found);
-        if (found.length > 0) byRequest.set(id, found);
+        attachedLookupByRequestId.set(id, found);
+        if (found.paths.length > 0) byRequest.set(id, found);
       }
     } catch (err) {
       logger.warn('qoder ide multimodal attachedImagePaths lookup failed', {
@@ -182,7 +185,7 @@ async function enrichInputAttachedImages(
   }
 
   // When request_id is only on llm.response, fall back to same-turn input carrier.
-  for (const [requestId, paths] of byRequest) {
+  for (const [requestId, lookup] of byRequest) {
     let carrier = carriersByRequest.get(requestId);
     let synthesized = false;
     let response: AgentActivityEntry | undefined;
@@ -202,11 +205,7 @@ async function enrichInputAttachedImages(
           && Array.isArray(e['gen_ai.input.messages_delta']),
         );
         if (!carrier) {
-          carrier = synthesizeUriOnlyRequest(
-            response,
-            requestId,
-            await readChatRecordGmtCreateMs(requestId),
-          );
+          carrier = synthesizeUriOnlyRequest(response, requestId, lookup.startMs);
           entries.push(carrier);
           synthesized = true;
         }
@@ -214,12 +213,12 @@ async function enrichInputAttachedImages(
     }
     if (!carrier) continue;
     const timeMs = entryTimeMs(carrier);
-    const n = await appendUriPartsToMessagesDelta(carrier, paths, pathToUri, timeMs, stats);
+    const n = await appendUriPartsToMessagesDelta(carrier, lookup.paths, pathToUri, timeMs, stats);
     if (n > 0) {
       stats.inputUri += n;
       touched.add(carrier);
       // Consume paths so this request_id is not attached again on later batches.
-      attachedPathsByRequestId.set(requestId, []);
+      attachedLookupByRequestId.set(requestId, { paths: [] });
     } else if (synthesized) {
       entries.pop();
       if (response && carrier['gen_ai.turn.start'] === true) {
@@ -235,8 +234,8 @@ async function enrichInputAttachedImages(
  */
 async function readAttachedImagePathsWithRetry(
   requestIds: string[],
-): Promise<Map<string, string[]>> {
-  const result = new Map<string, string[]>();
+): Promise<Map<string, AttachedImageLookup>> {
+  const result = new Map<string, AttachedImageLookup>();
   let pending = requestIds;
   let lastError: unknown;
 
@@ -249,8 +248,8 @@ async function readAttachedImagePathsWithRetry(
     try {
       const fetched = await readAttachedImagePathsForRequestIds(pending);
       for (const id of pending) {
-        const paths = fetched.get(id);
-        if (paths !== undefined) result.set(id, paths);
+        const lookup = fetched.get(id);
+        if (lookup !== undefined) result.set(id, lookup);
       }
       pending = pending.filter(id => !fetched.has(id));
     } catch (err) {

--- a/src/inputs/qoder-trace/qoder-ide-multimodal.ts
+++ b/src/inputs/qoder-trace/qoder-ide-multimodal.ts
@@ -1,5 +1,6 @@
-import * as crypto from 'node:crypto';
+import { v5 as uuidv5 } from 'uuid';
 import type { AgentActivityEntry, JsonValue, MultimodalUploadMode } from '../../types/index.js';
+import { AGENT_INPUT_EVENT_NAMESPACE } from '../../normalization/agent-input-dual-write.js';
 import {
   multimodalUploadIncludesInput,
   multimodalUploadIncludesOutput,
@@ -200,20 +201,7 @@ async function enrichInputAttachedImages(
           && Array.isArray(e['gen_ai.input.messages_delta']),
         );
         if (!carrier) {
-          carrier = {
-            'event.id': crypto.randomUUID(),
-            'event.name': 'llm.request',
-            'gen_ai.turn.id': turnId,
-            'gen_ai.step.id': response['gen_ai.step.id'],
-            'gen_ai.session.id': response['gen_ai.session.id'],
-            'gen_ai.agent.type': response['gen_ai.agent.type'],
-            'gen_ai.provider.name': response['gen_ai.provider.name'],
-            'gen_ai.request.model': response['gen_ai.request.model'],
-            'user.id': response['user.id'],
-            'gen_ai.request.id': requestId,
-            'agent.request_id': requestId,
-            time_unix_nano: response.time_unix_nano,
-          } as AgentActivityEntry;
+          carrier = synthesizeUriOnlyRequest(response, requestId);
           entries.push(carrier);
           synthesized = true;
         }
@@ -430,6 +418,37 @@ export function extractMarkdownImagePaths(text: string, cwd?: string): string[] 
     matchAll(MARKDOWN_IMAGE_RE, text, m => m[1] ?? m[2]),
     cwd ? raw => resolveImagePath(raw, cwd) : undefined,
   );
+}
+
+export function deriveSyntheticIdeRequestEventId(responseEventId: string, requestId: string): string {
+  return uuidv5(
+    `qoder-ide-synthetic-llm.request\0${responseEventId}\0${requestId}`,
+    AGENT_INPUT_EVENT_NAMESPACE,
+  );
+}
+
+function synthesizeUriOnlyRequest(
+  response: AgentActivityEntry,
+  requestId: string,
+): AgentActivityEntry {
+  const carrier = { ...response } as AgentActivityEntry;
+  carrier['event.id'] = deriveSyntheticIdeRequestEventId(String(response['event.id'] ?? ''), requestId);
+  carrier['event.name'] = 'llm.request';
+  for (const key of Object.keys(carrier)) {
+    if (isResponseOnlyField(key)) delete carrier[key];
+  }
+  if (response['gen_ai.turn.start'] === true) {
+    delete response['gen_ai.turn.start'];
+  }
+  return carrier;
+}
+
+function isResponseOnlyField(key: string): boolean {
+  return key === 'gen_ai.turn.end'
+    || key.startsWith('gen_ai.output.')
+    || key.startsWith('gen_ai.response.')
+    || key.startsWith('gen_ai.usage.')
+    || key.startsWith('error.');
 }
 
 function cwdOf(entry: AgentActivityEntry): string | undefined {

--- a/src/inputs/qoder-trace/qoder-ide-multimodal.ts
+++ b/src/inputs/qoder-trace/qoder-ide-multimodal.ts
@@ -18,7 +18,7 @@ import {
 } from '../../multimodal/index.js';
 import { LruMap, MULTIMODAL_LRU_LIMIT } from '../../multimodal/uploader/lru-set.js';
 import { createLogger } from '../../utils/logger.js';
-import { readAttachedImagePathsForRequestIds } from './sqlite-token-reader.js';
+import { readAttachedImagePathsForRequestIds, readChatRecordGmtCreateMs } from './sqlite-token-reader.js';
 
 const logger = createLogger('QoderIdeMultimodal');
 
@@ -202,7 +202,11 @@ async function enrichInputAttachedImages(
           && Array.isArray(e['gen_ai.input.messages_delta']),
         );
         if (!carrier) {
-          carrier = synthesizeUriOnlyRequest(response, requestId);
+          carrier = synthesizeUriOnlyRequest(
+            response,
+            requestId,
+            await readChatRecordGmtCreateMs(requestId),
+          );
           entries.push(carrier);
           synthesized = true;
         }
@@ -434,10 +438,15 @@ export function deriveSyntheticIdeRequestEventId(responseEventId: string, reques
 function synthesizeUriOnlyRequest(
   response: AgentActivityEntry,
   requestId: string,
+  gmtCreateMs?: number,
 ): AgentActivityEntry {
   const carrier = { ...response } as AgentActivityEntry;
   carrier['event.id'] = deriveSyntheticIdeRequestEventId(String(response['event.id'] ?? ''), requestId);
   carrier['event.name'] = 'llm.request';
+  const startNano = msToUnixNano(gmtCreateMs);
+  if (startNano !== undefined && isStrictlyBefore(startNano, response.time_unix_nano)) {
+    carrier.time_unix_nano = startNano;
+  }
   for (const key of Object.keys(carrier)) {
     if (isResponseOnlyField(key)) delete carrier[key];
   }
@@ -445,6 +454,20 @@ function synthesizeUriOnlyRequest(
     delete response['gen_ai.turn.start'];
   }
   return carrier;
+}
+
+function msToUnixNano(ms: number | undefined): string | undefined {
+  if (ms === undefined || !Number.isFinite(ms) || ms <= 0) return undefined;
+  return String(BigInt(Math.trunc(ms)) * 1_000_000n);
+}
+
+function isStrictlyBefore(candidateNano: string, responseNano: unknown): boolean {
+  if (typeof responseNano !== 'string' || !/^\d+$/.test(responseNano)) return true;
+  try {
+    return BigInt(candidateNano) < BigInt(responseNano);
+  } catch {
+    return true;
+  }
 }
 
 function isResponseOnlyField(key: string): boolean {

--- a/src/inputs/qoder-trace/qoder-ide-multimodal.ts
+++ b/src/inputs/qoder-trace/qoder-ide-multimodal.ts
@@ -434,6 +434,8 @@ function synthesizeUriOnlyRequest(
   const carrier = { ...response } as AgentActivityEntry;
   carrier['event.id'] = deriveSyntheticIdeRequestEventId(String(response['event.id'] ?? ''), requestId);
   carrier['event.name'] = 'llm.request';
+  const earlier = earlierByOneNano(response.time_unix_nano);
+  if (earlier !== undefined) carrier.time_unix_nano = earlier;
   for (const key of Object.keys(carrier)) {
     if (isResponseOnlyField(key)) delete carrier[key];
   }
@@ -441,6 +443,18 @@ function synthesizeUriOnlyRequest(
     delete response['gen_ai.turn.start'];
   }
   return carrier;
+}
+
+/** Image-only turns have no request clock; 1ns earlier keeps the pair ordered. */
+function earlierByOneNano(value: unknown): string | undefined {
+  if (typeof value !== 'string' || !/^\d+$/.test(value)) return undefined;
+  try {
+    const n = BigInt(value);
+    if (n < 1n) return undefined;
+    return String(n - 1n);
+  } catch {
+    return undefined;
+  }
 }
 
 function isResponseOnlyField(key: string): boolean {

--- a/src/inputs/qoder-trace/qoder-ide-multimodal.ts
+++ b/src/inputs/qoder-trace/qoder-ide-multimodal.ts
@@ -185,8 +185,9 @@ async function enrichInputAttachedImages(
   for (const [requestId, paths] of byRequest) {
     let carrier = carriersByRequest.get(requestId);
     let synthesized = false;
+    let response: AgentActivityEntry | undefined;
     if (!carrier) {
-      const response = entries.find(
+      response = entries.find(
         e => e['event.name'] === 'llm.response' && requestIdOf(e) === requestId,
       );
       if (response) {
@@ -217,6 +218,9 @@ async function enrichInputAttachedImages(
       attachedPathsByRequestId.set(requestId, []);
     } else if (synthesized) {
       entries.pop();
+      if (response && carrier['gen_ai.turn.start'] === true) {
+        response['gen_ai.turn.start'] = true;
+      }
     }
   }
 }
@@ -434,8 +438,6 @@ function synthesizeUriOnlyRequest(
   const carrier = { ...response } as AgentActivityEntry;
   carrier['event.id'] = deriveSyntheticIdeRequestEventId(String(response['event.id'] ?? ''), requestId);
   carrier['event.name'] = 'llm.request';
-  const earlier = earlierByOneNano(response.time_unix_nano);
-  if (earlier !== undefined) carrier.time_unix_nano = earlier;
   for (const key of Object.keys(carrier)) {
     if (isResponseOnlyField(key)) delete carrier[key];
   }
@@ -445,20 +447,11 @@ function synthesizeUriOnlyRequest(
   return carrier;
 }
 
-/** Image-only turns have no request clock; 1ns earlier keeps the pair ordered. */
-function earlierByOneNano(value: unknown): string | undefined {
-  if (typeof value !== 'string' || !/^\d+$/.test(value)) return undefined;
-  try {
-    const n = BigInt(value);
-    if (n < 1n) return undefined;
-    return String(n - 1n);
-  } catch {
-    return undefined;
-  }
-}
-
 function isResponseOnlyField(key: string): boolean {
   return key === 'gen_ai.turn.end'
+    || key === 'agent.stop_reason'
+    || key === 'agent.client_request_id'
+    || key === 'agent.qoder.match_ts'
     || key.startsWith('gen_ai.output.')
     || key.startsWith('gen_ai.response.')
     || key.startsWith('gen_ai.usage.')

--- a/src/inputs/qoder-trace/qoder-ide-multimodal.ts
+++ b/src/inputs/qoder-trace/qoder-ide-multimodal.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'node:crypto';
 import type { AgentActivityEntry, JsonValue, MultimodalUploadMode } from '../../types/index.js';
 import {
   multimodalUploadIncludesInput,
@@ -182,6 +183,7 @@ async function enrichInputAttachedImages(
   // When request_id is only on llm.response, fall back to same-turn input carrier.
   for (const [requestId, paths] of byRequest) {
     let carrier = carriersByRequest.get(requestId);
+    let synthesized = false;
     if (!carrier) {
       const response = entries.find(
         e => e['event.name'] === 'llm.response' && requestIdOf(e) === requestId,
@@ -197,6 +199,24 @@ async function enrichInputAttachedImages(
           && e['event.name'] === 'other'
           && Array.isArray(e['gen_ai.input.messages_delta']),
         );
+        if (!carrier) {
+          carrier = {
+            'event.id': crypto.randomUUID(),
+            'event.name': 'llm.request',
+            'gen_ai.turn.id': turnId,
+            'gen_ai.step.id': response['gen_ai.step.id'],
+            'gen_ai.session.id': response['gen_ai.session.id'],
+            'gen_ai.agent.type': response['gen_ai.agent.type'],
+            'gen_ai.provider.name': response['gen_ai.provider.name'],
+            'gen_ai.request.model': response['gen_ai.request.model'],
+            'user.id': response['user.id'],
+            'gen_ai.request.id': requestId,
+            'agent.request_id': requestId,
+            time_unix_nano: response.time_unix_nano,
+          } as AgentActivityEntry;
+          entries.push(carrier);
+          synthesized = true;
+        }
       }
     }
     if (!carrier) continue;
@@ -207,6 +227,8 @@ async function enrichInputAttachedImages(
       touched.add(carrier);
       // Consume paths so this request_id is not attached again on later batches.
       attachedPathsByRequestId.set(requestId, []);
+    } else if (synthesized) {
+      entries.pop();
     }
   }
 }

--- a/src/inputs/qoder-trace/qoder-trace-input.ts
+++ b/src/inputs/qoder-trace/qoder-trace-input.ts
@@ -236,10 +236,18 @@ export class QoderTraceInput extends BaseInput {
         // JetBrains shares this input but has no multimodal extractor yet.
         if (isQoderIdeaSession(sessionEntries)) continue;
         if (this.multimodalStopped) break;
+        const before = sessionEntries.length;
         await enrichIdeMultimodal(sessionEntries, {
           uploadMode: this.multimodalUploadMode,
           pathToUri,
         });
+        for (let i = before; i < sessionEntries.length; i++) {
+          const entry = sessionEntries[i];
+          rawEntries.push(entry);
+          const turnId = (entry['gen_ai.turn.id'] as string) || 'unknown';
+          const group = turnGroups.get(turnId);
+          if (group) group.push(entry);
+        }
       }
       for (const turnEntries of cliTurns) {
         if (this.multimodalStopped) break;

--- a/src/inputs/qoder-trace/qoder-trace-input.ts
+++ b/src/inputs/qoder-trace/qoder-trace-input.ts
@@ -243,10 +243,10 @@ export class QoderTraceInput extends BaseInput {
         });
         for (let i = before; i < sessionEntries.length; i++) {
           const entry = sessionEntries[i];
-          rawEntries.push(entry);
+          insertBeforeMatchingResponse(rawEntries, entry);
           const turnId = (entry['gen_ai.turn.id'] as string) || 'unknown';
           const group = turnGroups.get(turnId);
-          if (group) group.push(entry);
+          if (group) insertBeforeMatchingResponse(group, entry);
         }
       }
       for (const turnEntries of cliTurns) {
@@ -417,4 +417,16 @@ export class QoderTraceInput extends BaseInput {
     }
     return undefined;
   }
+}
+
+function insertBeforeMatchingResponse(
+  target: AgentActivityEntry[],
+  request: AgentActivityEntry,
+): void {
+  const requestId = request['gen_ai.request.id'];
+  const idx = target.findIndex(e =>
+    e['event.name'] === 'llm.response' && e['gen_ai.request.id'] === requestId,
+  );
+  if (idx >= 0) target.splice(idx, 0, request);
+  else target.push(request);
 }

--- a/src/inputs/qoder-trace/sqlite-token-reader.ts
+++ b/src/inputs/qoder-trace/sqlite-token-reader.ts
@@ -24,17 +24,23 @@ export interface SqliteTokenResult {
   matchedDbPath: string | null;
 }
 
+export interface AttachedImageLookup {
+  paths: string[];
+  /** Earliest user chat_message.gmt_create (unix ms). */
+  startMs?: number;
+}
+
 /**
  * Batch-read user-attached image paths from chat_record.extra.
- * Keys are request_id; values are local image paths for that request.
+ * Keys are request_id. Also returns the user-message start clock when present.
  * DB paths are resolved the same way as token enrichment (not caller-supplied).
  * Fail-open: query errors are logged and skipped.
- * Only request_ids that appear in a row are recorded (`[]` if extra has no images).
+ * Only request_ids that appear in a row are recorded (`paths: []` if extra has no images).
  */
 export async function readAttachedImagePathsForRequestIds(
   requestIds: string[],
-): Promise<Map<string, string[]>> {
-  const result = new Map<string, string[]>();
+): Promise<Map<string, AttachedImageLookup>> {
+  const result = new Map<string, AttachedImageLookup>();
   const unique = [...new Set(requestIds.map(id => id.trim()).filter(Boolean))];
   if (unique.length === 0) return result;
 
@@ -43,13 +49,25 @@ export async function readAttachedImagePathsForRequestIds(
 
   const placeholders = unique.map(() => '?').join(', ');
   const sql = `
-    SELECT request_id AS request_id, extra AS extra
-    FROM chat_record
-    WHERE request_id IN (${placeholders})
+    SELECT
+      cr.request_id AS request_id,
+      cr.extra AS extra,
+      (
+        SELECT MIN(cm.gmt_create)
+        FROM chat_message cm
+        WHERE cm.request_id = cr.request_id
+          AND cm.role = 'user'
+      ) AS user_gmt_create
+    FROM chat_record cr
+    WHERE cr.request_id IN (${placeholders})
   `;
 
   for (const dbPath of dbPaths) {
-    let rows: Array<{ request_id: string; extra: string | null }>;
+    let rows: Array<{
+      request_id: string;
+      extra: string | null;
+      user_gmt_create?: number | string | null;
+    }>;
     try {
       rows = await queryReadonly(dbPath, sql, unique);
     } catch (err) {
@@ -59,37 +77,19 @@ export async function readAttachedImagePathsForRequestIds(
     for (const row of rows) {
       const requestId = row.request_id?.trim();
       if (!requestId || result.has(requestId)) continue;
-      const paths = parseAttachedImagePaths(row.extra);
-      result.set(requestId, paths);
+      const lookup: AttachedImageLookup = { paths: parseAttachedImagePaths(row.extra) };
+      const startMs = parseGmtCreateMs(row.user_gmt_create);
+      if (startMs !== undefined) lookup.startMs = startMs;
+      result.set(requestId, lookup);
     }
     if (result.size >= unique.length) break;
   }
   return result;
 }
 
-/**
- * Request-row create time from chat_record.gmt_create (unix ms).
- * Fail-open: missing column / missing row / query error → undefined.
- */
-export async function readChatRecordGmtCreateMs(requestId: string): Promise<number | undefined> {
-  const id = requestId.trim();
-  if (!id) return undefined;
-
-  const dbPaths = resolveAllQoderDbPaths();
-  if (dbPaths.length === 0) return undefined;
-
-  const sql = 'SELECT gmt_create AS gmt_create FROM chat_record WHERE request_id = ? LIMIT 1';
-  for (const dbPath of dbPaths) {
-    try {
-      const rows = await queryReadonly<{ gmt_create: number | string | null }>(dbPath, sql, [id]);
-      const raw = rows[0]?.gmt_create;
-      const n = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number(raw) : NaN;
-      if (Number.isFinite(n) && n > 0) return n;
-    } catch (err) {
-      logger.debug('sqlite chat_record gmt_create query failed', { dbPath, error: String(err) });
-    }
-  }
-  return undefined;
+function parseGmtCreateMs(raw: number | string | null | undefined): number | undefined {
+  const n = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number(raw) : NaN;
+  return Number.isFinite(n) && n > 0 ? n : undefined;
 }
 
 function parseAttachedImagePaths(raw: string | null | undefined): string[] {

--- a/src/inputs/qoder-trace/sqlite-token-reader.ts
+++ b/src/inputs/qoder-trace/sqlite-token-reader.ts
@@ -67,6 +67,31 @@ export async function readAttachedImagePathsForRequestIds(
   return result;
 }
 
+/**
+ * Request-row create time from chat_record.gmt_create (unix ms).
+ * Fail-open: missing column / missing row / query error → undefined.
+ */
+export async function readChatRecordGmtCreateMs(requestId: string): Promise<number | undefined> {
+  const id = requestId.trim();
+  if (!id) return undefined;
+
+  const dbPaths = resolveAllQoderDbPaths();
+  if (dbPaths.length === 0) return undefined;
+
+  const sql = 'SELECT gmt_create AS gmt_create FROM chat_record WHERE request_id = ? LIMIT 1';
+  for (const dbPath of dbPaths) {
+    try {
+      const rows = await queryReadonly<{ gmt_create: number | string | null }>(dbPath, sql, [id]);
+      const raw = rows[0]?.gmt_create;
+      const n = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number(raw) : NaN;
+      if (Number.isFinite(n) && n > 0) return n;
+    } catch (err) {
+      logger.debug('sqlite chat_record gmt_create query failed', { dbPath, error: String(err) });
+    }
+  }
+  return undefined;
+}
+
 function parseAttachedImagePaths(raw: string | null | undefined): string[] {
   if (!raw) return [];
   try {

--- a/tests/unit/inputs/qoder-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-trace-input.test.ts
@@ -1825,33 +1825,40 @@ describe('QoderTraceInput multimodal', () => {
         expect((freshB['gen_ai.input.messages_delta'] as any[])[0].parts.some((p: any) => p.type === 'uri')).toBe(true);
       });
 
-      it('keeps cached paths when carrier is missing so a later batch can attach', async () => {
+      it('synthesizes a uri-only llm.request when sqlite has images but no user carrier', async () => {
         const dir = makeMmTempDir();
-        const img = writePng(dir, 'late.png', 'late');
+        const img = writePng(dir, 'solo.png', 'solo');
         const pathToUri = vi.fn(fakePathToUri);
-        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-late', [img]]]));
+        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-solo', [img]]]));
 
         const responseOnly = mmEntry({
           'event.name': 'llm.response',
-          'gen_ai.request.id': 'req-late',
+          'gen_ai.request.id': 'req-solo',
           'gen_ai.output.messages': [
             { role: 'assistant', parts: [{ type: 'text', content: 'ok' }] },
           ],
         });
-        await enrichIdeMultimodal([responseOnly], { uploadMode: 'input', pathToUri });
-        expect(mockReadAttachedImagePaths).toHaveBeenCalledTimes(1);
-        expect(pathToUri).not.toHaveBeenCalled();
+        const batch = [responseOnly];
+        await enrichIdeMultimodal(batch, { uploadMode: 'input', pathToUri });
 
-        const user = mmEntry({
+        expect(batch).toHaveLength(2);
+        const request = batch[1];
+        expect(request['event.name']).toBe('llm.request');
+        expect(request['gen_ai.request.id']).toBe('req-solo');
+        expect((request['gen_ai.input.messages_delta'] as any[])[0].parts).toEqual([
+          { type: 'uri', mime_type: 'image/png', modality: 'image', uri: 'oss://test/solo' },
+        ]);
+
+        const laterUser = mmEntry({
           'event.name': 'other',
-          'gen_ai.request.id': 'req-late',
+          'gen_ai.request.id': 'req-solo',
           'gen_ai.input.messages_delta': [
             { role: 'user', parts: [{ type: 'text', content: 'explain' }] },
           ],
         });
-        await enrichIdeMultimodal([user], { uploadMode: 'input', pathToUri });
-        expect(mockReadAttachedImagePaths).toHaveBeenCalledTimes(1);
-        expect((user['gen_ai.input.messages_delta'] as any[])[0].parts.some((p: any) => p.type === 'uri')).toBe(true);
+        await enrichIdeMultimodal([laterUser], { uploadMode: 'input', pathToUri });
+        expect((laterUser['gen_ai.input.messages_delta'] as any[])[0].parts.some((p: any) => p.type === 'uri')).toBe(false);
+        expect(pathToUri).toHaveBeenCalledTimes(1);
       });
 
       it('caches a confirmed empty lookup and does not re-query', async () => {

--- a/tests/unit/inputs/qoder-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-trace-input.test.ts
@@ -1859,6 +1859,7 @@ describe('QoderTraceInput multimodal', () => {
         expect(request['gen_ai.request.id']).toBe('req-solo');
         expect(request['gen_ai.turn.start']).toBe(true);
         expect(request['gen_ai.turn.end']).toBeUndefined();
+        expect(request.time_unix_nano).toBe(String(BigInt(responseOnly.time_unix_nano) - 1n));
         expect(responseOnly['gen_ai.turn.start']).toBeUndefined();
         expect(responseOnly['gen_ai.turn.end']).toBe(true);
         expect((request['gen_ai.input.messages_delta'] as any[])[0].parts).toEqual([
@@ -1910,6 +1911,7 @@ describe('QoderTraceInput multimodal', () => {
         expect(request['agent.source']).toBe('qoder-hook');
         expect(request['workspace.path']).toBe('/tmp/ws');
         expect(request['git.repo']).toBe('org/repo');
+        expect(request.time_unix_nano).toBe(String(BigInt(responseOnly.time_unix_nano) - 1n));
         expect(request.observed_time_unix_nano).toBe('1700000000000000001');
         expect(request.resourceAttributes).toEqual({ 'service.version': '1.0.0' });
         expect(request['multica.issue.id']).toBe('ISSUE-1');
@@ -2320,7 +2322,7 @@ describe('QoderTraceInput multimodal', () => {
       }
     });
 
-    it('collect emits the synthetic request before its response with the same trace_id', async () => {
+    it('collect inserts the synthetic request before its response with a 1ns clock and a positive OTLP span', async () => {
       const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'qoder-trace-mm-solo-'));
       const imgPath = path.join(tmpDir, 'solo.png');
       await fs.writeFile(imgPath, Buffer.from('solo'));
@@ -2339,6 +2341,7 @@ describe('QoderTraceInput multimodal', () => {
           'gen_ai.request.id': 'req-solo',
           'gen_ai.turn.start': true,
           'gen_ai.turn.end': true,
+          'gen_ai.response.finish_reasons': ['stop'],
           'gen_ai.output.messages': [
             { role: 'assistant', parts: [{ type: 'text', content: 'ok' }] },
           ],
@@ -2373,11 +2376,22 @@ describe('QoderTraceInput multimodal', () => {
         expect(entries[1]['gen_ai.turn.start']).toBeUndefined();
         expect(entries[0].trace_id).toBe(entries[1].trace_id);
         expect(entries[0].trace_id).toBeTruthy();
+        expect(entries[0].time_unix_nano).toBe('1779999999999999999');
+        expect(entries[1].time_unix_nano).toBe('1780000000000000000');
 
         new TurnBoundaryProcessor().enrich(entries);
         expect(entries[0]['gen_ai.turn.start']).toBe(true);
         expect(entries[1]['gen_ai.turn.end']).toBe(true);
         expect(entries[1]['gen_ai.turn.start']).toBeUndefined();
+
+        process.env.OTEL_SEMCONV_STABILITY_OPT_IN ??= 'gen_ai_latest_experimental';
+        process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT ??= 'SPAN_ONLY';
+        const { convertEventLogToReadableSpans } = await import('@loongsuite/otel-util-genai');
+        const result = await convertEventLogToReadableSpans(entries as never, { strict: false });
+        const llm = result.spans.find(span => span.attributes['gen_ai.span.kind'] === 'LLM');
+        expect(llm).toBeDefined();
+        const durationNs = llm!.duration[0] * 1_000_000_000 + llm!.duration[1];
+        expect(durationNs).toBeGreaterThan(0);
       } finally {
         await fs.rm(tmpDir, { recursive: true, force: true });
         clearAttachedImagePathsCache();

--- a/tests/unit/inputs/qoder-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-trace-input.test.ts
@@ -1859,7 +1859,7 @@ describe('QoderTraceInput multimodal', () => {
         expect(request['gen_ai.request.id']).toBe('req-solo');
         expect(request['gen_ai.turn.start']).toBe(true);
         expect(request['gen_ai.turn.end']).toBeUndefined();
-        expect(request.time_unix_nano).toBe(String(BigInt(responseOnly.time_unix_nano) - 1n));
+        expect(request.time_unix_nano).toBe(responseOnly.time_unix_nano);
         expect(responseOnly['gen_ai.turn.start']).toBeUndefined();
         expect(responseOnly['gen_ai.turn.end']).toBe(true);
         expect((request['gen_ai.input.messages_delta'] as any[])[0].parts).toEqual([
@@ -1902,6 +1902,9 @@ describe('QoderTraceInput multimodal', () => {
           'gen_ai.response.finish_reasons': ['stop'],
           'gen_ai.usage.input_tokens': 12,
           'error.type': 'none',
+          'agent.stop_reason': 'end_turn',
+          'agent.client_request_id': 'cli-req',
+          'agent.qoder.match_ts': 1_700_000_000_000,
         } as Partial<AgentActivityEntry>);
         const batch = [responseOnly];
         await enrichIdeMultimodal(batch, { uploadMode: 'input', pathToUri: fakePathToUri });
@@ -1911,8 +1914,11 @@ describe('QoderTraceInput multimodal', () => {
         expect(request['agent.source']).toBe('qoder-hook');
         expect(request['workspace.path']).toBe('/tmp/ws');
         expect(request['git.repo']).toBe('org/repo');
-        expect(request.time_unix_nano).toBe(String(BigInt(responseOnly.time_unix_nano) - 1n));
+        expect(request.time_unix_nano).toBe(responseOnly.time_unix_nano);
         expect(request.observed_time_unix_nano).toBe('1700000000000000001');
+        expect(request['agent.stop_reason']).toBeUndefined();
+        expect(request['agent.client_request_id']).toBeUndefined();
+        expect(request['agent.qoder.match_ts']).toBeUndefined();
         expect(request.resourceAttributes).toEqual({ 'service.version': '1.0.0' });
         expect(request['multica.issue.id']).toBe('ISSUE-1');
         expect(request[INVOCATION_SESSION_ID_FIELD]).toBe('inv-sess');
@@ -1956,10 +1962,12 @@ describe('QoderTraceInput multimodal', () => {
         const responseOnly = mmEntry({
           'event.name': 'llm.response',
           'gen_ai.request.id': 'req-fail',
+          'gen_ai.turn.start': true,
         });
         const batch = [responseOnly];
         await enrichIdeMultimodal(batch, { uploadMode: 'input', pathToUri: async () => null });
         expect(batch).toEqual([responseOnly]);
+        expect(responseOnly['gen_ai.turn.start']).toBe(true);
       });
 
       it('caches a confirmed empty lookup and does not re-query', async () => {
@@ -2322,7 +2330,7 @@ describe('QoderTraceInput multimodal', () => {
       }
     });
 
-    it('collect inserts the synthetic request before its response with a 1ns clock and a positive OTLP span', async () => {
+    it('collect inserts the synthetic request before its response and keeps the source response clock', async () => {
       const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'qoder-trace-mm-solo-'));
       const imgPath = path.join(tmpDir, 'solo.png');
       await fs.writeFile(imgPath, Buffer.from('solo'));
@@ -2341,7 +2349,6 @@ describe('QoderTraceInput multimodal', () => {
           'gen_ai.request.id': 'req-solo',
           'gen_ai.turn.start': true,
           'gen_ai.turn.end': true,
-          'gen_ai.response.finish_reasons': ['stop'],
           'gen_ai.output.messages': [
             { role: 'assistant', parts: [{ type: 'text', content: 'ok' }] },
           ],
@@ -2376,7 +2383,7 @@ describe('QoderTraceInput multimodal', () => {
         expect(entries[1]['gen_ai.turn.start']).toBeUndefined();
         expect(entries[0].trace_id).toBe(entries[1].trace_id);
         expect(entries[0].trace_id).toBeTruthy();
-        expect(entries[0].time_unix_nano).toBe('1779999999999999999');
+        expect(entries[0].time_unix_nano).toBe('1780000000000000000');
         expect(entries[1].time_unix_nano).toBe('1780000000000000000');
 
         new TurnBoundaryProcessor().enrich(entries);
@@ -2391,7 +2398,7 @@ describe('QoderTraceInput multimodal', () => {
         const llm = result.spans.find(span => span.attributes['gen_ai.span.kind'] === 'LLM');
         expect(llm).toBeDefined();
         const durationNs = llm!.duration[0] * 1_000_000_000 + llm!.duration[1];
-        expect(durationNs).toBeGreaterThan(0);
+        expect(durationNs).toBe(0);
       } finally {
         await fs.rm(tmpDir, { recursive: true, force: true });
         clearAttachedImagePathsCache();

--- a/tests/unit/inputs/qoder-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-trace-input.test.ts
@@ -38,6 +38,7 @@ import type { InterceptTokenData } from '../../../src/inputs/qoder-trace/interce
 import type { SegmentTokenData } from '../../../src/inputs/qoder-trace/segment-token-reader.js';
 import {
   readAttachedImagePathsForRequestIds,
+  readChatRecordGmtCreateMs,
   type SqliteTokenData,
 } from '../../../src/inputs/qoder-trace/sqlite-token-reader.js';
 import { getTodayDateString } from '../../../src/utils/fs-utils.js';
@@ -51,10 +52,12 @@ vi.mock('../../../src/inputs/qoder-trace/sqlite-token-reader.js', async (importO
   return {
     ...actual,
     readAttachedImagePathsForRequestIds: vi.fn(),
+    readChatRecordGmtCreateMs: vi.fn().mockResolvedValue(undefined),
   };
 });
 
 const mockReadAttachedImagePaths = vi.mocked(readAttachedImagePathsForRequestIds);
+const mockReadChatRecordGmtCreateMs = vi.mocked(readChatRecordGmtCreateMs);
 
 function makeEntry(overrides: Partial<AgentActivityEntry> = {}): AgentActivityEntry {
   return {
@@ -1533,6 +1536,8 @@ describe('QoderTraceInput multimodal', () => {
         clearAttachedImagePathsCache();
         mockReadAttachedImagePaths.mockReset();
         mockReadAttachedImagePaths.mockResolvedValue(new Map());
+        mockReadChatRecordGmtCreateMs.mockReset();
+        mockReadChatRecordGmtCreateMs.mockResolvedValue(undefined);
       });
 
       it('attaches paths onto llm.request messages_delta by request_id', async () => {
@@ -1876,6 +1881,25 @@ describe('QoderTraceInput multimodal', () => {
         await enrichIdeMultimodal([laterUser], { uploadMode: 'input', pathToUri });
         expect((laterUser['gen_ai.input.messages_delta'] as any[])[0].parts.some((p: any) => p.type === 'uri')).toBe(false);
         expect(pathToUri).toHaveBeenCalledTimes(1);
+      });
+
+      it('uses chat_record.gmt_create on the synthetic request when it is earlier than Stop', async () => {
+        const dir = makeMmTempDir();
+        const img = writePng(dir, 'clock.png', 'clock');
+        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-clock', [img]]]));
+        mockReadChatRecordGmtCreateMs.mockResolvedValue(1_699_999_995_000);
+
+        const responseOnly = mmEntry({
+          'event.id': 'resp-clock',
+          'event.name': 'llm.response',
+          'gen_ai.request.id': 'req-clock',
+          time_unix_nano: '1700000000000000000',
+        });
+        const batch = [responseOnly];
+        await enrichIdeMultimodal(batch, { uploadMode: 'input', pathToUri: fakePathToUri });
+
+        expect(batch[1].time_unix_nano).toBe('1699999995000000000');
+        expect(responseOnly.time_unix_nano).toBe('1700000000000000000');
       });
 
       it('inherits shared context and strips response-only fields on the synthetic request', async () => {
@@ -2330,13 +2354,15 @@ describe('QoderTraceInput multimodal', () => {
       }
     });
 
-    it('collect inserts the synthetic request before its response and keeps the source response clock', async () => {
+    it('collect inserts the synthetic request before its response on the chat_record clock', async () => {
       const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'qoder-trace-mm-solo-'));
       const imgPath = path.join(tmpDir, 'solo.png');
       await fs.writeFile(imgPath, Buffer.from('solo'));
       clearAttachedImagePathsCache();
       mockReadAttachedImagePaths.mockReset();
       mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-solo', [imgPath]]]));
+      mockReadChatRecordGmtCreateMs.mockReset();
+      mockReadChatRecordGmtCreateMs.mockResolvedValue(1_779_999_995_000);
       try {
         const logFileName = `qoder-${getTodayDateString()}.jsonl`;
         const logFile = path.join(tmpDir, logFileName);
@@ -2383,7 +2409,7 @@ describe('QoderTraceInput multimodal', () => {
         expect(entries[1]['gen_ai.turn.start']).toBeUndefined();
         expect(entries[0].trace_id).toBe(entries[1].trace_id);
         expect(entries[0].trace_id).toBeTruthy();
-        expect(entries[0].time_unix_nano).toBe('1780000000000000000');
+        expect(entries[0].time_unix_nano).toBe('1779999995000000000');
         expect(entries[1].time_unix_nano).toBe('1780000000000000000');
 
         new TurnBoundaryProcessor().enrich(entries);
@@ -2398,7 +2424,7 @@ describe('QoderTraceInput multimodal', () => {
         const llm = result.spans.find(span => span.attributes['gen_ai.span.kind'] === 'LLM');
         expect(llm).toBeDefined();
         const durationNs = llm!.duration[0] * 1_000_000_000 + llm!.duration[1];
-        expect(durationNs).toBe(0);
+        expect(durationNs).toBe(5_000_000_000);
       } finally {
         await fs.rm(tmpDir, { recursive: true, force: true });
         clearAttachedImagePathsCache();

--- a/tests/unit/inputs/qoder-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-trace-input.test.ts
@@ -38,7 +38,7 @@ import type { InterceptTokenData } from '../../../src/inputs/qoder-trace/interce
 import type { SegmentTokenData } from '../../../src/inputs/qoder-trace/segment-token-reader.js';
 import {
   readAttachedImagePathsForRequestIds,
-  readChatRecordGmtCreateMs,
+  type AttachedImageLookup,
   type SqliteTokenData,
 } from '../../../src/inputs/qoder-trace/sqlite-token-reader.js';
 import { getTodayDateString } from '../../../src/utils/fs-utils.js';
@@ -52,12 +52,14 @@ vi.mock('../../../src/inputs/qoder-trace/sqlite-token-reader.js', async (importO
   return {
     ...actual,
     readAttachedImagePathsForRequestIds: vi.fn(),
-    readChatRecordGmtCreateMs: vi.fn().mockResolvedValue(undefined),
   };
 });
 
 const mockReadAttachedImagePaths = vi.mocked(readAttachedImagePathsForRequestIds);
-const mockReadChatRecordGmtCreateMs = vi.mocked(readChatRecordGmtCreateMs);
+
+function attached(paths: string[], startMs?: number): AttachedImageLookup {
+  return startMs === undefined ? { paths } : { paths, startMs };
+}
 
 function makeEntry(overrides: Partial<AgentActivityEntry> = {}): AgentActivityEntry {
   return {
@@ -1536,8 +1538,6 @@ describe('QoderTraceInput multimodal', () => {
         clearAttachedImagePathsCache();
         mockReadAttachedImagePaths.mockReset();
         mockReadAttachedImagePaths.mockResolvedValue(new Map());
-        mockReadChatRecordGmtCreateMs.mockReset();
-        mockReadChatRecordGmtCreateMs.mockResolvedValue(undefined);
       });
 
       it('attaches paths onto llm.request messages_delta by request_id', async () => {
@@ -1553,7 +1553,7 @@ describe('QoderTraceInput multimodal', () => {
         });
         mockReadAttachedImagePaths.mockImplementation(async (ids) => {
           expect(ids).toEqual(['req-1']);
-          return new Map([['req-1', [img]]]);
+          return new Map([['req-1', attached([img])]]);
         });
 
         await enrichIdeMultimodal([request], {
@@ -1579,7 +1579,7 @@ describe('QoderTraceInput multimodal', () => {
             { role: 'user', parts: [{ type: 'text', content: 'look' }] },
           ],
         });
-        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-in-gate', [img]]]));
+        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-in-gate', attached([img])]]));
 
         for (const mode of ['tool', 'output'] as const) {
           clearAttachedImagePathsCache();
@@ -1615,7 +1615,7 @@ describe('QoderTraceInput multimodal', () => {
             { role: 'user', parts: [{ type: 'text', content: 'ctx' }] },
           ],
         });
-        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-pref', [img]]]));
+        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-pref', attached([img])]]));
 
         await enrichIdeMultimodal([request, user], { uploadMode: 'input', pathToUri });
 
@@ -1652,9 +1652,9 @@ describe('QoderTraceInput multimodal', () => {
         mockReadAttachedImagePaths.mockImplementation(async (ids) => {
           expect(ids.sort()).toEqual(['req-a', 'req-b', 'req-empty'].sort());
           return new Map([
-            ['req-a', [imgA]],
-            ['req-b', [imgB]],
-            ['req-empty', []],
+            ['req-a', attached([imgA])],
+            ['req-b', attached([imgB])],
+            ['req-empty', attached([])],
           ]);
         });
 
@@ -1726,7 +1726,7 @@ describe('QoderTraceInput multimodal', () => {
         });
         mockReadAttachedImagePaths
           .mockRejectedValueOnce(new Error('sqlite busy'))
-          .mockResolvedValueOnce(new Map([['req-recovered', [img]]]));
+          .mockResolvedValueOnce(new Map([['req-recovered', attached([img])]]));
 
         await enrichIdeMultimodal([request], {
           uploadMode: 'input',
@@ -1757,7 +1757,7 @@ describe('QoderTraceInput multimodal', () => {
             { role: 'assistant', parts: [{ type: 'text', content: 'ok' }] },
           ],
         });
-        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-fb', [img]]]));
+        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-fb', attached([img])]]));
 
         await enrichIdeMultimodal([other, response], {
           uploadMode: 'input',
@@ -1772,7 +1772,7 @@ describe('QoderTraceInput multimodal', () => {
         const dir = makeMmTempDir();
         const img = writePng(dir, 'cached.png', 'cached');
         const pathToUri = vi.fn(fakePathToUri);
-        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-cache', [img]]]));
+        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-cache', attached([img])]]));
 
         const first = mmEntry({
           'event.name': 'other',
@@ -1804,7 +1804,7 @@ describe('QoderTraceInput multimodal', () => {
         const imgB = writePng(dir, 'b.png', 'b');
         const pathToUri = fakePathToUri;
 
-        mockReadAttachedImagePaths.mockResolvedValueOnce(new Map([['req-a', [imgA]]]));
+        mockReadAttachedImagePaths.mockResolvedValueOnce(new Map([['req-a', attached([imgA])]]));
         const first = mmEntry({
           'event.name': 'other',
           'gen_ai.request.id': 'req-a',
@@ -1814,7 +1814,7 @@ describe('QoderTraceInput multimodal', () => {
         });
         await enrichIdeMultimodal([first], { uploadMode: 'input', pathToUri });
 
-        mockReadAttachedImagePaths.mockResolvedValueOnce(new Map([['req-b', [imgB]]]));
+        mockReadAttachedImagePaths.mockResolvedValueOnce(new Map([['req-b', attached([imgB])]]));
         const againA = mmEntry({
           'event.name': 'other',
           'gen_ai.request.id': 'req-a',
@@ -1841,7 +1841,7 @@ describe('QoderTraceInput multimodal', () => {
         const dir = makeMmTempDir();
         const img = writePng(dir, 'solo.png', 'solo');
         const pathToUri = vi.fn(fakePathToUri);
-        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-solo', [img]]]));
+        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-solo', attached([img])]]));
 
         const responseOnly = mmEntry({
           'event.id': 'resp-solo',
@@ -1883,11 +1883,12 @@ describe('QoderTraceInput multimodal', () => {
         expect(pathToUri).toHaveBeenCalledTimes(1);
       });
 
-      it('uses chat_record.gmt_create on the synthetic request when it is earlier than Stop', async () => {
+      it('uses the user chat_message clock on the synthetic request when it is earlier than Stop', async () => {
         const dir = makeMmTempDir();
         const img = writePng(dir, 'clock.png', 'clock');
-        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-clock', [img]]]));
-        mockReadChatRecordGmtCreateMs.mockResolvedValue(1_699_999_995_000);
+        mockReadAttachedImagePaths.mockResolvedValue(
+          new Map([['req-clock', attached([img], 1_699_999_995_000)]]),
+        );
 
         const responseOnly = mmEntry({
           'event.id': 'resp-clock',
@@ -1905,7 +1906,7 @@ describe('QoderTraceInput multimodal', () => {
       it('inherits shared context and strips response-only fields on the synthetic request', async () => {
         const dir = makeMmTempDir();
         const img = writePng(dir, 'ctx.png', 'ctx');
-        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-ctx', [img]]]));
+        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-ctx', attached([img])]]));
 
         const responseOnly = mmEntry({
           'event.id': 'resp-ctx',
@@ -1964,7 +1965,7 @@ describe('QoderTraceInput multimodal', () => {
       it('derives the same synthetic event.id when the same response is replayed', async () => {
         const dir = makeMmTempDir();
         const img = writePng(dir, 'replay.png', 'replay');
-        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-replay', [img]]]));
+        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-replay', attached([img])]]));
 
         const makeResponse = () => mmEntry({
           'event.id': 'resp-replay',
@@ -1982,7 +1983,7 @@ describe('QoderTraceInput multimodal', () => {
       });
 
       it('drops the synthetic request when pathToUri fails', async () => {
-        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-fail', ['/tmp/missing.png']]]));
+        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-fail', attached(['/tmp/missing.png'])]]));
         const responseOnly = mmEntry({
           'event.name': 'llm.response',
           'gen_ai.request.id': 'req-fail',
@@ -2004,7 +2005,7 @@ describe('QoderTraceInput multimodal', () => {
           ],
         });
 
-        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-empty', []]]));
+        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-empty', attached([])]]));
         await enrichIdeMultimodal([makeReq()], { uploadMode: 'input', pathToUri });
         await enrichIdeMultimodal([makeReq()], { uploadMode: 'input', pathToUri });
         expect(mockReadAttachedImagePaths).toHaveBeenCalledTimes(1);
@@ -2025,7 +2026,7 @@ describe('QoderTraceInput multimodal', () => {
 
         mockReadAttachedImagePaths
           .mockResolvedValueOnce(new Map())
-          .mockResolvedValueOnce(new Map([['req-retry', [img]]]));
+          .mockResolvedValueOnce(new Map([['req-retry', attached([img])]]));
 
         await enrichIdeMultimodal([request], { uploadMode: 'input', pathToUri });
 
@@ -2354,15 +2355,15 @@ describe('QoderTraceInput multimodal', () => {
       }
     });
 
-    it('collect inserts the synthetic request before its response on the chat_record clock', async () => {
+    it('collect inserts the synthetic request before its response on the user chat_message clock', async () => {
       const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'qoder-trace-mm-solo-'));
       const imgPath = path.join(tmpDir, 'solo.png');
       await fs.writeFile(imgPath, Buffer.from('solo'));
       clearAttachedImagePathsCache();
       mockReadAttachedImagePaths.mockReset();
-      mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-solo', [imgPath]]]));
-      mockReadChatRecordGmtCreateMs.mockReset();
-      mockReadChatRecordGmtCreateMs.mockResolvedValue(1_779_999_995_000);
+      mockReadAttachedImagePaths.mockResolvedValue(
+        new Map([['req-solo', attached([imgPath], 1_779_999_995_000)]]),
+      );
       try {
         const logFileName = `qoder-${getTodayDateString()}.jsonl`;
         const logFile = path.join(tmpDir, logFileName);

--- a/tests/unit/inputs/qoder-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-trace-input.test.ts
@@ -13,10 +13,17 @@ import {
 } from '../../../src/inputs/qoder-trace/token-enricher.js';
 import {
   clearAttachedImagePathsCache,
+  deriveSyntheticIdeRequestEventId,
   enrichIdeMultimodal,
   extractMarkdownImagePaths,
   extractToolImagePaths,
 } from '../../../src/inputs/qoder-trace/qoder-ide-multimodal.js';
+import { TurnBoundaryProcessor } from '../../../src/normalization/turn-boundary-processor.js';
+import {
+  INVOCATION_SESSION_ID_FIELD,
+  INVOCATION_USER_ID_FIELD,
+  applyInvocationIdentity,
+} from '../../../src/normalization/invocation-identity.js';
 import {
   QoderTraceInput,
   qoderDefaultAllowedRootPaths,
@@ -1832,8 +1839,11 @@ describe('QoderTraceInput multimodal', () => {
         mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-solo', [img]]]));
 
         const responseOnly = mmEntry({
+          'event.id': 'resp-solo',
           'event.name': 'llm.response',
           'gen_ai.request.id': 'req-solo',
+          'gen_ai.turn.start': true,
+          'gen_ai.turn.end': true,
           'gen_ai.output.messages': [
             { role: 'assistant', parts: [{ type: 'text', content: 'ok' }] },
           ],
@@ -1842,9 +1852,15 @@ describe('QoderTraceInput multimodal', () => {
         await enrichIdeMultimodal(batch, { uploadMode: 'input', pathToUri });
 
         expect(batch).toHaveLength(2);
+        expect(batch[0]).toBe(responseOnly);
         const request = batch[1];
         expect(request['event.name']).toBe('llm.request');
+        expect(request['event.id']).toBe(deriveSyntheticIdeRequestEventId('resp-solo', 'req-solo'));
         expect(request['gen_ai.request.id']).toBe('req-solo');
+        expect(request['gen_ai.turn.start']).toBe(true);
+        expect(request['gen_ai.turn.end']).toBeUndefined();
+        expect(responseOnly['gen_ai.turn.start']).toBeUndefined();
+        expect(responseOnly['gen_ai.turn.end']).toBe(true);
         expect((request['gen_ai.input.messages_delta'] as any[])[0].parts).toEqual([
           { type: 'uri', mime_type: 'image/png', modality: 'image', uri: 'oss://test/solo' },
         ]);
@@ -1859,6 +1875,89 @@ describe('QoderTraceInput multimodal', () => {
         await enrichIdeMultimodal([laterUser], { uploadMode: 'input', pathToUri });
         expect((laterUser['gen_ai.input.messages_delta'] as any[])[0].parts.some((p: any) => p.type === 'uri')).toBe(false);
         expect(pathToUri).toHaveBeenCalledTimes(1);
+      });
+
+      it('inherits shared context and strips response-only fields on the synthetic request', async () => {
+        const dir = makeMmTempDir();
+        const img = writePng(dir, 'ctx.png', 'ctx');
+        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-ctx', [img]]]));
+
+        const responseOnly = mmEntry({
+          'event.id': 'resp-ctx',
+          'event.name': 'llm.response',
+          'gen_ai.request.id': 'req-ctx',
+          'user.id': 'native-user',
+          'gen_ai.session.id': 'native-sess',
+          'agent.source': 'qoder-hook',
+          'workspace.path': '/tmp/ws',
+          'git.repo': 'org/repo',
+          observed_time_unix_nano: '1700000000000000001',
+          resourceAttributes: { 'service.version': '1.0.0' },
+          'multica.issue.id': 'ISSUE-1',
+          [INVOCATION_SESSION_ID_FIELD]: 'inv-sess',
+          [INVOCATION_USER_ID_FIELD]: 'inv-user',
+          'gen_ai.output.messages': [{ role: 'assistant', parts: [{ type: 'text', content: 'ok' }] }],
+          'gen_ai.response.id': 'chatcmpl-1',
+          'gen_ai.response.finish_reasons': ['stop'],
+          'gen_ai.usage.input_tokens': 12,
+          'error.type': 'none',
+        } as Partial<AgentActivityEntry>);
+        const batch = [responseOnly];
+        await enrichIdeMultimodal(batch, { uploadMode: 'input', pathToUri: fakePathToUri });
+
+        const request = batch[1];
+        expect(request['event.name']).toBe('llm.request');
+        expect(request['agent.source']).toBe('qoder-hook');
+        expect(request['workspace.path']).toBe('/tmp/ws');
+        expect(request['git.repo']).toBe('org/repo');
+        expect(request.observed_time_unix_nano).toBe('1700000000000000001');
+        expect(request.resourceAttributes).toEqual({ 'service.version': '1.0.0' });
+        expect(request['multica.issue.id']).toBe('ISSUE-1');
+        expect(request[INVOCATION_SESSION_ID_FIELD]).toBe('inv-sess');
+        expect(request[INVOCATION_USER_ID_FIELD]).toBe('inv-user');
+        expect(request['gen_ai.output.messages']).toBeUndefined();
+        expect(request['gen_ai.response.id']).toBeUndefined();
+        expect(request['gen_ai.response.finish_reasons']).toBeUndefined();
+        expect(request['gen_ai.usage.input_tokens']).toBeUndefined();
+        expect(request['error.type']).toBeUndefined();
+
+        applyInvocationIdentity(request, '', 'fallback');
+        applyInvocationIdentity(responseOnly, '', 'fallback');
+        expect(request['gen_ai.session.id']).toBe('inv-sess');
+        expect(responseOnly['gen_ai.session.id']).toBe('inv-sess');
+        expect(request['user.id']).toBe('inv-user');
+        expect(responseOnly['user.id']).toBe('inv-user');
+      });
+
+      it('derives the same synthetic event.id when the same response is replayed', async () => {
+        const dir = makeMmTempDir();
+        const img = writePng(dir, 'replay.png', 'replay');
+        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-replay', [img]]]));
+
+        const makeResponse = () => mmEntry({
+          'event.id': 'resp-replay',
+          'event.name': 'llm.response',
+          'gen_ai.request.id': 'req-replay',
+        });
+        const first = [makeResponse()];
+        await enrichIdeMultimodal(first, { uploadMode: 'input', pathToUri: fakePathToUri });
+        clearAttachedImagePathsCache();
+        const second = [makeResponse()];
+        await enrichIdeMultimodal(second, { uploadMode: 'input', pathToUri: fakePathToUri });
+
+        expect(first[1]['event.id']).toBe(second[1]['event.id']);
+        expect(first[1]['event.id']).toBe(deriveSyntheticIdeRequestEventId('resp-replay', 'req-replay'));
+      });
+
+      it('drops the synthetic request when pathToUri fails', async () => {
+        mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-fail', ['/tmp/missing.png']]]));
+        const responseOnly = mmEntry({
+          'event.name': 'llm.response',
+          'gen_ai.request.id': 'req-fail',
+        });
+        const batch = [responseOnly];
+        await enrichIdeMultimodal(batch, { uploadMode: 'input', pathToUri: async () => null });
+        expect(batch).toEqual([responseOnly]);
       });
 
       it('caches a confirmed empty lookup and does not re-query', async () => {
@@ -2218,6 +2317,70 @@ describe('QoderTraceInput multimodal', () => {
         expect(cli['agentcore.task_id']).toBe('task-cli-runtime');
       } finally {
         await fs.rm(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it('collect emits the synthetic request before its response with the same trace_id', async () => {
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'qoder-trace-mm-solo-'));
+      const imgPath = path.join(tmpDir, 'solo.png');
+      await fs.writeFile(imgPath, Buffer.from('solo'));
+      clearAttachedImagePathsCache();
+      mockReadAttachedImagePaths.mockReset();
+      mockReadAttachedImagePaths.mockResolvedValue(new Map([['req-solo', [imgPath]]]));
+      try {
+        const logFileName = `qoder-${getTodayDateString()}.jsonl`;
+        const logFile = path.join(tmpDir, logFileName);
+        const responseOnly = {
+          'event.id': 'resp-solo',
+          'event.name': 'llm.response',
+          'gen_ai.agent.type': 'qoder',
+          'gen_ai.session.id': 'ide-sess',
+          'gen_ai.turn.id': 'ide-turn',
+          'gen_ai.request.id': 'req-solo',
+          'gen_ai.turn.start': true,
+          'gen_ai.turn.end': true,
+          'gen_ai.output.messages': [
+            { role: 'assistant', parts: [{ type: 'text', content: 'ok' }] },
+          ],
+          time_unix_nano: '1780000000000000000',
+        };
+        await fs.writeFile(logFile, `${JSON.stringify(responseOnly)}\n`);
+
+        const stateStore = new MockStateStore();
+        stateStore.set('qoder-trace', {
+          lastFile: logFileName,
+          lastOffset: 0,
+          extra: { hookHistoryInitialized: true },
+        });
+        const input = new QoderTraceInput({
+          stateStore: stateStore as any,
+          logDir: tmpDir,
+          pollIntervalMs: 60_000,
+          multimodal: {
+            enabled: true,
+            uploadMode: 'input',
+            processor: {
+              pathToUri: fakePathToUri,
+            } as any,
+          },
+        });
+
+        const entries = await (input as any).collect() as AgentActivityEntry[];
+        expect(entries.map(e => e['event.name'])).toEqual(['llm.request', 'llm.response']);
+        expect(entries[0]['event.id']).toBe(deriveSyntheticIdeRequestEventId('resp-solo', 'req-solo'));
+        expect(entries[0]['gen_ai.turn.start']).toBe(true);
+        expect(entries[1]['event.id']).toBe('resp-solo');
+        expect(entries[1]['gen_ai.turn.start']).toBeUndefined();
+        expect(entries[0].trace_id).toBe(entries[1].trace_id);
+        expect(entries[0].trace_id).toBeTruthy();
+
+        new TurnBoundaryProcessor().enrich(entries);
+        expect(entries[0]['gen_ai.turn.start']).toBe(true);
+        expect(entries[1]['gen_ai.turn.end']).toBe(true);
+        expect(entries[1]['gen_ai.turn.start']).toBeUndefined();
+      } finally {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+        clearAttachedImagePathsCache();
       }
     });
 


### PR DESCRIPTION
## Summary

Qoder IDE image-only turns (paste / attach an image with empty `<user_query>`) never wrote a `user` row into the official transcript. Hook then emitted only `llm.response`. IDE multimodal looks up `chat_record.extra.attachedImagePaths` and needs an `llm.request` / `other` with `messages_delta` to hang `uri` parts. Without that carrier the local path was found in SQLite and then discarded — no `pathToUri`, no object upload, no `uri` on the event.

This PR synthesizes a uri-only `llm.request` when SQLite has attached images and the same turn has no input carrier. Pilot only registers Qoder `Stop`, so there is no measured request clock. The synthetic request uses the earliest `chat_message(role='user').gmt_create` when present, otherwise the Stop/response clock. Text+image turns are unchanged.

## Why it dropped

```text
IDE image-only
  transcript: session_meta → progress → assistant → Stop
              (no user, no attachment)
  hook:       llm.response only
  SQLite:     attachedImagePaths = [SharedClientCache/cache/images/…]
  enrich:     found paths → no carrier → continue
```

Contrast: “explain this image” + image still has a `user` row, so hook emits `other` + `llm.request` and the existing attach path works.

## What changed

When `attachedImagePaths` is non-empty and the turn has no `llm.request` / `other` with `messages_delta`:

- Build an `llm.request` by shallow-copying the response, then strip response-only fields (`output` / `response` / `usage` / `error` / `turn.end` / `agent.stop_reason` / `agent.client_request_id` / `agent.qoder.match_ts`).
- `event.id` is UUIDv5 from the source response `event.id` + `request_id` (replay-stable).
- `time_unix_nano` uses the earliest user `chat_message.gmt_create` from the same batch query as `attachedImagePaths` when that ms is strictly earlier than the Stop/response clock; otherwise it keeps the response clock. No invented `1ns` latency, and no borrowed `UserPromptSubmit`.
- `messages_delta` is only the `uri` part — no placeholder text.
- Reuse `appendUriPartsToMessagesDelta` + `pathToUri` (same conversion as the normal path).
- Conversion failure (`pathToUri` returns nothing) `pop`s the empty stub and restores `turn.start` on the response. A later async upload failure still keeps the request and optimistic URI.
- Success writes the existing `request_id` cache to `[]`, so a later user event does not convert again.
- `collect()` inserts the new row before the matching response on `rawEntries` and the turn group.

Existing carrier lookup is unchanged: `llm.request` still wins over `other`; same-turn fallback still runs first.

```json
{
  "event.name": "llm.request",
  "gen_ai.request.id": "…",
  "gen_ai.input.messages_delta": [{
    "role": "user",
    "parts": [{
      "type": "uri",
      "mime_type": "image/png",
      "modality": "image",
      "uri": "sls://{project}/{logstore}/{YYYYMMDD}/{sha256}.png"
    }]
  }]
}
```

## Quality results

### Automated checks

- `npx vitest run tests/unit/inputs/qoder-trace-input.test.ts`
- Response-only + SQLite paths → uri-only `llm.request` on user `chat_message.gmt_create` when present; `pathToUri` miss restores `turn.start`
- Existing attach / prefer-request / cache / retry cases unchanged
