### PR TITLE
fix(opencode): keep turn identity unique across resumed processes

### DIFF
--- a/assets/plugins/opencode/plugin.mjs
+++ b/assets/plugins/opencode/plugin.mjs
@@ -472,8 +472,12 @@ function handleChatMessage(inp, out, userId) {
 
   session.turnSeq += 1;
   if (session.turnSeq === 1) recordUpstreamEnvOnce(sessionID);
-  const turnId = `${sessionID}:t${session.turnSeq}`;
   const traceId = generateTraceId();
+  // `opencode run -s` resumes a session in a fresh process, resetting turnSeq.
+  // Include this invocation's random ID so the trace flusher cannot mistake
+  // a resumed turn for an already-exported one. This suffix stays unchanged
+  // even when upstream linking later replaces the record's trace_id.
+  const turnId = `${sessionID}:t${session.turnSeq}:${traceId}`;
 
   session.currentTurn = {
     turnId,

--- a/tests/fixtures/opencode/resumed-process.mjs
+++ b/tests/fixtures/opencode/resumed-process.mjs
@@ -1,0 +1,31 @@
+// Synthetic hook traffic through the real plugin in a fresh Node process.
+import plugin from '../../../assets/plugins/opencode/plugin.mjs';
+
+const hooks = await plugin.server({ directory: process.env.LOONGSUITE_PILOT_DATA_DIR }, {});
+const sessionID = 'ses_resume_fixture';
+const resumed = process.argv[2] === 'resume';
+let time = Date.now() - 10_000;
+const event = (type, properties) => hooks.event({ event: { type, properties } });
+await hooks['chat.message']({ sessionID }, {
+  message: { id: resumed ? 'user_second' : 'user_first', model: { providerID: 'openai', modelID: 'fixture-model' } },
+  parts: [{ type: 'text', text: resumed ? 'Update the fixture' : 'Hello' }],
+});
+const steps = resumed ? [['read'], ['write', 'edit'], []] : [[]];
+for (const [index, tools] of steps.entries()) {
+  const messageID = `${resumed ? 'second' : 'first'}_${index}`;
+  await event('message.part.updated', { sessionID, time: time += 100,
+    part: { type: 'step-start', messageID } });
+  for (const tool of tools) {
+    const callID = `call_${messageID}_${tool}`;
+    const start = time += 10;
+    const part = { type: 'tool', messageID, callID, tool };
+    await event('message.part.updated', { sessionID, part: { ...part,
+      state: { status: 'running', input: { filePath: 'fixture.txt' }, time: { start } } } });
+    await event('message.part.updated', { sessionID, part: { ...part,
+      state: { status: 'completed', output: `${tool} completed`, time: { start, end: time += 20 } } } });
+  }
+  await event('message.updated', { info: { role: 'assistant', sessionID, id: messageID,
+    modelID: 'fixture-model', providerID: 'openai', time: { completed: time += 10 },
+    tokens: { input: 10, output: 2 } } });
+}
+await event('session.idle', { sessionID });

--- a/tests/integration/opencode-resume-turn.test.ts
+++ b/tests/integration/opencode-resume-turn.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ExportResultCode } from '@opentelemetry/core';
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { OtlpTraceFlusher } from '../../src/flushers/otlp-trace-flusher.js';
+import { transformHookRecord } from '../../src/inputs/base/hook-record-transform.js';
+import { ClientType, type AgentActivityEntry } from '../../src/types/index.js';
+
+const fixture = fileURLToPath(new URL('../fixtures/opencode/resumed-process.mjs', import.meta.url));
+const tempDirs: string[] = [];
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+async function runProcess(mode: string): Promise<AgentActivityEntry[]> {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'pilot-resume-'));
+  tempDirs.push(dir);
+  execFileSync(process.execPath, [fixture, mode], {
+    env: { PATH: process.env.PATH, HOME: dir, USERPROFILE: dir, LOONGSUITE_PILOT_DATA_DIR: dir },
+  });
+  const logs = path.join(dir, 'logs', 'opencode');
+  const records = readdirSync(logs).filter(name => name.endsWith('.jsonl'))
+    .flatMap(name => readFileSync(path.join(logs, name), 'utf8').trim().split('\n'))
+    .map(line => JSON.parse(line));
+  return (await Promise.all(records.map(record =>
+    transformHookRecord(record, ClientType.OpenCode, 'opencode'))))
+    .filter((record): record is AgentActivityEntry => record !== null);
+}
+
+describe('OpenCode session resumed in a new process', () => {
+  it.each([false, true])('exports resumed tools across polls (shared first batch: %s)', async (sharedBatch) => {
+    const first = await runProcess('first');
+    const second = await runProcess('resume');
+    const spans: ReadableSpan[] = [];
+    const flusher = new OtlpTraceFlusher({
+      enabled: true, endpoints: [{ endpoint: 'http://localhost:4318/v1/traces', headers: {} }],
+      protocol: 'http/protobuf', serviceName: 'resume-test', debug: false,
+    }, undefined, () => ({
+      export(batch, callback) { spans.push(...batch); callback({ code: ExportResultCode.SUCCESS }); },
+      shutdown: async () => {},
+    }));
+    try {
+      // Upstream linking may put both invocations under the same trace. Turn
+      // uniqueness must survive that rewrite as well as process restarts.
+      for (const record of [...first, ...second]) record.trace_id = 'a'.repeat(32);
+      const cut = second.findIndex(record => record['gen_ai.step.id']?.endsWith(':s2'));
+      expect(cut).toBeGreaterThan(0);
+      await flusher.sendBatch(sharedBatch ? [...first, ...second.slice(0, cut)] : first);
+      if (!sharedBatch) await flusher.sendBatch(second.slice(0, cut));
+      await flusher.sendBatch(second.slice(cut));
+      // Do not call flush() between polls: it clears the late-arrival guard.
+      const tools = spans.filter(span => span.attributes['gen_ai.span.kind'] === 'TOOL');
+      expect(tools.map(span => span.attributes['gen_ai.tool.name']).sort()).toEqual(['edit', 'read', 'write']);
+      for (const kind of ['ENTRY', 'AGENT']) {
+        expect(spans.filter(span => span.attributes['gen_ai.span.kind'] === kind)).toHaveLength(2);
+      }
+      expect(spans.filter(span => span.attributes['gen_ai.span.kind'] === 'LLM')).toHaveLength(4);
+      expect(new Set(first.map(record => record['gen_ai.turn.id'])).size).toBe(1);
+      expect(new Set(second.map(record => record['gen_ai.turn.id'])).size).toBe(1);
+      expect(first[0]['gen_ai.turn.id']).not.toBe(second[0]['gen_ai.turn.id']);
+      expect(first[0]['gen_ai.session.id']).toBe(second[0]['gen_ai.session.id']);
+      const ids = new Set(spans.map(span => span.spanContext().spanId));
+      expect(ids.size).toBe(spans.length);
+      for (const tool of tools) {
+        expect(ids.has(tool.parentSpanId!)).toBe(true);
+        expect(tool.duration[0] * 1e9 + tool.duration[1]).toBeGreaterThan(0);
+        expect(tool.attributes['gen_ai.tool.call.result']).toBeTruthy();
+      }
+      const count = spans.length;
+      await flusher.sendBatch(second);
+      expect(spans).toHaveLength(count);
+    } finally {
+      await flusher.shutdown();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #389.

Prevent OpenCode sessions resumed with `opencode run -s` in a fresh process from reusing an already-exported turn ID and silently losing subsequent LLM/tool spans.

- Build turn IDs as `<session>:t<sequence>:<invocation-random-id>`, reusing the random trace ID already generated at turn creation. No extra randomness, disk state, or process-global configuration is introduced.
- Preserve session identity and a stable turn/step namespace even if downstream upstream-linking rewrites `trace_id`.
- Leave the shared trace flusher and its late-arrival/replay guard unchanged.

## Regression coverage

A synthetic fixture invokes the **real plugin in two fresh Node processes**, normalizes the emitted JSONL, and feeds it through the real `OtlpTraceFlusher` with an in-memory exporter. These are deterministic integration tests, distinct from the real CLI diagnostic below.

The two cases cover:

1. The first turn is exported before resumed events arrive in subsequent polls.
2. The first poll mixes the previous terminal turn and the resumed read step; write/edit arrive in a later poll.

Both force the two invocations to share an upstream `trace_id` and assert distinct turns, preserved session identity, complete read/write/edit spans, two ENTRY/AGENT pairs, four LLM spans, valid tool parents/results/durations, unique span IDs, and no re-export on replay.

## Validation

Executed after rebasing onto `main` at `7836a5d00e8d904876e197020d0feb57420644be`:

- **24 test files / 176 tests passed**, including the new integration tests, OpenCode plugin session/cwd/token tests, plugin injection/watchdog tests, hook normalization, and the OTLP trace-flusher test directory.
- `npm run typecheck` — passed.
- `npm run build` — passed.
- `git diff --check` — passed.

Earlier installed-product diagnostic, before the rebase: real OpenCode **1.18.18**, Linux/arm64, Qwen3 Coder Plus, automatic Pilot plugin injection, persistent collector with 30-second polling, and a local HTTP/protobuf OTLP receiver. This used baseline `74e825287c24ed23293fad9d31746fbb44fab6a9` plus the **identical plugin change**, not the final rebased PR SHA.

| Real CLI result | Before | After |
| --- | --- | --- |
| Successful source tools | write/read/edit | write/read/edit |
| Distinct turns after process restart | 1 | 2 |
| Exported TOOL spans | 0 | 3, matching source call IDs |
| Total exported spans | 4 | 17 |

The old collector logged `Dropping late entry for already-flushed turn`. The corrected traces passed structure/time/token validation with **0 errors**; the validator reported 179 SHOULD-level missing-attribute warnings, including optional model details and cloud-resource fields absent from this local OTLP setup.

## Scope and limitations

- Only the OpenCode plugin and synthetic regression fixtures/tests are changed; unrelated turn-boundary-marker work is excluded.
- New OpenCode turns use the new ID shape. Session IDs remain unchanged; consumers should treat turn IDs as opaque correlation keys.
- Existing dropped history is not backfilled, and already-running OpenCode processes must reload the updated plugin to use the fix.
- The full repository test suite and GitHub CI are not claimed as passed by the local targeted run.
- ACK connectivity failed during preflight. SLS/ARMS, customer-sandbox acceptance, and real upstream same-trace linking remain unverified; the same-trace case is covered by deterministic integration tests only.
- No customer logs, screenshots, credentials, or local diagnostic artifacts are included in this PR.
