### PR TITLE
fix(codex): preserve quoted hook trust tables and repair duplicates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "jsonc-parser": "^3.3.1",
         "pino": "^9.14.0",
         "pino-roll": "^3.1.0",
+        "smol-toml": "^1.8.0",
         "sqlite3": "^5.1.7",
         "undici": "^6.28.0",
         "uuid": "^9.0.0",
@@ -4594,6 +4595,18 @@
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/socks": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "jsonc-parser": "^3.3.1",
     "pino": "^9.14.0",
     "pino-roll": "^3.1.0",
+    "smol-toml": "^1.8.0",
     "sqlite3": "^5.1.7",
     "undici": "^6.28.0",
     "uuid": "^9.0.0",

--- a/src/deployment/codex-trust-writer.ts
+++ b/src/deployment/codex-trust-writer.ts
@@ -302,12 +302,14 @@ function removeLegacyTrustMarkers(content: string, marker: string): string {
   )).map(line => line.text).join('\n');
 }
 
+class InvalidCodexConfigError extends Error {}
+
 function validateConfig(content: string): void {
   try {
     parseToml(content, { integersAsBigInt: true });
   } catch {
     // Parser error messages include source excerpts, potentially credentials.
-    throw new Error('Refusing to write invalid Codex config.toml; original file left unchanged');
+    throw new InvalidCodexConfigError('Refusing to write invalid Codex config.toml; original file left unchanged');
   }
 }
 
@@ -456,17 +458,27 @@ export function removeTrustBlock(
   return true;
 }
 
-/** Remove exact position-based trust entries without touching the active block markers. */
+/**
+ * Remove exact position-based trust entries without touching the active markers.
+ * Retired-key cleanup runs before current trust repair: leave invalid TOML
+ * unchanged and return false so that repair still gets a chance to run.
+ * Filesystem errors still propagate to the caller's deployment error handler.
+ */
 export function removeTrustStateKeys(
   configPath: string,
   ownedHookStateKeys: readonly string[],
 ): boolean {
   if (!fs.existsSync(configPath) || ownedHookStateKeys.length === 0) return false;
   const before = fs.readFileSync(configPath, 'utf-8');
-  const content = removeExactTrustSections(before, new Set(ownedHookStateKeys));
-  if (content === before) return false;
-  writeValidatedConfig(configPath, content);
-  return true;
+  try {
+    const content = removeExactTrustSections(before, new Set(ownedHookStateKeys));
+    if (content === before) return false;
+    writeValidatedConfig(configPath, content);
+    return true;
+  } catch (err) {
+    if (err instanceof InvalidCodexConfigError) return false;
+    throw err;
+  }
 }
 
 export interface VerifyResult {

--- a/src/deployment/codex-trust-writer.ts
+++ b/src/deployment/codex-trust-writer.ts
@@ -1,5 +1,6 @@
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
+import { parse as parseToml } from 'smol-toml';
 
 export const CODEX_HOOK_EVENT_KEYS: Record<string, string> = {
   PreToolUse: 'pre_tool_use',
@@ -167,64 +168,152 @@ function encodeTomlBasicString(value: string): string {
   return JSON.stringify(value);
 }
 
-function decodeTomlBasicString(value: string): string | null {
-  try {
-    const decoded: unknown = JSON.parse(value);
-    return typeof decoded === 'string' ? decoded : null;
-  } catch {
-    return null;
-  }
+function asTable(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
 }
 
-function tomlKeyCandidates(value: string): string[] {
-  const decoded = decodeTomlBasicString(value);
-  const raw = value.startsWith('"') && value.endsWith('"') ? value.slice(1, -1) : null;
-  return [...new Set([decoded, raw].filter((candidate): candidate is string => candidate !== null))];
+/**
+ * Locate editable lines without mistaking text in multiline strings or arrays
+ * for config. This scanner only finds boundaries; smol-toml decodes keys and
+ * validates the complete document. Keep original lines so unrelated formatting
+ * and comments do not go through a TOML serialization round trip.
+ */
+function configLines(content: string): Array<{ text: string; editable: boolean }> {
+  let quote = '';
+  let multiline = false;
+  let depth = 0;
+  return content.split('\n').map(text => {
+    const editable = !quote && depth === 0;
+    for (let i = 0; i < text.length; i++) {
+      const ch = text[i]!;
+      if (quote) {
+        if (quote === '"' && ch === '\\') { i++; continue; }
+        if (ch !== quote) continue;
+        if (!multiline) { quote = ''; continue; }
+        if (text.slice(i, i + 3) !== quote.repeat(3)) continue;
+        // A multiline closing delimiter may have one or two literal quotes.
+        while (text[i + 1] === quote) i++;
+        quote = '';
+        multiline = false;
+      } else if (ch === '#') {
+        break;
+      } else if (ch === '"' || ch === "'") {
+        quote = ch;
+        multiline = text.slice(i, i + 3) === ch.repeat(3);
+        if (multiline) i += 2;
+      } else if (ch === '[' || ch === '{') {
+        depth++;
+      } else if (ch === ']' || ch === '}') {
+        depth--;
+      }
+    }
+    return { text, editable };
+  });
+}
+
+function trustSectionKey(header: string): string | undefined {
+  // Only a table declaration, never an assignment or an array of tables.
+  if (!/^\s*\[(?!\[)/.test(header)) return undefined;
+  try {
+    const parsed = parseToml(header);
+    const hooks = asTable(parsed.hooks);
+    const state = asTable(hooks?.state);
+    if (!state || Object.keys(parsed).length !== 1 || Object.keys(hooks!).length !== 1) {
+      return undefined;
+    }
+    const keys = Object.keys(state);
+    const table = keys.length === 1 ? asTable(state[keys[0]!]) : undefined;
+    return table && Object.keys(table).length === 0 ? keys[0] : undefined;
+  } catch {
+    // Recover the exact malformed Windows path emitted by old Pilot versions.
+    // Never use the raw spelling as an alternative when TOML decoding succeeds:
+    // an escaped key can name a different, third-party handler.
+    const legacy = header.match(/^\s*\[hooks\.state\."([^"\r\n]+)"\]\s*$/);
+    return legacy?.[1];
+  }
 }
 
 interface ParsedTrustSection {
   key: string;
   hash?: string;
-  enabledLine?: string;
+  enabled?: boolean;
+}
+
+interface TrustSectionRange {
+  key: string;
+  start: number;
+  end: number;
+}
+
+function trustSectionRanges(content: string): TrustSectionRange[] {
+  const lines = configLines(content);
+  const sections: TrustSectionRange[] = [];
+  let current: TrustSectionRange | undefined;
+  for (let i = 0; i < lines.length; i++) {
+    const { text, editable } = lines[i]!;
+    if (!editable || !/^\s*\[/.test(text)) continue;
+    if (current) current.end = i;
+    const key = trustSectionKey(text);
+    current = key === undefined ? undefined : { key, start: i, end: lines.length };
+    if (current) sections.push(current);
+  }
+  return sections;
 }
 
 function parseTrustSections(content: string): ParsedTrustSection[] {
   const lines = content.split('\n');
-  const sections: ParsedTrustSection[] = [];
-  const header = /^\s*\[hooks\.state\.("(?:\\.|[^"\\])*")\]\s*$/;
-  for (let i = 0; i < lines.length; i++) {
-    const match = lines[i]!.match(header);
-    if (!match) continue;
-    const key = tomlKeyCandidates(match[1]!)[0];
-    if (key === undefined) continue;
-    const section: ParsedTrustSection = { key };
-    for (let j = i + 1; j < lines.length && !/^\s*\[/.test(lines[j]!); j++) {
-      const hash = lines[j]!.match(/^\s*trusted_hash\s*=\s*"([^"]+)"/);
-      if (hash) section.hash = hash[1];
-      if (/^\s*enabled\s*=/.test(lines[j]!)) section.enabledLine = lines[j]!.trim();
+  return trustSectionRanges(content).map(({ key, start, end }) => {
+    try {
+      const fields = parseToml(lines.slice(start + 1, end).join('\n'), { integersAsBigInt: true });
+      return {
+        key,
+        hash: typeof fields.trusted_hash === 'string' ? fields.trusted_hash : undefined,
+        enabled: typeof fields.enabled === 'boolean' ? fields.enabled : undefined,
+      };
+    } catch {
+      return { key };
     }
-    sections.push(section);
-  }
-  return sections;
+  });
 }
 
 function removeExactTrustSections(content: string, keys: ReadonlySet<string>): string {
   if (keys.size === 0) return content;
   const lines = content.split('\n');
-  const out: string[] = [];
-  const header = /^\s*\[hooks\.state\.("(?:\\.|[^"\\])*")\]\s*$/;
-  let skipping = false;
-  for (const line of lines) {
-    const match = line.match(header);
-    if (match) {
-      skipping = tomlKeyCandidates(match[1]!).some(key => keys.has(key));
-      if (!skipping) out.push(line);
-      continue;
-    }
-    if (/^\s*\[/.test(line)) skipping = false;
-    if (!skipping) out.push(line);
+  const keep = lines.map(() => true);
+  for (const { key, start, end } of trustSectionRanges(content)) {
+    if (!keys.has(key)) continue;
+    // An unclosed value in an owned section can hide subsequent user tables.
+    // Refuse to delete an ambiguous range, even if its removal would produce
+    // syntactically valid output. Legacy malformed Windows *headers* remain
+    // repairable because only the body is checked here.
+    validateConfig(lines.slice(start + 1, end).join('\n'));
+    keep.fill(false, start, end);
   }
-  return out.join('\n').replace(/\n{3,}/g, '\n\n');
+  return lines.filter((_, i) => keep[i]).join('\n');
+}
+
+function removeLegacyTrustMarkers(content: string, marker: string): string {
+  return configLines(content).filter(({ text, editable }) => !editable || (
+    text.trim() !== `# BEGIN ${marker} trust`
+    && text.trim() !== `# END ${marker} trust`
+    && !/^\s*bypass_hook_trust\s*=/.test(text)
+  )).map(line => line.text).join('\n');
+}
+
+function validateConfig(content: string): void {
+  try {
+    parseToml(content, { integersAsBigInt: true });
+  } catch {
+    // Parser error messages include source excerpts, potentially credentials.
+    throw new Error('Refusing to write invalid Codex config.toml; original file left unchanged');
+  }
+}
+
+function writeValidatedConfig(configPath: string, content: string): void {
+  validateConfig(content);
+  fs.writeFileSync(configPath, content, 'utf-8');
 }
 
 export interface InstalledTrustOpts {
@@ -287,16 +376,22 @@ export function verifyTrustHashes(rawOpts: TrustOpts): VerifyResult {
     return { valid: false, mismatches: ['config.toml missing'] };
   }
   const content = fs.readFileSync(opts.configPath, 'utf-8');
-  const actual = new Map(parseTrustSections(content).map(section => [section.key, section.hash]));
+  let state: Record<string, unknown> | undefined;
+  try {
+    const parsed = parseToml(content, { integersAsBigInt: true });
+    state = asTable(asTable(parsed.hooks)?.state);
+  } catch {
+    return { valid: false, mismatches: ['invalid Codex config.toml'] };
+  }
   const mismatches: string[] = [];
   // Pilot briefly wrote this as an emergency bypass, but Codex only supports
   // bypassing trust via the per-invocation --dangerously-bypass-hook-trust flag.
   // Treat the unsupported legacy field as repairable state so deployment removes it.
-  if (/^\s*bypass_hook_trust\s*=/m.test(content)) {
+  if (configLines(content).some(line => line.editable && /^\s*bypass_hook_trust\s*=/.test(line.text))) {
     mismatches.push('unsupported config field bypass_hook_trust');
   }
   for (const [key, hash] of expectedTrustState(opts)) {
-    const current = actual.get(key);
+    const current = asTable(state?.[key])?.trusted_hash;
     if (current === undefined) mismatches.push(`missing key=${key}`);
     else if (current !== hash) mismatches.push(`hash mismatch key=${key} (expected=${hash}, got=${current})`);
   }
@@ -322,33 +417,28 @@ export function writeTrustedHashes(rawOpts: TrustOpts): boolean {
   // move the END comment past unrelated third-party sections. Until persisted
   // owned-key metadata is introduced, only touch the exact current Pilot keys.
   const exactKeys = new Set(expected.keys());
-  const enabledByKey = new Map(
-    parseTrustSections(existing)
-      .filter(section => (
-        section.enabledLine !== undefined
-        && expected.get(section.key) === section.hash
-      ))
-      .map(section => [section.key, section.enabledLine!]),
-  );
+  const enabledByKey = new Map<string, boolean>();
+  for (const section of parseTrustSections(existing)) {
+    if (section.enabled === undefined || expected.get(section.key) !== section.hash) continue;
+    // If old Pilot produced conflicting copies, an explicit disable wins.
+    enabledByKey.set(section.key, enabledByKey.get(section.key) === false ? false : section.enabled);
+  }
 
-  let content = existing.split('\n')
-    .filter(line => line.trim() !== begin && line.trim() !== end)
-    .filter(line => !/^\s*bypass_hook_trust\s*=/.test(line))
-    .join('\n');
+  let content = removeLegacyTrustMarkers(existing, opts.marker);
   content = removeExactTrustSections(content, exactKeys);
 
   const lines: string[] = [begin];
   for (const [key, hash] of expected) {
     lines.push(`[hooks.state.${encodeTomlBasicString(key)}]`);
     const enabled = enabledByKey.get(key);
-    if (enabled) lines.push(enabled);
+    if (enabled !== undefined) lines.push(`enabled = ${enabled}`);
     lines.push(`trusted_hash = "${hash}"`, '');
   }
   lines.push(end);
   const separator = !content || content.endsWith('\n') ? '' : '\n';
-  const output = `${content}${separator}\n${lines.join('\n')}\n`.replace(/\n{3,}/g, '\n\n');
+  const output = `${content}${separator}\n${lines.join('\n')}\n`;
   if (output === existing) return false;
-  fs.writeFileSync(opts.configPath, output, 'utf-8');
+  writeValidatedConfig(opts.configPath, output);
   return true;
 }
 
@@ -359,16 +449,10 @@ export function removeTrustBlock(
 ): boolean {
   if (!fs.existsSync(configPath)) return false;
   const before = fs.readFileSync(configPath, 'utf-8');
-  const begin = `# BEGIN ${marker} trust`;
-  const end = `# END ${marker} trust`;
   const owned = new Set(ownedHookStateKeys);
-  let content = before.split('\n')
-    .filter(line => line.trim() !== begin && line.trim() !== end)
-    .filter(line => !/^\s*bypass_hook_trust\s*=/.test(line))
-    .join('\n');
-  content = removeExactTrustSections(content, owned).replace(/\n{3,}/g, '\n\n').trimEnd() + '\n';
+  const content = removeExactTrustSections(removeLegacyTrustMarkers(before, marker), owned);
   if (content === before) return false;
-  fs.writeFileSync(configPath, content, 'utf-8');
+  writeValidatedConfig(configPath, content);
   return true;
 }
 
@@ -379,10 +463,9 @@ export function removeTrustStateKeys(
 ): boolean {
   if (!fs.existsSync(configPath) || ownedHookStateKeys.length === 0) return false;
   const before = fs.readFileSync(configPath, 'utf-8');
-  const content = removeExactTrustSections(before, new Set(ownedHookStateKeys))
-    .replace(/\n{3,}/g, '\n\n');
+  const content = removeExactTrustSections(before, new Set(ownedHookStateKeys));
   if (content === before) return false;
-  fs.writeFileSync(configPath, content, 'utf-8');
+  writeValidatedConfig(configPath, content);
   return true;
 }
 

--- a/tests/unit/deployment/codex-trust-writer.test.ts
+++ b/tests/unit/deployment/codex-trust-writer.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { parse as parseToml } from 'smol-toml';
 import {
   computeHookTrustHash,
   computeInstalledHookTrustHash,
@@ -10,6 +11,7 @@ import {
   type InstalledCodexHookLocation,
   writeTrustedHashes,
   removeTrustBlock,
+  removeTrustStateKeys,
   verifyTrustHashes,
 } from '../../../src/deployment/codex-trust-writer.js';
 
@@ -478,4 +480,149 @@ describe('writeTrustedHashes / verifyTrustHashes 闭环', () => {
     expect(repaired).toContain('enabled = false');
     expect(repaired).toContain(`trusted_hash = "${hash}"`);
   });
+});
+
+
+describe('Codex TOML reserialization compatibility', () => {
+  const hooksPath = '/abs/hooks.json';
+  const key = `${hooksPath}:session_start:0:0`;
+  const location: InstalledCodexHookLocation = {
+    eventName: 'SessionStart', eventKey: 'session_start', groupIndex: 0, handlerIndex: 0,
+    matcher: '*', handler: { type: 'command', command: 'pilot session-start' },
+  };
+  const hash = computeInstalledHookTrustHash(location);
+  const opts = () => ({
+    configPath, hooksJsonAbsPath: hooksPath,
+    locations: { SessionStart: location }, marker: 'otel-codex-hook',
+  });
+  const headers = [
+    `["hooks"."state"."${key}"]`,
+    `[hooks."state".'${key}']`,
+    `['hooks'.state."${key}"]`,
+    `[ 'hooks' . 'state' . '${key}' ] # preserved comment`,
+    String.raw`["\u0068ooks"."st\u0061te"."/abs/hooks.json:session_start:0:0"]`,
+  ];
+  const other = '["hooks"."state"."third-party:stop:0:0"]\nenabled = false\ntrusted_hash = "sha256:OTHER"\n';
+  const read = () => fs.readFileSync(configPath, 'utf8');
+
+  test.each(headers)('recognizes equivalent header %s without rewriting', header => {
+    const original = `${header}\n"trusted_hash" = '${hash}'\n"enabled" = false\n`;
+    fs.writeFileSync(configPath, original);
+    expect(() => parseToml(original)).not.toThrow();
+    expect(verifyTrustHashes(opts())).toEqual({ valid: true, mismatches: [] });
+    expect(writeTrustedHashes(opts())).toBe(false);
+    expect(read()).toBe(original);
+  });
+
+  test.each(headers)('repairs stale header %s and preserves third-party state', header => {
+    fs.writeFileSync(configPath, `${header}\ntrusted_hash = 'sha256:STALE'\n\n${other}`);
+    expect(writeTrustedHashes(opts())).toBe(true);
+    expect(read()).toContain(other);
+    expect(read()).not.toContain('sha256:STALE');
+    expect(() => parseToml(read())).not.toThrow();
+    expect(verifyTrustHashes(opts()).valid).toBe(true);
+    expect(writeTrustedHashes(opts())).toBe(false);
+  });
+
+  test.each([false, true])('repairs duplicates even with valid hashes (reversed=%s)', reversed => {
+    const sections = [
+      `["hooks"."state"."${key}"]\nenabled = false\ntrusted_hash = "${hash}"\n`,
+      `[hooks.state."${key}"]\nenabled = true\ntrusted_hash = "${hash}"\n`,
+    ];
+    if (reversed) sections.reverse();
+    fs.writeFileSync(configPath, sections.join('\n') + other);
+    expect(() => parseToml(read())).toThrow();
+    expect(verifyTrustHashes(opts()).valid).toBe(false);
+    expect(writeTrustedHashes(opts())).toBe(true);
+    const state = (parseToml(read()) as any).hooks.state;
+    expect(state[key]).toEqual({ enabled: false, trusted_hash: hash });
+    expect(Object.keys(state)).toHaveLength(2);
+    expect(read()).toContain(other);
+    expect(writeTrustedHashes(opts())).toBe(false);
+  });
+
+  test.each(headers)('preserves disabled state during repair of %s', header => {
+    fs.writeFileSync(configPath, `bypass_hook_trust = true\n${header}\n'enabled' = false # disabled by user\ntrusted_hash = '${hash}'\n`);
+    expect(writeTrustedHashes(opts())).toBe(true);
+    expect((parseToml(read()) as any).hooks.state[key].enabled).toBe(false);
+  });
+
+  test.each(headers)('cleans up quoted tables through both removal paths: %s', header => {
+    for (const remove of [
+      () => removeTrustBlock(configPath, 'otel-codex-hook', [key]),
+      () => removeTrustStateKeys(configPath, [key]),
+    ]) {
+      fs.writeFileSync(configPath, `${header}\ntrusted_hash = '${hash}'\n\n${other}`);
+      expect(remove()).toBe(true);
+      expect(read()).not.toContain(key);
+      expect(read()).toContain(other);
+      expect(() => parseToml(read())).not.toThrow();
+      expect(remove()).toBe(false);
+    }
+  });
+
+  test('recognizes literal Windows paths without interpreting backslashes', () => {
+    const winPath = String.raw`C:\Users\测试 User\.codex\hooks.json`;
+    const winKey = `${winPath}:session_start:0:0`;
+    const original = `["hooks".'state'.'${winKey}']\ntrusted_hash = '${hash}'\n`;
+    fs.writeFileSync(configPath, original);
+    const winOpts = { ...opts(), hooksJsonAbsPath: winPath };
+    expect(verifyTrustHashes(winOpts).valid).toBe(true);
+    expect(writeTrustedHashes(winOpts)).toBe(false);
+    expect(read()).toBe(original);
+  });
+
+  test.each(['"""', "'".repeat(3)])('ignores fake trust tables and markers inside %s strings', quote => {
+    const instructions = `instructions = ${quote}\n[hooks.state."${key}"]\ntrusted_hash = "${hash}"\n# BEGIN otel-codex-hook trust\nbypass_hook_trust = true\n\n\n# END otel-codex-hook trust\n${quote}\n`;
+    fs.writeFileSync(configPath, instructions + other);
+    expect(verifyTrustHashes(opts()).valid).toBe(false);
+    expect(writeTrustedHashes(opts())).toBe(true);
+    expect(read()).toContain(instructions);
+    expect((parseToml(read()) as any).hooks.state[key].trusted_hash).toBe(hash);
+    expect(removeTrustBlock(configPath, 'otel-codex-hook', [key])).toBe(true);
+    expect(read()).toContain(instructions);
+    expect(read()).toContain(other);
+  });
+
+  test.each([
+    'model = "a"\nmodel = "b"\n',
+    '[broken\nvalue = 1\n',
+    'model = "unterminated\n',
+    '["hooks"."state"."third-party"]\na = 1\n[hooks.state."third-party"]\na = 1\n',
+  ])('does not overwrite unrelated malformed TOML: %s', malformed => {
+    const original = malformed + `[hooks.state."${key}"]\ntrusted_hash = "${hash}"\n`;
+    fs.writeFileSync(configPath, original);
+    expect(verifyTrustHashes(opts()).valid).toBe(false);
+    expect(() => writeTrustedHashes(opts())).toThrow(/invalid Codex config.toml/);
+    expect(read()).toBe(original);
+    // Cleanup may decline to edit when a malformed value hides the table.
+    try { removeTrustBlock(configPath, 'otel-codex-hook', [key]); } catch {}
+    expect(read()).toBe(original);
+    // If a malformed open string hides the key, cleanup correctly makes no edit.
+    try { removeTrustStateKeys(configPath, [key]); } catch {}
+    expect(read()).toBe(original);
+  });
+
+  test('does not delete user tables hidden by an unterminated owned value', () => {
+    const original = `[hooks.state."${key}"]\ntrusted_hash = "unterminated\n\n[projects."/important"]\ntrust_level = "trusted"\n`;
+    fs.writeFileSync(configPath, original);
+    expect(() => writeTrustedHashes(opts())).toThrow(/invalid Codex config.toml/);
+    expect(read()).toBe(original);
+    expect(() => removeTrustStateKeys(configPath, [key])).toThrow();
+    expect(read()).toBe(original);
+  });
+
+  test('preserves multiline values, arrays, escaped keys and large integers', () => {
+    const prefix = 'large = 9223372036854775807\nitems = [\n[1, 2],\n{ text = "[hooks.state] # example" },\n]\n';
+    const escapedKey = key.replace('/abs', String.raw`\u002Fabs`);
+    const original = prefix + `["hooks"."state"."${escapedKey}"]\nenabled = false\ntrusted_hash = """\n${hash}"""\n`;
+    // Force a rewrite while retaining a same-handler disabled choice.
+    fs.writeFileSync(configPath, 'bypass_hook_trust = true\n' + original);
+    expect(writeTrustedHashes(opts())).toBe(true);
+    expect(read()).toContain(prefix);
+    const parsed = parseToml(read(), { integersAsBigInt: true }) as any;
+    expect(parsed.hooks.state[key].enabled).toBe(false);
+    expect(parsed.large).toBe(9223372036854775807n);
+  });
+
 });

--- a/tests/unit/deployment/codex-trust-writer.test.ts
+++ b/tests/unit/deployment/codex-trust-writer.test.ts
@@ -599,7 +599,7 @@ describe('Codex TOML reserialization compatibility', () => {
     try { removeTrustBlock(configPath, 'otel-codex-hook', [key]); } catch {}
     expect(read()).toBe(original);
     // If a malformed open string hides the key, cleanup correctly makes no edit.
-    try { removeTrustStateKeys(configPath, [key]); } catch {}
+    expect(removeTrustStateKeys(configPath, [key])).toBe(false);
     expect(read()).toBe(original);
   });
 
@@ -608,7 +608,7 @@ describe('Codex TOML reserialization compatibility', () => {
     fs.writeFileSync(configPath, original);
     expect(() => writeTrustedHashes(opts())).toThrow(/invalid Codex config.toml/);
     expect(read()).toBe(original);
-    expect(() => removeTrustStateKeys(configPath, [key])).toThrow();
+    expect(removeTrustStateKeys(configPath, [key])).toBe(false);
     expect(read()).toBe(original);
   });
 
@@ -623,6 +623,35 @@ describe('Codex TOML reserialization compatibility', () => {
     const parsed = parseToml(read(), { integersAsBigInt: true }) as any;
     expect(parsed.hooks.state[key].enabled).toBe(false);
     expect(parsed.large).toBe(9223372036854775807n);
+  });
+
+
+  test('declines retired-key cleanup so duplicate current trust can still be repaired', () => {
+    const retiredKey = `${hooksPath}:pre_tool_use:0:0`;
+    const retired = `[hooks.state."${retiredKey}"]\ntrusted_hash = "sha256:RETIRED"\n`;
+    const current = `[hooks.state."${key}"]\ntrusted_hash = "${hash}"\n`;
+    const quoted = `["hooks"."state"."${key}"]\nenabled = false\ntrusted_hash = "${hash}"\n`;
+    const original = retired + current + quoted + other;
+    fs.writeFileSync(configPath, original);
+
+    // Deployment cleans up retired keys before calling writeTrustedHashes.
+    // Removing just the retired table leaves invalid current duplicates.
+    expect(removeTrustStateKeys(configPath, [retiredKey])).toBe(false);
+    expect(read()).toBe(original);
+    expect(writeTrustedHashes(opts())).toBe(true);
+    expect((parseToml(read()) as any).hooks.state[key]).toEqual({ enabled: false, trusted_hash: hash });
+    expect(read()).toContain(other);
+
+    // Once the duplicate configuration is repaired, cleanup can succeed.
+    expect(removeTrustStateKeys(configPath, [retiredKey])).toBe(true);
+    expect(read()).not.toContain(retiredKey);
+    expect(verifyTrustHashes(opts()).valid).toBe(true);
+  });
+
+  test('does not hide filesystem errors during retired-key cleanup', () => {
+    fs.mkdirSync(configPath);
+    expect(() => removeTrustStateKeys(configPath, [key])).toThrow();
+    expect(fs.statSync(configPath).isDirectory()).toBe(true);
   });
 
 });


### PR DESCRIPTION
Codex configuration becomes unreadable when Pilot encounters `["hooks"."state"."<hook key>"]`: the old regex treats that valid table as missing and appends `[hooks.state."<hook key>"]`. Its own verification then incorrectly accepts the duplicate configuration.

This change uses `smol-toml` to decode table keys and verify the complete document. Correct trust records remain untouched regardless of quoting. Deployment repairs duplicate Pilot-owned tables, preserves an explicit `enabled = false` for the same trusted handler, and uses the same matching rules during cleanup. Retired-key cleanup returns false without writing on TOML validation errors so current trust repair can still run; filesystem errors continue to propagate. Edits preserve unrelated text, including table-looking examples in multiline strings. Ambiguous malformed sections and invalid candidate configurations are rejected before writing the original file.

Closes #400. Related to #380 and #381: this also covers quoted parent keys, existing duplicate repair, and whole-document validation beyond single-quoted path keys.

Validation:
- 149 tests passed across the trust writer, HookStrategy, plugin migration, and injection contracts; 33 new regression cases (the first 29 were verified failing before the fix).
- All 55 trust-writer tests also passed on Node 18; `npm run typecheck` passed.
- Tested the standalone built `inject-hooks.cjs` outside `node_modules`, with an isolated HOME and Python `tomllib` validation: five-event quoted config is unchanged; five duplicate tables are repaired; disabled and third-party state survive; a second deployment is a no-op; malformed input remains unchanged.
- After review: the actual standalone injection entry also passed a legacy-hook retirement plus duplicate-current-trust scenario; invalid intermediate cleanup is skipped and current trust is repaired.
- JavaScript bundles build successfully. The optional macOS Swift status-bar build times out locally (the build script treats this as non-fatal).
- Full-suite run: 4,491 passed, 42 failed, 58 skipped. On isolated reruns, 41 failures in three unrelated installer/OpenClaw suites reproduce identically on unmodified `origin/main` (`4e59a5b`), with subprocesses killed by SIGKILL. The remaining Codex transcript metrics timing test passes when rerun on both branches. No changes to those unrelated tests.

Scope: this fixes TOML recognition and safe duplicate repair; it does not add coordination with concurrent external writers or change hook trust policy.
