### PR TITLE
fix(qoder): derive IDE steps from transcript structure

### DIFF
--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -919,7 +919,7 @@ function hookEventOf(row) {
 
 // --- LLM Boundary Detection --------------------------------------------------
 
-export function buildLlmBoundaries(progressEvents, contentEvents) {
+export function buildLlmBoundaries(_progressEvents, contentEvents) {
   // Step 1: Group assistant blocks into LLM calls. Qoder transcript assistant
   // rows do not carry message.id, and progress windows are hook timing signals,
   // not reliable provider-call boundaries.
@@ -932,19 +932,26 @@ export function buildLlmBoundaries(progressEvents, contentEvents) {
   // the next assistant row starts a new LLM call.
   const assistantGroups = [];
   let currentGroup = [];
+  let currentGroupStartIndex = -1;
   let currentToolIds = new Set();
   let resolvedToolIds = new Set();
-  let currentToolStartNanos = null;
 
-  function flushGroup() {
-    if (currentGroup.length > 0) assistantGroups.push(currentGroup);
+  function flushGroup(contentEndIndex) {
+    if (currentGroup.length > 0) {
+      assistantGroups.push({
+        rows: currentGroup,
+        contentStartIndex: currentGroupStartIndex,
+        contentEndIndex,
+      });
+    }
     currentGroup = [];
+    currentGroupStartIndex = -1;
     currentToolIds = new Set();
     resolvedToolIds = new Set();
-    currentToolStartNanos = null;
   }
 
-  for (const row of contentEvents) {
+  for (let rowIndex = 0; rowIndex < contentEvents.length; rowIndex++) {
+    const row = contentEvents[rowIndex];
     if (row.type !== 'assistant') {
       if (isToolResult(row)) {
         for (const block of row.message?.content || []) {
@@ -961,69 +968,38 @@ export function buildLlmBoundaries(progressEvents, contentEvents) {
     const toolCycleComplete = currentGroup.length > 0 &&
       currentToolIds.size > 0 &&
       [...currentToolIds].every(id => resolvedToolIds.has(id));
-    // A cancelled/interrupted tool can omit its transcript tool_result even
-    // though Qoder emitted a completion hook. Count completion signals only
-    // within this group and require enough signals to cover every tool already
-    // declared; this preserves late parallel tool_use blocks after an early
-    // result while preventing an unresolved tool from swallowing all later LLMs.
-    const completedByHook = currentGroup.length > 0 &&
-      currentToolIds.size > 0 &&
-      currentToolStartNanos !== null &&
-      progressEvents.filter(pe => {
-        const peTs = timestampOrderNanos(pe.ts);
-        return peTs !== null && peTs > currentToolStartNanos && peTs < ts && (
-          pe.hookEvent === 'PostToolUse' || pe.hookEvent === 'PostToolUseFailure'
-        );
-      }).length >= currentToolIds.size;
-    if (toolCycleComplete || completedByHook) flushGroup();
+    // Progress hooks carry no tool id and third-party hooks share the same
+    // transcript. They cannot safely close an LLM group. If a transcript ever
+    // omits tool_result, conservatively retain later assistant rows in this
+    // group instead of inventing a boundary and an orphan request.
+    if (toolCycleComplete) flushGroup(rowIndex);
 
+    if (currentGroup.length === 0) currentGroupStartIndex = rowIndex;
     currentGroup.push(row);
     for (const block of row.message?.content || []) {
       if (block?.type === 'tool_use' && block.id) {
         currentToolIds.add(block.id);
-        if (currentToolStartNanos === null) currentToolStartNanos = ts;
       }
     }
   }
-  flushGroup();
+  flushGroup(contentEvents.length);
 
-  // Step 2: For each assistant group (= one LLM call), find timing from progress
+  // Step 2: Keep each group's exact transcript range. Timing is only fallback
+  // metadata and must never be used to reconstruct content ownership.
   const boundaries = [];
   for (let i = 0; i < assistantGroups.length; i++) {
     const group = assistantGroups[i];
-    const groupStartNanos = timestampOrderNanos(group[0].timestamp);
-    const groupEndNanos = timestampOrderNanos(group[group.length - 1].timestamp) ?? groupStartNanos;
+    const firstAssistant = group.rows[0];
+    const lastAssistant = group.rows[group.rows.length - 1];
+    const groupStartNanos = timestampOrderNanos(firstAssistant.timestamp);
+    const groupEndNanos = timestampOrderNanos(lastAssistant.timestamp) ?? groupStartNanos;
     if (groupStartNanos === null || groupEndNanos === null) continue;
 
-    // Find start time: last tool completion or UserPromptSubmit BEFORE this group
-    let startTs = null;
-    for (const pe of progressEvents) {
-      const peTs = timestampOrderNanos(pe.ts);
-      if (peTs === null) continue;
-      if (peTs >= groupStartNanos) break;
-      if (
-        pe.hookEvent === 'PostToolUse' ||
-        pe.hookEvent === 'PostToolUseFailure' ||
-        pe.hookEvent === 'UserPromptSubmit'
-      ) {
-        startTs = pe.ts;
-      }
-    }
-
-    // Find end time: first PreToolUse or Stop AFTER this group
-    let endTs = null;
-    for (const pe of progressEvents) {
-      const peTs = timestampOrderNanos(pe.ts);
-      if (peTs === null || peTs <= groupEndNanos) continue;
-      if (pe.hookEvent === 'PreToolUse' || pe.hookEvent === 'Stop') {
-        endTs = pe.ts;
-        break;
-      }
-    }
-
     boundaries.push({
-      startTs: startTs || group[0].timestamp,
-      endTs: endTs || group[group.length - 1].timestamp,
+      startTs: firstAssistant.timestamp,
+      endTs: lastAssistant.timestamp,
+      contentStartIndex: group.contentStartIndex,
+      contentEndIndex: group.contentEndIndex,
     });
   }
 
@@ -1068,7 +1044,7 @@ export function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, 
     }
   }
 
-  // If no progress boundaries detected, fall back to legacy behavior. The turn
+  // If no assistant boundaries were detected, fall back to legacy behavior. The turn
   // entry `other` is already in `records`, so hand the legacy path only the rows
   // it still owns. Qoder encodes tool results as type=user, so they must survive.
   if (boundaries.length === 0) {
@@ -1079,20 +1055,27 @@ export function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, 
     return finalizeRecords(legacyRecords, cwd);
   }
 
-  // Assign content events to boundaries.
-  // Use extended ranges: each boundary "owns" content from its startTs up to the NEXT boundary's startTs.
-  // This ensures tool_result events (which occur between boundaries) are assigned to the preceding boundary.
-  const assignedContent = assignContentToBoundaries(boundaries, contentEvents);
-
   // For each LLM call boundary, produce events
   let toolCallsForNextStep = [];
   let toolResultsForNextStep = [];
+  let previousResponseNanos = '';
   for (let i = 0; i < boundaries.length; i++) {
     const boundary = boundaries[i];
     const stepId = `${turnId}:s${i + 1}`;
-    const content = assignedContent[i] || [];
-    const startNanos = isoToUnixNanos(boundary.startTs);
-    const endNanos = boundary.endTs ? isoToUnixNanos(boundary.endTs) : startNanos;
+    const content = contentEvents.slice(boundary.contentStartIndex, boundary.contentEndIndex);
+    const responseEndNanos = isoToUnixNanos(boundary.endTs) || isoToUnixNanos(boundary.startTs);
+    const precedingNanos = [];
+    if (i === 0 && userRow?.timestamp) {
+      precedingNanos.push(isoToUnixNanos(userRow.timestamp));
+    } else {
+      precedingNanos.push(previousResponseNanos);
+      for (const result of toolResultsForNextStep) {
+        if (result.resultTs) precedingNanos.push(isoToUnixNanos(result.resultTs));
+      }
+    }
+    const startNanos = requestStartBeforeResponse(precedingNanos, responseEndNanos)
+      || isoToUnixNanos(boundary.startTs);
+    const endNanos = responseEndNanos || startNanos;
     const previousToolCallIds = new Set(toolCallsForNextStep.map(tc => tc.id).filter(Boolean));
     const currentContentToolResults = extractToolResults(content);
     const inputToolResultsById = new Map();
@@ -1155,7 +1138,6 @@ export function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, 
     const toolCalls = [];
     let responseId = undefined;
     let clientRequestId = undefined;
-    let lastAssistantTs = null;
     let firstAssistantTs = null;
 
     for (const row of content) {
@@ -1170,7 +1152,6 @@ export function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, 
             typeof msg.usage.request_id === 'string' && msg.usage.request_id) {
           clientRequestId = msg.usage.request_id;
         }
-        if (row.timestamp) lastAssistantTs = row.timestamp;
         if (row.timestamp && !firstAssistantTs) firstAssistantTs = row.timestamp;
         for (const block of blocks) {
           if (block.type === 'thinking') {
@@ -1199,12 +1180,6 @@ export function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, 
       name: tc.name,
       input: tc.input,
     }));
-
-    // When startTs == endTs (no distinguishable progress boundary), use assistant timestamp as end
-    let responseEndNanos = endNanos;
-    if (startNanos === endNanos && lastAssistantTs) {
-      responseEndNanos = isoToUnixNanos(lastAssistantTs) || endNanos;
-    }
 
     // Determine finish reason from the last assistant row's stop_reason (authoritative),
     // falling back to inference when not available.
@@ -1265,6 +1240,7 @@ export function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, 
         observed_time_unix_nano: observedTs,
       });
     }
+    previousResponseNanos = responseEndNanos;
 
     // tool.call + tool.result events. Parallel tools may finish out of order,
     // so array position is not a valid association key.
@@ -1372,38 +1348,6 @@ export function markTurnBoundaries(records) {
   return records;
 }
 
-// --- Content assignment to boundaries ----------------------------------------
-
-function assignContentToBoundaries(boundaries, contentEvents) {
-  const assigned = boundaries.map(() => []);
-
-  for (const row of contentEvents) {
-    // Skip the user prompt row (already handled as user-hook outside boundaries)
-    if (row.type === 'user' && !isToolResult(row)) continue;
-
-    const rowTs = timestampOrderNanos(row.timestamp);
-    if (rowTs === null) continue;
-
-    // Each boundary "owns" from its startTs to the NEXT boundary's startTs (exclusive).
-    // This ensures tool_result events (which occur between endTs and next startTs)
-    // are assigned to the current boundary, not lost in the gap.
-    let bestIdx = -1;
-    for (let i = 0; i < boundaries.length; i++) {
-      const startTs = timestampOrderNanos(boundaries[i].startTs);
-      const nextStartTs = (i + 1 < boundaries.length)
-        ? timestampOrderNanos(boundaries[i + 1].startTs)
-        : null;
-      if (startTs !== null && rowTs >= startTs && (nextStartTs === null || rowTs < nextStartTs)) {
-        bestIdx = i;
-        break;
-      }
-    }
-    if (bestIdx >= 0) assigned[bestIdx].push(row);
-  }
-
-  return assigned;
-}
-
 // --- Helpers -----------------------------------------------------------------
 
 /**
@@ -1444,6 +1388,21 @@ function ensureEndAfterStart(startNanos, candidateEndNanos) {
     return String(start + 1_000_000n);
   } catch {
     return candidateEndNanos || startNanos;
+  }
+}
+
+function requestStartBeforeResponse(precedingNanos, responseNanos) {
+  try {
+    const preceding = precedingNanos
+      .filter(value => typeof value === 'string' && /^\d+$/.test(value))
+      .map(value => BigInt(value));
+    if (preceding.length === 0 || !responseNanos) return '';
+    const response = BigInt(responseNanos);
+    let request = preceding.reduce((latest, value) => value > latest ? value : latest) + 1_000_000n;
+    if (request >= response) request = response - 1_000_000n;
+    return request >= 0n ? String(request) : '';
+  } catch {
+    return '';
   }
 }
 

--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -166,19 +166,17 @@ function clampInteger(value, fallback, min, max) {
 // --- Timestamp helpers -------------------------------------------------------
 
 function isoToUnixNanos(isoString) {
-  if (!isoString) return '';
-  const ms = Date.parse(isoString);
-  if (Number.isNaN(ms)) return '';
-  return String(BigInt(ms) * 1_000_000n);
+  const nanos = timestampOrderNanos(isoString);
+  return nanos === null ? '' : String(nanos);
 }
 
 function timestampToUnixNanos(value) {
   if (!value) return String(BigInt(Date.now()) * 1_000_000n);
   if (typeof value === 'number') return String(BigInt(Math.round(value)) * 1_000_000n);
   if (typeof value === 'string') {
-    const ms = Date.parse(value);
-    if (!Number.isNaN(ms)) return String(BigInt(ms) * 1_000_000n);
     if (/^\d+$/.test(value)) return value;
+    const nanos = timestampOrderNanos(value);
+    if (nanos !== null) return String(nanos);
   }
   return String(BigInt(Date.now()) * 1_000_000n);
 }
@@ -1063,7 +1061,7 @@ export function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, 
     const boundary = boundaries[i];
     const stepId = `${turnId}:s${i + 1}`;
     const content = contentEvents.slice(boundary.contentStartIndex, boundary.contentEndIndex);
-    const responseEndNanos = isoToUnixNanos(boundary.endTs) || isoToUnixNanos(boundary.startTs);
+    const candidateResponseEndNanos = isoToUnixNanos(boundary.endTs) || isoToUnixNanos(boundary.startTs);
     const precedingNanos = [];
     if (i === 0 && userRow?.timestamp) {
       precedingNanos.push(isoToUnixNanos(userRow.timestamp));
@@ -1073,9 +1071,11 @@ export function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, 
         if (result.resultTs) precedingNanos.push(isoToUnixNanos(result.resultTs));
       }
     }
-    const startNanos = requestStartBeforeResponse(precedingNanos, responseEndNanos)
-      || isoToUnixNanos(boundary.startTs);
-    const endNanos = responseEndNanos || startNanos;
+    const { startNanos, endNanos: responseEndNanos } = orderedLlmInterval(
+      precedingNanos,
+      candidateResponseEndNanos,
+      isoToUnixNanos(boundary.startTs),
+    );
     const previousToolCallIds = new Set(toolCallsForNextStep.map(tc => tc.id).filter(Boolean));
     const currentContentToolResults = extractToolResults(content);
     const inputToolResultsById = new Map();
@@ -1252,7 +1252,9 @@ export function buildEventsFromBoundaries(boundaries, contentEvents, allParsed, 
     for (let ti = 0; ti < toolCalls.length; ti++) {
       const tc = toolCalls[ti];
       const tr = toolResultsById.get(tc.id);
-      const toolCallTs = tc.callTs ? isoToUnixNanos(tc.callTs) || endNanos : endNanos;
+      const toolCallTs = tc.callTs
+        ? isoToUnixNanos(tc.callTs) || responseEndNanos
+        : responseEndNanos;
 
       records.push({
         'event.id': crypto.randomUUID(),
@@ -1385,24 +1387,39 @@ function ensureEndAfterStart(startNanos, candidateEndNanos) {
     if (candidateEndNanos && BigInt(candidateEndNanos) > start) {
       return candidateEndNanos;
     }
-    return String(start + 1_000_000n);
+    return String(start + 1n);
   } catch {
     return candidateEndNanos || startNanos;
   }
 }
 
-function requestStartBeforeResponse(precedingNanos, responseNanos) {
+function orderedLlmInterval(precedingNanos, candidateResponseNanos, fallbackStartNanos) {
   try {
     const preceding = precedingNanos
       .filter(value => typeof value === 'string' && /^\d+$/.test(value))
       .map(value => BigInt(value));
-    if (preceding.length === 0 || !responseNanos) return '';
-    const response = BigInt(responseNanos);
-    let request = preceding.reduce((latest, value) => value > latest ? value : latest) + 1_000_000n;
-    if (request >= response) request = response - 1_000_000n;
-    return request >= 0n ? String(request) : '';
+    const fallbackStart = /^\d+$/.test(fallbackStartNanos || '')
+      ? BigInt(fallbackStartNanos)
+      : null;
+    let response = /^\d+$/.test(candidateResponseNanos || '')
+      ? BigInt(candidateResponseNanos)
+      : null;
+    let request = preceding.length > 0
+      ? preceding.reduce((latest, value) => value > latest ? value : latest) + 1n
+      : fallbackStart;
+
+    if (request === null && response !== null) request = response - 1n;
+    if (request === null) return { startNanos: '', endNanos: '' };
+    if (response === null || response <= request) response = request + 1n;
+    return {
+      startNanos: request >= 0n ? String(request) : '',
+      endNanos: response >= 0n ? String(response) : '',
+    };
   } catch {
-    return '';
+    return {
+      startNanos: fallbackStartNanos || '',
+      endNanos: candidateResponseNanos || fallbackStartNanos || '',
+    };
   }
 }
 

--- a/src/inputs/qoder-trace/token-enricher.ts
+++ b/src/inputs/qoder-trace/token-enricher.ts
@@ -470,18 +470,12 @@ export function enrichIdeTurn(
   }
   matchedPairs.sort((a, b) => a.gmtCreate - b.gmtCreate);
 
-  // Find the user-boundary entry for step 1's request time.
-  // The normalizer emits user prompts as 'other' (not 'llm.request'), so match both.
-  const userBoundary = entries.find(e =>
-    !e['gen_ai.step.id'] &&
-    (e['event.name'] === 'llm.request' || (e['event.name'] === 'other' && e['gen_ai.input.messages_delta'])),
-  );
-
   for (let i = 0; i < matchedPairs.length; i++) {
     const { entry: respEntry, gmtCreate } = matchedPairs[i];
+    const responseTime = BigInt(gmtCreate) * 1_000_000n;
 
     // llm.response: use gmt_create as real response time
-    respEntry.time_unix_nano = String(BigInt(gmtCreate) * 1_000_000n);
+    respEntry.time_unix_nano = String(responseTime);
 
     // Find the llm.request for this response's step (same step.id).
     // Restrict to the same step to avoid cross-turn contamination in
@@ -507,38 +501,52 @@ export function enrichIdeTurn(
     }
 
     if (req) {
-      if (i > 0) {
-        // Start after the previous response and all of its tools. Hook records
-        // now carry per-tool result timestamps, so a fixed +1ms after the
-        // response would make the next LLM overlap a still-running tool.
-        let requestStart = BigInt(matchedPairs[i - 1].gmtCreate + 1) * 1_000_000n;
-        const previousResponseIndex = entries.indexOf(matchedPairs[i - 1].entry);
+      const turnId = respEntry['gen_ai.turn.id'];
+      const previousPair = matchedPairs
+        .slice(0, i)
+        .reverse()
+        .find(pair => pair.entry['gen_ai.turn.id'] === turnId);
+      let requestStart: bigint | undefined;
+
+      if (previousPair) {
+        // Start strictly after every event that precedes this provider call:
+        // the previous response and all tool results produced by that Step.
+        let latestPredecessor = BigInt(previousPair.gmtCreate) * 1_000_000n;
+        const previousResponseIndex = entries.indexOf(previousPair.entry);
         const currentResponseIndex = entries.indexOf(respEntry);
         for (let j = previousResponseIndex + 1; j < currentResponseIndex; j++) {
           if (entries[j]['event.name'] !== 'tool.result') continue;
           const resultTime = parseUnixNanos(entries[j].time_unix_nano);
-          if (resultTime !== undefined && resultTime >= requestStart) {
-            requestStart = resultTime + 1_000_000n;
+          if (resultTime !== undefined && resultTime > latestPredecessor) {
+            latestPredecessor = resultTime;
           }
         }
-        const hookRequestTime = parseUnixNanos(req.time_unix_nano);
-        if (hookRequestTime !== undefined && hookRequestTime > requestStart) {
-          requestStart = hookRequestTime;
-        }
-        req.time_unix_nano = String(requestStart);
-      } else if (userBoundary) {
-        // Use userBoundary.time + 1ms so the LLM request starts strictly after
-        // the user prompt event. When both share the same timestamp the converter
-        // generates a duplicate empty STEP (0ms, no LLM children) because it
-        // sees two events at the same instant inside step s1.
-        const ubNs = BigInt(String(userBoundary.time_unix_nano));
-        const minimumRequestTime = ubNs + 1_000_000n;
-        const hookRequestTime = parseUnixNanos(req.time_unix_nano);
-        req.time_unix_nano = String(
-          hookRequestTime !== undefined && hookRequestTime > minimumRequestTime
-            ? hookRequestTime
-            : minimumRequestTime,
+        requestStart = latestPredecessor + 1_000_000n;
+      } else {
+        // The normalizer emits user prompts as `other`; find the opening event
+        // for this Turn instead of borrowing one from another Turn in the batch.
+        const userBoundary = entries.find(e =>
+          e['gen_ai.turn.id'] === turnId &&
+          !e['gen_ai.step.id'] &&
+          (e['event.name'] === 'llm.request' ||
+            (e['event.name'] === 'other' && e['gen_ai.input.messages_delta'])),
         );
+        if (userBoundary) {
+          // Use userBoundary.time + 1ms so the LLM request starts strictly after
+          // the user prompt event. When both share the same timestamp the converter
+          // generates a duplicate empty STEP (0ms, no LLM children) because it
+          // sees two events at the same instant inside step s1.
+          const ubNs = parseUnixNanos(userBoundary.time_unix_nano);
+          if (ubNs !== undefined) requestStart = ubNs + 1_000_000n;
+        }
+      }
+
+      if (requestStart !== undefined) {
+        // Inconsistent source clocks can place all predecessors at or after the
+        // SQLite response. Preserve a positive LLM interval instead of emitting
+        // a zero/negative duration.
+        if (requestStart >= responseTime) requestStart = responseTime - 1_000_000n;
+        if (requestStart >= 0n) req.time_unix_nano = String(requestStart);
       }
     }
 

--- a/src/inputs/qoder-trace/token-enricher.ts
+++ b/src/inputs/qoder-trace/token-enricher.ts
@@ -472,7 +472,7 @@ export function enrichIdeTurn(
 
   for (let i = 0; i < matchedPairs.length; i++) {
     const { entry: respEntry, gmtCreate } = matchedPairs[i];
-    const responseTime = BigInt(gmtCreate) * 1_000_000n;
+    let responseTime = BigInt(gmtCreate) * 1_000_000n;
 
     // llm.response: use gmt_create as real response time
     respEntry.time_unix_nano = String(responseTime);
@@ -511,17 +511,19 @@ export function enrichIdeTurn(
       if (previousPair) {
         // Start strictly after every event that precedes this provider call:
         // the previous response and all tool results produced by that Step.
-        let latestPredecessor = BigInt(previousPair.gmtCreate) * 1_000_000n;
+        let latestPredecessor = parseUnixNanos(previousPair.entry.time_unix_nano)
+          ?? BigInt(previousPair.gmtCreate) * 1_000_000n;
         const previousResponseIndex = entries.indexOf(previousPair.entry);
         const currentResponseIndex = entries.indexOf(respEntry);
         for (let j = previousResponseIndex + 1; j < currentResponseIndex; j++) {
-          if (entries[j]['event.name'] !== 'tool.result') continue;
+          if (entries[j]['event.name'] !== 'tool.result' ||
+              entries[j]['gen_ai.turn.id'] !== turnId) continue;
           const resultTime = parseUnixNanos(entries[j].time_unix_nano);
           if (resultTime !== undefined && resultTime > latestPredecessor) {
             latestPredecessor = resultTime;
           }
         }
-        requestStart = latestPredecessor + 1_000_000n;
+        requestStart = latestPredecessor + 1n;
       } else {
         // The normalizer emits user prompts as `other`; find the opening event
         // for this Turn instead of borrowing one from another Turn in the batch.
@@ -532,30 +534,34 @@ export function enrichIdeTurn(
             (e['event.name'] === 'other' && e['gen_ai.input.messages_delta'])),
         );
         if (userBoundary) {
-          // Use userBoundary.time + 1ms so the LLM request starts strictly after
+          // Advance by the smallest representable unit so the LLM request starts strictly after
           // the user prompt event. When both share the same timestamp the converter
           // generates a duplicate empty STEP (0ms, no LLM children) because it
           // sees two events at the same instant inside step s1.
           const ubNs = parseUnixNanos(userBoundary.time_unix_nano);
-          if (ubNs !== undefined) requestStart = ubNs + 1_000_000n;
+          if (ubNs !== undefined) requestStart = ubNs + 1n;
         }
       }
 
       if (requestStart !== undefined) {
-        // Inconsistent source clocks can place all predecessors at or after the
-        // SQLite response. Preserve a positive LLM interval instead of emitting
-        // a zero/negative duration.
-        if (requestStart >= responseTime) requestStart = responseTime - 1_000_000n;
-        if (requestStart >= 0n) req.time_unix_nano = String(requestStart);
+        // SQLite stores only milliseconds. Equal gmt_create values and source-clock
+        // conflicts can leave no point between the previous Step and this response.
+        // Move the response forward by the minimum amount instead of clamping the
+        // request backwards into the previous Step.
+        if (requestStart >= responseTime) responseTime = requestStart + 1n;
+        if (requestStart >= 0n) {
+          req.time_unix_nano = String(requestStart);
+          respEntry.time_unix_nano = String(responseTime);
+        }
       }
     }
 
     // Preserve per-tool timestamps emitted by the hook. SQLite has no tool ID
-    // or tool-finished timestamp, so it cannot improve those values. The old
-    // gmt_create/+1ms fallback is retained only for legacy records whose tool
-    // timestamps are missing or malformed.
-    const toolCallTs = String(BigInt(gmtCreate) * 1_000_000n);
-    const toolResultTs = String(BigInt(gmtCreate + 1) * 1_000_000n);
+    // or tool-finished timestamp, so it cannot improve those values. For legacy
+    // records whose tool timestamps are missing or malformed, place the call and
+    // result immediately after the ordered response.
+    const toolCallTs = String(responseTime + 1n);
+    const toolResultTs = String(responseTime + 2n);
     const respIdx = entries.indexOf(respEntry);
     const rightBound = i < matchedPairs.length - 1
       ? entries.indexOf(matchedPairs[i + 1].entry)

--- a/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
+++ b/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
@@ -279,8 +279,8 @@ describe('buildLlmBoundaries complete-response priority', () => {
       .filter(record => record['event.name'] === 'llm.request')
       .map(record => record.time_unix_nano))
       .toEqual([
-        String(BigInt(Date.parse('2026-08-03T09:22:25.101Z')) * 1_000_000n),
-        String(BigInt(Date.parse('2026-08-03T09:22:26.669Z')) * 1_000_000n),
+        String(BigInt(Date.parse('2026-08-03T09:22:25.100Z')) * 1_000_000n + 1n),
+        String(BigInt(Date.parse('2026-08-03T09:22:26.668Z')) * 1_000_000n + 419_001n),
       ]);
   });
 
@@ -445,7 +445,60 @@ describe('buildLlmBoundaries complete-response priority', () => {
 
     expect(boundaries.map(boundary => [boundary.contentStartIndex, boundary.contentEndIndex]))
       .toEqual([[1, 3], [3, 4]]);
-    expect(records.filter(record => record['event.name'] === 'llm.response')).toHaveLength(2);
+    const responses = records.filter(record => record['event.name'] === 'llm.response');
+    const secondRequest = records.find(record =>
+      record['event.name'] === 'llm.request' &&
+      record['gen_ai.step.id'] === 'turn-same-ts:s2');
+    const firstToolResult = records.find(record => record['event.name'] === 'tool.result');
+
+    expect(responses).toHaveLength(2);
+    expect(BigInt(responses[0].time_unix_nano))
+      .toBeLessThan(BigInt(secondRequest.time_unix_nano));
+    expect(BigInt(firstToolResult.time_unix_nano))
+      .toBeLessThan(BigInt(secondRequest.time_unix_nano));
+    expect(BigInt(secondRequest.time_unix_nano))
+      .toBeLessThan(BigInt(responses[1].time_unix_nano));
+  });
+
+  it('preserves sub-millisecond transcript order in emitted timestamps', () => {
+    const rows = [
+      {
+        type: 'user',
+        timestamp: '2026-09-05T02:35:59.999900Z',
+        message: { role: 'user', content: 'go' },
+      },
+      assistant('2026-09-05T02:36:00.000100Z', [
+        { type: 'tool_use', id: 'tool-a', name: 'Read', input: {} },
+      ]),
+      toolResult('2026-09-05T02:36:00.000300Z', 'tool-a'),
+      assistant('2026-09-05T02:36:00.000900Z', [{ type: 'text', text: 'done' }]),
+    ];
+    const records = buildEventsFromBoundaries(
+      buildLlmBoundaries([], rows),
+      rows,
+      rows,
+      'turn-microsecond-order',
+      'session-1',
+      'qoder',
+      {},
+      undefined,
+    );
+    const firstResponse = records.find(record =>
+      record['event.name'] === 'llm.response' &&
+      record['gen_ai.step.id'] === 'turn-microsecond-order:s1');
+    const toolResultRecord = records.find(record => record['event.name'] === 'tool.result');
+    const secondRequest = records.find(record =>
+      record['event.name'] === 'llm.request' &&
+      record['gen_ai.step.id'] === 'turn-microsecond-order:s2');
+    const secondResponse = records.find(record =>
+      record['event.name'] === 'llm.response' &&
+      record['gen_ai.step.id'] === 'turn-microsecond-order:s2');
+
+    const second = BigInt(Date.parse('2026-09-05T02:36:00Z')) * 1_000_000n;
+    expect(firstResponse.time_unix_nano).toBe(String(second + 100_000n));
+    expect(toolResultRecord.time_unix_nano).toBe(String(second + 300_000n));
+    expect(secondRequest.time_unix_nano).toBe(String(second + 300_001n));
+    expect(secondResponse.time_unix_nano).toBe(String(second + 900_000n));
   });
 
   it('uses the final assistant timestamp when SQLite enrichment is unavailable', () => {

--- a/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
+++ b/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
@@ -233,7 +233,7 @@ describe('buildLlmBoundaries complete-response priority', () => {
     expect(buildLlmBoundaries(progress, rows)).toHaveLength(2);
   });
 
-  it('preserves microsecond ordering between tool completion and the next assistant response', () => {
+  it('derives the next request from the completed tool result, not progress timing', () => {
     const rows = [
       {
         type: 'user',
@@ -259,8 +259,8 @@ describe('buildLlmBoundaries complete-response priority', () => {
 
     const boundaries = buildLlmBoundaries(progress, rows);
     expect(boundaries.map(boundary => boundary.startTs)).toEqual([
-      '2026-08-03T09:22:25.000000Z',
-      '2026-08-03T09:22:26.999176Z',
+      '2026-08-03T09:22:25.555446Z',
+      '2026-08-03T09:22:26.999890Z',
     ]);
 
     const records = buildEventsFromBoundaries(
@@ -275,9 +275,16 @@ describe('buildLlmBoundaries complete-response priority', () => {
         ['llm.request', 'turn-microseconds:s2'],
         ['llm.response', 'turn-microseconds:s2'],
       ]);
+    expect(records
+      .filter(record => record['event.name'] === 'llm.request')
+      .map(record => record.time_unix_nano))
+      .toEqual([
+        String(BigInt(Date.parse('2026-08-03T09:22:25.101Z')) * 1_000_000n),
+        String(BigInt(Date.parse('2026-08-03T09:22:26.669Z')) * 1_000_000n),
+      ]);
   });
 
-  it('starts a complete next step after PostToolUseFailure', () => {
+  it('starts a complete next step from a failed tool_result, independent of PostToolUseFailure', () => {
     const rows = [
       {
         type: 'user',
@@ -314,8 +321,8 @@ describe('buildLlmBoundaries complete-response priority', () => {
 
     const boundaries = buildLlmBoundaries(progress, rows);
     expect(boundaries.map(boundary => boundary.startTs)).toEqual([
-      '2026-07-30T00:59:59.000Z',
-      '2026-07-30T01:00:01.500Z',
+      '2026-07-30T01:00:00.000Z',
+      '2026-07-30T01:00:02.000Z',
     ]);
 
     const records = buildEventsFromBoundaries(
@@ -332,7 +339,7 @@ describe('buildLlmBoundaries complete-response priority', () => {
       ]);
   });
 
-  it('uses PostToolUseFailure to close a tool cycle whose result is missing', () => {
+  it('conservatively merges later assistant rows when tool_result is missing', () => {
     const rows = [
       {
         type: 'user',
@@ -354,7 +361,7 @@ describe('buildLlmBoundaries complete-response priority', () => {
     ];
 
     const boundaries = buildLlmBoundaries(progress, rows);
-    expect(boundaries).toHaveLength(2);
+    expect(boundaries).toHaveLength(1);
     const records = buildEventsFromBoundaries(
       boundaries, rows, rows, 'turn-missing-result', 'session-1', 'qoder', {}, undefined,
     );
@@ -364,9 +371,113 @@ describe('buildLlmBoundaries complete-response priority', () => {
       .toEqual([
         ['llm.request', 'turn-missing-result:s1'],
         ['llm.response', 'turn-missing-result:s1'],
-        ['llm.request', 'turn-missing-result:s2'],
-        ['llm.response', 'turn-missing-result:s2'],
       ]);
+    expect(records.filter(record => record['event.name'] === 'tool.call')).toHaveLength(1);
+    expect(records.filter(record => record['event.name'] === 'tool.result')).toHaveLength(0);
+    expect(records.find(record => record['event.name'] === 'llm.response')
+      ['gen_ai.output.messages'][0].parts.map(part => part.type))
+      .toEqual(['tool_call', 'text']);
+  });
+
+  it('keeps structure and content identical when third-party PostToolUse progress is present', () => {
+    const rows = [
+      {
+        type: 'user',
+        timestamp: '2026-09-05T02:35:58.605Z',
+        message: { role: 'user', content: 'fix it' },
+      },
+      assistant('2026-09-05T02:36:31.960Z', [
+        { type: 'thinking', thinking: 'read' },
+        { type: 'tool_use', id: 'read-a', name: 'Read', input: {} },
+      ]),
+      toolResult('2026-09-05T02:36:32.017Z', 'read-a'),
+      assistant('2026-09-05T02:36:44.873Z', [
+        { type: 'text', text: 'write' },
+        { type: 'tool_use', id: 'write-a', name: 'Write', input: {} },
+      ]),
+      toolResult('2026-09-05T02:36:47.452Z', 'write-a'),
+      assistant('2026-09-05T02:37:03.225Z', [{ type: 'text', text: 'done' }]),
+    ];
+    const qoderSecProgress = [
+      { hookEvent: 'PostToolUse', hookName: 'PostToolUse:Write', ts: '2026-09-05T02:36:47.814Z' },
+      { hookEvent: 'PostToolUse', hookName: 'PostToolUse:Write', ts: '2026-09-05T02:36:47.814Z' },
+      { hookEvent: 'Stop', hookName: 'Stop', ts: '2026-09-05T02:37:05.726Z' },
+    ];
+
+    const withThirdParty = buildLlmBoundaries(qoderSecProgress, rows);
+    const withoutThirdParty = buildLlmBoundaries(
+      qoderSecProgress.filter(event => event.hookEvent !== 'PostToolUse'),
+      rows,
+    );
+    expect(withThirdParty).toEqual(withoutThirdParty);
+    expect(withThirdParty.map(boundary => [boundary.contentStartIndex, boundary.contentEndIndex]))
+      .toEqual([[1, 3], [3, 5], [5, 6]]);
+
+    const summarize = boundaries => buildEventsFromBoundaries(
+      boundaries, rows, rows, 'turn-qodersec', 'session-1', 'qoder', {}, undefined,
+    ).map(record => ({
+      name: record['event.name'],
+      step: record['gen_ai.step.id'],
+      toolId: record['gen_ai.tool.call.id'],
+      parts: record['gen_ai.output.messages']?.[0]?.parts?.map(part => part.type),
+      time: record.time_unix_nano,
+    }));
+    expect(summarize(withThirdParty)).toEqual(summarize(withoutThirdParty));
+  });
+
+  it('keeps responses populated when adjacent groups have the same assistant timestamp', () => {
+    const rows = [
+      {
+        type: 'user',
+        timestamp: '2026-09-05T02:35:58.000Z',
+        message: { role: 'user', content: 'go' },
+      },
+      assistant('2026-09-05T02:36:00.000Z', [
+        { type: 'tool_use', id: 'tool-a', name: 'Read', input: {} },
+      ]),
+      toolResult('2026-09-05T02:36:00.100Z', 'tool-a'),
+      assistant('2026-09-05T02:36:00.000Z', [{ type: 'text', text: 'done' }]),
+    ];
+    const boundaries = buildLlmBoundaries([], rows);
+    const records = buildEventsFromBoundaries(
+      boundaries, rows, rows, 'turn-same-ts', 'session-1', 'qoder', {}, undefined,
+    );
+
+    expect(boundaries.map(boundary => [boundary.contentStartIndex, boundary.contentEndIndex]))
+      .toEqual([[1, 3], [3, 4]]);
+    expect(records.filter(record => record['event.name'] === 'llm.response')).toHaveLength(2);
+  });
+
+  it('uses the final assistant timestamp when SQLite enrichment is unavailable', () => {
+    const rows = [
+      {
+        type: 'user',
+        timestamp: '2026-09-05T02:35:58.000Z',
+        message: { role: 'user', content: 'explain it' },
+      },
+      assistant('2026-09-05T02:36:00.000Z', [
+        { type: 'thinking', thinking: 'reasoning' },
+      ]),
+      assistant('2026-09-05T02:36:02.345Z', [
+        { type: 'text', text: 'answer' },
+      ]),
+    ];
+
+    const records = buildEventsFromBoundaries(
+      buildLlmBoundaries([], rows),
+      rows,
+      rows,
+      'turn-no-sqlite',
+      'session-1',
+      'qoder',
+      {},
+      undefined,
+    );
+    const response = records.find(record => record['event.name'] === 'llm.response');
+
+    expect(response.time_unix_nano).toBe(
+      String(BigInt(Date.parse('2026-09-05T02:36:02.345Z')) * 1_000_000n),
+    );
   });
 
   it('does not close a parallel response until completion signals cover its declared tools', () => {
@@ -730,6 +841,8 @@ describe('buildEventsFromBoundaries tool result matching', () => {
     const boundaries = [{
       startTs: '2026-07-30T01:00:00.000Z',
       endTs: '2026-07-30T01:00:03.000Z',
+      contentStartIndex: 1,
+      contentEndIndex: content.length,
     }];
 
     const records = buildEventsFromBoundaries(

--- a/tests/unit/inputs/qoder-cn-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-cn-trace-input.test.ts
@@ -225,10 +225,13 @@ describe('QoderCnTraceInput.collect (session-level enrich)', () => {
     ]);
 
     const entries = await collectOnce();
-    // Only one llm.request for step 1 (last occurrence, ts = baseTs + 1)
+    // Only one llm.request for step 1. Enrichment places it one nanosecond
+    // after the Turn boundary without discarding the deduplication result.
     const step1Requests = entries.filter(e => e['event.name'] === 'llm.request' && e['gen_ai.step.id'] === 'turn-d:s1');
     expect(step1Requests).toHaveLength(1);
-    expect(step1Requests[0].time_unix_nano).toBe(`${baseTs + 1}000000`);
+    expect(step1Requests[0].time_unix_nano).toBe(
+      String(BigInt(baseTs) * 1_000_000n + 1n),
+    );
 
     // Only one llm.response for step 1
     const step1Responses = entries.filter(e => e['event.name'] === 'llm.response' && e['gen_ai.step.id'] === 'turn-d:s1');

--- a/tests/unit/inputs/qoder-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-trace-input.test.ts
@@ -1077,6 +1077,115 @@ describe('QoderTraceInput token-enricher', () => {
       expect(entries[4]['tool.result.status']).toBe('failure');
       expect(entries[5].time_unix_nano).toBe(ms(base + 4202));
     });
+
+    it('starts a later request after the latest preceding tool result', () => {
+      const ms = (value: number) => String(BigInt(value) * 1_000_000n);
+      const base = 1_780_000_000_000;
+      const entries: AgentActivityEntry[] = [
+        makeEntry({
+          'event.name': 'llm.request',
+          'gen_ai.session.id': 'sess-tools',
+          'gen_ai.turn.id': 'turn-tools',
+          'gen_ai.step.id': 'turn-tools:s1',
+          time_unix_nano: ms(base),
+        } as any),
+        makeEntry({
+          'event.name': 'llm.response',
+          'gen_ai.session.id': 'sess-tools',
+          'gen_ai.turn.id': 'turn-tools',
+          'gen_ai.step.id': 'turn-tools:s1',
+          time_unix_nano: ms(base + 200),
+        } as any),
+        makeEntry({
+          'event.name': 'tool.result',
+          'gen_ai.session.id': 'sess-tools',
+          'gen_ai.turn.id': 'turn-tools',
+          'gen_ai.step.id': 'turn-tools:s1',
+          time_unix_nano: ms(base + 1200),
+        } as any),
+        makeEntry({
+          'event.name': 'tool.result',
+          'gen_ai.session.id': 'sess-tools',
+          'gen_ai.turn.id': 'turn-tools',
+          'gen_ai.step.id': 'turn-tools:s1',
+          time_unix_nano: ms(base + 1800),
+        } as any),
+        makeEntry({
+          'event.name': 'llm.request',
+          'gen_ai.session.id': 'sess-tools',
+          'gen_ai.turn.id': 'turn-tools',
+          'gen_ai.step.id': 'turn-tools:s2',
+          time_unix_nano: ms(base + 9999),
+        } as any),
+        makeEntry({
+          'event.name': 'llm.response',
+          'gen_ai.session.id': 'sess-tools',
+          'gen_ai.turn.id': 'turn-tools',
+          'gen_ai.step.id': 'turn-tools:s2',
+          time_unix_nano: ms(base + 2500),
+        } as any),
+      ];
+      const sqliteRows: SqliteTokenData[] = [
+        {
+          sessionId: 'sess-tools', requestId: 'request-tools', messageId: 'message-1',
+          gmtCreate: base + 200, inputTokens: 1, outputTokens: 1, cacheReadTokens: 0,
+        },
+        {
+          sessionId: 'sess-tools', requestId: 'request-tools', messageId: 'message-2',
+          gmtCreate: base + 2500, inputTokens: 1, outputTokens: 1, cacheReadTokens: 0,
+        },
+      ];
+
+      enrichIdeTurn(entries, sqliteRows);
+
+      expect(entries[4].time_unix_nano).toBe(ms(base + 1801));
+    });
+
+    it('clamps request to one millisecond before its SQLite response when clocks conflict', () => {
+      const ms = (value: number) => String(BigInt(value) * 1_000_000n);
+      const base = 1_780_000_000_000;
+      const entries: AgentActivityEntry[] = [
+        makeEntry({
+          'event.name': 'llm.request', 'gen_ai.session.id': 'sess-clamp',
+          'gen_ai.turn.id': 'turn-clamp', 'gen_ai.step.id': 'turn-clamp:s1',
+          time_unix_nano: ms(base),
+        } as any),
+        makeEntry({
+          'event.name': 'llm.response', 'gen_ai.session.id': 'sess-clamp',
+          'gen_ai.turn.id': 'turn-clamp', 'gen_ai.step.id': 'turn-clamp:s1',
+          time_unix_nano: ms(base + 200),
+        } as any),
+        makeEntry({
+          'event.name': 'tool.result', 'gen_ai.session.id': 'sess-clamp',
+          'gen_ai.turn.id': 'turn-clamp', 'gen_ai.step.id': 'turn-clamp:s1',
+          time_unix_nano: ms(base + 6000),
+        } as any),
+        makeEntry({
+          'event.name': 'llm.request', 'gen_ai.session.id': 'sess-clamp',
+          'gen_ai.turn.id': 'turn-clamp', 'gen_ai.step.id': 'turn-clamp:s2',
+          time_unix_nano: ms(base + 6001),
+        } as any),
+        makeEntry({
+          'event.name': 'llm.response', 'gen_ai.session.id': 'sess-clamp',
+          'gen_ai.turn.id': 'turn-clamp', 'gen_ai.step.id': 'turn-clamp:s2',
+          time_unix_nano: ms(base + 5000),
+        } as any),
+      ];
+      const sqliteRows: SqliteTokenData[] = [
+        {
+          sessionId: 'sess-clamp', requestId: 'request-clamp', messageId: 'message-1',
+          gmtCreate: base + 200, inputTokens: 1, outputTokens: 1, cacheReadTokens: 0,
+        },
+        {
+          sessionId: 'sess-clamp', requestId: 'request-clamp', messageId: 'message-2',
+          gmtCreate: base + 5000, inputTokens: 1, outputTokens: 1, cacheReadTokens: 0,
+        },
+      ];
+
+      enrichIdeTurn(entries, sqliteRows);
+
+      expect(entries[3].time_unix_nano).toBe(ms(base + 4999));
+    });
   });
 
   describe('enrichIdeTurn (timestamp-based fallback)', () => {

--- a/tests/unit/inputs/qoder-trace-input.test.ts
+++ b/tests/unit/inputs/qoder-trace-input.test.ts
@@ -1075,7 +1075,7 @@ describe('QoderTraceInput token-enricher', () => {
       expect(entries[4].time_unix_nano).toBe(ms(base + 4201));
       expect(entries[4]['gen_ai.tool.call.duration']).toBe(4000);
       expect(entries[4]['tool.result.status']).toBe('failure');
-      expect(entries[5].time_unix_nano).toBe(ms(base + 4202));
+      expect(entries[5].time_unix_nano).toBe(String(BigInt(ms(base + 4201)) + 1n));
     });
 
     it('starts a later request after the latest preceding tool result', () => {
@@ -1138,10 +1138,10 @@ describe('QoderTraceInput token-enricher', () => {
 
       enrichIdeTurn(entries, sqliteRows);
 
-      expect(entries[4].time_unix_nano).toBe(ms(base + 1801));
+      expect(entries[4].time_unix_nano).toBe(String(BigInt(ms(base + 1800)) + 1n));
     });
 
-    it('clamps request to one millisecond before its SQLite response when clocks conflict', () => {
+    it('keeps the next request after its predecessors when the SQLite clock is earlier', () => {
       const ms = (value: number) => String(BigInt(value) * 1_000_000n);
       const base = 1_780_000_000_000;
       const entries: AgentActivityEntry[] = [
@@ -1184,7 +1184,65 @@ describe('QoderTraceInput token-enricher', () => {
 
       enrichIdeTurn(entries, sqliteRows);
 
-      expect(entries[3].time_unix_nano).toBe(ms(base + 4999));
+      expect(entries[3].time_unix_nano).toBe(String(BigInt(ms(base + 6000)) + 1n));
+      expect(entries[4].time_unix_nano).toBe(String(BigInt(ms(base + 6000)) + 2n));
+      expect(BigInt(entries[2].time_unix_nano))
+        .toBeLessThan(BigInt(entries[3].time_unix_nano));
+      expect(BigInt(entries[3].time_unix_nano))
+        .toBeLessThan(BigInt(entries[4].time_unix_nano));
+    });
+
+    it('orders adjacent steps when SQLite responses share the same millisecond', () => {
+      const ms = (value: number) => String(BigInt(value) * 1_000_000n);
+      const base = 1_780_000_000_000;
+      const entries: AgentActivityEntry[] = [
+        makeEntry({
+          'event.name': 'other', 'gen_ai.session.id': 'sess-same-ms',
+          'gen_ai.turn.id': 'turn-same-ms', 'gen_ai.step.id': undefined,
+          'gen_ai.input.messages_delta': [{ role: 'user', parts: [] }],
+          time_unix_nano: ms(base - 100),
+        } as any),
+        makeEntry({
+          'event.name': 'llm.request', 'gen_ai.session.id': 'sess-same-ms',
+          'gen_ai.turn.id': 'turn-same-ms', 'gen_ai.step.id': 'turn-same-ms:s1',
+          time_unix_nano: ms(base - 50),
+        } as any),
+        makeEntry({
+          'event.name': 'llm.response', 'gen_ai.session.id': 'sess-same-ms',
+          'gen_ai.turn.id': 'turn-same-ms', 'gen_ai.step.id': 'turn-same-ms:s1',
+          time_unix_nano: ms(base),
+        } as any),
+        makeEntry({
+          'event.name': 'llm.request', 'gen_ai.session.id': 'sess-same-ms',
+          'gen_ai.turn.id': 'turn-same-ms', 'gen_ai.step.id': 'turn-same-ms:s2',
+          time_unix_nano: ms(base),
+        } as any),
+        makeEntry({
+          'event.name': 'llm.response', 'gen_ai.session.id': 'sess-same-ms',
+          'gen_ai.turn.id': 'turn-same-ms', 'gen_ai.step.id': 'turn-same-ms:s2',
+          time_unix_nano: ms(base),
+        } as any),
+      ];
+      const sqliteRows: SqliteTokenData[] = [
+        {
+          sessionId: 'sess-same-ms', requestId: 'request-same-ms', messageId: 'message-1',
+          gmtCreate: base, inputTokens: 1, outputTokens: 1, cacheReadTokens: 0,
+        },
+        {
+          sessionId: 'sess-same-ms', requestId: 'request-same-ms', messageId: 'message-2',
+          gmtCreate: base, inputTokens: 1, outputTokens: 1, cacheReadTokens: 0,
+        },
+      ];
+
+      enrichIdeTurn(entries, sqliteRows);
+
+      expect(entries[2].time_unix_nano).toBe(ms(base));
+      expect(entries[3].time_unix_nano).toBe(String(BigInt(ms(base)) + 1n));
+      expect(entries[4].time_unix_nano).toBe(String(BigInt(ms(base)) + 2n));
+      expect(BigInt(entries[2].time_unix_nano))
+        .toBeLessThan(BigInt(entries[3].time_unix_nano));
+      expect(BigInt(entries[3].time_unix_nano))
+        .toBeLessThan(BigInt(entries[4].time_unix_nano));
     });
   });
 


### PR DESCRIPTION
## Summary

- derive Qoder IDE LLM boundaries from transcript structure instead of progress-hook timestamps
- retain exact transcript index ranges for each response so third-party hooks cannot merge or reassign response content
- treat a non-empty assistant `stop_reason` as provider-response completion, while delaying the split until the next assistant so intervening tool results remain in the preceding response range
- keep `tool_use.id` / `tool_result.tool_use_id` closure as the fallback for older transcripts without `stop_reason`
- preserve Qoder transcript fractional timestamps at nanosecond precision and use the final assistant timestamp when SQLite enrichment is unavailable
- place each enriched request after the previous response and every preceding tool result
- when SQLite millisecond timestamps collide or conflict with transcript ordering, minimally move the current response forward so `previousResponse/toolResult < request < response` remains true

## Compatibility behavior

Third-party progress records, including QoderSec `PostToolUse` hooks, no longer define LLM boundaries or content ownership. Tool call/result association remains ID-based.

If a transcript omits `tool_result` but the tool-call response has `stop_reason`, the following assistant response remains a separate LLM step and can carry the terminal `end_turn` event. No tool result is fabricated. The split occurs only when the following assistant arrives, so tool results written after `stop_reason` still belong to the preceding response range. If both `tool_result` and `stop_reason` are absent, the collector conservatively retains later assistant rows in the current group instead of inventing a boundary.

## Validation

- focused Qoder regression suite: 9 files, 199 tests passed
- `npm run typecheck`
- `npm run build`
- replayed all seven affected customer QoderSec turns (203 LLM steps): zero missing pairs, invalid intervals, predecessor-order violations, duplicate response timestamps, or unnecessary response adjustments
- replayed the older customer transcript after the terminal-response change: unchanged at 7 turns / 203 LLM steps because it has no `stop_reason` and continues to use tool-ID closure
- replayed two affected turns through the installed Hook -> history -> QoderTraceInput -> output path:
  - 16 expected LLM calls: old output 9 responses, new output 16 request/response pairs
  - 3 expected LLM calls: old output 2 responses, new output 3 request/response pairs
  - zero empty responses, invalid intervals, predecessor-order violations, transcript-fallback mismatches, or tool ID mismatches
