### PR TITLE
fix(qoderwork): resolve development runtimes and avoid initialization timeouts

### DIFF
--- a/assets/hooks/qoderwork-runtime-wrapper.mjs
+++ b/assets/hooks/qoderwork-runtime-wrapper.mjs
@@ -15,8 +15,8 @@
 // running process. There is intentionally NO hardcoded/app-specific fallback:
 // loading a foreign runtime (e.g. QoderWork's runtime inside QwenWorkCN) is
 // exactly what corrupts the app. If we cannot locate the host app's own runtime
-// with certainty, we install nothing and load nothing — token interception is
-// sacrificed, the app is never handed a wrong runtime.
+// with certainty, we report a worker error immediately. An empty successful
+// worker cannot answer the SDK initialize request and causes a long timeout.
 //
 // On the success path only, token/system-prompt records are appended to the
 // host-specific intercept file. Keeping these files separate is required even
@@ -25,6 +25,7 @@
 
 import { createRequire } from 'module';
 import { fileURLToPath, pathToFileURL } from 'url';
+import { isMainThread, workerData } from 'node:worker_threads';
 const require = createRequire(import.meta.url);
 const fs = require('node:fs');
 const path = require('node:path');
@@ -69,6 +70,16 @@ function logDiag(msg) {
     fs.mkdirSync(INTERCEPT_DIR, { recursive: true });
     fs.appendFileSync(ERROR_LOG, `[${new Date().toISOString()}] ${msg}\n`);
   } catch {}
+}
+
+async function failWorker(error) {
+  if (!isMainThread) {
+    // Some SDK versions destroy Worker stdout on error without ending their
+    // downstream line reader. End stdout first so readMessages can reach the
+    // Worker error and reject initialize, instead of waiting for its timeout.
+    await new Promise(resolve => process.stdout.end(resolve));
+  }
+  throw error;
 }
 
 // Install the JSON.parse / JSON.stringify interception hooks. Only ever called
@@ -200,12 +211,57 @@ function findHostAppRuntime(resourceRoots) {
   return null;
 }
 
+// Development Electron has no app.asar.unpacked. Anchor resolution to the
+// executable's owning project, never the conversation CWD or installed apps.
+// npm_package_json supports workspaces with a hoisted Electron, but is accepted
+// only when that package declares the SDK and resolves the running Electron.
+function findDevelopmentRuntime() {
+  const exec = fs.realpathSync(process.execPath);
+  const normalized = exec.replace(/\\/g, '/');
+  if (!normalized.includes('/node_modules/electron/dist/')) return null;
+  const projectRoot = exec.slice(0, normalized.indexOf('/node_modules/'));
+  const manifests = [process.env.npm_package_json, path.join(projectRoot, 'package.json')];
+  for (const manifest of [...new Set(manifests.filter(Boolean))]) {
+    if (!path.isAbsolute(manifest)) continue;
+    let verifiedProject = false;
+    try {
+      const pkg = origParse(fs.readFileSync(manifest, 'utf8'));
+      const sdkName = '@qoder-ai/qoder-agent-sdk';
+      if (![pkg.dependencies, pkg.devDependencies, pkg.optionalDependencies]
+        .some(deps => deps && Object.hasOwn(deps, sdkName))) continue;
+      const hostRequire = createRequire(manifest);
+      const electronDir = path.dirname(hostRequire.resolve('electron/package.json'));
+      const electronBinary = fs.readFileSync(path.join(electronDir, 'path.txt'), 'utf8').trim();
+      if (fs.realpathSync(path.join(electronDir, 'dist', electronBinary)) !== exec) continue;
+      verifiedProject = true;
+      // Resolve the public entry instead of package.json: SDK exports may hide
+      // its manifest, and the installed package may be an npm alias.
+      const entryDir = path.dirname(hostRequire.resolve(sdkName));
+      for (const dir of [path.join(entryDir, '_worker'), path.join(entryDir, 'dist', '_worker')]) {
+        for (const name of RUNTIME_NAMES) {
+          const candidate = path.join(dir, name);
+          if (fs.existsSync(candidate)) {
+            const real = fs.realpathSync(candidate);
+            if (real !== fs.realpathSync(WRAPPER_PATH)) return real;
+          }
+        }
+      }
+      // A verified workspace owns this SDK even when its worker is missing.
+      // Do not fall through to a different SDK hoisted at the repository root.
+      return null;
+    } catch {
+      if (verifiedProject) return null;
+    }
+  }
+  return null;
+}
+
 const resourceRoots = candidateResourceRoots();
 const host = classifyHost(resourceRoots);
 // Runtime discovery is intentionally independent from host classification.
 // A future/unknown sibling app still needs its own worker to run normally even
 // though we do not yet know which product-specific intercept file to use.
-const hostRuntime = findHostAppRuntime(resourceRoots);
+const hostRuntime = findHostAppRuntime(resourceRoots) || findDevelopmentRuntime();
 
 if (hostRuntime) {
   // Only recognized products get interception. Unknown hosts are transparently
@@ -215,24 +271,28 @@ if (hostRuntime) {
     installInterceptHooks(interceptFile);
   }
   try {
+    // The SDK derives these from the override path (our hooks directory).
+    // Restore the real runtime's asset root without changing the task CWD.
+    const runtimeRoot = path.dirname(hostRuntime);
+    process.env.QODER_WORKER_RUNTIME_ASSET_ROOT = runtimeRoot;
+    if (workerData?.qoderWorkerRuntime) {
+      workerData.qoderWorkerRuntime.runtimeRoot = runtimeRoot;
+    }
     // Use file:// URL so Windows absolute paths (C:\...) work with ESM import.
     await import(pathToFileURL(hostRuntime).href);
   } catch (e) {
-    // The app's own runtime failed to load — the app would have hit this even
-    // without us. Do not throw (module-level throw crashes the worker_thread and
-    // blocks the SDK's own transport fallback) and do not try any other runtime.
+    // Propagate through Worker 'error'; never leave initialize pending behind
+    // a successful empty worker or try a different SDK after a load failure.
     logDiag(
       `host runtime import failed: host=${host?.id || 'unrecognized'}, runtime=${hostRuntime} `
       + `:: ${e && e.message}`,
     );
+    await failWorker(e);
   }
 } else {
-  // Could not locate the host app's own runtime. Per design priority we refuse
-  // to load any guessed/foreign runtime (that is what broke QwenWorkCN). Install
-  // nothing, load nothing: token interception is lost, the app is never handed a
-  // wrong runtime. The SDK detects the empty worker entry and degrades on its own.
-  logDiag(
-    'host app runtime not found — skipping intercept to avoid loading a foreign runtime '
-    + `(execPath=${process.execPath || ''}, resourcesPath=${process.resourcesPath || ''})`,
-  );
+  const message =
+    'Pilot host app runtime not found; refusing to load a foreign runtime '
+    + `(execPath=${process.execPath || ''}, resourcesPath=${process.resourcesPath || ''})`;
+  logDiag(message);
+  await failWorker(new Error(message));
 }

--- a/assets/skills/loongsuite-pilot-ops/references/qoderwork-diagnostics.md
+++ b/assets/skills/loongsuite-pilot-ops/references/qoderwork-diagnostics.md
@@ -244,8 +244,31 @@ for line in sys.stdin:
 tail -50 ~/.loongsuite-pilot/logs/qoderwork-wrapper-error.log 2>/dev/null
 ```
 
-若 error 日志提示 `real runtime not found`，说明 wrapper 已注入，但未找到 QoderWork 内置 worker runtime。常见原因是 QoderWork 安装路径或 SDK 版本结构变化，
-需升级 pilot 或补充 wrapper 的 runtime candidate。
+若 error 日志提示 `host app runtime not found`，说明 wrapper 已注入，但未找到宿主自己的 worker runtime。
+应根据日志中的 `execPath` / `resourcesPath` 核对安装路径和 SDK 目录，不要把其他应用的 runtime 填入作为替代。
+
+### 开发态 QwenWork / QoderWork 初始化失败
+
+macOS 全局 runtime 环境变量也会被开发实例继承。旧 wrapper 只查找安装包内的
+`app.asar.unpacked/node_modules/@qoder-ai/qoder-agent-sdk/dist/_worker`，开发实例可能因此没有启动原生 runtime，
+最终出现 `Control request "initialize" timed out after 120000ms`。
+
+更新后的 wrapper 支持从 `node_modules/electron/dist` 可执行文件定位开发项目，支持 npm 和项目内 pnpm 布局。
+workspace 可使用启动脚本提供的 `npm_package_json`，但必须声明 SDK 依赖，并解析到同一个 Electron 可执行文件。
+wrapper 只加载该项目解析出的 SDK，不搜索会话工作目录或其他已安装应用；同时恢复原生 runtime 的资源目录。
+开发态没有可靠的产品身份时只转发 runtime，不写入 QwenWork / QoderWork 专属 intercept 文件。
+
+找不到 runtime 或导入失败时，wrapper 会记录诊断、结束 stdout，再抛出 worker 错误，避免 SDK 输出读取挂起。
+是否回退 CLI 由宿主应用决定。macOS 安装器和 watchdog 在 wrapper 文件缺失时会清理当前 Pilot 所属的环境变量及 plist；
+已运行的应用、终端和 IDE 仍可能保留旧环境，需要重新启动相应进程。
+
+对于尚未升级 Pilot 或使用非标准开发目录的用户，可先完全退出开发实例，并在实际开发启动命令上排除两个变量：
+
+```bash
+env -u QW_QODER_WORKER_RUNTIME_PATH -u QODER_WORKER_RUNTIME_PATH npm run dev
+```
+
+将 `npm run dev` 换成项目实际启动命令；此方式只影响该命令及其子进程，不更改全局配置。
 
 ---
 

--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -1409,7 +1409,10 @@ inject_qoderwork_runtime_wrapper() {
     fi
 
     local wrapper_script="$DATA_DIR/hooks/qoderwork-runtime-wrapper.mjs"
-    if [ ! -f "$wrapper_script" ]; then return 0; fi
+    if [ ! -f "$wrapper_script" ]; then
+        remove_qoderwork_runtime_wrapper
+        return 0
+    fi
 
     msg "==> 配置 QoderWork 系列 token 采集..." "==> Configuring QoderWork-family token intercept..."
 
@@ -1509,20 +1512,19 @@ remove_qoderwork_runtime_wrapper() {
     for plist_path in \
         "$HOME/Library/LaunchAgents/com.loongsuite-pilot.qoderwork-env.plist" \
         "$HOME/Library/LaunchAgents/com.loongsuite-pilot.qwenworkcn-env.plist"; do
-        if [ -f "$plist_path" ]; then
+        if [ -f "$plist_path" ] && grep -Fq "<string>$DATA_DIR/hooks/qoderwork-runtime-wrapper.mjs</string>" "$plist_path"; then
             launchctl unload "$plist_path" 2>/dev/null || true
             rm -f "$plist_path"
         fi
     done
 
-    # Drop the env from the current session too (conservative grep avoids
-    # touching env values the user set manually to a non-loongsuite path).
-    if launchctl getenv QODER_WORKER_RUNTIME_PATH 2>/dev/null | grep -q 'loongsuite-pilot'; then
+    # Drop only values owned by this Pilot installation.
+    if [ "$(launchctl getenv QODER_WORKER_RUNTIME_PATH 2>/dev/null)" = "$DATA_DIR/hooks/qoderwork-runtime-wrapper.mjs" ]; then
         launchctl unsetenv QODER_WORKER_RUNTIME_PATH
         msg "    已清理 QODER_WORKER_RUNTIME_PATH" \
             "    Cleaned up QODER_WORKER_RUNTIME_PATH"
     fi
-    if launchctl getenv QW_QODER_WORKER_RUNTIME_PATH 2>/dev/null | grep -q 'loongsuite-pilot'; then
+    if [ "$(launchctl getenv QW_QODER_WORKER_RUNTIME_PATH 2>/dev/null)" = "$DATA_DIR/hooks/qoderwork-runtime-wrapper.mjs" ]; then
         launchctl unsetenv QW_QODER_WORKER_RUNTIME_PATH
         msg "    已清理 QW_QODER_WORKER_RUNTIME_PATH" \
             "    Cleaned up QW_QODER_WORKER_RUNTIME_PATH"

--- a/src/core/hook-watchdog.ts
+++ b/src/core/hook-watchdog.ts
@@ -733,11 +733,31 @@ export class HookWatchdog {
           path.join(home, 'Applications', appName),
         ]);
 
+        const cleanup = async () => {
+          // Each product-specific target only removes its own env/plist.
+          try {
+            const { stdout } = await execFileAsync('launchctl', ['getenv', def.envName]);
+            if (stdout.trim() === wrapperPath) {
+              await execFileAsync('launchctl', ['unsetenv', def.envName]).catch(() => {});
+            }
+          } catch {
+            // getenv fails when unset — nothing to drop.
+          }
+          const plist = await fs.readFile(plistPath, 'utf8').catch(() => '');
+          if (plist.includes(`<string>${wrapperPath}</string>`)) {
+            await execFileAsync('launchctl', ['unload', plistPath]).catch(() => {});
+            await fs.rm(plistPath, { force: true }).catch(() => {});
+          }
+        };
+
         targets.push({
           id: def.id,
           enabled: () => def.agentIds.some(agentId => isAgentEnabled(agentId)),
           precondition: async () => {
-            if (!await fileExists(wrapperPath)) return false;
+            if (!await fileExists(wrapperPath)) {
+              await cleanup();
+              return false;
+            }
             for (const appPath of appPaths) {
               if (await directoryExists(appPath)) return true;
             }
@@ -784,21 +804,7 @@ export class HookWatchdog {
             await execFileAsync('launchctl', ['unload', plistPath]).catch(() => {});
             await execFileAsync('launchctl', ['load', plistPath]).catch(() => {});
           },
-          cleanup: async () => {
-            // Each product-specific target only removes its own env/plist.
-            try {
-              const { stdout } = await execFileAsync('launchctl', ['getenv', def.envName]);
-              if (stdout.trim() === wrapperPath) {
-                await execFileAsync('launchctl', ['unsetenv', def.envName]).catch(() => {});
-              }
-            } catch {
-              // getenv fails when unset — nothing to drop.
-            }
-            if (await fileExists(plistPath)) {
-              await execFileAsync('launchctl', ['unload', plistPath]).catch(() => {});
-              await fs.rm(plistPath, { force: true }).catch(() => {});
-            }
-          },
+          cleanup,
         });
       }
     }

--- a/tests/unit/core/hook-watchdog-mac-runtime.test.ts
+++ b/tests/unit/core/hook-watchdog-mac-runtime.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { execFile } from 'node:child_process';
+import { HookWatchdog } from '../../../src/core/hook-watchdog.js';
+
+vi.mock('node:os', async importOriginal => ({ ...await importOriginal<typeof os>(), homedir: vi.fn() }));
+vi.mock('node:child_process', () => {
+  const execFile = vi.fn();
+  Object.defineProperty(execFile, Symbol.for('nodejs.util.promisify.custom'), {
+    value: (...args: unknown[]) => new Promise((resolve, reject) => {
+      execFile(...args, (error: Error | null, stdout: string, stderr: string) => {
+        error ? reject(error) : resolve({ stdout, stderr });
+      });
+    }),
+  });
+  return { spawn: vi.fn(), execFile };
+});
+vi.mock('../../../src/utils/logger.js', () => ({
+  createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+describe('macOS runtime override cleanup', () => {
+  let root: string;
+  let wrapper: string;
+  let values: Map<string, string>;
+  let calls: string[][];
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'pilot-mac-runtime-'));
+    wrapper = path.join(root, 'data', 'hooks', 'qoderwork-runtime-wrapper.mjs');
+    values = new Map();
+    calls = [];
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+    vi.mocked(os.homedir).mockReturnValue(root);
+    vi.mocked(execFile).mockImplementation(((command: string, args: string[], callback: Function) => {
+      expect(command).toBe('launchctl');
+      calls.push(args);
+      const [operation, key] = args;
+      if (operation === 'unsetenv') values.delete(key);
+      callback(null, operation === 'getenv' ? values.get(key) ?? '' : '', '');
+    }) as any);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it.each(HookWatchdog.macRuntimeInterceptDefs())('cleans missing wrapper for $id without repairing it', async def => {
+    values.set(def.envName, wrapper);
+    const plist = path.join(root, 'Library', 'LaunchAgents', `${def.plistLabel}.plist`);
+    await fs.mkdir(path.dirname(plist), { recursive: true });
+    await fs.writeFile(plist, `<plist><string>${wrapper}</string></plist>`);
+    const target = HookWatchdog.defaultInterceptTargets(path.join(root, 'data')).find(t => t.id === def.id)!;
+    const watchdog = new HookWatchdog({ enabled: true, intervalMs: 1000, repairCooldownMs: 1000 }, [], [target]);
+    const result = await watchdog.runCheck();
+    expect(result.skipped).toBe(1);
+    expect(values.has(def.envName)).toBe(false);
+    await expect(fs.stat(plist)).rejects.toThrow();
+    expect(calls).toContainEqual(['unload', plist]);
+    expect(calls.some(c => c[0] === 'setenv' || c[0] === 'load')).toBe(false);
+  });
+
+  it('preserves foreign overrides and plists even with the Pilot label', async () => {
+    const def = HookWatchdog.macRuntimeInterceptDefs()[0];
+    const foreign = '/custom/loongsuite-pilot/another-wrapper.mjs';
+    values.set(def.envName, foreign);
+    const plist = path.join(root, 'Library', 'LaunchAgents', `${def.plistLabel}.plist`);
+    await fs.mkdir(path.dirname(plist), { recursive: true });
+    await fs.writeFile(plist, `<plist><string>${foreign}</string></plist>`);
+    const target = HookWatchdog.defaultInterceptTargets(path.join(root, 'data')).find(t => t.id === def.id)!;
+    expect(await target.precondition()).toBe(false);
+    expect(values.get(def.envName)).toBe(foreign);
+    expect(await fs.readFile(plist, 'utf8')).toContain(foreign);
+    expect(calls.every(c => c[0] === 'getenv')).toBe(true);
+  });
+});

--- a/tests/unit/deploy/installer-uninstall-cleanup.test.mjs
+++ b/tests/unit/deploy/installer-uninstall-cleanup.test.mjs
@@ -768,3 +768,45 @@ describe('Windows QoderWork-family runtime override lifecycle', () => {
       .toBeLessThan(uninstall.indexOf('Remove-PilotInstallationFiles'));
   });
 });
+
+describe('macOS missing runtime override cleanup', () => {
+  it.each([true, false])('removes only owned stale configuration (owned=%s)', owned => {
+    const root = mkdtempSync(join(tmpdir(), 'pilot-mac-installer-'));
+    try {
+      const dataDir = join(root, 'custom-data');
+      const value = owned ? join(dataDir, 'hooks', 'qoderwork-runtime-wrapper.mjs') : '/custom/loongsuite-pilot/other.mjs';
+      const plistDir = join(root, 'Library', 'LaunchAgents');
+      mkdirSync(plistDir, { recursive: true });
+      const plists = ['qoderwork', 'qwenworkcn'].map(name => join(plistDir, `com.loongsuite-pilot.${name}-env.plist`));
+      for (const plist of plists) writeFileSync(plist, `<plist><string>${value}</string></plist>`);
+      const functions = ['inject_qoderwork_runtime_wrapper', 'remove_qoderwork_runtime_wrapper'].map(name => {
+        const match = sh.match(new RegExp(`^${name}\\(\\) \\{[\\s\\S]*?^\\}`, 'm'));
+        expect(match).not.toBeNull();
+        // Isolate path references without changing the test runner's home.
+        return match[0].replaceAll('$HOME', '$PILOT_TEST_HOME');
+      }).join('\n');
+      const result = spawnSync('bash', ['-s'], {
+        encoding: 'utf8', timeout: 5000,
+        env: { ...process.env, PILOT_TEST_HOME: root, DATA_DIR: dataDir, TEST_RUNTIME_VALUE: value, SELECTED_AGENTS: 'qoder-work,qwen-work-cn' },
+        input: `set -e
+uname() { echo Darwin; }
+msg() { :; }
+launchctl() {
+  if [ "$1" = getenv ]; then printf '%s' "$TEST_RUNTIME_VALUE";
+  else printf '%s\\n' "$*" >> "$PILOT_TEST_HOME/calls"; fi
+}
+${functions}
+inject_qoderwork_runtime_wrapper
+`,
+      });
+      expect(result.status, result.stderr).toBe(0);
+      for (const plist of plists) expect(existsSync(plist)).toBe(!owned);
+      const calls = existsSync(join(root, 'calls')) ? readFileSync(join(root, 'calls'), 'utf8') : '';
+      if (owned) {
+        expect(calls).toContain('unsetenv QODER_WORKER_RUNTIME_PATH');
+        expect(calls).toContain('unsetenv QW_QODER_WORKER_RUNTIME_PATH');
+        for (const plist of plists) expect(calls).toContain(`unload ${plist}`);
+      } else expect(calls).toBe('');
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  });
+});

--- a/tests/unit/hooks/qoderwork-runtime-wrapper.test.mjs
+++ b/tests/unit/hooks/qoderwork-runtime-wrapper.test.mjs
@@ -1,3 +1,6 @@
+import { pathToFileURL } from 'node:url';
+import { PassThrough } from 'node:stream';
+import { Worker } from 'node:worker_threads';
 import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import * as fs from 'node:fs/promises';
@@ -21,7 +24,7 @@ describe('QoderWork-family runtime wrapper forwarding', () => {
   let wrapper;
 
   beforeEach(async () => {
-    root = await fs.mkdtemp(path.join(os.tmpdir(), 'pilot-runtime-wrapper-'));
+    root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'pilot-runtime-wrapper-')));
     dataDir = path.join(root, 'pilot-data');
     wrapper = path.join(dataDir, 'hooks', 'qoderwork-runtime-wrapper.mjs');
     await fs.mkdir(path.dirname(wrapper), { recursive: true });
@@ -117,6 +120,161 @@ describe('QoderWork-family runtime wrapper forwarding', () => {
 
     expect(await fs.readFile(marker, 'utf-8')).toBe('loaded');
     expect(existsSync(path.join(dataDir, 'logs', 'qwenworkcn-intercept.jsonl'))).toBe(false);
+  });
+
+  async function createDevProject(name, { pnpm = false } = {}) {
+    const project = path.join(root, name);
+    const electronDir = path.join(project, 'node_modules', ...(pnpm ? ['.pnpm', 'electron@1', 'node_modules'] : []), 'electron');
+    const executable = path.join(electronDir, 'dist', 'Electron.app', 'Contents', 'MacOS', 'Electron');
+    await fs.mkdir(path.dirname(executable), { recursive: true });
+    await fs.writeFile(executable, 'fixture');
+    await fs.writeFile(path.join(electronDir, 'package.json'), '{"name":"electron"}');
+    await fs.writeFile(path.join(electronDir, 'path.txt'), 'Electron.app/Contents/MacOS/Electron');
+    if (pnpm) await fs.symlink(electronDir, path.join(project, 'node_modules', 'electron'));
+    await fs.writeFile(path.join(project, 'package.json'), JSON.stringify({
+      dependencies: { '@qoder-ai/qoder-agent-sdk': 'npm:@ali/qodercn-agent-sdk-next@1' },
+    }));
+    const sdk = path.join(project, 'node_modules', '@qoder-ai', 'qoder-agent-sdk');
+    await fs.mkdir(path.join(sdk, 'dist', '_worker'), { recursive: true });
+    await fs.writeFile(path.join(sdk, 'package.json'), JSON.stringify({
+      name: '@ali/qodercn-agent-sdk-next', exports: './dist/index.js',
+    }));
+    await fs.writeFile(path.join(sdk, 'dist', 'index.js'), '');
+    const runtime = path.join(sdk, 'dist', '_worker', 'qoder-worker-runtime.mjs');
+    await fs.writeFile(runtime, protocolRuntime);
+    return { project, executable, runtime };
+  }
+
+  const protocolRuntime = String.raw`
+import { createInterface } from 'node:readline';
+import { workerData } from 'node:worker_threads';
+createInterface({ input: process.stdin }).on('line', line => {
+  const request = JSON.parse(line);
+  process.stdout.write(JSON.stringify({
+    type: 'control_response', response: { subtype: 'success', request_id: request.request_id },
+    runtime: import.meta.url,
+    assetRoot: process.env.QODER_WORKER_RUNTIME_ASSET_ROOT,
+    runtimeRoot: workerData.qoderWorkerRuntime.runtimeRoot,
+    cwd: workerData.qoderWorkerRuntime.cwd,
+  }) + '\n');
+});
+`;
+
+  async function initializeWorker({ executable = process.execPath, resources = '', manifest = '', cwd = '/task/workspace' } = {}) {
+    const worker = new Worker(`
+      Object.defineProperty(process, 'execPath', { value: ${JSON.stringify(executable)} });
+      process.resourcesPath = ${JSON.stringify(resources)};
+      import(${JSON.stringify(wrapper)});
+    `, {
+      eval: true, stdin: true, stdout: true, stderr: true,
+      env: { ...process.env, npm_package_json: manifest, QODER_WORKER_RUNTIME_ASSET_ROOT: path.dirname(wrapper) },
+      workerData: { qoderWorkerRuntime: { cwd, runtimeRoot: path.dirname(wrapper) } },
+    });
+    try {
+      return await new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('fixture initialize timed out')), 3000);
+        const finish = (err, value) => { clearTimeout(timer); err ? reject(err) : resolve(value); };
+        // Model the SDK: it destroys stdout on error without ending the
+        // downstream reader. Failure must still reach that reader promptly.
+        const reader = new PassThrough();
+        worker.stdout.pipe(reader);
+        let workerFailure;
+        let readerEnded = false;
+        worker.on('error', error => {
+          workerFailure = error;
+          worker.stdout.destroy();
+          if (readerEnded) finish(error);
+        });
+        worker.on('exit', code => {
+          workerFailure ??= new Error(`worker exited before initialize: ${code}`);
+          worker.stdout.destroy();
+          if (readerEnded) finish(workerFailure);
+        });
+        reader.on('end', () => {
+          readerEnded = true;
+          if (workerFailure) finish(workerFailure);
+        });
+        let output = '';
+        reader.on('data', data => {
+          output += data;
+          if (output.includes('\n')) {
+            try { finish(null, JSON.parse(output.split('\n')[0])); } catch (err) { finish(err); }
+          }
+        });
+        worker.stdin.on('error', error => finish(error));
+        worker.stdin.write(JSON.stringify({ type: 'control_request', request_id: 'init-1', request: { subtype: 'initialize' } }) + '\n');
+      });
+    } finally {
+      await worker.terminate();
+    }
+  }
+
+  it.each([false, true])('answers initialize with the development SDK (pnpm=%s)', async pnpm => {
+    const dev = await createDevProject('dev', { pnpm });
+    const result = await initializeWorker({ executable: dev.executable });
+    expect(result.response).toEqual({ subtype: 'success', request_id: 'init-1' });
+    expect(result.runtime).toBe(pathToFileURL(dev.runtime).href);
+    expect(result.assetRoot).toBe(path.dirname(dev.runtime));
+    expect(result.runtimeRoot).toBe(path.dirname(dev.runtime));
+    expect(result.cwd).toBe('/task/workspace');
+    expect(existsSync(path.join(dataDir, 'logs', 'qwenworkcn-intercept.jsonl'))).toBe(false);
+  });
+
+  it('prefers the verified workspace SDK over a different hoisted SDK', async () => {
+    const rootDev = await createDevProject('monorepo');
+    const workspace = await createDevProject('monorepo/packages/app');
+    await fs.rm(path.join(workspace.project, 'node_modules', 'electron'), { recursive: true });
+    const result = await initializeWorker({ executable: rootDev.executable, manifest: path.join(workspace.project, 'package.json') });
+    expect(result.runtime).toBe(pathToFileURL(workspace.runtime).href);
+    await fs.rm(workspace.runtime);
+    await expect(initializeWorker({ executable: rootDev.executable, manifest: path.join(workspace.project, 'package.json') }))
+      .rejects.toThrow('Pilot host app runtime not found');
+  });
+
+  it('ignores a manifest belonging to another Electron installation', async () => {
+    const host = await createDevProject('host');
+    const foreign = await createDevProject('foreign');
+    const result = await initializeWorker({ executable: host.executable, manifest: path.join(foreign.project, 'package.json') });
+    expect(result.runtime).toBe(pathToFileURL(host.runtime).href);
+  });
+
+  it('answers initialize for packaged hosts and restores runtime asset context', async () => {
+    const resources = await createHostRuntime('QwenWorkCN.app', 'unused');
+    const runtime = path.join(resources, sdkWorkerRelative, 'qoder-worker-runtime.mjs');
+    await fs.writeFile(runtime, protocolRuntime);
+    const result = await initializeWorker({ resources });
+    expect(result.response.request_id).toBe('init-1');
+    expect(result.assetRoot).toBe(path.dirname(runtime));
+  });
+
+  it('reports missing runtime as a Worker error instead of an empty successful exit', async () => {
+    await expect(initializeWorker()).rejects.toThrow('Pilot host app runtime not found');
+    expect(await fs.readFile(path.join(dataDir, 'logs', 'qoderwork-wrapper-error.log'), 'utf8'))
+      .toContain('Pilot host app runtime not found');
+  });
+
+  it('propagates runtime import errors without trying another runtime', async () => {
+    const dev = await createDevProject('broken');
+    await fs.writeFile(path.join(path.dirname(dev.runtime), 'qoder-worker-runtime.obf.mjs'), "throw new Error('native dependency unavailable');");
+    await expect(initializeWorker({ executable: dev.executable })).rejects.toThrow('native dependency unavailable');
+    expect(await fs.readFile(path.join(dataDir, 'logs', 'qoderwork-wrapper-error.log'), 'utf8'))
+      .toContain('host runtime import failed');
+  });
+
+  it('does not use a conversation workspace runtime when the host runtime is missing', async () => {
+    const host = await createDevProject('host-missing');
+    const foreign = await createDevProject('task-workspace');
+    await fs.rm(host.runtime);
+    await expect(initializeWorker({ executable: host.executable, cwd: foreign.project }))
+      .rejects.toThrow('Pilot host app runtime not found');
+  });
+
+  it('rejects a runtime symlink pointing back to the wrapper', async () => {
+    const dev = await createDevProject('recursive');
+    await fs.rm(dev.runtime);
+    await fs.symlink(wrapper, dev.runtime);
+    await expect(initializeWorker({ executable: dev.executable }))
+      .rejects.toThrow('Pilot host app runtime not found');
   });
 
   async function createHostRuntime(appName, marker) {


### PR DESCRIPTION
Closes #395

QwenWork / QoderWork 开发实例继承 Pilot 的全局 runtime override 后，旧 wrapper 只查找安装包布局，找不到宿主 runtime 时静默退出，导致 SDK 的 `initialize` 等待 120 秒。此修复让常规 Electron 开发项目加载自身 SDK，并让启动失败及时返回。

## 变更

- 从当前 Electron 可执行文件定位开发项目，支持 npm、项目内 pnpm，以及通过 `npm_package_json` 标识的 workspace；校验 SDK 声明与 Electron 身份，不借用会话工作目录或其他应用的 runtime。
- 恢复原生 runtime 的 asset root；无法识别产品身份的开发实例仅转发，不写产品专属 intercept 文件。保留安装态转发和采集行为。
- runtime 缺失或导入失败时记录诊断，先结束 stdout 再抛出错误，防止 SDK 下游读取流挂起。
- macOS 安装器和 watchdog 在 wrapper 缺失时清理当前 Pilot 所属的环境变量和 plist，保留其他 runtime 配置；补充诊断文档和进程级回归测试。

## 验证

基于 `main` 的 `d4ab8b6d`：

- 6 个相关测试文件，163 项测试通过。覆盖开发态/安装态初始化、npm/pnpm/workspace、多 SDK 隔离、runtime 缺失、导入失败、递归路径，以及 macOS 配置清理。
- `npm run typecheck`、`npm run build`、`bash -n deploy/installer-opensource.sh`、`node --check assets/hooks/qoderwork-runtime-wrapper.mjs` 和 diff 空白检查通过。
- 本机 QwenWorkCN SDK 1.0.28、QoderWork SDK 1.0.25 配合独立测试 runtime 验证：开发态初始化通过；缺失和导入异常在 26–33 ms 返回错误，查询可正常关闭。未调用模型。

## 验证边界

全量 Node 18/20/22 CI 由 PR 流水线执行；报告问题的用户实际开发目录仍需候选包复测。非标准 Electron 布局若无法确定宿主 SDK，会明确报错；是否自动回退 CLI 取决于宿主应用。
