### PR TITLE
fix(qoder): preserve terminal response without tool result

### DIFF
--- a/assets/hooks/qoder-hook-processor.mjs
+++ b/assets/hooks/qoder-hook-processor.mjs
@@ -919,20 +919,24 @@ function hookEventOf(row) {
 
 export function buildLlmBoundaries(_progressEvents, contentEvents) {
   // Step 1: Group assistant blocks into LLM calls. Qoder transcript assistant
-  // rows do not carry message.id, and progress windows are hook timing signals,
-  // not reliable provider-call boundaries.
+  // rows do not consistently carry message.id, and progress windows are hook
+  // timing signals, not reliable provider-call boundaries.
   //
   // IDE transcript rows are content blocks, not one row per provider call. A
   // complete response may therefore be spread over thinking, text and multiple
   // tool_use rows, and parallel tool execution may even place an early
   // tool_result between later tool_use rows. The deterministic boundary is:
-  // after every tool_use in the current response has a matching tool_result,
-  // the next assistant row starts a new LLM call.
+  // a non-empty stop_reason marks the current provider response complete. The
+  // actual split is delayed until the next assistant row so any intervening
+  // tool_result remains in the completed response's transcript range. For old
+  // rows without stop_reason, matching every tool_use to a tool_result remains
+  // the structural fallback.
   const assistantGroups = [];
   let currentGroup = [];
   let currentGroupStartIndex = -1;
   let currentToolIds = new Set();
   let resolvedToolIds = new Set();
+  let currentResponseComplete = false;
 
   function flushGroup(contentEndIndex) {
     if (currentGroup.length > 0) {
@@ -946,6 +950,7 @@ export function buildLlmBoundaries(_progressEvents, contentEvents) {
     currentGroupStartIndex = -1;
     currentToolIds = new Set();
     resolvedToolIds = new Set();
+    currentResponseComplete = false;
   }
 
   for (let rowIndex = 0; rowIndex < contentEvents.length; rowIndex++) {
@@ -967,10 +972,10 @@ export function buildLlmBoundaries(_progressEvents, contentEvents) {
       currentToolIds.size > 0 &&
       [...currentToolIds].every(id => resolvedToolIds.has(id));
     // Progress hooks carry no tool id and third-party hooks share the same
-    // transcript. They cannot safely close an LLM group. If a transcript ever
-    // omits tool_result, conservatively retain later assistant rows in this
-    // group instead of inventing a boundary and an orphan request.
-    if (toolCycleComplete) flushGroup(rowIndex);
+    // transcript, so they cannot safely close an LLM group. stop_reason belongs
+    // to the provider response itself and preserves a following terminal
+    // response even when a cancelled/interrupted tool omitted tool_result.
+    if (currentResponseComplete || toolCycleComplete) flushGroup(rowIndex);
 
     if (currentGroup.length === 0) currentGroupStartIndex = rowIndex;
     currentGroup.push(row);
@@ -978,6 +983,9 @@ export function buildLlmBoundaries(_progressEvents, contentEvents) {
       if (block?.type === 'tool_use' && block.id) {
         currentToolIds.add(block.id);
       }
+    }
+    if (typeof row.message?.stop_reason === 'string' && row.message.stop_reason.length > 0) {
+      currentResponseComplete = true;
     }
   }
   flushGroup(contentEvents.length);

--- a/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
+++ b/tests/unit/hooks/qoder-hook-processor-retry.test.mjs
@@ -170,10 +170,14 @@ describe('selectTurnSegmentsForCollection', () => {
 });
 
 describe('buildLlmBoundaries complete-response priority', () => {
-  const assistant = (timestamp, content) => ({
+  const assistant = (timestamp, content, stopReason) => ({
     type: 'assistant',
     timestamp,
-    message: { role: 'assistant', content },
+    message: {
+      role: 'assistant',
+      content,
+      ...(stopReason ? { stop_reason: stopReason } : {}),
+    },
   });
   const toolResult = (timestamp, id) => ({
     type: 'user',
@@ -339,7 +343,7 @@ describe('buildLlmBoundaries complete-response priority', () => {
       ]);
   });
 
-  it('conservatively merges later assistant rows when tool_result is missing', () => {
+  it('preserves a terminal response when tool_result is missing', () => {
     const rows = [
       {
         type: 'user',
@@ -348,10 +352,13 @@ describe('buildLlmBoundaries complete-response priority', () => {
       },
       assistant('2026-07-30T01:00:00.000Z', [
         { type: 'tool_use', id: 'tool-a', name: 'Read', input: { path: 'missing' } },
+      ], 'tool_use'),
+      assistant('2026-07-30T01:00:01.900Z', [
+        { type: 'thinking', thinking: 'the tool was cancelled' },
       ]),
       assistant('2026-07-30T01:00:02.000Z', [
         { type: 'text', text: 'the tool was cancelled' },
-      ]),
+      ], 'end_turn'),
     ];
     const progress = [
       { hookEvent: 'UserPromptSubmit', ts: '2026-07-30T00:59:59.000Z' },
@@ -361,7 +368,7 @@ describe('buildLlmBoundaries complete-response priority', () => {
     ];
 
     const boundaries = buildLlmBoundaries(progress, rows);
-    expect(boundaries).toHaveLength(1);
+    expect(boundaries).toHaveLength(2);
     const records = buildEventsFromBoundaries(
       boundaries, rows, rows, 'turn-missing-result', 'session-1', 'qoder', {}, undefined,
     );
@@ -371,12 +378,33 @@ describe('buildLlmBoundaries complete-response priority', () => {
       .toEqual([
         ['llm.request', 'turn-missing-result:s1'],
         ['llm.response', 'turn-missing-result:s1'],
+        ['llm.request', 'turn-missing-result:s2'],
+        ['llm.response', 'turn-missing-result:s2'],
       ]);
     expect(records.filter(record => record['event.name'] === 'tool.call')).toHaveLength(1);
     expect(records.filter(record => record['event.name'] === 'tool.result')).toHaveLength(0);
-    expect(records.find(record => record['event.name'] === 'llm.response')
-      ['gen_ai.output.messages'][0].parts.map(part => part.type))
-      .toEqual(['tool_call', 'text']);
+    const responses = records.filter(record => record['event.name'] === 'llm.response');
+    expect(responses.map(record => ({
+      parts: record['gen_ai.output.messages'][0].parts.map(part => part.type),
+      finishReasons: record['gen_ai.response.finish_reasons'],
+      turnEnd: record['gen_ai.turn.end'],
+    }))).toEqual([
+      { parts: ['tool_call'], finishReasons: ['tool_call'], turnEnd: undefined },
+      { parts: ['reasoning', 'text'], finishReasons: ['end_turn'], turnEnd: true },
+    ]);
+  });
+
+  it('conservatively merges later assistant rows when both tool_result and stop_reason are missing', () => {
+    const rows = [
+      assistant('2026-07-30T01:00:00.000Z', [
+        { type: 'tool_use', id: 'tool-a', name: 'Read', input: { path: 'missing' } },
+      ]),
+      assistant('2026-07-30T01:00:02.000Z', [
+        { type: 'text', text: 'the tool state is unknown' },
+      ]),
+    ];
+
+    expect(buildLlmBoundaries([], rows)).toHaveLength(1);
   });
 
   it('keeps structure and content identical when third-party PostToolUse progress is present', () => {


### PR DESCRIPTION
## Summary

- follow up #385 by treating a non-empty Qoder assistant `stop_reason` as provider-response completion
- delay the actual group split until the next assistant row so intervening `tool_result` records remain in the preceding response range
- preserve a later terminal `end_turn` response when a cancelled/interrupted tool has no `tool_result`
- retain tool-ID closure as the fallback when older transcripts have no `stop_reason`

Third-party progress records, including QoderSec `PostToolUse`, remain excluded from LLM boundary decisions. The collector does not fabricate a missing tool result.

## Validation

- focused Qoder regression suite: 9 files, 199 tests passed
- `npm run typecheck`
- `npm run build`
- older customer transcript without `stop_reason`: unchanged at 7 turns / 203 LLM steps
