### PR TITLE
fix(codex): reconcile retired and current trust together

### DIFF
--- a/src/deployment/codex-trust-writer.ts
+++ b/src/deployment/codex-trust-writer.ts
@@ -322,6 +322,7 @@ export interface InstalledTrustOpts {
   configPath: string;
   hooksJsonAbsPath: string;
   locations: Record<string, InstalledCodexHookLocation>;
+  retiredKeys?: readonly string[];
   marker: string;
 }
 
@@ -331,6 +332,7 @@ interface LegacyTrustOpts {
   hookEvents: readonly string[];
   eventToCommand: Record<string, string>;
   eventToGroupIndex: Record<string, number>;
+  retiredKeys?: readonly string[];
   marker: string;
 }
 
@@ -356,6 +358,7 @@ function normalizeTrustOpts(opts: TrustOpts): InstalledTrustOpts {
     configPath: opts.configPath,
     hooksJsonAbsPath: opts.hooksJsonAbsPath,
     locations,
+    retiredKeys: opts.retiredKeys,
     marker: opts.marker,
   };
 }
@@ -371,13 +374,7 @@ function expectedTrustState(opts: InstalledTrustOpts): Map<string, string> {
   return expected;
 }
 
-/** Exact deterministic verification against the installed hooks.json locations. */
-export function verifyTrustHashes(rawOpts: TrustOpts): VerifyResult {
-  const opts = normalizeTrustOpts(rawOpts);
-  if (!fs.existsSync(opts.configPath)) {
-    return { valid: false, mismatches: ['config.toml missing'] };
-  }
-  const content = fs.readFileSync(opts.configPath, 'utf-8');
+function verifyTrustContent(content: string, opts: InstalledTrustOpts): VerifyResult {
   let state: Record<string, unknown> | undefined;
   try {
     const parsed = parseToml(content, { integersAsBigInt: true });
@@ -397,7 +394,19 @@ export function verifyTrustHashes(rawOpts: TrustOpts): VerifyResult {
     if (current === undefined) mismatches.push(`missing key=${key}`);
     else if (current !== hash) mismatches.push(`hash mismatch key=${key} (expected=${hash}, got=${current})`);
   }
+  for (const key of opts.retiredKeys ?? []) {
+    if (state?.[key] !== undefined) mismatches.push(`retired key still present=${key}`);
+  }
   return { valid: mismatches.length === 0, mismatches };
+}
+
+/** Exact deterministic verification against the installed hooks.json locations. */
+export function verifyTrustHashes(rawOpts: TrustOpts): VerifyResult {
+  const opts = normalizeTrustOpts(rawOpts);
+  if (!fs.existsSync(opts.configPath)) {
+    return { valid: false, mismatches: ['config.toml missing'] };
+  }
+  return verifyTrustContent(fs.readFileSync(opts.configPath, 'utf-8'), opts);
 }
 
 /**
@@ -410,15 +419,18 @@ export function writeTrustedHashes(rawOpts: TrustOpts): boolean {
   const existing = fs.existsSync(opts.configPath)
     ? fs.readFileSync(opts.configPath, 'utf-8')
     : '';
-  if (verifyTrustHashes(opts).valid) return false;
+  // The write-before idempotency check must inspect the same snapshot that will
+  // be reconciled. A parse failure (including duplicate Pilot tables) means the
+  // snapshot is not yet satisfied; owned duplicates remain repairable below.
+  if (verifyTrustContent(existing, opts).valid) return false;
 
   const begin = `# BEGIN ${opts.marker} trust`;
   const end = `# END ${opts.marker} trust`;
   const expected = expectedTrustState(opts);
   // Never infer ownership from marker position: Codex may reserialize TOML and
-  // move the END comment past unrelated third-party sections. Until persisted
-  // owned-key metadata is introduced, only touch the exact current Pilot keys.
-  const exactKeys = new Set(expected.keys());
+  // move the END comment past unrelated third-party sections. Only touch exact
+  // current keys plus retired keys proven from the still-installed Pilot hooks.
+  const exactKeys = new Set([...expected.keys(), ...(opts.retiredKeys ?? [])]);
   const enabledByKey = new Map<string, boolean>();
   for (const section of parseTrustSections(existing)) {
     if (section.enabled === undefined || expected.get(section.key) !== section.hash) continue;

--- a/src/deployment/hook-strategy.ts
+++ b/src/deployment/hook-strategy.ts
@@ -25,7 +25,6 @@ import {
   installedHookStateKey,
   writeTrustedHashes,
   removeTrustBlock,
-  removeTrustStateKeys,
   verifyTrustHashes,
 } from './codex-trust-writer.js';
 
@@ -222,18 +221,16 @@ export class HookStrategy implements DeployStrategy {
           });
         }
       }
-      for (const retiredHookDef of retiredHookDefs) {
-        const removed = await this.hookManager.uninstallHook(retiredHookDef);
-        if (!removed) {
-          return { success: false, agentId: def.id, deployMode: 'hook', error: 'failed to remove retired hook event' };
+      // Non-Codex agents have no trust transaction to protect. Preserve their
+      // existing cleanup-before-install order; Codex cleanup is deferred until
+      // the unified current+retired trust reconciliation succeeds below.
+      if (!hookConfig.trustToml) {
+        for (const retiredHookDef of retiredHookDefs) {
+          const removed = await this.hookManager.uninstallHook(retiredHookDef);
+          if (!removed) {
+            return { success: false, agentId: def.id, deployMode: 'hook', error: 'failed to remove retired hook event' };
+          }
         }
-      }
-      if (hookConfig.trustToml && retiredHookDefs.length > 0) {
-        const trust = hookConfig.trustToml;
-        removeTrustStateKeys(
-          resolveHome(trust.configPath),
-          retiredTrustKeys,
-        );
       }
 
       if (hookConfig.env) {
@@ -264,7 +261,16 @@ export class HookStrategy implements DeployStrategy {
       // Hook trust bypass 仅是 Codex 进程级 CLI 参数，不是合法的 config.toml 字段；
       // Pilot 不拥有 Codex 启动入口，因此这里不能提供 bypass 通道。
       if (hookConfig.trustToml) {
-        await this.writeCodexTrust(def);
+        await this.writeCodexTrust(def, retiredTrustKeys);
+        // Keep retired hooks installed until config.toml has been reconciled and
+        // re-read successfully. A failed trust repair then preserves the only
+        // runtime evidence from which their position-based keys can be proven.
+        for (const retiredHookDef of retiredHookDefs) {
+          const removed = await this.hookManager.uninstallHook(retiredHookDef);
+          if (!removed) {
+            return { success: false, agentId: def.id, deployMode: 'hook', error: 'failed to remove retired hook event' };
+          }
+        }
       }
 
       logger.info('hooks deployed', { agentId: def.id, events: hookConfig.events.length });
@@ -301,7 +307,10 @@ export class HookStrategy implements DeployStrategy {
    * 解决:HookManager 已支持每事件独立 hookCommand(我们在 buildHookDefinitions 里拼了 subcommand),
    * 见下方 buildHookDefinitions 改动。
    */
-  private async writeCodexTrust(def: AgentDefinition): Promise<void> {
+  private async writeCodexTrust(
+    def: AgentDefinition,
+    retiredKeys: readonly string[] = [],
+  ): Promise<void> {
     const cfg = def.hook!.trustToml!;
     const configPath = resolveHome(cfg.configPath);
     const hooksJsonAbsPath = path.resolve(resolveHome(def.hook!.settingsPath));
@@ -311,6 +320,7 @@ export class HookStrategy implements DeployStrategy {
       configPath,
       hooksJsonAbsPath,
       locations,
+      retiredKeys,
       marker: cfg.marker,
     });
 
@@ -318,6 +328,7 @@ export class HookStrategy implements DeployStrategy {
       configPath,
       hooksJsonAbsPath,
       locations,
+      retiredKeys,
       marker: cfg.marker,
     });
     if (!verify.valid) {

--- a/tests/unit/deployment/codex-trust-deploy-reconciliation.test.ts
+++ b/tests/unit/deployment/codex-trust-deploy-reconciliation.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { parse as parseToml } from 'smol-toml';
+import { HookStrategy } from '../../../src/deployment/hook-strategy.js';
+import { HookManager, type HookDefinition } from '../../../src/hooks/hook-manager.js';
+import {
+  computeInstalledHookTrustHash,
+  type InstalledCodexHookLocation,
+} from '../../../src/deployment/codex-trust-writer.js';
+import type { AgentDefinition } from '../../../src/types/index.js';
+
+let tmpDir: string;
+let codexDir: string;
+let hooksPath: string;
+let configPath: string;
+let hookCommand: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-trust-deploy-'));
+  codexDir = path.join(tmpDir, '.codex');
+  hooksPath = path.join(codexDir, 'hooks.json');
+  configPath = path.join(codexDir, 'config.toml');
+  hookCommand = path.join(tmpDir, 'codex-hook.sh');
+  fs.mkdirSync(codexDir, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function location(eventName: 'Stop' | 'PreToolUse'): InstalledCodexHookLocation {
+  const eventKey = eventName === 'Stop' ? 'stop' : 'pre_tool_use';
+  const subcommand = eventName === 'Stop' ? 'stop' : 'pre-tool-use';
+  return {
+    eventName,
+    eventKey,
+    groupIndex: 0,
+    handlerIndex: 0,
+    matcher: '*',
+    handler: { type: 'command', command: `${hookCommand} ${subcommand}` },
+  };
+}
+
+function codexDefinition(): AgentDefinition {
+  return {
+    id: 'codex',
+    displayName: 'Codex',
+    deployMode: 'hook',
+    detection: { paths: [codexDir], commands: [] },
+    hook: {
+      settingsPath: hooksPath,
+      events: ['Stop'],
+      retiredEvents: ['PreToolUse'],
+      hookCommand,
+      format: 'nested',
+      matcher: '*',
+      eventSubcommand: 'kebab-case',
+      trustToml: {
+        configPath,
+        trustAlgo: 'v1',
+        marker: 'otel-codex-hook',
+      },
+    },
+  };
+}
+
+function writeInstalledHooks(): void {
+  fs.writeFileSync(hooksPath, `${JSON.stringify({
+    hooks: {
+      Stop: [{ matcher: '*', hooks: [{ type: 'command', command: `${hookCommand} stop` }] }],
+      PreToolUse: [{ matcher: '*', hooks: [{ type: 'command', command: `${hookCommand} pre-tool-use` }] }],
+    },
+  }, null, 2)}\n`);
+}
+
+function writeDuplicateTrust(): { currentKey: string; retiredKey: string; thirdParty: string } {
+  const currentKey = `${hooksPath}:stop:0:0`;
+  const retiredKey = `${hooksPath}:pre_tool_use:0:0`;
+  const currentHash = computeInstalledHookTrustHash(location('Stop'));
+  const retiredHash = computeInstalledHookTrustHash(location('PreToolUse'));
+  const thirdParty = '["hooks"."state"."third-party:stop:0:0"]\nenabled = true\ntrusted_hash = "sha256:OTHER"\n';
+  fs.writeFileSync(configPath,
+    `[hooks.state."${retiredKey}"]\ntrusted_hash = "${retiredHash}"\n\n`
+    + `["hooks"."state"."${retiredKey}"]\ntrusted_hash = "${retiredHash}"\n\n`
+    + `[hooks.state."${currentKey}"]\ntrusted_hash = "${currentHash}"\n\n`
+    + `["hooks"."state"."${currentKey}"]\nenabled = false\ntrusted_hash = "${currentHash}"\n\n`
+    + thirdParty,
+  );
+  return { currentKey, retiredKey, thirdParty };
+}
+
+describe('Codex deploy trust reconciliation', () => {
+  test('repairs duplicate retired and current trust before removing the retired hook', async () => {
+    writeInstalledHooks();
+    const { currentKey, retiredKey, thirdParty } = writeDuplicateTrust();
+    const strategy = new HookStrategy(new HookManager(path.join(tmpDir, 'pilot-hooks'), path.join(tmpDir, 'logs')));
+
+    const result = await strategy.deploy(codexDefinition());
+
+    expect(result.success).toBe(true);
+    const repaired = fs.readFileSync(configPath, 'utf8');
+    const state = (parseToml(repaired) as any).hooks.state;
+    expect(state[retiredKey]).toBeUndefined();
+    expect(state[currentKey]).toEqual({
+      enabled: false,
+      trusted_hash: computeInstalledHookTrustHash(location('Stop')),
+    });
+    expect(repaired).toContain(thirdParty);
+    expect((JSON.parse(fs.readFileSync(hooksPath, 'utf8')) as any).hooks.PreToolUse).toBeUndefined();
+
+    const mtimeBeforeRetry = fs.statSync(configPath, { bigint: true }).mtimeNs;
+    const retry = await strategy.deploy(codexDefinition());
+    expect(retry.success).toBe(true);
+    expect(fs.statSync(configPath, { bigint: true }).mtimeNs).toBe(mtimeBeforeRetry);
+  });
+
+  test('retries retired hook removal without rewriting already reconciled trust', async () => {
+    writeInstalledHooks();
+    writeDuplicateTrust();
+    const realManager = new HookManager(path.join(tmpDir, 'pilot-hooks'), path.join(tmpDir, 'logs'));
+    let failRemoval = true;
+    const manager = {
+      isHookInstalled: (def: HookDefinition) => realManager.isHookInstalled(def),
+      installHook: (def: HookDefinition) => realManager.installHook(def),
+      uninstallHook: (def: HookDefinition) => {
+        if (failRemoval && def.hookJsonPath.at(-1) === 'PreToolUse') {
+          failRemoval = false;
+          return Promise.resolve(false);
+        }
+        return realManager.uninstallHook(def);
+      },
+    };
+    const strategy = new HookStrategy(manager as HookManager);
+
+    const first = await strategy.deploy(codexDefinition());
+    expect(first.success).toBe(false);
+    expect(first.error).toContain('failed to remove retired hook event');
+    expect((JSON.parse(fs.readFileSync(hooksPath, 'utf8')) as any).hooks.PreToolUse).toBeDefined();
+
+    const mtimeBeforeRetry = fs.statSync(configPath, { bigint: true }).mtimeNs;
+    const retry = await strategy.deploy(codexDefinition());
+    expect(retry.success).toBe(true);
+    expect(fs.statSync(configPath, { bigint: true }).mtimeNs).toBe(mtimeBeforeRetry);
+    expect((JSON.parse(fs.readFileSync(hooksPath, 'utf8')) as any).hooks.PreToolUse).toBeUndefined();
+  });
+});

--- a/tests/unit/deployment/codex-trust-writer.test.ts
+++ b/tests/unit/deployment/codex-trust-writer.test.ts
@@ -626,26 +626,33 @@ describe('Codex TOML reserialization compatibility', () => {
   });
 
 
-  test('declines retired-key cleanup so duplicate current trust can still be repaired', () => {
+  test('reconciles duplicate retired and current trust in one write', () => {
     const retiredKey = `${hooksPath}:pre_tool_use:0:0`;
     const retired = `[hooks.state."${retiredKey}"]\ntrusted_hash = "sha256:RETIRED"\n`;
+    const retiredQuoted = `["hooks"."state"."${retiredKey}"]\ntrusted_hash = "sha256:RETIRED"\n`;
     const current = `[hooks.state."${key}"]\ntrusted_hash = "${hash}"\n`;
     const quoted = `["hooks"."state"."${key}"]\nenabled = false\ntrusted_hash = "${hash}"\n`;
-    const original = retired + current + quoted + other;
+    const original = retired + retiredQuoted + current + quoted + other;
     fs.writeFileSync(configPath, original);
 
-    // Deployment cleans up retired keys before calling writeTrustedHashes.
-    // Removing just the retired table leaves invalid current duplicates.
-    expect(removeTrustStateKeys(configPath, [retiredKey])).toBe(false);
-    expect(read()).toBe(original);
-    expect(writeTrustedHashes(opts())).toBe(true);
+    expect(writeTrustedHashes({ ...opts(), retiredKeys: [retiredKey] })).toBe(true);
     expect((parseToml(read()) as any).hooks.state[key]).toEqual({ enabled: false, trusted_hash: hash });
+    expect((parseToml(read()) as any).hooks.state[retiredKey]).toBeUndefined();
     expect(read()).toContain(other);
+    expect(verifyTrustHashes({ ...opts(), retiredKeys: [retiredKey] }).valid).toBe(true);
+    expect(writeTrustedHashes({ ...opts(), retiredKeys: [retiredKey] })).toBe(false);
+  });
 
-    // Once the duplicate configuration is repaired, cleanup can succeed.
-    expect(removeTrustStateKeys(configPath, [retiredKey])).toBe(true);
-    expect(read()).not.toContain(retiredKey);
+  test('does not return early when current trust is valid but retired trust remains', () => {
+    const retiredKey = `${hooksPath}:pre_tool_use:0:0`;
+    const original = `[hooks.state."${key}"]\ntrusted_hash = "${hash}"\n\n`
+      + `[hooks.state."${retiredKey}"]\ntrusted_hash = "sha256:RETIRED"\n`;
+    fs.writeFileSync(configPath, original);
+
     expect(verifyTrustHashes(opts()).valid).toBe(true);
+    expect(writeTrustedHashes({ ...opts(), retiredKeys: [retiredKey] })).toBe(true);
+    expect((parseToml(read()) as any).hooks.state[retiredKey]).toBeUndefined();
+    expect(verifyTrustHashes({ ...opts(), retiredKeys: [retiredKey] }).valid).toBe(true);
   });
 
   test('does not hide filesystem errors during retired-key cleanup', () => {

--- a/tests/unit/deployment/hook-strategy.test.ts
+++ b/tests/unit/deployment/hook-strategy.test.ts
@@ -39,6 +39,7 @@ vi.mock('../../../src/deployment/codex-trust-writer.js', () => ({
     SubagentStart: 'subagent_start',
     SubagentStop: 'subagent_stop',
     Stop: 'stop',
+    PreToolUse: 'pre_tool_use',
     PostToolUse: 'post_tool_use',
   },
   installedHookStateKey: vi.fn((hooksPath: string, location: { eventKey: string; groupIndex: number; handlerIndex: number }) =>
@@ -762,9 +763,11 @@ describe('HookStrategy', () => {
       vi.mocked(readJsonFile).mockResolvedValue({
         hooks: {
           Stop: [{ hooks: [{ type: 'command', command: '/opt/pilot/hooks/codex-hook.sh stop' }] }],
+          PreToolUse: [{ hooks: [{ type: 'command', command: '/opt/pilot/hooks/codex-hook.sh pre-tool-use' }] }],
         },
       });
       mockHookManager.isHookInstalled.mockResolvedValue(true);
+      mockHookManager.uninstallHook.mockResolvedValue(true);
       vi.mocked(writeTrustedHashes).mockImplementationOnce(() => {
         throw new Error('trust write failed');
       });
@@ -774,6 +777,7 @@ describe('HookStrategy', () => {
         hook: {
           settingsPath: '/home/.codex/hooks.json',
           events: ['Stop'],
+          retiredEvents: ['PreToolUse'],
           hookCommand: '/opt/pilot/hooks/codex-hook.sh',
           format: 'nested',
           eventSubcommand: 'kebab-case',
@@ -787,6 +791,44 @@ describe('HookStrategy', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('trust write failed');
+      expect(mockHookManager.uninstallHook).not.toHaveBeenCalled();
+    });
+
+    it('reconciles Codex trust before removing retired hooks and checks removal', async () => {
+      vi.mocked(readJsonFile).mockResolvedValue({
+        hooks: {
+          Stop: [{ hooks: [{ type: 'command', command: '/opt/pilot/hooks/codex-hook.sh stop' }] }],
+          PreToolUse: [{ hooks: [{ type: 'command', command: '/opt/pilot/hooks/codex-hook.sh pre-tool-use' }] }],
+        },
+      });
+      mockHookManager.isHookInstalled.mockResolvedValue(true);
+      mockHookManager.uninstallHook.mockResolvedValue(false);
+
+      const result = await strategy.deploy(makeDef({
+        id: 'codex',
+        hook: {
+          settingsPath: '/home/.codex/hooks.json',
+          events: ['Stop'],
+          retiredEvents: ['PreToolUse'],
+          hookCommand: '/opt/pilot/hooks/codex-hook.sh',
+          format: 'nested',
+          eventSubcommand: 'kebab-case',
+          trustToml: {
+            configPath: '/home/.codex/config.toml',
+            trustAlgo: 'v1',
+            marker: 'otel-codex-hook',
+          },
+        },
+      }));
+
+      expect(writeTrustedHashes).toHaveBeenCalledWith(expect.objectContaining({
+        retiredKeys: ['/home/.codex/hooks.json:pre_tool_use:0:0'],
+      }));
+      expect(vi.mocked(writeTrustedHashes).mock.invocationCallOrder[0]).toBeLessThan(
+        mockHookManager.uninstallHook.mock.invocationCallOrder[0],
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('failed to remove retired hook event');
     });
 
     it('returns failure when Codex trust self-check fails', async () => {


### PR DESCRIPTION
## Summary

- reconcile proven retired Codex trust keys and current trust keys from one config.toml snapshot and commit them in one write
- include retired-key absence in idempotency and post-write verification
- keep retired hooks installed until trust reconciliation has been written and re-read successfully
- preserve the existing section-body safety validation and check uninstallHook failures

## Problem

PR #401 repairs equivalent quoted and bare Codex trust tables, but deployment still cleaned retired trust and repaired current trust as two independent writes. If both retired and current keys had duplicate semantic tables, neither partial candidate was valid TOML, so both writes were rejected. The retired hook could already have been removed, losing the runtime evidence needed to prove ownership on the next retry.

This change resolves retired ownership while the old hook is still installed, installs or confirms current hooks, reconciles both key sets in memory, verifies the written file, and only then removes retired hooks.

## Failure semantics

- candidate generation or validation failure leaves retired hooks installed
- retired hook removal returning false fails deployment
- a retry after hook-removal failure does not rewrite an already reconciled config.toml
- unrelated malformed or third-party duplicate TOML remains conservatively untouched

## Tests

- npm test -- tests/unit/deployment/codex-trust-writer.test.ts tests/unit/deployment/hook-strategy.test.ts tests/unit/deployment/codex-trust-deploy-reconciliation.test.ts
- npm test -- tests/unit/deployment
- npm run typecheck
- npm run build
