### PR TITLE
feat(installer): add menu bar startup option

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,9 @@ the port, run the shortcut install command again. See [Dashboard shortcut](docs/
 
 macOS menu bar app:
 
-On macOS, Pilot automatically runs a menu bar app after installation — no extra command needed. It shows live token, session, request, and tool counts, plus per-agent and per-provider breakdowns, so you can keep an eye on activity without opening the dashboard.
+To disable automatic menu bar startup during installation, append `--enable-status-bar-app false` to the install command. This persists `enableStatusBarApp` in `config.json` before the collector starts. Omit the option to preserve the existing setting, or pass `true` to enable it. See the [installation guide](docs/installation.md#start-or-stop-the-macos-menu-bar-app).
+
+On macOS, Pilot runs a menu bar app after installation by default. It shows live token, session, request, and tool counts, plus per-agent and per-provider breakdowns, so you can keep an eye on activity without opening the dashboard.
 
 If you quit the menu bar app, reopen it without restarting collection:
 

--- a/deploy/installer-opensource.ps1
+++ b/deploy/installer-opensource.ps1
@@ -49,6 +49,8 @@ param(
     [string]$Version,
     [string]$CollectLog,
     [string]$CollectTrace,
+    [ValidateSet("true", "false")]
+    [string]$EnableStatusBarApp,
     [string]$CmsLicenseKey,
     [string]$CmsEndpoint,
     [string]$CmsWorkspace,
@@ -105,6 +107,10 @@ if (-not $PackageUrl -and $env:LOONGSUITE_PILOT_PACKAGE_URL) {
 # ============================================================
 # Validate install options
 # ============================================================
+if ($PSBoundParameters.Keys -contains 'EnableStatusBarApp' -and $Command -ne 'install') {
+    Write-Error "-EnableStatusBarApp is only supported with install"
+    exit 1
+}
 if ($PSBoundParameters.Keys -contains 'DashboardPort') {
     if ($DashboardPort -notmatch '\A[0-9]{1,5}\z' -or [int]$DashboardPort -lt 1 -or [int]$DashboardPort -gt 65535) {
         Write-Error "-DashboardPort must be an integer between 1 and 65535"
@@ -1324,6 +1330,7 @@ function Write-Config {
         userId            = "$($script:UserId)"
         collectLog        = "$CollectLog"
         collectTrace      = "$CollectTrace"
+        enableStatusBarApp = "$EnableStatusBarApp"
         cmsLicenseKey     = "$CmsLicenseKey"
         cmsEndpoint       = "$CmsEndpoint"
         cmsWorkspace      = "$CmsWorkspace"
@@ -1400,6 +1407,7 @@ if (opts.logLevel) config.logLevel = opts.logLevel;
 if (opts.userId) { config.userId = opts.userId; delete config.identity; }
 if (opts.collectLog) config.collectLog = opts.collectLog === 'true';
 if (opts.collectTrace) config.collectTrace = opts.collectTrace === 'true';
+if (opts.enableStatusBarApp) config.enableStatusBarApp = opts.enableStatusBarApp.toLowerCase() === 'true';
 if (opts.cmsLicenseKey || opts.cmsEndpoint || opts.cmsWorkspace) {
   config.cms = config.cms || {};
   if (opts.cmsLicenseKey) config.cms.licenseKey = opts.cmsLicenseKey;

--- a/deploy/installer-opensource.sh
+++ b/deploy/installer-opensource.sh
@@ -64,6 +64,7 @@ LOG_LEVEL=""
 USER_ID=""
 COLLECT_LOG=""
 COLLECT_TRACE=""
+ENABLE_STATUS_BAR_APP=""
 CMS_LICENSE_KEY=""
 CMS_ENDPOINT=""
 CMS_WORKSPACE=""
@@ -127,6 +128,20 @@ while [[ $# -gt 0 ]]; do
         --collect-log=*)      COLLECT_LOG="${1#*=}"; shift ;;
         --collect-trace)      COLLECT_TRACE="$2"; shift 2 ;;
         --collect-trace=*)    COLLECT_TRACE="${1#*=}"; shift ;;
+        --enable-status-bar-app|--enable-status-bar-app=*)
+            if [[ "$1" == *=* ]]; then
+                ENABLE_STATUS_BAR_APP="${1#*=}"; shift
+            else
+                if [ "$#" -lt 2 ]; then
+                    echo "--enable-status-bar-app requires true or false" >&2
+                    exit 1
+                fi
+                ENABLE_STATUS_BAR_APP="$2"; shift 2
+            fi
+            case "$ENABLE_STATUS_BAR_APP" in
+                true|false) ;;
+                *) echo "--enable-status-bar-app requires true or false" >&2; exit 1 ;;
+            esac ;;
         --cms-license-key)    CMS_LICENSE_KEY="$2"; shift 2 ;;
         --cms-license-key=*)  CMS_LICENSE_KEY="${1#*=}"; shift ;;
         --cms-endpoint)       CMS_ENDPOINT="$2"; shift 2 ;;
@@ -152,6 +167,11 @@ while [[ $# -gt 0 ]]; do
             exit 1 ;;
     esac
 done
+
+if [ -n "$ENABLE_STATUS_BAR_APP" ] && [ "$COMMAND" != "install" ]; then
+    echo "--enable-status-bar-app is only supported with install" >&2
+    exit 1
+fi
 
 if [ "$DASHBOARD_PORT_SET" -eq 1 ]; then
     if ! [[ "$DASHBOARD_PORT" =~ ^[0-9]{1,5}$ ]] || (( 10#$DASHBOARD_PORT < 1 || 10#$DASHBOARD_PORT > 65535 )); then
@@ -1006,6 +1026,7 @@ write_config() {
         LP_SELECTED_AGENTS="$SELECTED_AGENTS" \
         LP_AGENT_SELECTION_EXPLICIT="$AGENT_SELECTION_EXPLICIT" \
         LP_DASHBOARD_PORT="$DASHBOARD_PORT" \
+        LP_ENABLE_STATUS_BAR_APP="$ENABLE_STATUS_BAR_APP" \
         "$NODE_BIN" -e "
 const fs = require('fs');
 const path = '$config_file';
@@ -1022,6 +1043,8 @@ if (!config.dashboard || typeof config.dashboard !== 'object' || Array.isArray(c
   config.dashboard = {};
 }
 const dashboardPort = process.env.LP_DASHBOARD_PORT || '';
+const enableStatusBarApp = process.env.LP_ENABLE_STATUS_BAR_APP || '';
+if (enableStatusBarApp) config.enableStatusBarApp = enableStatusBarApp === 'true';
 if (dashboardPort) config.dashboard.port = Number(dashboardPort);
 if (config.dashboard.port === undefined) config.dashboard.port = 8765;
 delete config.internal;

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -73,6 +73,7 @@ The Linux/macOS installer uses `--kebab-case` options. The Windows PowerShell in
 | `--agents <list>` | Comma-separated agent list. Skips interactive selection. |
 | `--userId <id>` | Set user identity written to output events. |
 | `--data-dir <path>` | Override data directory. Default is `~/.loongsuite-pilot`. |
+| `--enable-status-bar-app <true\|false>` | Set automatic macOS menu bar startup during `install`. Omission preserves the existing setting; fresh installs default to enabled. Windows: `-EnableStatusBarApp <true\|false>` (stores the setting; the UI is macOS-only). |
 | `--dashboard-port <port>` | Optional Dashboard port, an integer from `1` to `65535`. Defaults to `8765` on first install; preserves the existing port on reinstall when omitted. Windows: `-DashboardPort <port>`. |
 | `--package-url <url>` | Install from a custom URL or local `file://` path. |
 | `--sls-endpoint <url>` | SLS endpoint URL. |
@@ -135,6 +136,14 @@ The page reads `logs/metrics-summary.json` directly and does not run a second
 aggregation pipeline.
 
 ### Start or stop the macOS menu bar app
+
+To keep the menu bar closed from the first collector startup, add the option to the installation command:
+
+```bash
+bash /tmp/loongsuite-pilot-installer.sh install --enable-status-bar-app false
+```
+
+The installer writes `"enableStatusBarApp": false` to `config.json` before starting collection. Explicit `true` re-enables automatic startup; omission preserves the existing value. This option applies to `install`, including reinstall; `upgrade` preserves the saved configuration. Collection and the local Dashboard remain enabled. The runtime environment variable `LOONGSUITE_PILOT_ENABLE_STATUS_BAR_APP` still takes precedence over this setting.
 
 The menu bar app starts with the collector by default. Quitting it leaves collection running, so another `loongsuite-pilot start` does not reopen it. Use:
 

--- a/docs/zh-CN/installation.md
+++ b/docs/zh-CN/installation.md
@@ -72,6 +72,7 @@ Linux/macOS 安装器使用 `--kebab-case` 参数；Windows PowerShell 安装器
 | `--agents <list>` | 逗号分隔的 Agent 列表，跳过交互选择。 |
 | `--userId <id>` | 设置写入输出事件的用户标识。 |
 | `--data-dir <path>` | 覆盖数据目录，默认 `~/.loongsuite-pilot`。 |
+| `--enable-status-bar-app <true\|false>` | 在 `install` 时设置是否自动启动 macOS 菜单栏。未传时保留已有配置，首次安装默认启用。Windows 对应 `-EnableStatusBarApp <true\|false>`（保存配置，菜单栏仅支持 macOS）。 |
 | `--dashboard-port <port>` | 可选的 Dashboard 端口，取值为 `1–65535` 的整数。首次安装不指定时使用 `8765`；重新安装不指定时保留已有端口。Windows 对应 `-DashboardPort <port>`。 |
 | `--package-url <url>` | 从自定义 URL 或本地 `file://` 路径安装。 |
 | `--sls-endpoint <url>` | SLS endpoint。 |
@@ -176,6 +177,14 @@ http://127.0.0.1:8765/
 页面直接读取 `logs/metrics-summary.json`，不会另起一套聚合计算。
 
 ### 手动启动和停止 macOS 菜单栏
+
+如果希望首次启动采集服务时就不显示菜单栏，在安装命令中添加：
+
+```bash
+bash /tmp/loongsuite-pilot-installer.sh install --enable-status-bar-app false
+```
+
+安装器会在启动采集服务前将 `"enableStatusBarApp": false` 写入 `config.json`。显式传 `true` 可恢复自动启动，不传则保留已有值。该参数用于 `install`，也适用于覆盖安装；`upgrade` 保留已保存的配置。采集服务和本地 Dashboard 不受影响。运行时环境变量 `LOONGSUITE_PILOT_ENABLE_STATUS_BAR_APP` 仍优先于此配置。
 
 菜单栏默认随采集服务启动。菜单栏里的“退出”只会关闭菜单栏，采集服务继续运行；此时再次执行 `loongsuite-pilot start` 不会重新打开菜单栏。请执行：
 

--- a/tests/unit/deploy/installer-status-bar.test.mjs
+++ b/tests/unit/deploy/installer-status-bar.test.mjs
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { runInNewContext } from 'node:vm';
+
+const require = createRequire(import.meta.url);
+
+const shell = readFileSync(resolve('deploy/installer-opensource.sh'), 'utf8');
+const ps = readFileSync(resolve('deploy/installer-opensource.ps1'), 'utf8');
+const shellPrelude = shell.slice(0, shell.indexOf('# Validate current user'));
+const shellWriter = shell.slice(shell.indexOf('write_config() {'), shell.indexOf('install_loongsuite_pilot_command() {'));
+const psPrelude = ps.slice(0, ps.indexOf('# Resolve package URL'));
+const psWriter = ps.slice(ps.indexOf('function Write-Config {'), ps.indexOf('# QoderWork-family runtime wrapper:'));
+const psJs = psWriter.match(/-e @'\r?\n([\s\S]*?)\r?\n'@ \$cfgTmp/)?.[1];
+const powershell = process.platform === 'win32' ? 'powershell.exe' : 'pwsh';
+const hasPowerShell = spawnSync(powershell, ['-NoProfile', '-NonInteractive', '-Command', 'exit 0']).status === 0;
+
+// Exercise the real parser and capture its expanded Node program, then execute
+// that program in-process against a temporary data dir. This tests shell-to-JS
+// value transport without requiring a second Node runtime or any installation.
+function runConfig(platform, args = [], existing, command = 'install') {
+  const root = mkdtempSync(resolve(tmpdir(), 'pilot-status-bar-config-'));
+  const configPath = resolve(root, 'config.json');
+  try {
+    if (existing !== undefined) writeFileSync(configPath, JSON.stringify(existing));
+    const env = { ...process.env, PILOT_TEST_NODE: process.execPath };
+    let result;
+    if (platform === 'bash') {
+      const scriptPath = resolve(root, 'config-writer.js');
+      const valuePath = resolve(root, 'status-bar-value');
+      result = spawnSync('bash', ['-c', `${shellPrelude}
+msg() { :; }
+capture_node() {
+  printf '%s' "$2" > "$PILOT_TEST_JS"
+  printf '%s' "$LP_ENABLE_STATUS_BAR_APP" > "$PILOT_TEST_STATUS_BAR"
+}
+NODE_BIN=capture_node
+PROBE_RESULT='[]'
+${shellWriter}
+write_config`, 'installer-test', command, '--data-dir', root, ...args], {
+        encoding: 'utf8', env: { ...env, PILOT_TEST_JS: scriptPath, PILOT_TEST_STATUS_BAR: valuePath },
+      });
+      if (result.status === 0) {
+        runInNewContext(readFileSync(scriptPath, 'utf8'), {
+          require, console,
+          process: { env: { LP_ENABLE_STATUS_BAR_APP: readFileSync(valuePath, 'utf8') } },
+        });
+      }
+    } else if (platform === 'powershell') {
+      const scriptPath = resolve(root, 'installer-test.ps1');
+      writeFileSync(scriptPath, `${psPrelude}
+function Msg { }
+$script:NODE_BIN = $env:PILOT_TEST_NODE
+$script:PROBE_RESULT = '[]'
+${psWriter}
+Write-Config`);
+      result = spawnSync(powershell, ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File',
+        scriptPath, command, '-DataDir', root, ...args], {
+        encoding: 'utf8', env: { ...env, USERPROFILE: root, TEMP: root, LOONGSUITE_PILOT_CACHE_DIR: root },
+      });
+    } else {
+      expect(psJs).toBeTruthy();
+      const optionsPath = resolve(root, 'options.json');
+      writeFileSync(optionsPath, JSON.stringify({ configPath, dataDir: root, enableStatusBarApp: args[0] ?? '' }));
+      runInNewContext(psJs, { require, console, process: { argv: ['node', optionsPath] } });
+      result = { status: 0, stderr: '' };
+    }
+    expect(result.error).toBeUndefined();
+    return { ...result, config: existsSync(configPath) ? JSON.parse(readFileSync(configPath, 'utf8')) : undefined };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe('installer menu bar startup option', () => {
+  for (const platform of ['bash', 'powershell-js']) {
+    describe(platform, () => {
+      it('leaves the runtime default unchanged on a fresh install when omitted', () => {
+        const result = runConfig(platform);
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.config).not.toHaveProperty('enableStatusBarApp');
+        expect(result.config.enabled).toBe(true);
+      });
+
+      it.each([true, false])('preserves existing %s and unrelated settings when omitted', enabled => {
+        const existing = { enableStatusBarApp: enabled, dashboard: { port: 9010 }, userId: 'test-user' };
+        const result = runConfig(platform, [], existing);
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.config).toMatchObject(existing);
+      });
+
+      it.each(['true', 'false'])('writes %s as a boolean on fresh install and reinstall', value => {
+        const args = platform === 'bash' ? ['--enable-status-bar-app', value] : [value];
+        for (const existing of [undefined, { enableStatusBarApp: value !== 'true', dashboard: { port: 9010 } }]) {
+          const result = runConfig(platform, args, existing);
+          expect(result.status, result.stderr).toBe(0);
+          expect(result.config.enableStatusBarApp).toBe(value === 'true');
+          expect(result.config.enabled).toBe(true);
+          expect(result.config.dashboard.port).toBe(existing?.dashboard.port ?? 8765);
+        }
+      });
+    });
+  }
+
+  it.each(['true', 'false'])('accepts the Bash equals form: %s', value => {
+    const result = runConfig('bash', [`--enable-status-bar-app=${value}`]);
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.config.enableStatusBarApp).toBe(value === 'true');
+  });
+
+  it.each(['', '0', '1', 'yes', 'false\n', "false';process.exit(0);//"])(
+    'rejects invalid Bash value %j before changing config', value => {
+      const existing = { enableStatusBarApp: true, userId: 'test-user' };
+      for (const args of [['--enable-status-bar-app', value], [`--enable-status-bar-app=${value}`]]) {
+        const result = runConfig('bash', args, existing);
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('--enable-status-bar-app requires true or false');
+        expect(result.config).toEqual(existing);
+      }
+    },
+  );
+
+  it.each([['--enable-status-bar-app'], ['--enable-status-bar-app', '--agents', 'codex']])(
+    'rejects missing Bash values: %j', (...args) => {
+      const result = runConfig('bash', args);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('--enable-status-bar-app requires true or false');
+      expect(result.config).toBeUndefined();
+    },
+  );
+
+  it.each(['upgrade', 'uninstall'])('does not silently ignore the option for %s', command => {
+    const result = runConfig('bash', ['--enable-status-bar-app', 'false'], undefined, command);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('only supported with install');
+    expect(result.config).toBeUndefined();
+  });
+
+  it.runIf(hasPowerShell)('validates native PowerShell arguments and persists boolean values', () => {
+    for (const value of ['true', 'false', 'False']) {
+      const result = runConfig('powershell', ['-EnableStatusBarApp', value]);
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.config.enableStatusBarApp).toBe(value.toLowerCase() === 'true');
+    }
+    for (const args of [['-EnableStatusBarApp'], ['-EnableStatusBarApp', ''], ['-EnableStatusBarApp', 'yes']]) {
+      const result = runConfig('powershell', args);
+      expect(result.status).not.toBe(0);
+      expect(result.config).toBeUndefined();
+    }
+    for (const command of ['upgrade', 'uninstall']) {
+      const result = runConfig('powershell', ['-EnableStatusBarApp', 'false'], undefined, command);
+      expect(result.status).not.toBe(0);
+      expect(result.config).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
Adds `install --enable-status-bar-app false` so unattended macOS installations can keep the menu bar closed from the first collector startup. The installer persists the existing `enableStatusBarApp` setting as a JSON boolean before starting the service. Explicit `true` re-enables startup; omission preserves existing configuration and the current fresh-install default. Collection and the Dashboard are unaffected.

Includes the PowerShell equivalent `-EnableStatusBarApp true|false`, early argument validation, and English/Chinese documentation. The option is limited to `install` (including reinstall); `upgrade` retains saved configuration. Runtime environment-variable precedence is unchanged.

Validation:
- Bash syntax and `git diff --check` passed.
- 54 focused tests passed; one native PowerShell test skipped because PowerShell is unavailable locally. Both installers' actual JavaScript config writers are exercised, and Bash option parsing is executed against temporary directories.
- `npm run typecheck` and `npm run build` passed.
- The broader existing `dashboard-lifecycle` tests encountered Node child-process `SIGKILL` failures on this host. The unmodified `origin/main` config writer reproduces exit 137. This is not a successful full-install smoke test; the new config tests execute the captured writer in-process.

Closes #398
