### PR TITLE
fix(claude-code): fill request timestamps in fallback turns

### DIFF
--- a/assets/hooks/claude-code/transcript-parser.mjs
+++ b/assets/hooks/claude-code/transcript-parser.mjs
@@ -115,6 +115,17 @@ function normalizeRequestStart(candidate, responseTs) {
   return candidate;
 }
 
+function fillRequestStartTimes(llmCalls, promptTimestamp) {
+  // Apply the same source-time fallback to every call, including turns without
+  // promptId. Keep this scoped to one turn so unrelated prompts cannot leak in.
+  let fallbackTs = promptTimestamp || llmCalls[0]?.timestamp || null;
+  for (const call of llmCalls) {
+    const candidate = call.request_start_time || fallbackTs || call.timestamp || null;
+    call.request_start_time = normalizeRequestStart(candidate, call.timestamp);
+    fallbackTs = laterTimestamp(fallbackTs, call.timestamp);
+  }
+}
+
 /**
  * 解析 Claude Code transcript JSONL 文件。
  *
@@ -500,8 +511,9 @@ function splitIntoTurns(conversationRecords, llmCalls, skillLoads = []) {
   }
 
   if (promptIdOrder.length === 0) {
-    // 无 promptId (所有 user record 都是系统注入的),fallback 为单 turn
+    // 当前片段没有 promptId，fallback 为单 turn。
     const firstTs = llmCalls[0]?.timestamp || null;
+    fillRequestStartTimes(llmCalls, firstTs);
     return [{
       promptId: null,
       prompt: '',
@@ -520,15 +532,7 @@ function splitIntoTurns(conversationRecords, llmCalls, skillLoads = []) {
     const info = promptIdInfo.get(pid) || {};
     const promptTimestamp = info.promptTimestamp || promptIdBoundaryTs.get(pid) || turnLlmCalls[0]?.timestamp || null;
 
-    // request_start_time: 每个 llmCall 都必须有有效起点。
-    // Claude Code resume 会在真实回答前插入 synthetic "No response requested" 调用,
-    // 不能只给第一个 llmCall 补时间,否则后续真实调用会落成 time_unix_nano=0。
-    let fallbackTs = promptTimestamp || turnLlmCalls[0]?.timestamp || null;
-    for (const call of turnLlmCalls) {
-      const candidate = call.request_start_time || fallbackTs || call.timestamp || null;
-      call.request_start_time = normalizeRequestStart(candidate, call.timestamp);
-      fallbackTs = laterTimestamp(fallbackTs, call.timestamp);
-    }
+    fillRequestStartTimes(turnLlmCalls, promptTimestamp);
 
     turns.push({
       promptId: pid,
@@ -543,6 +547,7 @@ function splitIntoTurns(conversationRecords, llmCalls, skillLoads = []) {
   const orphanCalls = llmCalls.filter((c) => !c.promptId);
   if (orphanCalls.length > 0) {
     // 无法归属的 assistant 使用独立 fallback turn,不能污染任何真实 promptId。
+    fillRequestStartTimes(orphanCalls, orphanCalls[0]?.timestamp);
     turns.push({
       promptId: null,
       prompt: '',

--- a/tests/unit/hooks/claude-code/hook-processor.test.mjs
+++ b/tests/unit/hooks/claude-code/hook-processor.test.mjs
@@ -1032,6 +1032,19 @@ describe('claude-code 一级子 Agent 上报', () => {
       record['gen_ai.agent.scope'] === 'subagent');
 
     expect(parentAgentTool?.['gen_ai.tool.name']).toBe('Agent');
+    // Both transcripts lack promptId: request timestamps must survive export
+    // as source-time fallbacks, including the recursively parsed child turn.
+    const requests = records.filter((record) => record['event.name'] === 'llm.request');
+    expect(requests).toHaveLength(3);
+    const childRequest = requests.find((record) => record['gen_ai.agent.scope'] === 'subagent');
+    expect(childRequest.time_unix_nano).toBe('1780541855900000000');
+    for (const request of requests) {
+      const response = records.find((record) => record['event.name'] === 'llm.response'
+        && record.span_id === request.span_id);
+      expect(response).toBeDefined();
+      expect(BigInt(request.time_unix_nano)).toBeGreaterThan(0n);
+      expect(BigInt(request.time_unix_nano)).toBeLessThanOrEqual(BigInt(response.time_unix_nano));
+    }
     expect(childRecords.length).toBeGreaterThan(0);
     for (const record of childRecords) {
       expect(record.trace_id).toBe(parentAgentTool.trace_id);

--- a/tests/unit/hooks/claude-code/transcript-parser.test.mjs
+++ b/tests/unit/hooks/claude-code/transcript-parser.test.mjs
@@ -299,6 +299,74 @@ describe('parseClaudeTranscript', () => {
     expect(llm2.message_id).toMatch(/^_syn_/);
   });
 
+  test.each([false, true])('无 promptId 的连续调用补齐起点并保留工具边界 (missing message.id=%s)', (missingMessageId) => {
+    const file = path.join(TMP, 'missing-prompt-id.jsonl');
+    const assistant = (id, timestamp, content) => ({
+      type: 'assistant', timestamp,
+      message: { ...(missingMessageId ? {} : { id }), content },
+    });
+    writeJsonl(file, [
+      { type: 'user', timestamp: '2026-06-04T02:57:32.000Z', message: { content: 'hello' } },
+      assistant('m1', '2026-06-04T02:57:40.000Z', [{ type: 'text', text: 'first' }]),
+      assistant('m2', '2026-06-04T02:57:41.000Z', [{ type: 'text', text: 'second' }]),
+      assistant('m3', '2026-06-04T02:57:42.000Z', [{ type: 'tool_use', id: 't1', name: 'Bash', input: {} }]),
+      { type: 'user', timestamp: '2026-06-04T02:57:43.000Z', message: { content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }] } },
+      assistant('m4', '2026-06-04T02:57:44.000Z', [{ type: 'text', text: 'done' }]),
+    ]);
+    const { turns } = parseClaudeTranscript(file);
+    expect(turns).toHaveLength(1);
+    expect(turns[0].promptId).toBeNull();
+    expect(turns[0].llmCalls.map((call) => call.request_start_time)).toEqual([
+      '2026-06-04T02:57:40.000Z',
+      '2026-06-04T02:57:40.000Z',
+      '2026-06-04T02:57:41.000Z',
+      '2026-06-04T02:57:43.000Z',
+    ]);
+  });
+
+  test('孤立 assistant 补齐起点且不使用其他 turn 的边界', () => {
+    const file = path.join(TMP, 'orphan.jsonl');
+    writeJsonl(file, [
+      { type: 'assistant', timestamp: '2026-06-04T02:57:30.000Z', message: { id: 'orphan', content: [] } },
+      { type: 'user', timestamp: '2026-06-04T02:57:32.000Z', promptId: 'p1', message: { content: 'hello' } },
+      { type: 'assistant', timestamp: '2026-06-04T02:57:40.000Z', message: { id: 'm1', content: [] } },
+    ]);
+    const { turns } = parseClaudeTranscript(file);
+    expect(turns).toHaveLength(2);
+    expect(turns.find((turn) => turn.promptId === 'p1').llmCalls[0].request_start_time)
+      .toBe('2026-06-04T02:57:32.000Z');
+    expect(turns.find((turn) => turn.promptId === null).llmCalls[0].request_start_time)
+      .toBe('2026-06-04T02:57:30.000Z');
+  });
+
+  test('增量片段只有 assistant 时使用片段内时间补齐起点', () => {
+    const file = path.join(TMP, 'incremental.jsonl');
+    writeJsonl(file, [
+      { type: 'user', timestamp: '2026-06-04T02:57:32.000Z', promptId: 'p1', message: { content: 'hello' } },
+      { type: 'assistant', timestamp: '2026-06-04T02:57:40.000Z', message: { id: 'm1', content: [] } },
+    ]);
+    const first = parseClaudeTranscript(file);
+    fs.appendFileSync(file, JSON.stringify({
+      type: 'assistant', timestamp: '2026-06-04T02:57:45.000Z',
+      message: { id: 'm2', content: [] },
+    }) + '\n');
+    const next = parseClaudeTranscript(file, first.nextOffset);
+    expect(next.nextOffset).toBe(fs.statSync(file).size);
+    expect(next.turns).toHaveLength(1);
+    expect(next.turns[0].llmCalls).toHaveLength(1);
+    expect(next.turns[0].llmCalls[0].request_start_time).toBe('2026-06-04T02:57:45.000Z');
+  });
+
+  test('无 promptId 时同样限制请求起点不能晚于响应', () => {
+    const file = path.join(TMP, 'late-tool-result.jsonl');
+    writeJsonl(file, [
+      { type: 'user', timestamp: '2026-06-04T02:57:50.000Z', message: { content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }] } },
+      { type: 'assistant', timestamp: '2026-06-04T02:57:40.000Z', message: { id: 'm1', content: [] } },
+    ]);
+    const { turns } = parseClaudeTranscript(file);
+    expect(turns[0].llmCalls[0].request_start_time).toBe('2026-06-04T02:57:40.000Z');
+  });
+
   test('首个 llmCall 的 request_start_time 使用 prompt 时间', () => {
     const file = path.join(TMP, 't.jsonl');
     writeJsonl(file, [


### PR DESCRIPTION
Claude Code 当前 transcript 片段没有 `promptId`，或包含无法归属到 prompt 的 assistant 时，请求起点没有经过补齐，即使响应时间有效，仍会导出 `llm.request.time_unix_nano = "0"`。

本次将正常分支已有的请求起点补齐逻辑提取为 `fillRequestStartTimes()`，由正常、无 `promptId` 和孤立 assistant 三个分支共同调用。子 Agent 复用同一解析器，因此一并修复。生产代码仅涉及 `transcript-parser.mjs`（新增 15 行、删除 10 行）。

- 保留已有工具结果起点、同轮时间兜底和 request ≤ response 校验，正常分支行为不变。
- 缺少请求边界时，首个调用使用自身响应时间兜底，避免导出 epoch 时间；这是保守估计，不能还原真实耗时。
- 保持轮次归属和事件数量，不增加事件丢弃策略，不使用采集时间。所有源时间均缺失或无效的处理不在本次范围内。

验证：
- 新增/加强的回归检查在修复前均失败，覆盖无 `promptId` 的连续调用（有/无 `message.id`）、工具结果边界、孤立 assistant、增量片段、时间倒置和父子 Agent 的实际 JSONL 输出。
- `npm test -- tests/unit/hooks/claude-code`：5 个文件、84 项通过（Node 22.23.2 / 25.9.0）。
- `npm run typecheck`、`npm run build`、`git diff --check` 通过。
- 尚未进行真实 Claude Code/SLS 部署验收。

Closes #386
